### PR TITLE
Add function triggers with optional callbacks

### DIFF
--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -4,6 +4,7 @@ import "@client/src/main.ts"
 import npc from "./npc.json";
 import mapData from "../../data/mapExport.json"
 import colors from "../../data/colors.json"
+import {color} from "@client/src/Colors.ts";
 
 window.clientExtension.eventTarget.dispatchEvent(new CustomEvent("npc", {detail: npc}));
 const frame: HTMLIFrameElement = document.getElementById("cm-frame")! as HTMLIFrameElement;
@@ -52,4 +53,9 @@ window.Input.send("wybierz paczke 3")
 window.clientExtension.fake("Pracownik poczty przekazuje ci jakas paczke.")
 
 
+window.clientExtension.Triggers.registerTrigger((rawLine, line, _matches, type) => {
+    return type == "combat.avatar" ? {index: 0} : undefined
+}, (rawLine, line, matches, type) => {
+    return color(25) + rawLine
+})
 window.clientExtension.fake("Ledwo muskasz brudnego brzydkiego goblina ciezkim bojowym toporem, trafiajac go w lewe ramie.", "combat.avatar")

--- a/sandbox/src/types/globals.d.ts
+++ b/sandbox/src/types/globals.d.ts
@@ -1,3 +1,5 @@
+import Client from "@client/src/Client.ts";
+
 interface ClientInput {
     send(command: string): void;
 }
@@ -46,17 +48,21 @@ interface ClientConf {
 
 }
 
+interface FakeClient extends Client {
+    fake: Function
+}
 
-declare var clientExtensions: ClientExtension
 
-interface Window {
-    Input: ClientInput;
-    Output: ClientOutput;
-    Maps: ClientMap;
-    Text: ClientText;
-    Conf: ClientConf
-    Gmcp: ClientGmcp;
-    clientExtension: ClientExtension
+declare global {
+    interface Window {
+        Input: ClientInput;
+        Output: ClientOutput;
+        Maps: ClientMap;
+        Text: ClientText;
+        Conf: ClientConf
+        Gmcp: ClientGmcp;
+        clientExtension: FakeClient
+    }
 }
 
 declare var Input: ClientInput;

--- a/sandbox/tsconfig.json
+++ b/sandbox/tsconfig.json
@@ -7,5 +7,10 @@
     {
       "path": "./tsconfig.node.json"
     }
-  ]
+  ],
+  "compilerOptions": {
+    "typeRoots": [
+      "node_modules/@types", "./src/types"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- support trigger patterns as functions
- make trigger callbacks optional

## Testing
- `npx tsc -p tsconfig.json` *(fails: Property 'scopes' in type ... not assignable)*

------
https://chatgpt.com/codex/tasks/task_e_685c6870e0a0832aa1c55eaac33aeaea