### PR TITLE
Fix /zabici to show personal kills only

### DIFF
--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -216,12 +216,15 @@ export default function init(
 ) {
     let kills: KillCounts = {};
     const loadTotals = (totals: Record<string, number> = {}) => {
-        kills = Object.fromEntries(
-            Object.entries(totals).map(([name, total]) => [
-                name,
-                { mySession: 0, myTotal: total as number, teamSession: 0 },
-            ])
-        );
+        Object.entries(totals).forEach(([name, total]) => {
+            const entry = kills[name] ?? {
+                mySession: 0,
+                myTotal: 0,
+                teamSession: 0,
+            };
+            entry.myTotal = total as number;
+            kills[name] = entry;
+        });
     };
 
     client.addEventListener("storage", (event: CustomEvent) => {

--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -103,14 +103,15 @@ function formatTable(counts: KillCounts): string {
     const header = createHeader(WIDTH, 2, HEADER_COLOR);
 
     const entries = Object.entries(counts)
-        .filter(([_, v]) => v.mySession > 0 || v.teamSession > 0)
+        .filter(([_, v]) => v.mySession > 0)
         .sort(([a], [b]) => a.localeCompare(b));
 
     const totalMy = Object.values(counts).reduce((s, v) => s + v.mySession, 0);
-    const totalCombined = totalMy + Object.values(counts).reduce((s, v) => s + v.teamSession, 0);
+    const totalCombined = totalMy +
+        Object.values(counts).reduce((s, v) => s + v.teamSession, 0);
 
-    const mobLine = (name: string, my: number, combined: number) => {
-        const numbers = `${my} / ${combined}`;
+    const mobLine = (name: string, my: number) => {
+        const numbers = `${my}`;
         let text = `${name} `;
         const dots = CONTENT_WIDTH - text.length - numbers.length - 1;
         text += ".".repeat(Math.max(0, dots));
@@ -135,8 +136,8 @@ function formatTable(counts: KillCounts): string {
     lines.push(header("Licznik zabitych"));
     lines.push(pad());
     lines.push(pad(encloseColor("JA", MY_COLOR)));
-    entries.forEach(([name, { mySession, teamSession }]) => {
-        lines.push(mobLine(name, mySession, mySession + teamSession));
+    entries.forEach(([name, { mySession }]) => {
+        lines.push(mobLine(name, mySession));
     });
     lines.push(pad());
     lines.push(summaryLine("LACZNIE:", totalMy, TOTAL_COLOR));

--- a/client/test/kill.test.ts
+++ b/client/test/kill.test.ts
@@ -52,6 +52,17 @@ describe('kill counter team kills', () => {
     expect(result).toContain('[   ZABIL   ]');
     expect(result).toContain('(0 / 1)');
   });
+
+  test('session count persists after storage update', () => {
+    client.TeamManager.isInTeam.mockReturnValue(true);
+    let result = parse('> Eamon zabil smoka chaosu.');
+    expect(result).toContain('(0 / 1)');
+
+    client.dispatch('storage', { key: 'kill_counter', value: { 'smoka chaosu': 1 } });
+
+    result = parse('> Eamon zabil smoka chaosu.');
+    expect(result).toContain('(0 / 2)');
+  });
 });
 
 describe('parseName and formatTable', () => {

--- a/client/test/kill.test.ts
+++ b/client/test/kill.test.ts
@@ -68,7 +68,7 @@ describe('parseName and formatTable', () => {
     });
     expect(table).toMatch(/Licznik zabitych/);
     expect(table).toMatch(/troll/);
-    expect(table).toMatch(/1 \/ 1/);
+    expect(table).toMatch(/troll .* 1/);
     expect(table).toMatch(/DRUZYNA LACZNIE/);
   });
 

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -9,5 +9,5 @@ Poniższa lista opisuje dostępne aliasy w rozszerzeniu:
 - **/prowadz _id_** - rozpoczyna prowadzenie innej osoby do wskazanego pokoju.
 - **/prowadz-** - kończy prowadzenie rozpoczęte komendą `/prowadz`.
 - **/zlok** - wymusza odświeżenie bieżącej pozycji na mapie.
-- **/zabici** - wyświetla tabelę z licznikiem zabitych istot.
+- **/zabici** - pokazuje tabelę z liczbą twoich zabitych istot w bieżącej sesji.
 - **/zabici2** - wyświetla podsumowanie liczby zabitych istot.


### PR DESCRIPTION
## Summary
- show only player kills in `/zabici` table
- update kill test for new output
- clarify alias docs

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686092b915e0832a8b03338d9654832f