### PR TITLE
Improve kill counter with team checks

### DIFF
--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -57,19 +57,19 @@ export default class TeamManager {
             this.removeMember(m[1]);
         }, tag);
         const clear = (): undefined => {
-            this.clear_team();
+            this.clearTeam();
         };
         t.registerTrigger(/^\[?([A-Z][a-z ]+?)\]? zmusza cie do opuszczenia druzyny\.$/, clear, tag);
         t.registerTrigger(/Nie jestes w zadnej druzynie\./, clear, tag);
         t.registerTrigger(/^\[?([A-Z][a-z ]+?)\]? rozwiazuje druzyne\.$/, clear, tag);
         t.registerTrigger(/^Porzucasz (?:swoja druzyne|druzyne, ktorej przewodzil[ea]s)\.$/, clear, tag);
         t.registerTrigger(/^Przewodzisz druzynie, w ktorej oprocz ciebie (?:jest|sa) jeszcze(?:\:|) (?<team>.*)\.$/, (_r, _l, m): undefined => {
-            this.clear_team();
+            this.clearTeam();
             const list = m.groups?.team ?? '';
             this.parseNames(list).forEach(n => this.addMember(n));
         }, tag);
         t.registerTrigger(/^Druzyne prowadzi (?<leader>.+?)(?:, zas ty jestes jej jedynym czlonkiem| i oprocz ciebie (?:jest|sa) w niej jeszcze:? (?<team>.*))\.$/, (_r, _l, m): undefined => {
-            this.clear_team();
+            this.clearTeam();
             const leader = m.groups?.leader?.trim();
             if (leader) {
                 this.leader = leader;
@@ -97,19 +97,19 @@ export default class TeamManager {
         }
     }
 
-    get_team_members(): string[] {
+    getTeamMembers(): string[] {
         return Array.from(this.members);
     }
 
-    is_in_team(name: string): boolean {
+    isInTeam(name: string): boolean {
         return this.members.has(name);
     }
 
-    get_leader(): string | undefined {
+    getLeader(): string | undefined {
         return this.leader;
     }
 
-    clear_team() {
+    clearTeam() {
         this.members.clear();
         this.leader = undefined;
     }

--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -3,9 +3,9 @@ import { encloseColor, findClosestColor } from "../Colors";
 import { stripAnsiCodes } from "../Triggers";
 
 type KillEntry = {
-    my_session: number;
-    my_total: number;
-    team_session: number;
+    mySession: number;
+    myTotal: number;
+    teamSession: number;
 };
 
 type KillCounts = Record<string, KillEntry>;
@@ -83,11 +83,11 @@ function formatTable(counts: KillCounts): string {
     };
 
     const entries = Object.entries(counts)
-        .filter(([_, v]) => v.my_total > 0 || v.team_session > 0)
+        .filter(([_, v]) => v.myTotal > 0 || v.teamSession > 0)
         .sort(([a], [b]) => a.localeCompare(b));
 
-    const totalMy = Object.values(counts).reduce((s, v) => s + v.my_total, 0);
-    const totalCombined = totalMy + Object.values(counts).reduce((s, v) => s + v.team_session, 0);
+    const totalMy = Object.values(counts).reduce((s, v) => s + v.myTotal, 0);
+    const totalCombined = totalMy + Object.values(counts).reduce((s, v) => s + v.teamSession, 0);
 
     const mobLine = (name: string, myTotal: number, combined: number) => {
         const numbers = `${myTotal} / ${combined}`;
@@ -115,8 +115,8 @@ function formatTable(counts: KillCounts): string {
     lines.push(header("Licznik zabitych"));
     lines.push(pad());
     lines.push(pad(encloseColor("JA", MY_COLOR)));
-    entries.forEach(([name, { my_total, team_session }]) => {
-        lines.push(mobLine(name, my_total, my_total + team_session));
+    entries.forEach(([name, { myTotal, teamSession }]) => {
+        lines.push(mobLine(name, myTotal, myTotal + teamSession));
     });
     lines.push(pad());
     lines.push(summaryLine("LACZNIE:", totalMy, TOTAL_COLOR));
@@ -139,7 +139,7 @@ export default function init(
             kills = Object.fromEntries(
                 Object.entries(totals).map(([name, total]) => [
                     name,
-                    { my_session: 0, my_total: total as number, team_session: 0 },
+                    { mySession: 0, myTotal: total as number, teamSession: 0 },
                 ])
             );
         });
@@ -148,7 +148,7 @@ export default function init(
     const persistTotals = () => {
         const totals: Record<string, number> = {};
         Object.entries(kills).forEach(([name, entry]) => {
-            totals[name] = entry.my_total;
+            totals[name] = entry.myTotal;
         });
         chrome.storage?.local.set({ [STORAGE_KEY]: totals });
     };
@@ -163,14 +163,14 @@ export default function init(
         (rawLine, _line, matches): string => {
             const mob = parseName(matches.groups?.name ?? "");
             if (!kills[mob]) {
-                kills[mob] = { my_session: 0, my_total: 0, team_session: 0 };
+                kills[mob] = { mySession: 0, myTotal: 0, teamSession: 0 };
             }
-            kills[mob].my_session += 1;
-            kills[mob].my_total += 1;
+            kills[mob].mySession += 1;
+            kills[mob].myTotal += 1;
             persistTotals();
 
-            const combined = kills[mob].my_session + kills[mob].team_session;
-            const counts = ` (${kills[mob].my_session} / ${combined})`;
+            const combined = kills[mob].mySession + kills[mob].teamSession;
+            const counts = ` (${kills[mob].mySession} / ${combined})`;
             const modified = rawLine + counts;
             return (
                 "  \n" +
@@ -192,12 +192,12 @@ export default function init(
             if (client.TeamManager.isInTeam(player)) {
                 const mob = parseName(matches.groups?.name ?? "");
                 if (!kills[mob]) {
-                    kills[mob] = { my_session: 0, my_total: 0, team_session: 0 };
+                    kills[mob] = { mySession: 0, myTotal: 0, teamSession: 0 };
                 }
-                kills[mob].team_session += 1;
+                kills[mob].teamSession += 1;
 
-                const combined = kills[mob].my_session + kills[mob].team_session;
-                counts = ` (${kills[mob].my_session} / ${combined})`;
+                const combined = kills[mob].mySession + kills[mob].teamSession;
+                counts = ` (${kills[mob].mySession} / ${combined})`;
             }
 
             const modified = rawLine + counts;

--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -185,20 +185,21 @@ export default function init(
 
     client.Triggers.registerTrigger(
         teamKillRegex,
-        (rawLine, _line, matches): string | undefined => {
+        (rawLine, _line, matches): string => {
             const player = stripAnsiCodes(matches.groups?.player ?? "").trim();
-            if (!client.TeamManager.isInTeam(player)) {
-                return;
+
+            let counts = "";
+            if (client.TeamManager.isInTeam(player)) {
+                const mob = parseName(matches.groups?.name ?? "");
+                if (!kills[mob]) {
+                    kills[mob] = { my_session: 0, my_total: 0, team_session: 0 };
+                }
+                kills[mob].team_session += 1;
+
+                const combined = kills[mob].my_session + kills[mob].team_session;
+                counts = ` (${kills[mob].my_session} / ${combined})`;
             }
 
-            const mob = parseName(matches.groups?.name ?? "");
-            if (!kills[mob]) {
-                kills[mob] = { my_session: 0, my_total: 0, team_session: 0 };
-            }
-            kills[mob].team_session += 1;
-
-            const combined = kills[mob].my_session + kills[mob].team_session;
-            const counts = ` (${kills[mob].my_session} / ${combined})`;
             const modified = rawLine + counts;
             return (
                 "  \n" +

--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -186,6 +186,11 @@ export default function init(
     client.Triggers.registerTrigger(
         teamKillRegex,
         (rawLine, _line, matches): string | undefined => {
+            const player = stripAnsiCodes(matches.groups?.player ?? "").trim();
+            if (!client.TeamManager.isInTeam(player)) {
+                return;
+            }
+
             const mob = parseName(matches.groups?.name ?? "");
             if (!kills[mob]) {
                 kills[mob] = { my_session: 0, my_total: 0, team_session: 0 };

--- a/client/test/TeamManager.test.ts
+++ b/client/test/TeamManager.test.ts
@@ -29,7 +29,7 @@ describe('TeamManager', () => {
     client.sendEvent('gmcp.objects.data', {
       '1': { desc: 'Pablo', living: true, team: true },
     });
-    expect(manager.is_in_team('Pablo')).toBe(true);
+    expect(manager.isInTeam('Pablo')).toBe(true);
   });
 
   test('removes member on leave message', () => {
@@ -37,7 +37,7 @@ describe('TeamManager', () => {
       '1': { desc: 'Vesper', living: true, team: true },
     });
     client.Triggers.parseLine('Vesper porzuca twoja druzyne.', '');
-    expect(manager.is_in_team('Vesper')).toBe(false);
+    expect(manager.isInTeam('Vesper')).toBe(false);
   });
 
   test('clears team on clear message', () => {
@@ -45,14 +45,14 @@ describe('TeamManager', () => {
       '1': { desc: 'Bob', living: true, team: true },
     });
     client.Triggers.parseLine('Nie jestes w zadnej druzynie.', '');
-    expect(manager.get_team_members()).toEqual([]);
+    expect(manager.getTeamMembers()).toEqual([]);
   });
 
   test('full sync message sets leader and members', () => {
     client.Triggers.parseLine('Druzyne prowadzi Vesper i oprocz ciebie sa w niej jeszcze: Pablo i Opeteh.', '');
-    expect(manager.get_leader()).toBe('Vesper');
-    const members = manager.get_team_members();
+    expect(manager.getLeader()).toBe('Vesper');
+    const members = manager.getTeamMembers();
     expect(members).toEqual(expect.arrayContaining(['Vesper', 'Pablo', 'Opeteh']));
-    expect(manager.is_in_team('Pablo')).toBe(true);
+    expect(manager.isInTeam('Pablo')).toBe(true);
   });
 });

--- a/client/test/kill.test.ts
+++ b/client/test/kill.test.ts
@@ -1,0 +1,39 @@
+import initKillTrigger from '../src/scripts/kill';
+import Triggers from '../src/Triggers';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+  TeamManager = { isInTeam: jest.fn() };
+  prefix = (line: string, prefix: string) => prefix + line;
+  print = jest.fn();
+}
+
+describe('kill counter team kills', () => {
+  let client: FakeClient;
+
+  beforeEach(() => {
+    (global as any).chrome = {
+      storage: { local: { get: jest.fn(() => Promise.resolve({})), set: jest.fn() } },
+    };
+    client = new FakeClient();
+    initKillTrigger((client as unknown) as any, []);
+  });
+
+  const parse = (line: string) => {
+    return Triggers.prototype.parseLine.call(client.Triggers, line, '');
+  };
+
+  test('ignores kills from outside the team', () => {
+    client.TeamManager.isInTeam.mockReturnValue(false);
+    const line = '> Eamon zabil smoka chaosu.';
+    const result = parse(line);
+    expect(result).toBe(line);
+  });
+
+  test('counts kills from team members', () => {
+    client.TeamManager.isInTeam.mockReturnValue(true);
+    const line = '> Eamon zabil smoka chaosu.';
+    const result = parse(line);
+    expect(result).toContain('[   ZABIL   ]');
+  });
+});

--- a/client/test/kill.test.ts
+++ b/client/test/kill.test.ts
@@ -26,8 +26,13 @@ describe('kill counter team kills', () => {
   test('ignores kills from outside the team', () => {
     client.TeamManager.isInTeam.mockReturnValue(false);
     const line = '> Eamon zabil smoka chaosu.';
-    const result = parse(line);
-    expect(result).toBe(line);
+    let result = parse(line);
+    expect(result).toContain('[   ZABIL   ]');
+    expect(result).not.toContain('(');
+
+    client.TeamManager.isInTeam.mockReturnValue(true);
+    result = parse(line);
+    expect(result).toContain('(0 / 1)');
   });
 
   test('counts kills from team members', () => {
@@ -35,5 +40,6 @@ describe('kill counter team kills', () => {
     const line = '> Eamon zabil smoka chaosu.';
     const result = parse(line);
     expect(result).toContain('[   ZABIL   ]');
+    expect(result).toContain('(0 / 1)');
   });
 });

--- a/sandbox/src/scenario/team-events-demo.ts
+++ b/sandbox/src/scenario/team-events-demo.ts
@@ -7,9 +7,9 @@ export default new ClientScript(fakeClient)
         "1": { desc: "Vesper", living: true, team: true, team_leader: true },
         "2": { desc: "Pablo", living: true, team: true },
     })
-    .debug("window.clientExtension.TeamManager.get_team_members()")
+    .debug("window.clientExtension.TeamManager.getTeamMembers()")
     .fake("Pablo porzuca twoja druzyne.")
-    .debug("window.clientExtension.TeamManager.get_team_members()")
+    .debug("window.clientExtension.TeamManager.getTeamMembers()")
     .fake("Nie jestes w zadnej druzynie.")
-    .debug("window.clientExtension.TeamManager.get_team_members()");
+    .debug("window.clientExtension.TeamManager.getTeamMembers()");
 


### PR DESCRIPTION
## Summary
- use TeamManager.isInTeam() before counting team kills
- rename TeamManager methods to camelCase

## Testing
- `yarn --cwd client test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686024cc1080832a923e10e7aae41770