### PR TITLE
Add /zlok alias with docs

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -96,6 +96,11 @@ const aliases = [
         pattern: /\/prowadz-$/, callback: () => {
             client.sendEvent('leadTo');
         }
+    },
+    {
+        pattern: /\/zlok$/, callback: () => {
+            Maps.refresh_position();
+        }
     }
 ]
 

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -1,0 +1,11 @@
+# Aliasy
+
+Poniższa lista opisuje dostępne aliasy w rozszerzeniu:
+
+- **/fake _tekst_** - wyświetla podany tekst jak zwykłą wiadomość klienta.
+- **/cofnij** - cofa postać do poprzedniego pomieszczenia na mapie.
+- **/move _kierunek_** - przesuwa postać w wybranym kierunku.
+- **/ustaw _id_** - ustawia bieżącą pozycję na mapie na podany identyfikator.
+- **/prowadz _id_** - rozpoczyna prowadzenie innej osoby do wskazanego pokoju.
+- **/prowadz-** - kończy prowadzenie rozpoczęte komendą `/prowadz`.
+- **/zlok** - wymusza odświeżenie bieżącej pozycji na mapie.


### PR DESCRIPTION
## Summary
- add `/zlok` alias to force refresh map position
- document available aliases in Polish

## Testing
- `yarn workspace arkadia-www-client test`

------
https://chatgpt.com/codex/tasks/task_e_685d7bb71970832ab0c06f10b3dfc4f9