### PR TITLE
Enhance pretty container formatting

### DIFF
--- a/client/test/prettyContainers.test.ts
+++ b/client/test/prettyContainers.test.ts
@@ -48,4 +48,17 @@ describe('prettyContainers', () => {
     const last = table.trim().split('\n').pop()!;
     expect(last).toMatch(/^\\-+\/$/);
   });
+
+  test('formatTable applies transforms', () => {
+    const parsed = parseContainer(input)!;
+    const cat = categorizeItems(parsed.items, groups);
+    const transforms = [
+      {
+        check: (item: string) => item.includes('piryt'),
+        transform: (v: string) => v.toUpperCase(),
+      },
+    ];
+    const table = formatTable('POJEMNIK', cat, { columns: 1, transforms });
+    expect(table).toMatch(/ZLOCISTY PIRYT/);
+  });
 });


### PR DESCRIPTION
## Summary
- export parsing helpers from prettyContainers
- add `TransformDefinition` type and allow transforms when formatting tables
- fix `parseItems` to handle lines without trailing dot
- test style transformations for container tables

## Testing
- `yarn --cwd client test` *(fails: This package doesn't seem to be present in your lockfile)*
- `npx --no-install jest`

------
https://chatgpt.com/codex/tasks/task_e_685dd211a79c832a967208793bb2fafc