### PR TITLE
Add tabs and trigger tester filter in sandbox

### DIFF
--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -17,6 +17,7 @@
                 <iframe id="cm-frame" src="embedded.html"></iframe>
             </div>
         </div>
+        <div id="tester-container" style="display: none;"></div>
         <div id="panel_buttons_bottom"></div>
         <div id="root"></div>
     </div>

--- a/sandbox/src/App.tsx
+++ b/sandbox/src/App.tsx
@@ -1,4 +1,5 @@
 import {Button, Form, InputGroup, Tab, Tabs} from "react-bootstrap";
+import {createPortal} from "react-dom";
 import {createRef, useEffect, useState} from "react";
 import {Controls} from "./Controls.tsx";
 import TriggerTester from "./TriggerTester.tsx";
@@ -13,8 +14,10 @@ export default function App() {
 
     useEffect(() => {
         const main = document.getElementById('main-container')
+        const tester = document.getElementById('tester-container')
         const bottom = document.getElementById('panel_buttons_bottom')
         if (main) main.style.display = tab === 'client' ? 'flex' : 'none'
+        if (tester) tester.style.display = tab === 'tester' ? 'block' : 'none'
         if (bottom) bottom.style.display = tab === 'client' ? '' : 'none'
     }, [tab])
 
@@ -55,10 +58,9 @@ export default function App() {
                         </InputGroup>
                     </Form>
                 </Tab>
-                <Tab eventKey="tester" title="Trigger Tester" className="pt-3">
-                    <TriggerTester/>
-                </Tab>
+                <Tab eventKey="tester" title="Trigger Tester" className="pt-3" />
             </Tabs>
+            {tab === 'tester' && createPortal(<TriggerTester/>, document.getElementById('tester-container')!)}
         </>
     )
 }

--- a/sandbox/src/App.tsx
+++ b/sandbox/src/App.tsx
@@ -1,5 +1,5 @@
-import {Button, Form, InputGroup} from "react-bootstrap";
-import {createRef, useState} from "react";
+import {Button, Form, InputGroup, Tab, Tabs} from "react-bootstrap";
+import {createRef, useEffect, useState} from "react";
 import {Controls} from "./Controls.tsx";
 import TriggerTester from "./TriggerTester.tsx";
 import type {KeyboardEvent} from 'react';
