### PR TITLE
Add mock background service in sandbox

### DIFF
--- a/sandbox/src/MockPort.ts
+++ b/sandbox/src/MockPort.ts
@@ -1,0 +1,55 @@
+export default class MockPort {
+    listeners: Array<(msg: any) => void> = [];
+    onMessage = {
+        addListener: (cb: (msg: any) => void) => {
+            this.listeners.push(cb);
+        }
+    };
+
+    constructor() {
+        // Delay initialization to allow client.connect to attach listeners
+        setTimeout(() => this.init(), 0);
+    }
+
+    private dispatch(message: any) {
+        this.listeners.forEach(l => l(message));
+    }
+
+    private init() {
+        const sendStorage = (key: string) => {
+            const raw = localStorage.getItem(key);
+            if (raw !== null) {
+                try {
+                    const value = JSON.parse(raw);
+                    this.dispatch({ storage: { key, value } });
+                    if (key === 'settings' || key === 'npc') {
+                        this.dispatch({ [key]: value });
+                    }
+                } catch {
+                    // ignore malformed json
+                }
+            }
+        };
+
+        ['settings', 'npc', 'kill_counter'].forEach(sendStorage);
+    }
+
+    postMessage(message: any) {
+        if (message.type === 'NEW_NPC') {
+            const raw = localStorage.getItem('npc');
+            const npc = raw ? JSON.parse(raw) : [];
+            npc.push({ name: message.name, loc: message.loc });
+            localStorage.setItem('npc', JSON.stringify(npc));
+            this.dispatch({ npc });
+            this.dispatch({ storage: { key: 'npc', value: npc } });
+            return;
+        }
+        if (message.type === 'SET_STORAGE') {
+            localStorage.setItem(message.key, JSON.stringify(message.value));
+            this.dispatch({ storage: { key: message.key, value: message.value } });
+            if (message.key === 'settings' || message.key === 'npc') {
+                this.dispatch({ [message.key]: message.value });
+            }
+        }
+    }
+}

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -2,12 +2,31 @@ import "./sandbox.ts"
 import "@client/src/main.ts"
 
 import npc from "./npc.json";
-import mapData from "../../data/mapExport.json"
-import colors from "../../data/colors.json"
-import {client} from "@client/src/main.ts";
-import {FakeClient} from "./types/globals";
+import mapData from "../../data/mapExport.json";
+import colors from "../../data/colors.json";
+import { client } from "@client/src/main.ts";
+import { FakeClient } from "./types/globals";
+import MockPort from "./MockPort.ts";
 
 export const fakeClient = client as FakeClient
+
+const port = new MockPort()
+fakeClient.connect(port as any)
+
+if (!localStorage.getItem('npc')) {
+    localStorage.setItem('npc', JSON.stringify(npc))
+}
+const defaultSettings = {
+    guilds: [],
+    packageHelper: true,
+    inlineCompassRose: true
+}
+if (!localStorage.getItem('settings')) {
+    localStorage.setItem('settings', JSON.stringify(defaultSettings))
+}
+if (!localStorage.getItem('kill_counter')) {
+    localStorage.setItem('kill_counter', JSON.stringify({}))
+}
 
 const originalDispatch = fakeClient.eventTarget.dispatchEvent.bind(fakeClient.eventTarget)
 fakeClient.eventTarget.dispatchEvent = (event: Event) => {
@@ -35,13 +54,6 @@ const frame: HTMLIFrameElement = document.getElementById("cm-frame")! as HTMLIFr
 frame.contentWindow?.postMessage({mapData, colors}, '*')
 
 window.dispatchEvent(new CustomEvent("ready"));
-fakeClient.eventTarget.dispatchEvent(new CustomEvent("settings", {
-    detail: {
-        guilds: [],
-        packageHelper: true,
-        inlineCompassRose: true
-    }
-}))
 
 
 window.dispatchEvent(new CustomEvent("map-ready", {


### PR DESCRIPTION
## Summary
- mock chrome runtime port with localStorage-based implementation
- connect sandbox client to the mocked port
- seed sandbox storage with default NPC data and settings

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68608ef3077c832a85276ca0a00b3134