### PR TITLE
Fix kill counter session vs persistent data

### DIFF
--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -103,14 +103,14 @@ function formatTable(counts: KillCounts): string {
     const header = createHeader(WIDTH, 2, HEADER_COLOR);
 
     const entries = Object.entries(counts)
-        .filter(([_, v]) => v.myTotal > 0 || v.teamSession > 0)
+        .filter(([_, v]) => v.mySession > 0 || v.teamSession > 0)
         .sort(([a], [b]) => a.localeCompare(b));
 
-    const totalMy = Object.values(counts).reduce((s, v) => s + v.myTotal, 0);
+    const totalMy = Object.values(counts).reduce((s, v) => s + v.mySession, 0);
     const totalCombined = totalMy + Object.values(counts).reduce((s, v) => s + v.teamSession, 0);
 
-    const mobLine = (name: string, myTotal: number, combined: number) => {
-        const numbers = `${myTotal} / ${combined}`;
+    const mobLine = (name: string, my: number, combined: number) => {
+        const numbers = `${my} / ${combined}`;
         let text = `${name} `;
         const dots = CONTENT_WIDTH - text.length - numbers.length - 1;
         text += ".".repeat(Math.max(0, dots));
@@ -135,8 +135,8 @@ function formatTable(counts: KillCounts): string {
     lines.push(header("Licznik zabitych"));
     lines.push(pad());
     lines.push(pad(encloseColor("JA", MY_COLOR)));
-    entries.forEach(([name, { myTotal, teamSession }]) => {
-        lines.push(mobLine(name, myTotal, myTotal + teamSession));
+    entries.forEach(([name, { mySession, teamSession }]) => {
+        lines.push(mobLine(name, mySession, mySession + teamSession));
     });
     lines.push(pad());
     lines.push(summaryLine("LACZNIE:", totalMy, TOTAL_COLOR));


### PR DESCRIPTION
## Summary
- make `/zabici` use only session counters
- leave `/zabici2` to use persistent totals
- update kill counter logic

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68608aee4774832aa780179e14c226e8