### PR TITLE
Show gmcp events in sandbox output

### DIFF
--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -63,3 +63,9 @@ iframe {
     margin: 0;
     padding-bottom: 1px;
 }
+
+.gmcp-event {
+    border: 1px dashed #555;
+    padding: 2px;
+    margin: 2px 0;
+}

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -9,6 +9,26 @@ import {FakeClient} from "./types/globals";
 
 export const fakeClient = client as FakeClient
 
+const originalDispatch = fakeClient.eventTarget.dispatchEvent.bind(fakeClient.eventTarget)
+fakeClient.eventTarget.dispatchEvent = (event: Event) => {
+    if (event.type.startsWith('gmcp')) {
+        const detail = (event as CustomEvent).detail
+        let text = ''
+        try {
+            text = detail !== undefined ? JSON.stringify(detail) : ''
+        } catch (e) {
+            text = String(detail)
+        }
+        fakeClient.print(`${event.type}${text ? ' ' + text : ''}`)
+        const wrapper = document.getElementById('main_text_output_msg_wrapper')!
+        const last = wrapper.lastElementChild as HTMLElement | null
+        if (last) {
+            last.classList.add('gmcp-event')
+        }
+    }
+    return originalDispatch(event)
+}
+
 
 fakeClient.eventTarget.dispatchEvent(new CustomEvent("npc", {detail: npc}));
 const frame: HTMLIFrameElement = document.getElementById("cm-frame")! as HTMLIFrameElement;


### PR DESCRIPTION
## Summary
- display gmcp events dispatched by `FakeClient` in the sandbox output
- style these events with a dashed border so they stand out

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68602f9b8254832abc7da1243d8e57d4