### PR TITLE
Move sandbox buttons outside main container

### DIFF
--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -7,12 +7,12 @@
 </head>
 <body>
 <div class="container">
+    <div id="sandbox-buttons" class="me-2 d-flex flex-column"></div>
     <div id="main-container">
         <div class="mb-2 d-flex gap-2 align-items-center" id="controls">
             <h4 class="p-0 m-0">Arkadia Extension Sandbox</h4>
         </div>
         <div id="main-content" class="d-flex align-items-stretch flex-grow-1">
-            <div id="sandbox-buttons" class="me-2 d-flex flex-column"></div>
             <div id="main_text_output_msg_wrapper"></div>
             <div id="map" class="border">
                 <iframe id="cm-frame" src="embedded.html"></iframe>

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -11,7 +11,12 @@ body {
     box-sizing: border-box;
 }
 
-.container, .container > div {
+.container {
+    height: 100%;
+    display: flex;
+}
+
+.container > div {
     height: 100%;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- adjust layout so sandbox buttons are siblings of main container
- update styling for new layout

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_685f24952b68832ab5cc7f4d9e8eff1f