### PR TITLE
Fix sandbox build type resolution

### DIFF
--- a/sandbox/tsconfig.app.json
+++ b/sandbox/tsconfig.app.json
@@ -16,6 +16,10 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "typeRoots": [
+      "./src",
+      "./node_modules/@types"
+    ],
     "paths": {
       "@extension/*": [
         "../extension/*"


### PR DESCRIPTION
## Summary
- include sandbox global declarations directory in TypeScript `typeRoots`

## Testing
- `yarn build` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685c312f4888832a99fc8cba4403b977