### PR TITLE
Add portal-based side buttons in sandbox

### DIFF
--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -12,6 +12,7 @@
             <h4 class="p-0 m-0">Arkadia Extension Sandbox</h4>
         </div>
         <div id="main-container" class="d-flex align-items-stretch">
+            <div id="sandbox-buttons" class="me-2 d-flex flex-column"></div>
             <div id="main_text_output_msg_wrapper"></div>
             <div id="map" class="border">
                 <iframe id="cm-frame" src="embedded.html"></iframe>

--- a/sandbox/src/Controls.tsx
+++ b/sandbox/src/Controls.tsx
@@ -2,11 +2,20 @@ import {createPortal} from "react-dom";
 import {Button} from "react-bootstrap";
 
 export function Controls() {
-
-    return <>
-        {createPortal(
-            <Button size={"sm"} variant={'secondary'} onClick={() => window.Output.clear()}>Reset</Button>,
-            document.getElementById('controls')!
-        )}
-    </>
+    return (
+        <>
+            {createPortal(
+                <Button size="sm" variant="secondary" onClick={() => window.Output.clear()}>Reset</Button>,
+                document.getElementById('controls')!
+            )}
+            {createPortal(
+                <div className="d-flex flex-column gap-2">
+                    <Button size="sm" variant="primary">Button 1</Button>
+                    <Button size="sm" variant="primary">Button 2</Button>
+                    <Button size="sm" variant="primary">Button 3</Button>
+                </div>,
+                document.getElementById('sandbox-buttons')!
+            )}
+        </>
+    );
 }

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -29,6 +29,10 @@ textarea, input {
     width: 30%;
 }
 
+#sandbox-buttons {
+    width: 120px;
+}
+
 iframe {
     height: 100%;
     width: 100%;


### PR DESCRIPTION
## Summary
- add a `sandbox-buttons` container in sandbox layout
- style the new side button container
- render example buttons in `Controls` using a portal

## Testing
- `yarn --cwd client test` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685e74e4f2d4832a942fd1318d03f70b