### PR TITLE
Handle GMCP objects as a map

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -6,6 +6,7 @@ import {Howl} from "howler"
 import {FunctionalBind} from "./scripts/functionalBind";
 import OutputHandler from "./OutputHandler";
 import {rawSend} from "./main";
+import TeamManager from "./TeamManager";
 
 const originalSend = Input.send
 
@@ -18,6 +19,7 @@ export default class Client {
     packageHelper = new PackageHelper(this)
     Map = new MapHelper(this)
     OutputHandler = new OutputHandler(this)
+    TeamManager = new TeamManager(this)
     inlineCompassRose = new InlineCompassRose(this)
     panel = document.getElementById("panel_buttons_bottom")
     sounds: Record<string, Howl> = {

--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -1,0 +1,116 @@
+import Client from "./Client";
+
+export default class TeamManager {
+    private client: Client;
+    private members: Set<string> = new Set();
+    private leader?: string;
+    private tag = 'teamManager';
+
+    constructor(client: Client) {
+        this.client = client;
+        this.client.addEventListener('gmcp.objects.data', (e: CustomEvent) => {
+            this.handleObjectsData(e.detail);
+        });
+        if (typeof (this.client as any).Triggers?.registerTrigger === 'function') {
+            this.registerTriggers();
+        }
+    }
+
+    private handleObjectsData(data: any) {
+        let objects: any[] = [];
+        if (Array.isArray(data)) {
+            objects = data;
+        } else if (Array.isArray(data?.objects)) {
+            objects = data.objects;
+        } else if (data && typeof data === 'object') {
+            if (data.data && typeof data.data === 'object') {
+                objects = Object.values(data.data);
+            } else {
+                objects = Object.values(data);
+            }
+        }
+
+        if (!Array.isArray(objects)) {
+            return;
+        }
+
+        objects.forEach(obj => {
+            if (obj && obj.living && obj.team) {
+                const name = obj.desc;
+                if (name) {
+                    this.members.add(name);
+                    if (obj.team_leader) {
+                        this.leader = name;
+                    }
+                }
+            }
+        });
+    }
+
+    private registerTriggers() {
+        const t = this.client.Triggers;
+        const tag = this.tag;
+        t.registerTrigger(/^Zmuszasz \[?([A-Za-z][a-z ]+?)\]? do opuszczenia druzyny\.$/, (_r, _l, m): undefined => {
+            this.removeMember(m[1]);
+        }, tag);
+        t.registerTrigger(/^\[?([A-Z][a-z ]+?)\]? porzuca twoja druzyne\.$/, (_r, _l, m): undefined => {
+            this.removeMember(m[1]);
+        }, tag);
+        const clear = (): undefined => {
+            this.clear_team();
+        };
+        t.registerTrigger(/^\[?([A-Z][a-z ]+?)\]? zmusza cie do opuszczenia druzyny\.$/, clear, tag);
+        t.registerTrigger(/Nie jestes w zadnej druzynie\./, clear, tag);
+        t.registerTrigger(/^\[?([A-Z][a-z ]+?)\]? rozwiazuje druzyne\.$/, clear, tag);
+        t.registerTrigger(/^Porzucasz (?:swoja druzyne|druzyne, ktorej przewodzil[ea]s)\.$/, clear, tag);
+        t.registerTrigger(/^Przewodzisz druzynie, w ktorej oprocz ciebie (?:jest|sa) jeszcze(?:\:|) (?<team>.*)\.$/, (_r, _l, m): undefined => {
+            this.clear_team();
+            const list = m.groups?.team ?? '';
+            this.parseNames(list).forEach(n => this.addMember(n));
+        }, tag);
+        t.registerTrigger(/^Druzyne prowadzi (?<leader>.+?)(?:, zas ty jestes jej jedynym czlonkiem| i oprocz ciebie (?:jest|sa) w niej jeszcze:? (?<team>.*))\.$/, (_r, _l, m): undefined => {
+            this.clear_team();
+            const leader = m.groups?.leader?.trim();
+            if (leader) {
+                this.leader = leader;
+                this.addMember(leader);
+            }
+            const list = m.groups?.team;
+            if (list) {
+                this.parseNames(list).forEach(n => this.addMember(n));
+            }
+        }, tag);
+    }
+
+    private parseNames(list: string): string[] {
+        return list.split(/,| i /).map(s => s.trim()).filter(Boolean);
+    }
+
+    private addMember(name: string) {
+        this.members.add(name);
+    }
+
+    private removeMember(name: string) {
+        this.members.delete(name);
+        if (this.leader === name) {
+            this.leader = undefined;
+        }
+    }
+
+    get_team_members(): string[] {
+        return Array.from(this.members);
+    }
+
+    is_in_team(name: string): boolean {
+        return this.members.has(name);
+    }
+
+    get_leader(): string | undefined {
+        return this.leader;
+    }
+
+    clear_team() {
+        this.members.clear();
+        this.leader = undefined;
+    }
+}

--- a/client/test/TeamManager.test.ts
+++ b/client/test/TeamManager.test.ts
@@ -1,0 +1,58 @@
+import TeamManager from '../src/TeamManager';
+import Triggers from '../src/Triggers';
+
+class FakeClient {
+  eventTarget = new EventTarget();
+  Triggers = new Triggers({} as any);
+  addEventListener(event: string, cb: any, options?: any) {
+    this.eventTarget.addEventListener(event, cb, options);
+    return () => this.eventTarget.removeEventListener(event, cb, options);
+  }
+  removeEventListener(event: string, cb: any) {
+    this.eventTarget.removeEventListener(event, cb);
+  }
+  sendEvent(type: string, detail?: any) {
+    this.eventTarget.dispatchEvent(new CustomEvent(type, { detail }));
+  }
+}
+
+describe('TeamManager', () => {
+  let client: FakeClient;
+  let manager: TeamManager;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    manager = new TeamManager((client as unknown) as any);
+  });
+
+  test('adds member from gmcp objects', () => {
+    client.sendEvent('gmcp.objects.data', {
+      '1': { desc: 'Pablo', living: true, team: true },
+    });
+    expect(manager.is_in_team('Pablo')).toBe(true);
+  });
+
+  test('removes member on leave message', () => {
+    client.sendEvent('gmcp.objects.data', {
+      '1': { desc: 'Vesper', living: true, team: true },
+    });
+    client.Triggers.parseLine('Vesper porzuca twoja druzyne.', '');
+    expect(manager.is_in_team('Vesper')).toBe(false);
+  });
+
+  test('clears team on clear message', () => {
+    client.sendEvent('gmcp.objects.data', {
+      '1': { desc: 'Bob', living: true, team: true },
+    });
+    client.Triggers.parseLine('Nie jestes w zadnej druzynie.', '');
+    expect(manager.get_team_members()).toEqual([]);
+  });
+
+  test('full sync message sets leader and members', () => {
+    client.Triggers.parseLine('Druzyne prowadzi Vesper i oprocz ciebie sa w niej jeszcze: Pablo i Opeteh.', '');
+    expect(manager.get_leader()).toBe('Vesper');
+    const members = manager.get_team_members();
+    expect(members).toEqual(expect.arrayContaining(['Vesper', 'Pablo', 'Opeteh']));
+    expect(manager.is_in_team('Pablo')).toBe(true);
+  });
+});

