### PR TITLE
Add DaisyUI business theme

### DIFF
--- a/options/index.html
+++ b/options/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en" data-theme="business">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/options/package.json
+++ b/options/package.json
@@ -30,6 +30,7 @@
     "vite": "^6.3.5",
     "tailwindcss": "^3.4.4",
     "autoprefixer": "^10.4.15",
-    "postcss": "^8.4.24"
+    "postcss": "^8.4.24",
+    "daisyui": "^4.10.1"
   }
 }

--- a/options/src/Npc.tsx
+++ b/options/src/Npc.tsx
@@ -34,8 +34,8 @@ function Npc() {
     return (
         <>
             <div className={'m-2'}>
-                <button className={'mb-2 mr-2 px-2 py-1 text-sm bg-blue-600 text-white rounded'} onClick={() => downloadNpcs()}>Pobierz bazę</button>
-                <button className={'mb-2 px-2 py-1 text-sm bg-red-600 text-white rounded'} onClick={() => clearNpcs()}>Wyczyść bazę</button>
+                <button className={'btn btn-primary btn-sm mb-2 mr-2'} onClick={() => downloadNpcs()}>Pobierz bazę</button>
+                <button className={'btn btn-error btn-sm mb-2'} onClick={() => clearNpcs()}>Wyczyść bazę</button>
                 <table className="min-w-full border border-gray-700 text-sm">
                     <tbody>
                     {npcs.sort((a, b) => a.name.localeCompare(b.name)).map((item) => (

--- a/options/src/Settings.tsx
+++ b/options/src/Settings.tsx
@@ -100,7 +100,7 @@ function SettingsForm() {
                         </label>
                     </div>
                 </div>
-                <button className="mt-2 px-4 py-2 bg-blue-600 text-white rounded" onClick={() => handleSubmission()}>Zapisz</button>
+                <button className="btn btn-primary mt-2" onClick={() => handleSubmission()}>Zapisz</button>
             </div>
         </>
     )

--- a/options/tailwind.config.js
+++ b/options/tailwind.config.js
@@ -1,3 +1,5 @@
+import daisyui from 'daisyui'
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
@@ -7,5 +9,8 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [daisyui],
+  daisyui: {
+    themes: ["business"]
+  }
 }


### PR DESCRIPTION
## Summary
- add DaisyUI to options package
- enable DaisyUI plugin with business theme
- apply theme on the options HTML page
- use DaisyUI button styles in options UI

## Testing
- `yarn --cwd client test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d90d6458c832a93d2f4b05670cd09