### PR TITLE
Fix test failure due to missing transforms option

### DIFF
--- a/client/src/scripts/prettyContainers.ts
+++ b/client/src/scripts/prettyContainers.ts
@@ -81,11 +81,13 @@ export type TransformDefinition = {
 export type FormatOptions = {
     columns?: number;
     padding?: number;
+    transforms?: TransformDefinition[];
 };
 
 export function formatTable(title: string, groups: Record<string, ContainerItem[]>, opts: FormatOptions = {}): string {
     const columns = opts.columns ?? 1;
     const padding = opts.padding ?? 1;
+    const activeTransforms = opts.transforms ?? defaultTransforms;
     const padSpace = ' '.repeat(padding);
 
     const entries = Object.entries(groups).filter(([, it]) => it.length > 0);
@@ -93,7 +95,7 @@ export function formatTable(title: string, groups: Record<string, ContainerItem[
     const allLines = entries.flatMap(([name, items]) => {
         const itemTexts = items.map(it => {
             let text = `${String(it.count).padStart(3, ' ')} | ${it.name}`;
-            for (const tr of transforms) {
+            for (const tr of activeTransforms) {
                 if (tr.check(it.name, it.count, name)) {
                     text = tr.transform(text);
                     break;
@@ -135,7 +137,7 @@ export function formatTable(title: string, groups: Record<string, ContainerItem[
                 const item = grp && grp[1][i];
                 let text = item ? `${String(item.count).padStart(3, ' ')} | ${item.name}` : '';
                 if (item && grp) {
-                    for (const tr of transforms) {
+                    for (const tr of activeTransforms) {
                         if (tr.check(item.name, item.count, grp[0])) {
                             text = tr.transform(text);
                             break;
@@ -224,7 +226,7 @@ const defs = [
     {name: "kamienie", filter: createRegexpFilter(gems)},
 ]
 
-const transforms: TransformDefinition[] = [
+const defaultTransforms: TransformDefinition[] = [
     { check: (item: string) => item.match("mithryl\\w+ monet") != null, transform: (item) => encloseColor(item, findClosestColor("#afeeee"))},
     { check: (item: string) => item.match("zlot\\w+ monet") != null, transform: (item) => encloseColor(item, findClosestColor("#FFD700"))},
     { check: (item: string) => item.match("srebrn\\w+") != null, transform: (item) => encloseColor(item, findClosestColor("#C0C0C0"))},

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -7,6 +7,7 @@ jest.mock('../src/Triggers', () => ({ __esModule: true, default: jest.fn().mockI
 jest.mock('../src/PackageHelper', () => ({ __esModule: true, default: jest.fn() }));
 jest.mock('../src/OutputHandler', () => ({ __esModule: true, default: jest.fn() }));
 jest.mock('../src/scripts/functionalBind', () => ({ FunctionalBind: jest.fn() }));
+jest.mock('../src/main', () => ({ __esModule: true, rawSend: jest.fn() }));
 
 
 jest.mock('../src/MapHelper', () => {


### PR DESCRIPTION
## Summary
- allow specifying custom transforms for `formatTable`
- rename default transform list to avoid conflicts
- mock `main` module in tests to prevent unwanted side effects

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_685e95c790e8832a9d3537a1e92e3d20