@@ -8,7 +8,15 @@ import type {KeyboardEvent} from 'react';
 export default function App() {
 
     const [text, setText] = useState('')
+    const [tab, setTab] = useState('client')
     const input = createRef<HTMLInputElement>();
+
+    useEffect(() => {
+        const main = document.getElementById('main-container')
+        const bottom = document.getElementById('panel_buttons_bottom')
+        if (main) main.style.display = tab === 'client' ? 'flex' : 'none'
+        if (bottom) bottom.style.display = tab === 'client' ? '' : 'none'
+    }, [tab])
 
     function send() {
         //window.clientExtension.fake(text)
@@ -34,17 +42,23 @@ export default function App() {
     return (
         <>
             <Controls/>
-            <Form onSubmit={(e) => {
-                e.preventDefault();
-                send()
-            }}>
-                <InputGroup className="mt-3">
-                    <Form.Control ref={input} value={text} onKeyDown={handleKeyDown} onKeyUp={handleKeys}
-                                  onChange={event => setText(event.currentTarget.value)}></Form.Control>
-                    <Button variant={'secondary'} onClick={send}>Wyślij</Button>
-                </InputGroup>
-            </Form>
-            <TriggerTester/>
+            <Tabs activeKey={tab} onSelect={(k) => setTab(k || 'client')} className="mt-3">
+                <Tab eventKey="client" title="Client" className="pt-3">
+                    <Form onSubmit={(e) => {
+                        e.preventDefault();
+                        send()
+                    }}>
+                        <InputGroup className="mb-3">
+                            <Form.Control ref={input} value={text} onKeyDown={handleKeyDown} onKeyUp={handleKeys}
+                                          onChange={event => setText(event.currentTarget.value)}></Form.Control>
+                            <Button variant={'secondary'} onClick={send}>Wyślij</Button>
+                        </InputGroup>
+                    </Form>
+                </Tab>
+                <Tab eventKey="tester" title="Trigger Tester" className="pt-3">
+                    <TriggerTester/>
+                </Tab>
+            </Tabs>
         </>
     )
 }

--- a/sandbox/src/App.tsx
+++ b/sandbox/src/App.tsx
@@ -1,4 +1,4 @@
-import {Button, Form, InputGroup, Tab, Tabs} from "react-bootstrap";
+import {Button, Form, InputGroup, Nav} from "react-bootstrap";
 import {createPortal} from "react-dom";
 import {createRef, useEffect, useState} from "react";
 import {Controls} from "./Controls.tsx";
@@ -42,24 +42,33 @@ export default function App() {
         }
     }
 
+    const nav = (
+        <Nav variant="tabs" activeKey={tab} onSelect={(k) => setTab((k as string) || 'client')} className="ms-2">
+            <Nav.Item>
+                <Nav.Link eventKey="client">Client</Nav.Link>
+            </Nav.Item>
+            <Nav.Item>
+                <Nav.Link eventKey="tester">Trigger Tester</Nav.Link>
+            </Nav.Item>
+        </Nav>
+    )
+
     return (
         <>
+            {createPortal(nav, document.getElementById('controls')!)}
             <Controls/>
-            <Tabs activeKey={tab} onSelect={(k) => setTab(k || 'client')} className="mt-3">
-                <Tab eventKey="client" title="Client" className="pt-3">
-                    <Form onSubmit={(e) => {
-                        e.preventDefault();
-                        send()
-                    }}>
-                        <InputGroup className="mb-3">
-                            <Form.Control ref={input} value={text} onKeyDown={handleKeyDown} onKeyUp={handleKeys}
-                                          onChange={event => setText(event.currentTarget.value)}></Form.Control>
-                            <Button variant={'secondary'} onClick={send}>Wyślij</Button>
-                        </InputGroup>
-                    </Form>
-                </Tab>
-                <Tab eventKey="tester" title="Trigger Tester" className="pt-3" />
-            </Tabs>
+            {tab === 'client' && (
+                <Form onSubmit={(e) => {
+                    e.preventDefault();
+                    send()
+                }}>
+                    <InputGroup className="mb-3 mt-3">
+                        <Form.Control ref={input} value={text} onKeyDown={handleKeyDown} onKeyUp={handleKeys}
+                                      onChange={event => setText(event.currentTarget.value)}></Form.Control>
+                        <Button variant={'secondary'} onClick={send}>Wyślij</Button>
+                    </InputGroup>
+                </Form>
+            )}
             {tab === 'tester' && createPortal(<TriggerTester/>, document.getElementById('tester-container')!)}
         </>
     )

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -14,6 +14,11 @@ body {
     height: calc(100vh - 150px);
 }
 
+#tester-container {
+    height: calc(100vh - 150px);
+    overflow: auto;
+}
+
 #main_text_output_msg_wrapper {
     border: 1px solid #333;
     font-family: monospace;

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -10,6 +10,10 @@ body {
     margin: 0;
 }
 
+.container > div {
+    height: 100%;
+}
+
 #main-container {
     height: calc(100vh - 150px);
 }

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -1,12 +1,17 @@
+html, body {
+    height: 100%;
+}
+
 body {
     background: #000;
     color: #fff;
     font-family: Verdana, Geneva, Tahoma, sans-serif;
     padding: 10px;
+    margin: 0;
 }
 
 #main-container {
-    height: 600px;
+    height: calc(100vh - 150px);
 }
 
 #main_text_output_msg_wrapper {


### PR DESCRIPTION
## Summary
- add tabbed view to switch between client and trigger tester
- filter triggers with checkbox
- allow sandbox to occupy full window height

## Testing
- `yarn workspace arkadia-www-client test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d6ec81014832a808d453dc26d0f21