### PR TITLE
Update kill counter demo with team members

### DIFF
--- a/sandbox/src/scenario/kill-counter-demo.ts
+++ b/sandbox/src/scenario/kill-counter-demo.ts
@@ -3,6 +3,10 @@ import { fakeClient } from "../index.ts";
 
 export default new ClientScript(fakeClient)
     .reset()
+    .event("gmcp.objects.data", {
+        "1": { desc: "Eamon", living: true, team: true, team_leader: true },
+        "2": { desc: "Beata", living: true, team: true },
+    })
     .fake("Zabiles poteznego smoka chaosu.")
     .fake("Zabiles malego smoka chaosu.")
     .fake("Zabiles silnego kamiennego trolla.")


### PR DESCRIPTION
## Summary
- extend kill counter scenario with team setup so kills from the team are recognized

## Testing
- `yarn --cwd client test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686037c48288832a9c75a044f77acd59