--- a/sandbox/src/ClientScript.ts
+++ b/sandbox/src/ClientScript.ts
@@ -21,6 +21,19 @@ export default class ClientScript {
         return this;
     }
 
+    debug(expression: string) {
+        this.actions.push(() => {
+            try {
+                // eslint-disable-next-line no-new-func
+                const value = new Function('return (' + expression + ')')();
+                this.client.print(value as any);
+            } catch (err) {
+                this.client.println(String(err));
+            }
+        });
+        return this;
+    }
+
     setMapPosition(position: number) {
         this.actions.push(() => {
             this.event("enterLocation", {room: {id: position}});

--- a/sandbox/src/Controls.tsx
+++ b/sandbox/src/Controls.tsx
@@ -4,6 +4,7 @@ import {useState} from "react";
 import TriggerTester from "./TriggerTester.tsx";
 import packageAssistant from "./scenario/package-assistant.ts";
 import killCounterDemo from "./scenario/kill-counter-demo.ts";
+import teamEventsDemo from "./scenario/team-events-demo.ts";
 
 
 
@@ -23,6 +24,14 @@ export function Controls() {
                         onClick={() => killCounterDemo.run()}
                     >
                         Kill Counter Demo
+                    </Button>
+                    <Button
+                        size="sm"
+                        className="w-100"
+                        variant="secondary"
+                        onClick={() => teamEventsDemo.run()}
+                    >
+                        Team Events Demo
                     </Button>
                 </div>,
                 document.getElementById('sandbox-buttons')!,

--- a/sandbox/src/scenario/team-events-demo.ts
+++ b/sandbox/src/scenario/team-events-demo.ts
@@ -1,0 +1,15 @@
+import ClientScript from "../ClientScript.ts";
+import { fakeClient } from "../index.ts";
+
+export default new ClientScript(fakeClient)
+    .reset()
+    .event("gmcp.objects.data", {
+        "1": { desc: "Vesper", living: true, team: true, team_leader: true },
+        "2": { desc: "Pablo", living: true, team: true },
+    })
+    .debug("window.clientExtension.TeamManager.get_team_members()")
+    .fake("Pablo porzuca twoja druzyne.")
+    .debug("window.clientExtension.TeamManager.get_team_members()")
+    .fake("Nie jestes w zadnej druzynie.")
+    .debug("window.clientExtension.TeamManager.get_team_members()");
+


### PR DESCRIPTION
## Summary
- update TeamManager to handle gmcp.objects data when it's keyed by id
- adjust TeamManager tests for new gmcp.objects shape
- tweak Team Events demo scenario to use the map structure

## Testing
- `yarn --cwd client test` *(fails: lockfile issue)*
- `node node_modules/jest/bin/jest.js --config client/jest.config.js`


------
https://chatgpt.com/codex/tasks/task_e_68601a0bda30832abf4a036821c3b627