### PR TITLE
Add kill counter feature

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -169,7 +169,7 @@ client.Triggers.registerTrigger(/^(?!Ktos|Jakis|Jakas).*(Doplynelismy.*(Mozna|w 
 })
 
 import initKillTrigger from "./scripts/kill"
-initKillTrigger(client)
+initKillTrigger(client, aliases)
 
 import initContainers from "./scripts/prettyContainers"
 initContainers(client)

--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -1,8 +1,146 @@
 import Client from "../Client";
-import {encloseColor, findClosestColor} from "../Colors";
+import { encloseColor, findClosestColor } from "../Colors";
 
-export default function init(client: Client) {
-    client.Triggers.registerTrigger(/(^[ >]*(Zabil(?:es|as|)) (?<target>[a-zA-Z (),!]+)\.$)/, (rawLine): string => {
-        return "  \n" + client.prefix(rawLine, encloseColor("[  ZABILES  ] ", findClosestColor("#ff6347"))) + "\n  "
-    })
+type KillCounts = Record<string, { session: number; total: number }>;
+
+const STORAGE_KEY = "kill_counter";
+
+const twoWordNames = [
+    "czarnego orka",
+    "dzikiego orka",
+    "elfiego egzekutora",
+    "kamiennego trolla",
+    "konia bojowego",
+    "krasnoluda chaosu",
+    "lodowego trolla",
+    "pajaka sieciarza",
+    "pomiot chaosu",
+    "rumaka bojowego",
+    "rycerza chaosu",
+    "smoczego ogra",
+    "smoka chaosu",
+    "straznika wiezy",
+    "szkielet goblina",
+    "szkielet krasnoluda",
+    "szkielet orka",
+    "tancerza wojny",
+    "trolla gorskiego",
+    "trolla jaskiniowego",
+    "zjawe kobiety",
+    "zjawe straznika",
+    "zywiolaka ognia",
+    "zywiolaka powietrza",
+    "zywiolaka wody",
+    "zywiolaka ziemi",
+];
+
+function parseName(full: string): string {
+    const words = full.trim().toLowerCase().split(/\s+/);
+    const lastTwo = words.slice(-2).join(" ");
+    if (twoWordNames.includes(lastTwo)) {
+        return lastTwo;
+    }
+    return words[words.length - 1];
 }
+
+function formatTable(counts: KillCounts): string {
+    const WIDTH = 47;
+    const pad = (content = "") => `| ${content.padEnd(WIDTH - 1)}|`;
+    const header = (title: string) => {
+        const dashes = WIDTH - title.length - 2;
+        const left = Math.floor(dashes / 2);
+        const right = dashes - left;
+        return `+${"-".repeat(left)} ${title} ${"-".repeat(right)}+`;
+    };
+
+    const entries = Object.entries(counts)
+        .filter(([_, v]) => v.session > 0 || v.total > 0)
+        .sort(([a], [b]) => a.localeCompare(b));
+
+    const total = Object.values(counts).reduce((s, v) => s + v.total, 0);
+
+    const mobLine = (name: string, session: number, totalKills: number) => {
+        const numbers = `${session} / ${totalKills}`;
+        let text = `${name} `;
+        text += ".".repeat(WIDTH - 1 - text.length - numbers.length - 1);
+        text += ` ${numbers}`;
+        return pad(text);
+    };
+
+    const summaryLine = (label: string, value: number) => {
+        let text = `${label} `;
+        const num = String(value);
+        text += ".".repeat(WIDTH - 1 - text.length - num.length);
+        text += num;
+        return pad(text);
+    };
+
+    const lines: string[] = [];
+    lines.push(header("Licznik zabitych"));
+    lines.push(pad());
+    lines.push(pad("JA"));
+    entries.forEach(([name, { session, total }]) => {
+        lines.push(mobLine(name, session, total));
+    });
+    lines.push(pad());
+    lines.push(summaryLine("LACZNIE:", total));
+    lines.push(pad());
+    lines.push(pad());
+    lines.push(summaryLine("DRUZYNA LACZNIE:", total));
+    lines.push(pad());
+    lines.push(`+${"-".repeat(WIDTH)}+`);
+    return lines.join("\n");
+}
+
+export default function init(
+    client: Client,
+    aliases?: { pattern: RegExp; callback: Function }[]
+) {
+    let kills: KillCounts = {};
+    if (chrome.storage) {
+        chrome.storage.local.get(STORAGE_KEY).then((data) => {
+            kills = data[STORAGE_KEY] ?? {};
+        });
+    }
+
+    window.addEventListener("beforeunload", () => {
+        chrome.storage?.local.set({ [STORAGE_KEY]: kills });
+    });
+
+    const killRegex =
+        /^[ >]*(Zabil(?:es|as) (?<name>[A-Za-z\u0105\u0107\u0119\u0142\u0144\u00f3\u015b\u017c\u017a\u017b\u0104\u0106\u0118\u0141\u0143\u00d3\u015a\u0179\u017b ]+))\.$/;
+
+    client.Triggers.registerTrigger(
+        killRegex,
+        (rawLine, _line, matches): string => {
+            const mob = parseName(matches.groups?.name ?? "");
+            if (!kills[mob]) {
+                kills[mob] = { session: 0, total: 0 };
+            }
+            kills[mob].session += 1;
+            kills[mob].total += 1;
+            chrome.storage?.local.set({ [STORAGE_KEY]: kills });
+
+            const counts = ` (${kills[mob].session} / ${kills[mob].total})`;
+            const modified = rawLine.replace(/\.$/, `${counts}.`);
+            return (
+                "  \n" +
+                client.prefix(
+                    modified,
+                    encloseColor("[  ZABILES  ] ", findClosestColor("#ff6347"))
+                ) +
+                "\n  "
+            );
+        }
+    );
+
+    if (aliases) {
+        aliases.push({
+            pattern: /\/zabici$/,
+            callback: () => {
+                client.print("\n" + formatTable(kills) + "\n");
+            },
+        });
+    }
+}
+

--- a/sandbox/src/Controls.tsx
+++ b/sandbox/src/Controls.tsx
@@ -3,6 +3,7 @@ import {Button, Modal} from "react-bootstrap";
 import {useState} from "react";
 import TriggerTester from "./TriggerTester.tsx";
 import packageAssistant from "./scenario/package-assistant.ts";
+import killCounterDemo from "./scenario/kill-counter-demo.ts";
 
 
 
@@ -15,7 +16,14 @@ export function Controls() {
                     <Button size="sm" className="w-100" variant="secondary" onClick={() => window.Output.clear()}>Reset</Button>
                     <Button size="sm" className="w-100" variant="secondary" onClick={() => setShowTester(true)}>Trigger Tester</Button>
                     <Button size="sm" className="w-100" variant="secondary" onClick={() => packageAssistant.run()}>Asystent paczek</Button>
-                    <Button size="sm" className="w-100" variant="secondary">Button 3</Button>
+                    <Button
+                        size="sm"
+                        className="w-100"
+                        variant="secondary"
+                        onClick={() => killCounterDemo.run()}
+                    >
+                        Kill Counter Demo
+                    </Button>
                 </div>,
                 document.getElementById('sandbox-buttons')!,
             )}

--- a/sandbox/src/scenario/kill-counter-demo.ts
+++ b/sandbox/src/scenario/kill-counter-demo.ts
@@ -1,0 +1,12 @@
+import ClientScript from "../ClientScript.ts";
+import { fakeClient } from "../index.ts";
+
+export default new ClientScript(fakeClient)
+    .reset()
+    .fake("Zabiles wielkiego dzikiego kamiennego trolla.")
+    .fake("Zabiles poteznego wscieklego krasnoluda chaosu.")
+    .fake("Zabiles malutkiego wscieklego snotlinga.")
+    .fake("Zabiles brzydkiego zgarbionego goblina.")
+    .fake("Zabiles dzikiego wscieklego trolla.")
+    .send("/zabici");
+


### PR DESCRIPTION
## Summary
- count mob kills and store them to chrome storage
- display kill table with `/zabici` alias
- append kill counts to kill messages
- add sandbox scenario to demo kill counter

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_685ff23ed050832abdab4ef729babd6b