### PR TITLE
Fix kill summary header width

### DIFF
--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -76,7 +76,7 @@ function formatTable(counts: KillCounts): string {
         )}${" ".repeat(RIGHT_PADDING)}|`;
     const header = (title: string) => {
         const colored = encloseColor(title, HEADER_COLOR);
-        const dashes = WIDTH - visibleLength(title) - 2;
+        const dashes = WIDTH - visibleLength(title) - 4;
         const left = Math.floor(dashes / 2);
         const right = dashes - left;
         return `+${"-".repeat(left)} ${colored} ${"-".repeat(right)}+`;
@@ -148,7 +148,7 @@ function formatSummary(counts: KillCounts): string {
 
     const header = (title: string) => {
         const colored = encloseColor(title, HEADER_COLOR);
-        const dashes = WIDTH - visibleLength(title) - 2;
+        const dashes = WIDTH - visibleLength(title) - 4;
         const left = Math.floor(dashes / 2);
         const right = dashes - left;
         return `+${"-".repeat(left)} ${colored} ${"-".repeat(right)}+`;


### PR DESCRIPTION
## Summary
- adjust header width calculation for `/zabici2` kill summary

## Testing
- `yarn --cwd client install`
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68607e82117c832aad1d69e58e590f52