### PR TITLE
Request settings and kills via backend event

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -111,6 +111,8 @@ const aliases = [
 function connectToBackground(extensionId: string) {
     const port: Port = chrome.runtime.connect(extensionId)
     client.connect(port)
+    port.postMessage({type: 'GET_STORAGE', key: 'settings'})
+    port.postMessage({type: 'GET_STORAGE', key: 'kill_counter'})
     port.onDisconnect.addListener(() => {
         connectToBackground(extensionId)
     })

--- a/extension/background.js
+++ b/extension/background.js
@@ -16,10 +16,12 @@ chrome.runtime.onConnectExternal.addListener(function (port) {
 
     chrome.storage.local.get(null).then(items => {
         Object.entries(items).forEach(([key, value]) => {
-            if (key === 'settings' || key === 'npc') {
+            if (key === 'npc') {
                 port.postMessage({ [key]: value })
             }
-            port.postMessage({ storage: { key, value } })
+            if (key !== 'settings' && key !== 'kill_counter') {
+                port.postMessage({ storage: { key, value } })
+            }
         })
     })
 
@@ -29,6 +31,15 @@ chrome.runtime.onConnectExternal.addListener(function (port) {
                 const npc = data.npc ?? []
                 npc.push({name: msg.name, loc: msg.loc})
                 chrome.storage.local.set({ npc: npc })
+            })
+        }
+        if (msg.type === 'GET_STORAGE') {
+            chrome.storage.local.get(msg.key).then(data => {
+                const value = data[msg.key]
+                if (msg.key === 'settings' || msg.key === 'npc') {
+                    port.postMessage({ [msg.key]: value })
+                }
+                port.postMessage({ storage: { key: msg.key, value } })
             })
         }
         if (msg.type === 'SET_STORAGE') {


### PR DESCRIPTION
## Summary
- avoid sending settings and kill counter automatically on connection
- add `GET_STORAGE` background handler
- request settings and kill counter after connecting

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68608aa6e64c832aa332a0d5979d3c62