### PR TITLE
Add /zabici2 kill summary alias

### DIFF
--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -76,7 +76,7 @@ function formatTable(counts: KillCounts): string {
         )}${" ".repeat(RIGHT_PADDING)}|`;
     const header = (title: string) => {
         const colored = encloseColor(title, HEADER_COLOR);
-        const dashes = WIDTH - visibleLength(title) - 2;
+        const dashes = WIDTH - visibleLength(title) - 4;
         const left = Math.floor(dashes / 2);
         const right = dashes - left;
         return `+${"-".repeat(left)} ${colored} ${"-".repeat(right)}+`;
@@ -148,7 +148,7 @@ function formatSummary(counts: KillCounts): string {
 
     const header = (title: string) => {
         const colored = encloseColor(title, HEADER_COLOR);
-        const dashes = WIDTH - visibleLength(title) - 2;
+        const dashes = WIDTH - visibleLength(title) - 4;
         const left = Math.floor(dashes / 2);
         const right = dashes - left;
         return `+${"-".repeat(left)} ${colored} ${"-".repeat(right)}+`;

--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -46,7 +46,7 @@ function parseName(full: string): string {
     const words = originalWords.map((w) => w.toLowerCase());
     if (
         words.length === 1 &&
-        /^[A-Z\u0104\u0106\u0118\u0141\u0143\u00D3\u015A\u0179\u017B]/.test(
+        /^[A-Z]/.test(
             originalWords[0]
         )
     ) {
@@ -128,7 +128,56 @@ function formatTable(counts: KillCounts): string {
     return lines.join("\n");
 }
 
-export { parseName, formatTable };
+function formatSummary(counts: KillCounts): string {
+    const WIDTH = 59;
+    const INNER = WIDTH - 2;
+
+    const UPPER_COLOR = findClosestColor("#ffa500");
+    const LOWER_COLOR = findClosestColor("#7cfc00");
+    const PINK_COLOR = findClosestColor("#ff69b4");
+
+    const visibleLength = (str: string) => stripAnsiCodes(str).length;
+    const pad = (content = "") =>
+        `|${content}${" ".repeat(Math.max(0, INNER - visibleLength(content)))}|`;
+
+    const entries = Object.entries(counts)
+        .filter(([_, v]) => v.myTotal > 0)
+        .sort(([a], [b]) => a.localeCompare(b));
+
+    const total = Object.values(counts).reduce((s, v) => s + v.myTotal, 0);
+
+    const mobLine = (name: string, count: number) => {
+        const color = /^[A-Z]/.test(name)
+            ? UPPER_COLOR
+            : LOWER_COLOR;
+        const colored = encloseColor(name, color);
+        const start = `  ${colored} `;
+        const dots = INNER - visibleLength(start) - String(count).length;
+        const text = `${start}${".".repeat(Math.max(0, dots))}${count}`;
+        return pad(text);
+    };
+
+    const lines: string[] = [];
+    lines.push(`+${"-".repeat(INNER)}+`);
+    lines.push(pad());
+    entries.forEach(([name, entry]) => {
+        lines.push(mobLine(name, entry.myTotal));
+    });
+    lines.push(pad());
+    lines.push(pad("       ------------------------------------"));
+    lines.push(pad());
+    const summary =
+        "  " +
+        encloseColor("WSZYSTKICH DO TEJ PORY: ", PINK_COLOR) +
+        encloseColor(String(total), LOWER_COLOR) +
+        encloseColor(" zabitych", LOWER_COLOR);
+    lines.push(pad(summary));
+    lines.push(pad());
+    lines.push(`+${"-".repeat(INNER)}+`);
+    return lines.join("\n");
+}
+
+export { parseName, formatTable, formatSummary };
 
 export default function init(
     client: Client,
@@ -226,6 +275,12 @@ export default function init(
             pattern: /\/zabici$/,
             callback: () => {
                 client.print("\n" + formatTable(kills) + "\n");
+            },
+        });
+        aliases.push({
+            pattern: /\/zabici2$/,
+            callback: () => {
+                client.print("\n" + formatSummary(kills) + "\n");
             },
         });
     }

--- a/client/test/kill.test.ts
+++ b/client/test/kill.test.ts
@@ -72,14 +72,16 @@ describe('parseName and formatTable', () => {
     expect(table).toMatch(/DRUZYNA LACZNIE/);
   });
 
-  test('formatSummary prints simple kill list', () => {
+  test('formatSummary prints header and sorts names', () => {
     const summary = formatSummary({
+      Bbb: { mySession: 0, myTotal: 1, teamSession: 0 },
       Aaa: { mySession: 0, myTotal: 2, teamSession: 0 },
       goblin: { mySession: 0, myTotal: 1, teamSession: 0 },
     });
     const stripped = stripAnsiCodes(summary);
-    expect(stripped).toMatch(/WSZYSTKICH DO TEJ PORY/);
-    expect(stripped).toMatch(/Aaa/);
-    expect(stripped).toMatch(/goblin/);
+    expect(stripped).toMatch(/Licznik zabitych/);
+    const indexAaa = stripped.indexOf('Aaa');
+    const indexGoblin = stripped.indexOf('goblin');
+    expect(indexAaa).toBeLessThan(indexGoblin);
   });
 });

--- a/client/test/kill.test.ts
+++ b/client/test/kill.test.ts
@@ -1,5 +1,5 @@
-import initKillTrigger, { parseName, formatTable } from '../src/scripts/kill';
-import Triggers from '../src/Triggers';
+import initKillTrigger, { parseName, formatTable, formatSummary } from '../src/scripts/kill';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
 
 class FakeClient {
   eventTarget = new EventTarget();
@@ -70,5 +70,16 @@ describe('parseName and formatTable', () => {
     expect(table).toMatch(/troll/);
     expect(table).toMatch(/1 \/ 1/);
     expect(table).toMatch(/DRUZYNA LACZNIE/);
+  });
+
+  test('formatSummary prints simple kill list', () => {
+    const summary = formatSummary({
+      Aaa: { mySession: 0, myTotal: 2, teamSession: 0 },
+      goblin: { mySession: 0, myTotal: 1, teamSession: 0 },
+    });
+    const stripped = stripAnsiCodes(summary);
+    expect(stripped).toMatch(/WSZYSTKICH DO TEJ PORY/);
+    expect(stripped).toMatch(/Aaa/);
+    expect(stripped).toMatch(/goblin/);
   });
 });

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -9,3 +9,4 @@ Poniższa lista opisuje dostępne aliasy w rozszerzeniu:
 - **/prowadz _id_** - rozpoczyna prowadzenie innej osoby do wskazanego pokoju.
 - **/prowadz-** - kończy prowadzenie rozpoczęte komendą `/prowadz`.
 - **/zlok** - wymusza odświeżenie bieżącej pozycji na mapie.
+- **/zabici2** - wyświetla podsumowanie liczby zabitych istot.


### PR DESCRIPTION
## Summary
- implement formatted kill counter summary
- register `/zabici2` alias
- document new alias
- test formatting for kill summary
- simplify uppercase check in kill counter

## Testing
- `yarn --cwd client install`
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_68606da6e8bc832a8b26627ec7777879