### PR TITLE
Add Client print buffering test

### DIFF
--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -65,3 +65,26 @@ test('sendCommand dispatches event and sends parsed command', () => {
   expect((window as any).Input.send).toHaveBeenCalledWith('parsed:test');
 });
 
+test('onLine sends printed messages after line and restores Output.send', () => {
+  const client = new Client();
+  const originalOutputSend = (window as any).Output.send;
+
+  client.Triggers.parseLine = jest.fn(() => {
+    expect((window as any).Output.send).not.toBe(originalOutputSend);
+    client.print('printed');
+    return 'processed';
+  });
+
+  const result = client.onLine('line', '');
+
+  expect(result).toBe('processed');
+  expect((window as any).Output.send).toBe(originalOutputSend);
+  expect(originalOutputSend).not.toHaveBeenCalled();
+
+  originalOutputSend(result);
+  client.sendEvent('output-sent');
+
+  expect(originalOutputSend).toHaveBeenNthCalledWith(1, 'processed');
+  expect(originalOutputSend).toHaveBeenNthCalledWith(2, 'printed', undefined);
+});
+


### PR DESCRIPTION
## Summary
- expand Client tests to cover print buffer behaviour

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_685d6b9d0010832ab8d726cf026ee303