### PR TITLE
Add container table formatter

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -171,5 +171,7 @@ client.Triggers.registerTrigger(/^(?!Ktos|Jakis|Jakas).*(Doplynelismy.*(Mozna|w 
 import initKillTrigger from "./scripts/kill"
 initKillTrigger(client)
 
+import initContainers from "./scripts/prettyContainers"
+initContainers(client)
 
 window["clientExtension"] = client

--- a/client/src/scripts/prettyContainers.ts
+++ b/client/src/scripts/prettyContainers.ts
@@ -1,0 +1,116 @@
+export type GroupDefinition = {
+    name: string;
+    filter: (item: string) => boolean;
+};
+
+export type ContainerItem = {
+    name: string;
+    count: string | number;
+};
+
+export type ParsedContainer = {
+    container: string;
+    items: ContainerItem[];
+};
+
+export function createRegexpFilter(patterns: (string | RegExp)[]): (item: string) => boolean {
+    const regs = patterns.map(p => typeof p === 'string' ? new RegExp(p, 'i') : p);
+    return (item: string) => regs.some(r => r.test(item));
+}
+
+export const defaultContainerPatterns: RegExp[] = [
+    /^Otwart(?:y|a|e) (?<container>.+? (?:plecak|torba|sakwa|sakiewka|szkatulka|wor|worek))(?: z .*?)? zawiera (?<content>.*)\.$/i,
+    /^Otwarty .+? (?<container>kosz(?:|yk)) zawiera (?<content>.*)\.$/i,
+];
+
+export function parseItems(content: string): ContainerItem[] {
+    let rest = content.trim();
+    rest = rest.replace(/\s+i\s+([^,]+)\.$/, ', $1');
+    rest = rest.replace(/\.$/, '');
+    const parts = rest.split(/,\s*/).map(p => p.trim()).filter(p => p.length > 0);
+    return parts.map(p => {
+        const mm = p.match(/^(wiele|\d+)\s+(.*)/i);
+        if (mm) {
+            return { count: mm[1] === 'wiele' ? 'wie' : mm[1], name: mm[2] };
+        }
+        return { count: 1, name: p };
+    });
+}
+
+export function parseContainer(line: string, patterns: RegExp[] = defaultContainerPatterns): ParsedContainer | null {
+    for (const re of patterns) {
+        const m = line.match(re);
+        if (m && (m.groups?.content || m.groups?.container)) {
+            const container = m.groups?.container?.trim() ?? '';
+            const content = m.groups?.content ?? '';
+            return { container, items: parseItems(content) };
+        }
+    }
+    return null;
+}
+
+
+export function categorizeItems(items: ContainerItem[], groups: GroupDefinition[]) {
+    const result: Record<string, ContainerItem[]> = {};
+    for (const g of groups) result[g.name] = [];
+    result['inne'] = [];
+    for (const item of items) {
+        const g = groups.find(gr => gr.filter(item.name));
+        if (g) result[g.name].push(item); else result['inne'].push(item);
+    }
+    return result;
+}
+
+function pad(str: string, len: number) {
+    return str + ' '.repeat(Math.max(0, len - str.length));
+}
+
+function center(str: string, len: number) {
+    const total = Math.max(len, str.length);
+    const left = Math.floor((total - str.length) / 2);
+    const right = total - str.length - left;
+    return ' '.repeat(left) + str + ' '.repeat(right);
+}
+
+export function formatTable(title: string, groups: Record<string, ContainerItem[]>, columns = 1): string {
+    const allItems: ContainerItem[] = Object.values(groups).flat();
+    const itemLines = allItems.map(it => `${String(it.count).padStart(3, ' ')} | ${it.name}`);
+    let colWidth = Math.max(title.length, ...itemLines.map(l => l.length)) + 2;
+    const width = columns * colWidth + (columns - 1) * 3 + 2;
+    const horiz = '-'.repeat(width - 2);
+    let out = `/${horiz}\\\n`;
+    out += `|${center(title, width - 2)}|\n`;
+    out += `+${horiz}+\n`;
+    for (const [gName, items] of Object.entries(groups)) {
+        if (items.length === 0) continue;
+        out += `|${pad(' ' + gName, width - 2)}|\n`;
+        out += `+${horiz}+\n`;
+        for (let i = 0; i < items.length; i += columns) {
+            let line = '|';
+            for (let c = 0; c < columns; c++) {
+                const it = items[i + c];
+                if (it) {
+                    const text = `${String(it.count).padStart(3, ' ')} | ${it.name}`;
+                    line += pad(text, colWidth);
+                } else {
+                    line += ' '.repeat(colWidth);
+                }
+                line += c === columns - 1 ? '' : ' | ';
+            }
+            line += '|\n';
+            out += line;
+        }
+        out += `+${horiz}+\n`;
+    }
+    out = out.slice(0, -1); // remove last \n
+    out += `\\${horiz}/`;
+    return out;
+}
+
+export function prettyPrintContainer(line: string, defs: GroupDefinition[], columns = 1, title = 'POJEMNIK', patterns: RegExp[] = defaultContainerPatterns) {
+    const parsed = parseContainer(line, patterns);
+    if (!parsed) return '';
+    const categorized = categorizeItems(parsed.items, defs);
+    const tableTitle = title || parsed.container;
+    return formatTable(tableTitle, categorized, columns);
+}

--- a/client/src/scripts/prettyContainers.ts
+++ b/client/src/scripts/prettyContainers.ts
@@ -106,7 +106,7 @@ export function formatTable(title: string, groups: Record<string, ContainerItem[
         lines.push(gLine);
         lines.push(`+${horiz}+`);
 
-        const maxItems = Math.max(...pair.map(([,_items]) => _items.length));
+        const maxItems = Math.max(...pair.map(([, _items]) => _items.length));
         for (let i = 0; i < maxItems; i++) {
             let rowLine = '|';
             for (let c = 0; c < columns; c++) {
@@ -127,19 +127,18 @@ export function formatTable(title: string, groups: Record<string, ContainerItem[
 }
 
 export function prettyPrintContainer(
-    line: string,
-    defs: GroupDefinition[],
+    matches: RegExpMatchArray,
     columns = 1,
     title = 'POJEMNIK',
-    patterns: RegExp[] = defaultContainerPatterns,
     padding = 1,
 ) {
-    return formatTable(tableTitle, categorized, { columns, padding });
+    const parsed = parseContainer(matches);
     if (!parsed) return '';
     const categorized = categorizeItems(parsed.items, defs);
     const tableTitle = title || parsed.container;
-    return formatTable(tableTitle, categorized, columns);
+    return formatTable(tableTitle, categorized, {columns, padding});
 }
+
 
 const defaultContainerPatterns: RegExp[] = [
     /^Otwart(?:y|a|e) (?<container>.+? (?:plecak|torba|sakwa|sakiewka|szkatulka|wor|worek))(?: z .*?)? zawiera (?<content>.*)\.$/i,
@@ -199,7 +198,7 @@ const defs = [
 export default function initContainers(client: Client) {
     defaultContainerPatterns.forEach(pattern => {
         client.Triggers.registerTrigger(pattern, (_, __, matches): undefined => {
-            client.print(prettyPrintContainer(matches))
+            client.print(prettyPrintContainer(matches, 2, null, 5))
         });
     })
 }

--- a/client/src/scripts/prettyContainers.ts
+++ b/client/src/scripts/prettyContainers.ts
@@ -1,3 +1,5 @@
+import Client from "../Client";
+
 export type GroupDefinition = {
     name: string;
     filter: (item: string) => boolean;
@@ -13,17 +15,12 @@ export type ParsedContainer = {
     items: ContainerItem[];
 };
 
-export function createRegexpFilter(patterns: (string | RegExp)[]): (item: string) => boolean {
+function createRegexpFilter(patterns: (string | RegExp)[]): (item: string) => boolean {
     const regs = patterns.map(p => typeof p === 'string' ? new RegExp(p, 'i') : p);
     return (item: string) => regs.some(r => r.test(item));
 }
 
-export const defaultContainerPatterns: RegExp[] = [
-    /^Otwart(?:y|a|e) (?<container>.+? (?:plecak|torba|sakwa|sakiewka|szkatulka|wor|worek))(?: z .*?)? zawiera (?<content>.*)\.$/i,
-    /^Otwarty .+? (?<container>kosz(?:|yk)) zawiera (?<content>.*)\.$/i,
-];
-
-export function parseItems(content: string): ContainerItem[] {
+function parseItems(content: string): ContainerItem[] {
     let rest = content.trim();
     rest = rest.replace(/\s+i\s+([^,]+)\.$/, ', $1');
     rest = rest.replace(/\.$/, '');
@@ -31,22 +28,19 @@ export function parseItems(content: string): ContainerItem[] {
     return parts.map(p => {
         const mm = p.match(/^(wiele|\d+)\s+(.*)/i);
         if (mm) {
-            return { count: mm[1] === 'wiele' ? 'wie' : mm[1], name: mm[2] };
+            return {count: mm[1] === 'wiele' ? 'wie' : mm[1], name: mm[2]};
         }
-        return { count: 1, name: p };
+        return {count: 1, name: p};
     });
 }
 
-export function parseContainer(line: string, patterns: RegExp[] = defaultContainerPatterns): ParsedContainer | null {
-    for (const re of patterns) {
-        const m = line.match(re);
-        if (m && (m.groups?.content || m.groups?.container)) {
-            const container = m.groups?.container?.trim() ?? '';
-            const content = m.groups?.content ?? '';
-            return { container, items: parseItems(content) };
-        }
+function parseContainer(matches: RegExpMatchArray): ParsedContainer | null {
+    if (matches && (matches.groups?.content || matches.groups?.container)) {
+        const container = matches.groups?.container?.trim() ?? '';
+        const content = matches.groups?.content ?? '';
+        return {container, items: parseItems(content)};
     }
-    return null;
+    return null
 }
 
 
@@ -107,10 +101,74 @@ export function formatTable(title: string, groups: Record<string, ContainerItem[
     return out;
 }
 
-export function prettyPrintContainer(line: string, defs: GroupDefinition[], columns = 1, title = 'POJEMNIK', patterns: RegExp[] = defaultContainerPatterns) {
-    const parsed = parseContainer(line, patterns);
+export function prettyPrintContainer(matches: RegExpMatchArray, columns = 1, title = 'POJEMNIK') {
+    const parsed = parseContainer(matches);
     if (!parsed) return '';
     const categorized = categorizeItems(parsed.items, defs);
     const tableTitle = title || parsed.container;
     return formatTable(tableTitle, categorized, columns);
 }
+
+const defaultContainerPatterns: RegExp[] = [
+    /^Otwart(?:y|a|e) (?<container>.+? (?:plecak|torba|sakwa|sakiewka|szkatulka|wor|worek))(?: z .*?)? zawiera (?<content>.*)\.$/i,
+    /^Otwarty .+? (?<container>kosz(?:|yk)) zawiera (?<content>.*)\.$/i,
+];
+
+const weapons = ["darda", "dardy", "multon", "kord", "puginal", "gladius", "topor", "berdysz", "siekier", "czekan",
+    "oskard", "kilof", "tasak", "tabar", "nadziak", "macan", "miecz", "sihill", "drannach", "szabl", "szabel", "rapier",
+    "scimitar", "katzbalger", "stilett", "pal", "sztylet", "halabard", "falchion", "mlot", "obusz", "wloczni", "pik[ei]",
+    "noz", "maczug", "morgenstern", "kordelas", "mizerykordi", "buzdygan", "korbacz", "gal[ae]z(?!k) ", "bulaw", "drag",
+    "kiscien", "nog[ai] stolow", "dag[ai]", "wloczni[aei]", "floret", "wekier", "walek", "kostur", "kos[aye]", "szponton",
+    "partyzan", "glewi", "gizarm", "dzid", "naginat", "rohatyn", "korsek", "cep", "trojz[ea]b", "ronkon", "runk",
+    "flamberg", "poltorak", "bulat", "nimsz", "szamszir", "lami", "schiavon", "lewak", "sierp", "lask[^o]", "wid[el]",
+    "saif", "koncerz", "kij", "espadon", "claymor", "cinquend", "szpad", "karabel", "jatagan", "baselard", "katar",
+    "bastard", "kafar", "kindzal", "harpun", "kotwic", "kadzielnic", "lancet", "ostrz", "berl", "chepesz",
+    "spis( |$|y|e|a)", "talwar", "dluto", "pejcz", "kanczug", "parazonium", "lancuch", "kropacz", "piernacz", "estok",
+    "bosak", "fink[aei]", "parazoni", "tulich", "navaj", "smocz.+ pazur"]
+const shields = ["tarcz", "puklerz", "pawez", "luskow. pancern. skorup. zolwia"]
+const torso = ["brygantyn", "napiersnik", "kirys", "kolczug", "karacen", "kaftan", "tunik", "zbroj", "bajdan[ay]",
+    "anim[eay]", "kozus", "kurt", "kamizel", "becht", "pancerz", "zbro. plytow", "polpancerz", "nabrzusznik", "bajdan",
+    "aketo"]
+const head = ["helm", "burgonet", "misiurk", "kaptur", "morion", "basinet", "salad", "przylbic", "diadem", "szyszak",
+    "narbut[ay]", "armet", "casquett", "czapk", "beret", "turban", "gigantyczn. wzmacnian. czaszk", "barbut", "kapalin",
+    "koron[^k]", "klobuk"]
+const legs = ["nagolennik", "spoden", "nogawic", "buty", "butow", "trzewik", "spodni", "spodnic", "naudziak", "sandal",
+    "nakolannik", "nabiodr", "pantofel", "muszkieter"]
+const hands = ["nareczak", "naramiennik", "rekawic", "karwasz"]
+const wear = ["futro", "kubraczek", "koszul", "sukni", "sukien", "plaszcz", "peleryn", "tog", "szat",
+    "bloniaste skrzydl", "chust", "pas( |$|y)", "gemm", "obroz", "szat", "kolnierz", "dublet", "kapelusz", "przepask",
+    "wams", "oficer[ek]", "bigwant", "calun", "kapuz", "bluzk", "gorset", "kabat", "szal", "tiar", "tocz[ek]", "peruk",
+    "kolpak", "opask", "wian[ek]"]
+const jewelery = ["pierscien(?!iowa)", "naszyjnik", "bransolet", "spink", "talizman", "amulet", "kolczyk", "lancuszki",
+    "koral", "wisior", "medalion", "lancusz", "brosz", "szarf", "koli[iae]", "sygnet", "obracze?k", "potrojn. sznur.+",
+    "cwiek( |$|i|ow)(?!ana)", "serduszk", "grzebyk"]
+const gems = ["obsydia(ny|now|n)", "labrado(ry|row|r)", "oliwi(ny|now|n)", "gaga(ty|tow|t)", "fluory(ty|tow|t)",
+    "burszty(ny|now|n)", "ametys(ty|tow|t)", "kwar(ce|cow|c)", "rubi(ny|now|n)", "piry(ty|tow|t)", "serpenty(ny|now|n)",
+    "per(ly|le|la|el)", "serpenty(ny|now|n)", "malachi(ty|tow|t)", "karneo(le|low|l)", "lazury(ty|tow|t)",
+    "nefry(ty|tow|t)", "aleksandry(ty|tow|t)", "celesty(ny|now|n)", "monacy(ty|tow|t)", "azury(ty|tow|t)",
+    "jaspi(sy|sow|s)", "onyk(sy|sow|s)", "turmali(ny|now|n)", "awentury(ny|now|n)", "turku(sy|sow|s)", "opa(li|le|l)",
+    "kryszta(ly|low|l)", "hematy(ty|tow|t)", "rodoli(ty|tow|t)", "aga(ty|tow|t)", "jaskrawozolt.+ cytry(ny|now|n(?!e))",
+    "apaty(ty|tow|t)", "kyani(ty|tow|t)", "akwamary(ny|now|n)", "ioli(ty|tow|t)", "diopsy(dy|dow|d)", "cyrko(ny|now|n)",
+    "zoisy(ty|tow|t)", "grana(ty|tow|t)", "almandy(ny|now|n)", "ortokla(zy|zow|z)", "topa(zy|zow|z)", "tytani(ty|tow|t)",
+    "diamen(ty|tow|t)", "szafi(ry|row|r)", "szmaragd", "chryzoberyl", "spinel", "chryzopraz", "rodochrozyt", "heliodor"]
+
+const defs = [
+    {name: "bronie", filter: createRegexpFilter(weapons)},
+    {name: "korpus", filter: createRegexpFilter(torso)},
+    {name: "tarcze", filter: createRegexpFilter(shields)},
+    {name: "glowa", filter: createRegexpFilter(head)},
+    {name: "rece", filter: createRegexpFilter(hands)},
+    {name: "nogi", filter: createRegexpFilter(legs)},
+    {name: "ubrania", filter: createRegexpFilter(wear)},
+    {name: "bizuteria", filter: createRegexpFilter(jewelery)},
+    {name: "kamienie", filter: createRegexpFilter(gems)},
+]
+
+export default function initContainers(client: Client) {
+    defaultContainerPatterns.forEach(pattern => {
+        client.Triggers.registerTrigger(pattern, (_, __, matches): undefined => {
+            client.print(prettyPrintContainer(matches))
+        });
+    })
+}
+

--- a/client/src/scripts/prettyContainers.ts
+++ b/client/src/scripts/prettyContainers.ts
@@ -69,16 +69,17 @@ function center(str: string, len: number) {
 export function formatTable(title: string, groups: Record<string, ContainerItem[]>, columns = 1): string {
     const allItems: ContainerItem[] = Object.values(groups).flat();
     const itemLines = allItems.map(it => `${String(it.count).padStart(3, ' ')} | ${it.name}`);
-    let colWidth = Math.max(title.length, ...itemLines.map(l => l.length)) + 2;
+    const colWidth = Math.max(title.length, ...itemLines.map(l => l.length)) + 2;
     const width = columns * colWidth + (columns - 1) * 3 + 2;
     const horiz = '-'.repeat(width - 2);
-    let out = `/${horiz}\\\n`;
-    out += `|${center(title, width - 2)}|\n`;
-    out += `+${horiz}+\n`;
+    const lines: string[] = [];
+    lines.push(`/${horiz}\\`);
+    lines.push(`|${center(title, width - 2)}|`);
+    lines.push(`+${horiz}+`);
     for (const [gName, items] of Object.entries(groups)) {
         if (items.length === 0) continue;
-        out += `|${pad(' ' + gName, width - 2)}|\n`;
-        out += `+${horiz}+\n`;
+        lines.push(`|${pad(' ' + gName, width - 2)}|`);
+        lines.push(`+${horiz}+`);
         for (let i = 0; i < items.length; i += columns) {
             let line = '|';
             for (let c = 0; c < columns; c++) {
@@ -91,14 +92,14 @@ export function formatTable(title: string, groups: Record<string, ContainerItem[
                 }
                 line += c === columns - 1 ? '' : ' | ';
             }
-            line += '|\n';
-            out += line;
+            line += '|';
+            lines.push(line);
         }
-        out += `+${horiz}+\n`;
+        lines.push(`+${horiz}+`);
     }
-    out = out.slice(0, -1); // remove last \n
-    out += `\\${horiz}/`;
-    return out;
+    // replace final separator with closing line
+    lines[lines.length - 1] = `\\${horiz}/`;
+    return lines.join('\n');
 }
 
 export function prettyPrintContainer(matches: RegExpMatchArray, columns = 1, title = 'POJEMNIK') {

--- a/client/test/prettyContainers.test.ts
+++ b/client/test/prettyContainers.test.ts
@@ -39,4 +39,12 @@ describe('prettyContainers', () => {
     // Should have two counts in one line when columns=2
     expect(table.split('\n').some(line => line.split('|').length > 4)).toBe(true);
   });
+
+  test('formatTable ends with closing line', () => {
+    const parsed = parseContainer(input)!;
+    const cat = categorizeItems(parsed.items, groups);
+    const table = formatTable('POJEMNIK', cat, 1);
+    const last = table.trim().split('\n').pop()!;
+    expect(last).toMatch(/^\\-+\/$/);
+  });
 });

--- a/client/test/prettyContainers.test.ts
+++ b/client/test/prettyContainers.test.ts
@@ -27,7 +27,7 @@ describe('prettyContainers', () => {
   test('formatTable prints table', () => {
     const parsed = parseContainer(input)!;
     const cat = categorizeItems(parsed.items, groups);
-    const table = formatTable('POJEMNIK', cat, 1);
+    const table = formatTable('POJEMNIK', cat, { columns: 1 });
     expect(table).toMatch(/kamienie/);
     expect(table).toMatch(/upiorny mglisty calun/);
   });
@@ -35,15 +35,16 @@ describe('prettyContainers', () => {
   test('formatTable supports multiple columns', () => {
     const parsed = parseContainer(input)!;
     const cat = categorizeItems(parsed.items, groups);
-    const table = formatTable('POJEMNIK', cat, 2);
-    // Should have two counts in one line when columns=2
-    expect(table.split('\n').some(line => line.split('|').length > 4)).toBe(true);
+    const table = formatTable('POJEMNIK', cat, { columns: 2 });
+    const firstHeader = table.split('\n')[3];
+    expect(firstHeader).toMatch(/ubrania/);
+    expect(firstHeader).toMatch(/kamienie/);
   });
 
   test('formatTable ends with closing line', () => {
     const parsed = parseContainer(input)!;
     const cat = categorizeItems(parsed.items, groups);
-    const table = formatTable('POJEMNIK', cat, 1);
+    const table = formatTable('POJEMNIK', cat, { columns: 1 });
     const last = table.trim().split('\n').pop()!;
     expect(last).toMatch(/^\\-+\/$/);
   });

--- a/client/test/prettyContainers.test.ts
+++ b/client/test/prettyContainers.test.ts
@@ -48,4 +48,17 @@ describe('prettyContainers', () => {
     const last = table.trim().split('\n').pop()!;
     expect(last).toMatch(/^\\-+\/$/);
   });
+
+  test('formatTable applies transforms', () => {
+    const parsed = parseContainer(input)!;
+    const cat = categorizeItems(parsed.items, groups);
+    const transforms = [
+      {
+        check: (item: string) => item.includes('piryt'),
+        transform: (v: string) => v.toUpperCase(),
+      },
+    ];
+    const table = formatTable('POJEMNIK', cat, { columns: 1, transforms });
+    expect(table).toMatch(/ZLOCISTY PIRYT/);
+  });
 });

--- a/client/test/prettyContainers.test.ts
+++ b/client/test/prettyContainers.test.ts
@@ -1,0 +1,42 @@
+import {parseContainer, categorizeItems, createRegexpFilter, formatTable} from '../src/scripts/prettyContainers';
+
+describe('prettyContainers', () => {
+  const input = 'Otwarty szary skorzany plecak zawiera zlocisty piryt, upiorny mglisty calun, skorzany buklak, gornicza lampe, oliwkowozielony serpentyn, zielonkawy awenturyn, zolty celestyn, bezbarwny gorski krysztal, mithrylowa monete, wiele zlotych monet, wiele srebrnych monet i wiele miedzianych monet.';
+  const groups = [
+    { name: 'ubrania', filter: createRegexpFilter(['calun']) },
+    { name: 'kamienie', filter: createRegexpFilter(['piryt', 'serpentyn', 'awenturyn', 'celestyn', 'krysztal']) },
+  ];
+
+  test('parseContainer splits items', () => {
+    const parsed = parseContainer(input)!;
+    expect(parsed.container).toContain('plecak');
+    expect(parsed.items.length).toBe(12);
+    expect(parsed.items[0]).toEqual({count: 1, name: 'zlocisty piryt'});
+    expect(parsed.items[10]).toEqual({count: 'wie', name: 'srebrnych monet'});
+  });
+
+  test('categorizeItems groups by filters', () => {
+    const parsed = parseContainer(input)!;
+    const cat = categorizeItems(parsed.items, groups);
+    expect(cat.ubrania.map(i => i.name)).toContain('upiorny mglisty calun');
+    expect(cat.kamienie.map(i => i.name)).toContain('zlocisty piryt');
+    expect(cat.inne.map(i => i.name)).toContain('skorzany buklak');
+    expect(Object.keys(cat).slice(-1)[0]).toBe('inne');
+  });
+
+  test('formatTable prints table', () => {
+    const parsed = parseContainer(input)!;
+    const cat = categorizeItems(parsed.items, groups);
+    const table = formatTable('POJEMNIK', cat, 1);
+    expect(table).toMatch(/kamienie/);
+    expect(table).toMatch(/upiorny mglisty calun/);
+  });
+
+  test('formatTable supports multiple columns', () => {
+    const parsed = parseContainer(input)!;
+    const cat = categorizeItems(parsed.items, groups);
+    const table = formatTable('POJEMNIK', cat, 2);
+    // Should have two counts in one line when columns=2
+    expect(table.split('\n').some(line => line.split('|').length > 4)).toBe(true);
+  });
+});

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -69,22 +69,26 @@ fakeClient.fake = (text: string, type?: string) => {
 // client.fake("Ranisz brzydkiego zgarbionego goblina ciezkim bojowym toporem, trafiajac go w glowe.", "combat.avatar");
 // client.fake("Brzydki zgarbiony goblin probuje cie trafic krzywym krotkim nozem, lecz tobie udaje sie uniknac tego ciosu.", "combat.avatar");
 // client.fake("Ranisz brzydkiego zgarbionego goblina ciezkim bojowym toporem, trafiajac go w nogi.", "combat.avatar");
-fakeClient.fake("Brzydki zgarbiony goblin wykonuje zamaszyste ciecie krzywym krotkim nozem mierzac w ciebie, lecz udaje ci sie oslonic okragla drewniana tarcza.", "combat.avatar");
-fakeClient.fake("Nurkujac pod atakiem brzydkiego zgarbionego goblina mocno ranisz go ciosem okraglej drewnianej tarczy i zaraz po tym kaleczysz uderzeniem ciezkiego bojowego topora w glowe.", "combat.avatar");
-fakeClient.fake("W slepiach brzydkiego zgarbionego goblina pojawia sie nienawistny blysk, gdy zdecydowanym uderzeniem krzywego krotkiego noza przecina powietrze tuz przed twoja glowa.", "combat.avatar");
-fakeClient.fake("Ranisz brzydkiego zgarbionego goblina ciezkim bojowym toporem, trafiajac go w glowe.", "combat.avatar");
-fakeClient.fake("W slepiach brzydkiego zgarbionego goblina pojawia sie nienawistny blysk, gdy zdecydowanym uderzeniem krzywego krotkiego noza przecina powietrze tuz przed twoja glowa.", "combat.avatar");
-fakeClient.fake("Ranisz brzydkiego zgarbionego goblina ciezkim bojowym toporem, trafiajac go w nogi.", "combat.avatar");
-fakeClient.fake("Brzydki zgarbiony goblin trafia cie krzywym krotkim nozem w korpus, lecz caly impet uderzenia zostaje wyparowany przez wzmocniony pelny pancerz kolczy.", "combat.avatar");
-fakeClient.fake("Kilkakrotnie tluczesz w korpus brzydkiego zgarbionego goblina poteznymi ciosami okraglej drewnianej tarczy i krwawo ranisz go ciezkim bojowym toporem.", "combat.avatar");
-fakeClient.fake("Brzydki zgarbiony goblin probuje cie trafic krzywym krotkim nozem, lecz tobie udaje sie uniknac tego ciosu.", "combat.avatar");
-fakeClient.fake("Wykonujesz zamaszyste ciecie ciezkim bojowym toporem mierzac w brzydkiego zgarbionego goblina, lecz ten oslania sie okragla drewniana tarcza.", "combat.avatar");
-fakeClient.fake("Powaznie ranisz brzydkiego zgarbionego goblina ciezkim bojowym toporem, trafiajac go w glowe.", "combat.avatar");
-fakeClient.fake("Brzydki zgarbiony goblin wykonuje zamaszyste ciecie krzywym krotkim nozem mierzac w ciebie, lecz udaje ci sie oslonic okragla drewniana tarcza.", "combat.avatar");
-fakeClient.fake("Masakrujesz brzydkiego zgarbionego goblina ciezkim bojowym toporem, trafiajac go w nogi.", "combat.avatar");
-fakeClient.fake("Brzydki zgarbiony goblin umarl.", "combat.avatar");
-fakeClient.fake("Zabiles zgarbionego brzydkiego goblina.");
-fakeClient.fake("Wyszczerzony zielony goblin ledwo muska cie krzywym krotkim nozem, trafiajac cie w korpus.", "combat.avatar");
+// fakeClient.fake("Brzydki zgarbiony goblin wykonuje zamaszyste ciecie krzywym krotkim nozem mierzac w ciebie, lecz udaje ci sie oslonic okragla drewniana tarcza.", "combat.avatar");
+// fakeClient.fake("Nurkujac pod atakiem brzydkiego zgarbionego goblina mocno ranisz go ciosem okraglej drewnianej tarczy i zaraz po tym kaleczysz uderzeniem ciezkiego bojowego topora w glowe.", "combat.avatar");
+// fakeClient.fake("W slepiach brzydkiego zgarbionego goblina pojawia sie nienawistny blysk, gdy zdecydowanym uderzeniem krzywego krotkiego noza przecina powietrze tuz przed twoja glowa.", "combat.avatar");
+// fakeClient.fake("Ranisz brzydkiego zgarbionego goblina ciezkim bojowym toporem, trafiajac go w glowe.", "combat.avatar");
+// fakeClient.fake("W slepiach brzydkiego zgarbionego goblina pojawia sie nienawistny blysk, gdy zdecydowanym uderzeniem krzywego krotkiego noza przecina powietrze tuz przed twoja glowa.", "combat.avatar");
+// fakeClient.fake("Ranisz brzydkiego zgarbionego goblina ciezkim bojowym toporem, trafiajac go w nogi.", "combat.avatar");
+// fakeClient.fake("Brzydki zgarbiony goblin trafia cie krzywym krotkim nozem w korpus, lecz caly impet uderzenia zostaje wyparowany przez wzmocniony pelny pancerz kolczy.", "combat.avatar");
+// fakeClient.fake("Kilkakrotnie tluczesz w korpus brzydkiego zgarbionego goblina poteznymi ciosami okraglej drewnianej tarczy i krwawo ranisz go ciezkim bojowym toporem.", "combat.avatar");
+// fakeClient.fake("Brzydki zgarbiony goblin probuje cie trafic krzywym krotkim nozem, lecz tobie udaje sie uniknac tego ciosu.", "combat.avatar");
+// fakeClient.fake("Wykonujesz zamaszyste ciecie ciezkim bojowym toporem mierzac w brzydkiego zgarbionego goblina, lecz ten oslania sie okragla drewniana tarcza.", "combat.avatar");
+// fakeClient.fake("Powaznie ranisz brzydkiego zgarbionego goblina ciezkim bojowym toporem, trafiajac go w glowe.", "combat.avatar");
+// fakeClient.fake("Brzydki zgarbiony goblin wykonuje zamaszyste ciecie krzywym krotkim nozem mierzac w ciebie, lecz udaje ci sie oslonic okragla drewniana tarcza.", "combat.avatar");
+// fakeClient.fake("Masakrujesz brzydkiego zgarbionego goblina ciezkim bojowym toporem, trafiajac go w nogi.", "combat.avatar");
+// fakeClient.fake("Brzydki zgarbiony goblin umarl.", "combat.avatar");
+// fakeClient.fake("Zabiles zgarbionego brzydkiego goblina.");
+// fakeClient.fake("Wyszczerzony zielony goblin ledwo muska cie krzywym krotkim nozem, trafiajac cie w korpus.", "combat.avatar");
+//
+// fakeClient.fake("Karczma.", 'room.short')
+// fakeClient.fake("Sa tutaj dwa widoczne wyjscia: polnoc i poludniowy-zachod..", 'room.exits')
 
-fakeClient.fake("Karczma.", 'room.short')
-fakeClient.fake("Sa tutaj dwa widoczne wyjscia: polnoc i poludniowy-zachod..", 'room.exits')
+
+fakeClient.fake("Otwarty szary skorzany plecak zawiera zlocisty piryt, upiorny mglisty calun, skorzany buklak, gornicza lampe, oliwkowozielony serpentyn, zielonkawy awenturyn, zolty celestyn, bezbarwny" +
+    "gorski krysztal, mithrylowa monete, wiele zlotych monet, wiele srebrnych monet i wiele miedzianych monet.")


### PR DESCRIPTION
## Summary
- add `prettyContainers` helpers for categorizing container items
- support custom grouping and multi‑column tables
- test container parser and table formatter

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_685dbfabbc30832ab6925833a4b31cd9