### PR TITLE
Fix tests failing due to undefined Input

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -5,8 +5,6 @@ import {Howl} from "howler"
 import {FunctionalBind} from "./scripts/functionalBind";
 import OutputHandler from "./OutputHandler";
 
-const originalSend = Input.send
-
 export default class Client {
 
     port: chrome.runtime.Port;
@@ -55,7 +53,7 @@ export default class Client {
 
     sendCommand(command: string) {
         this.eventTarget.dispatchEvent(new CustomEvent('command', {detail: command}))
-        originalSend(this.Map.parseCommand(command))
+        Input.send(this.Map.parseCommand(command))
     }
 
     onLine(line: string, type: string) {


### PR DESCRIPTION
## Summary
- remove top-level access of `Input` in `Client`
- call `Input.send` directly inside `sendCommand`

## Testing
- `node node_modules/jest/bin/jest.js -c jest.config.js`

------
https://chatgpt.com/codex/tasks/task_e_685d69092260832aa55d81ac66a93145