### PR TITLE
Add toggle for inline compass rose

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -1,6 +1,7 @@
 import Triggers from "./Triggers";
 import PackageHelper from "./PackageHelper";
 import MapHelper from "./MapHelper";
+import InlineCompassRose from "./scripts/inlineCompassRose";
 import {Howl} from "howler"
 import {FunctionalBind} from "./scripts/functionalBind";
 import OutputHandler from "./OutputHandler";
@@ -16,6 +17,7 @@ export default class Client {
     packageHelper = new PackageHelper(this)
     Map = new MapHelper(this)
     OutputHandler = new OutputHandler(this)
+    inlineCompassRose = new InlineCompassRose(this)
     panel = document.getElementById("panel_buttons_bottom")
     sounds: Record<string, Howl> = {
         // beep: new Howl({

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -171,7 +171,5 @@ client.Triggers.registerTrigger(/^(?!Ktos|Jakis|Jakas).*(Doplynelismy.*(Mozna|w 
 import initKillTrigger from "./scripts/kill"
 initKillTrigger(client)
 
-import initInlineCompassRose from "./scripts/inlineCompassRose"
-initInlineCompassRose(client)
 
 window["clientExtension"] = client

--- a/client/src/scripts/inlineCompassRose.ts
+++ b/client/src/scripts/inlineCompassRose.ts
@@ -1,5 +1,5 @@
 import Client from "../Client";
-import {color, findClosestColor} from "../Colors";
+import { color, findClosestColor } from "../Colors";
 
 const SPRING_GREEN = findClosestColor("#00ff7f");
 const DIM_GRAY = findClosestColor("#696969");
@@ -19,74 +19,99 @@ const shortToLong: Record<string, string> = {
 };
 
 const polishToShort: Record<string, string> = {
-    "polnoc": "n",
-    "poludnie": "s",
-    "wschod": "e",
-    "zachod": "w",
+    polnoc: "n",
+    poludnie: "s",
+    wschod: "e",
+    zachod: "w",
     "polnocny-wschod": "ne",
     "polnocny-zachod": "nw",
     "poludniowy-wschod": "se",
     "poludniowy-zachod": "sw",
-    "dol": "d",
-    "gora": "u",
-    "gore": "u",
+    dol: "d",
+    gora: "u",
+    gore: "u",
 };
 
-export default function initInlineCompassRose(client: Client) {
-    let exits = new Set<string>();
-
-    client.addEventListener('gmcp_msg.room.exits', () => {
+export default class InlineCompassRose {
+    private client: Client;
+    private exits = new Set<string>();
+    private enabled = false;
+    private listener = () => {
         const data = (window as any).gmcp?.room?.info;
-        exits = new Set(parseExits(data));
-        showCompassRose();
-    });
+        this.exits = new Set(this.parseExits(data));
+        this.showCompassRose();
+    };
 
-    function parseExits(detail: any): string[] {
+    constructor(client: Client) {
+        this.client = client;
+        this.client.addEventListener("settings", (event: CustomEvent) => {
+            const enabled = !!event.detail.inlineCompassRose;
+            if (enabled) {
+                this.enable();
+            } else {
+                this.disable();
+            }
+        });
+    }
+
+    enable() {
+        if (this.enabled) return;
+        this.enabled = true;
+        this.client.addEventListener("gmcp_msg.room.exits", this.listener);
+    }
+
+    disable() {
+        if (!this.enabled) return;
+        this.enabled = false;
+        this.client.removeEventListener("gmcp_msg.room.exits", this.listener);
+    }
+
+    private parseExits(detail: any): string[] {
         let list: string[] = [];
         if (!detail) return list;
         if (Array.isArray(detail)) {
             list = detail;
         } else if (Array.isArray(detail.exits)) {
             list = detail.exits;
-        } else if (detail.exits && typeof detail.exits === 'object') {
+        } else if (detail.exits && typeof detail.exits === "object") {
             list = Object.keys(detail.exits);
         } else if (detail.room && detail.room.exits) {
             const e = detail.room.exits;
             list = Array.isArray(e) ? e : Object.keys(e);
         }
-        return list.map(toShort).filter(Boolean);
+        return list.map((e) => this.toShort(e)).filter(Boolean);
     }
 
-    function toShort(exit: string): string {
+    private toShort(exit: string): string {
         if (polishToShort[exit]) return polishToShort[exit];
         if (shortToLong[exit]) return exit;
         const long = exit.toLowerCase();
         const short = Object.entries(shortToLong).find(([_, l]) => l === long);
         if (short) return short[0];
-        return '';
+        return "";
     }
 
-    function hasExit(short: string): boolean {
-        return exits.has(short);
+    private hasExit(short: string): boolean {
+        return this.exits.has(short);
     }
 
-    function printExit(short: string): string {
-        const label = hasExit(short) ? short.toUpperCase() : " ".repeat(short.length);
+    private printExit(short: string): string {
+        const label = this.hasExit(short) ? short.toUpperCase() : " ".repeat(short.length);
         return color(SPRING_GREEN) + label + RESET;
     }
 
-    function showCompassRose() {
-        client.println([
-            "",
-            `       ${printExit("nw")}  ${printExit("n")}  ${printExit("ne")}       ${printExit("u")}`,
-            `         ${hasExit("nw") ? "\\" : " "} ${hasExit("n") ? "|" : " "} ${hasExit("ne") ? "/" : " "}         ${hasExit("u") ? "|" : ""}`,
-            `       ${printExit("w")}${hasExit("w") ? "---" : "   "}${color(DIM_GRAY)}X${RESET}${hasExit("e") ? "---" : "   "}${printExit("e")}       ${(hasExit("d") || hasExit("u")) ? "o" : ""}`,
-            `         ${hasExit("sw") ? "/" : " "} ${hasExit("s") ? "|" : " "} ${hasExit("se") ? "\\" : " "}         ${hasExit("d") ? "|" : ""}`,
-            `       ${printExit("sw")}  ${printExit("s")}  ${printExit("se")}       ${printExit("d")}`,
-            "",
-            ""
-        ].join("\n"));
+    private showCompassRose() {
+        this.client.println(
+            [
+                "",
+                `       ${this.printExit("nw")}  ${this.printExit("n")}  ${this.printExit("ne")}    ${this.printExit("u")}`,
+                `         ${this.hasExit("nw") ? "\\" : " "} ${this.hasExit("n") ? "|" : " "} ${this.hasExit("ne") ? "/" : " "}         ${this.hasExit("u") ? "|" : ""}`,
+                `       ${this.printExit("w")}${this.hasExit("w") ? "---" : "   "}${color(DIM_GRAY)}X${RESET}${this.hasExit("e") ? "---" : "   "}${this.printExit("e")}       ${this.hasExit("d") || this.hasExit("u") ? "o" : ""}`,
+                `         ${this.hasExit("sw") ? "/" : " "} ${this.hasExit("s") ? "|" : " "} ${this.hasExit("se") ? "\\" : " "}         ${this.hasExit("d") ? "|" : ""}`,
+                `       ${this.printExit("sw")}  ${this.printExit("s")}  ${this.printExit("se")}    ${this.printExit("d")}`,
+                "",
+                "",
+            ].join("\n")
+        );
     }
 }
-
-

--- a/options/src/Settings.tsx
+++ b/options/src/Settings.tsx
@@ -13,6 +13,7 @@ interface Settings {
     guilds: string[];
     packageHelper: boolean;
     replaceMap: boolean;
+    inlineCompassRose: boolean;
 }
 
 function SettingsForm() {
@@ -20,7 +21,8 @@ function SettingsForm() {
     const [settings, setSettings] = useState<Settings>({
         guilds: [],
         packageHelper: false,
-        replaceMap: false
+        replaceMap: false,
+        inlineCompassRose: false,
     })
 
     function onChangeSetting(modifier: (settings: Settings) => void) {
@@ -97,6 +99,17 @@ function SettingsForm() {
                                 checked={settings.packageHelper}
                             />
                             Asystent paczek
+                        </label>
+                        <label className="flex items-center gap-1">
+                            <input
+                                type="checkbox"
+                                id="inlineCompassRose"
+                                name="inlineCompassRose"
+                                onChange={event => onChangeSetting((s) => s.inlineCompassRose = event.target.checked)}
+                                className="mx-1"
+                                checked={settings.inlineCompassRose}
+                            />
+                            Róża wiatrów w linii
                         </label>
                     </div>
                 </div>

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -17,7 +17,8 @@ window.dispatchEvent(new CustomEvent("ready"));
 fakeClient.eventTarget.dispatchEvent(new CustomEvent("settings", {
     detail: {
         guilds: [],
-        packageHelper: true
+        packageHelper: true,
+        inlineCompassRose: true
     }
 }))
 


### PR DESCRIPTION
## Summary
- introduce `InlineCompassRose` class with enable/disable support
- wire compass rose toggle through `Client` and settings form
- expose new checkbox option in extension settings
- update sandbox settings for new feature

## Testing
- `yarn --cwd client test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d91056958832a84ada3b5bf4c16d5