### PR TITLE
Fix layout height overflow

### DIFF
--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -23,6 +23,7 @@ body {
     flex-direction: column;
     min-height: 0;
     height: 100%;
+    gap: 5px;
 }
 
 #main-content {
@@ -30,7 +31,6 @@ body {
     min-height: 0;
     display: flex;
     align-items: stretch;
-    margin-bottom: 5px;
     overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- ensure layout doesn't exceed 100% height by removing margin from `#main-content`
- keep spacing by adding `gap` on `#main-container`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6860368957ac832a886d10eda88316be