### PR TITLE
Implement nested trigger hierarchy

### DIFF
--- a/client/src/Triggers.ts
+++ b/client/src/Triggers.ts
@@ -10,6 +10,7 @@ export interface Trigger {
     pattern: string | RegExp;
     callback: TriggerCallback
     tag?: string;
+    children: Map<string, Trigger>;
 }
 
 export default class Triggers {
@@ -21,48 +22,97 @@ export default class Triggers {
         this.clientExtension = clientExtension;
     }
 
-    registerTrigger(pattern: string | RegExp, callback: TriggerCallback, tag?: string): string {
-        const uuid = crypto.randomUUID()
-        this.triggers.set(uuid, {
-            pattern: pattern,
-            callback: callback,
-            tag: tag
-        })
-        return uuid;
+    private findTrigger(id: string, collection: Map<string, Trigger> = this.triggers): Trigger | undefined {
+        if (collection.has(id)) {
+            return collection.get(id)
+        }
+        for (const trigger of collection.values()) {
+            const found = this.findTrigger(id, trigger.children)
+            if (found) return found
+        }
+        return undefined
     }
 
-    registerOneTimeTrigger(pattern: string | RegExp, callback: TriggerCallback, tag?: string) {
+    private findParentMap(id: string, collection: Map<string, Trigger>): Map<string, Trigger> | undefined {
+        if (collection.has(id)) return collection
+        for (const trigger of collection.values()) {
+            const res = this.findParentMap(id, trigger.children)
+            if (res) return res
+        }
+        return undefined
+    }
+
+    private removeByTagRecursive(tag: string, collection: Map<string, Trigger>) {
+        Array.from(collection.entries()).forEach(([key, trigger]) => {
+            if (trigger.tag === tag) {
+                collection.delete(key)
+            } else {
+                this.removeByTagRecursive(tag, trigger.children)
+            }
+        })
+    }
+
+    registerTrigger(pattern: string | RegExp, callback: TriggerCallback, tag?: string, parentId?: string): string {
+        const uuid = crypto.randomUUID()
+        const trigger: Trigger = {
+            pattern: pattern,
+            callback: callback,
+            tag: tag,
+            children: new Map(),
+        }
+        if (parentId) {
+            const parent = this.findTrigger(parentId)
+            if (parent) {
+                parent.children.set(uuid, trigger)
+            } else {
+                this.triggers.set(uuid, trigger)
+            }
+        } else {
+            this.triggers.set(uuid, trigger)
+        }
+        return uuid
+    }
+
+    registerOneTimeTrigger(pattern: string | RegExp, callback: TriggerCallback, tag?: string, parentId?: string) {
         const uuid = this.registerTrigger(pattern, (rawLine, line, matches, type): string => {
             this.removeTrigger(uuid)
             return callback(rawLine, line, matches, type)
-        }, tag)
+        }, tag, parentId)
         return uuid;
     }
 
     removeByTag(tag: string) {
-        Array.from(this.triggers.entries()).filter(([, trigger]) => trigger.tag === tag).forEach(([key]) => {
-            this.removeTrigger(key)
-        })
+        this.removeByTagRecursive(tag, this.triggers)
     }
 
     removeTrigger(uuid: string) {
-        this.triggers.delete(uuid)
+        const parentMap = this.findParentMap(uuid, this.triggers)
+        if (!parentMap) return
+        parentMap.delete(uuid)
+    }
+
+    private executeTrigger(trigger: Trigger, rawLine: string, type: string): string {
+        const line = stripAnsiCodes(rawLine).replace(/\s$/g, '')
+        let matches: { index: number } | RegExpMatchArray
+        if (trigger.pattern instanceof RegExp) {
+            matches = line.match(trigger.pattern)
+        } else if (rawLine.toLowerCase().indexOf(trigger.pattern.toLowerCase()) > -1) {
+            matches = {
+                index: rawLine.toLowerCase().indexOf(trigger.pattern.toLowerCase())
+            }
+        }
+        if (matches) {
+            rawLine = trigger.callback(rawLine, line, matches, type) ?? rawLine
+            trigger.children.forEach(child => {
+                rawLine = this.executeTrigger(child, rawLine, type)
+            })
+        }
+        return rawLine
     }
 
     parseLine(rawLine: string, type: string) {
-        const line = stripAnsiCodes(rawLine).replace(/\s$/g, '')
-        Array.from(this.triggers.entries()).forEach(([_, trigger]) => {
-            let matches: { index: number } | RegExpMatchArray;
-            if (trigger.pattern instanceof RegExp) {
-                matches = line.match(trigger.pattern)
-            } else if (rawLine.toLowerCase().indexOf(trigger.pattern.toLowerCase()) > -1) {
-                matches = {
-                    index: rawLine.toLowerCase().indexOf(trigger.pattern.toLowerCase())
-                }
-            }
-            if (matches) {
-                rawLine = trigger.callback(rawLine, line, matches, type) ?? rawLine
-            }
+        this.triggers.forEach(trigger => {
+            rawLine = this.executeTrigger(trigger, rawLine, type)
         })
         return rawLine
     }


### PR DESCRIPTION
## Summary
- refactor `Triggers` to hold nested child objects rather than IDs
- add recursive helper functions for finding, removing and executing triggers
- update trigger registration and execution for the new structure

## Testing
- `yarn workspace arkadia-www-client build`
- `yarn build` *(fails: options workspace not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685c5bc408d0832abcf948a97275d16f