### PR TITLE
Add team kill tracking to kill counter

### DIFF
--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -63,6 +63,11 @@ function formatTable(counts: KillCounts): string {
     const LEFT_PADDING = 2;
     const RIGHT_PADDING = 5;
     const CONTENT_WIDTH = WIDTH - LEFT_PADDING - RIGHT_PADDING;
+
+    const HEADER_COLOR = findClosestColor("#7cfc00");
+    const MY_COLOR = findClosestColor("#ffff00");
+    const TOTAL_COLOR = findClosestColor("#778899");
+
     const pad = (content = "") =>
         `|${" ".repeat(LEFT_PADDING)}${content.padEnd(CONTENT_WIDTH)}${" ".repeat(
             RIGHT_PADDING
@@ -71,7 +76,7 @@ function formatTable(counts: KillCounts): string {
         const dashes = WIDTH - title.length - 2;
         const left = Math.floor(dashes / 2);
         const right = dashes - left;
-        return `+${"-".repeat(left)} ${title} ${"-".repeat(right)}+`;
+        return `+${"-".repeat(left)} ${encloseColor(title, HEADER_COLOR)} ${"-".repeat(right)}+`;
     };
 
     const entries = Object.entries(counts)
@@ -89,7 +94,10 @@ function formatTable(counts: KillCounts): string {
         return pad(text);
     };
 
-    const summaryLine = (label: string, value: number) => {
+    const summaryLine = (label: string, value: number, color?: number) => {
+        if (color !== undefined) {
+            label = encloseColor(label, color);
+        }
         let text = `${label} `;
         const num = String(value);
         text += ".".repeat(CONTENT_WIDTH - text.length - num.length);
@@ -100,15 +108,15 @@ function formatTable(counts: KillCounts): string {
     const lines: string[] = [];
     lines.push(header("Licznik zabitych"));
     lines.push(pad());
-    lines.push(pad("JA"));
+    lines.push(pad(encloseColor("JA", MY_COLOR)));
     entries.forEach(([name, { my_total, team_session }]) => {
         lines.push(mobLine(name, my_total, my_total + team_session));
     });
     lines.push(pad());
-    lines.push(summaryLine("LACZNIE:", totalMy));
+    lines.push(summaryLine("LACZNIE:", totalMy, TOTAL_COLOR));
     lines.push(pad());
     lines.push(pad());
-    lines.push(summaryLine("DRUZYNA LACZNIE:", totalCombined));
+    lines.push(summaryLine("DRUZYNA LACZNIE:", totalCombined, TOTAL_COLOR));
     lines.push(pad());
     lines.push(`+${"-".repeat(WIDTH)}+`);
     return lines.join("\n");

--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -171,13 +171,24 @@ export default function init(
 
     client.Triggers.registerTrigger(
         teamKillRegex,
-        (_raw, _line, matches): string | undefined => {
+        (rawLine, _line, matches): string | undefined => {
             const mob = parseName(matches.groups?.name ?? "");
             if (!kills[mob]) {
                 kills[mob] = { my_session: 0, my_total: 0, team_session: 0 };
             }
             kills[mob].team_session += 1;
-            return undefined;
+
+            const combined = kills[mob].my_session + kills[mob].team_session;
+            const counts = ` (${kills[mob].my_session} / ${combined})`;
+            const modified = rawLine.replace(/\.$/, `${counts}.`);
+            return (
+                "  \n" +
+                client.prefix(
+                    modified,
+                    encloseColor("[   ZABIL   ] ", findClosestColor("#ff6347"))
+                ) +
+                "\n  "
+            );
         }
     );
 

--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -171,7 +171,7 @@ export default function init(
 
             const combined = kills[mob].my_session + kills[mob].team_session;
             const counts = ` (${kills[mob].my_session} / ${combined})`;
-            const modified = rawLine.replace(/\.$/, `${counts}.`);
+            const modified = rawLine + counts;
             return (
                 "  \n" +
                 client.prefix(
@@ -194,7 +194,7 @@ export default function init(
 
             const combined = kills[mob].my_session + kills[mob].team_session;
             const counts = ` (${kills[mob].my_session} / ${combined})`;
-            const modified = rawLine.replace(/\.$/, `${counts}.`);
+            const modified = rawLine + counts;
             return (
                 "  \n" +
                 client.prefix(

--- a/sandbox/src/scenario/kill-counter-demo.ts
+++ b/sandbox/src/scenario/kill-counter-demo.ts
@@ -3,15 +3,17 @@ import { fakeClient } from "../index.ts";
 
 export default new ClientScript(fakeClient)
     .reset()
-    .fake("Zabiles wielkiego dzikiego kamiennego trolla.")
-    .fake("Zabiles poteznego wscieklego krasnoluda chaosu.")
-    .fake("Zabiles malutkiego wscieklego snotlinga.")
-    .fake("Zabiles brzydkiego zgarbionego goblina.")
-    .fake("Zabiles dzikiego wscieklego trolla.")
-    .fake("Zabiles ogromnego szybkiego kamiennego trolla.")
-    .fake("Zabiles dzikiego roslego krasnoluda chaosu.")
-    .fake("Zabiles malego przebieglego goblina.")
-    .fake("Zabiles silnego roslego trolla.")
-    .fake("Zabiles Ryszard.")
+    // moje zabicia
+    .fake("Zabiles poteznego smoka chaosu.")
+    .fake("Zabiles malego smoka chaosu.")
+    .fake("Zabiles silnego kamiennego trolla.")
+    .fake("Zabiles poteznego kamiennego trolla.")
+    .fake("Zabiles wscieklego krasnoluda chaosu.")
+    .fake("Zabiles Helga.")
+    // zabicia druzyny
+    .fake("> Eamon zabil smoka chaosu.")
+    .fake("> Beata zabila smoka chaosu.")
+    .fake("> Eamon zabil poteznego kamiennego trolla.")
+    .fake("> Beata zabila wscieklego krasnoluda chaosu.")
     .send("/zabici");
 

--- a/sandbox/src/scenario/kill-counter-demo.ts
+++ b/sandbox/src/scenario/kill-counter-demo.ts
@@ -15,5 +15,6 @@ export default new ClientScript(fakeClient)
     .fake("> Beata zabila smoka chaosu.")
     .fake("> Eamon zabil poteznego kamiennego trolla.")
     .fake("> Beata zabila wscieklego krasnoluda chaosu.")
+    .fake("> Sindarion zabil barczystego jasnowlosego bykocentaura.")
     .send("/zabici");
 


### PR DESCRIPTION
## Summary
- extend `kill.ts` to track personal and team kills separately
- display personal/combined session counts when killing
- update `/zabici` table for team totals

## Testing
- `yarn --cwd client build`
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_685ffec7bae4832aa01ffc5b20f686b8