### PR TITLE
Fix unused import warning in main.ts

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,7 +1,7 @@
 import Client from "./Client";
 import People from "./People";
 import registerGagTriggers from "./scripts/gags";
-import { gmcp, setGmcp } from "./gmcp";
+import { setGmcp } from "./gmcp";
 
 const originalRefreshPosition = Maps.refresh_position
 const originalSetPosition = Maps.set_position


### PR DESCRIPTION
## Summary
- remove unused `gmcp` import

## Testing
- `npx jest --config client/jest.config.js --runInBand --no-color`

------
https://chatgpt.com/codex/tasks/task_e_68602d80ca1c832a8fc36aa21bb8372e