### PR TITLE
Increase coverage for client module

### DIFF
--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -128,6 +128,8 @@ function formatTable(counts: KillCounts): string {
     return lines.join("\n");
 }
 
+export { parseName, formatTable };
+
 export default function init(
     client: Client,
     aliases?: { pattern: RegExp; callback: Function }[]

--- a/client/test/inlineCompassRose.test.ts
+++ b/client/test/inlineCompassRose.test.ts
@@ -1,0 +1,28 @@
+import InlineCompassRose from '../src/scripts/inlineCompassRose';
+
+class FakeClient {
+  addEventListener() {}
+  removeEventListener() {}
+  println = jest.fn();
+}
+
+describe('InlineCompassRose parsing', () => {
+  const client = new FakeClient();
+  const rose = new InlineCompassRose((client as unknown) as any);
+  const parse = (detail: any) => (rose as any).parseExits(detail);
+  const toShort = (exit: string) => (rose as any).toShort(exit);
+
+  test('parseExits accepts various formats', () => {
+    expect(parse(['north', 'south'])).toEqual(['n', 's']);
+    expect(parse({ exits: ['east', 'west'] })).toEqual(['e', 'w']);
+    expect(parse({ exits: { north: 1, south: 2 } })).toEqual(['n', 's']);
+    expect(parse({ room: { exits: { up: 3 } } })).toEqual(['u']);
+  });
+
+  test('toShort converts directions', () => {
+    expect(toShort('polnoc')).toBe('n');
+    expect(toShort('south')).toBe('s');
+    expect(toShort('north')).toBe('n');
+    expect(toShort('unknown')).toBe('');
+  });
+});

--- a/client/test/kill.test.ts
+++ b/client/test/kill.test.ts
@@ -1,4 +1,4 @@
-import initKillTrigger from '../src/scripts/kill';
+import initKillTrigger, { parseName, formatTable } from '../src/scripts/kill';
 import Triggers from '../src/Triggers';
 
 class FakeClient {
@@ -41,5 +41,24 @@ describe('kill counter team kills', () => {
     const result = parse(line);
     expect(result).toContain('[   ZABIL   ]');
     expect(result).toContain('(0 / 1)');
+  });
+});
+
+describe('parseName and formatTable', () => {
+  test('parseName returns expected values', () => {
+    expect(parseName('Troll')).toBe('Troll');
+    expect(parseName('smoka chaosu')).toBe('smoka chaosu');
+    expect(parseName('Wielki Troll')).toBe('troll');
+  });
+
+  test('formatTable prints table with totals', () => {
+    const table = formatTable({
+      troll: { mySession: 1, myTotal: 1, teamSession: 0 },
+      smok: { mySession: 0, myTotal: 0, teamSession: 2 },
+    });
+    expect(table).toMatch(/Licznik zabitych/);
+    expect(table).toMatch(/troll/);
+    expect(table).toMatch(/1 \/ 1/);
+    expect(table).toMatch(/DRUZYNA LACZNIE/);
   });
 });


### PR DESCRIPTION
## Summary
- export helper functions from kill counter script
- expand kill counter tests
- add InlineCompassRose unit tests

## Testing
- `yarn --cwd client test`
- `yarn --cwd client test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686055f13628832a834c641d95b1721d