### PR TITLE
Move fake client into its own file

### DIFF
--- a/sandbox/src/fakeClient.ts
+++ b/sandbox/src/fakeClient.ts
@@ -1,0 +1,43 @@
+import { client } from "@client/src/main.ts";
+import { FakeClient } from "./types/globals";
+import MockPort from "./MockPort.ts";
+import { setGmcp } from "@client/src/gmcp.ts";
+
+export const fakeClient = client as FakeClient;
+
+const port = new MockPort();
+fakeClient.connect(port as any);
+
+const originalDispatch = fakeClient.eventTarget.dispatchEvent.bind(fakeClient.eventTarget);
+fakeClient.eventTarget.dispatchEvent = (event: Event) => {
+    if (event.type.startsWith('gmcp.')) {
+        const detail = (event as CustomEvent).detail;
+        setGmcp(event.type.replace(/^gmcp\./, ''), detail);
+        let text = '';
+        try {
+            text = detail !== undefined ? JSON.stringify(detail, null, 2) : '';
+        } catch (e) {
+            text = String(detail);
+        }
+        fakeClient.print(`${event.type}${text ? ' ' + text : ''}`);
+        const wrapper = document.getElementById('main_text_output_msg_wrapper')!;
+        const last = wrapper.lastElementChild as HTMLElement | null;
+        if (last) {
+            last.classList.add('gmcp-event');
+        }
+    } else if (event.type.startsWith('gmcp_msg.')) {
+        const wrapper = document.getElementById('main_text_output_msg_wrapper')!;
+        const last = wrapper.lastElementChild as HTMLElement | null;
+        if (last) {
+            last.classList.add('gmcp-msg');
+            last.setAttribute('data-gmcp-type', event.type.replace(/^gmcp_msg\./, ''));
+        }
+
+    }
+    return originalDispatch(event);
+};
+
+fakeClient.fake = (text: string, type?: string) => {
+    window.Output.send(window.Text.parse_patterns(client.onLine(text, type)), type);
+    client.sendEvent('gmcp_msg.' + type, text);
+};

--- a/sandbox/src/sandbox.ts
+++ b/sandbox/src/sandbox.ts
@@ -1,5 +1,5 @@
 import Convert from "ansi-to-html";
-import {fakeClient} from "./index.ts";
+import {fakeClient} from "./fakeClient.ts";
 
 const converter = new Convert({})
 

--- a/sandbox/src/scenario/combat-demo.ts
+++ b/sandbox/src/scenario/combat-demo.ts
@@ -1,5 +1,5 @@
 import ClientScript from "../ClientScript.ts";
-import {fakeClient} from "../index.ts";
+import {fakeClient} from "../fakeClient.ts";
 
 export default new ClientScript(fakeClient)
     .reset()

--- a/sandbox/src/scenario/compass-demo.ts
+++ b/sandbox/src/scenario/compass-demo.ts
@@ -1,5 +1,5 @@
 import ClientScript from "../ClientScript.ts";
-import {fakeClient} from "../index.ts";
+import {fakeClient} from "../fakeClient.ts";
 
 export default new ClientScript(fakeClient)
     .reset()

--- a/sandbox/src/scenario/containers-demo.ts
+++ b/sandbox/src/scenario/containers-demo.ts
@@ -1,5 +1,5 @@
 import ClientScript from "../ClientScript.ts";
-import {fakeClient} from "../index.ts";
+import {fakeClient} from "../fakeClient.ts";
 
 export default new ClientScript(fakeClient)
     .reset()

--- a/sandbox/src/scenario/kill-counter-demo.ts
+++ b/sandbox/src/scenario/kill-counter-demo.ts
@@ -1,5 +1,5 @@
 import ClientScript from "../ClientScript.ts";
-import {fakeClient} from "../index.ts";
+import {fakeClient} from "../fakeClient.ts";
 
 export default new ClientScript(fakeClient)
     .reset()

--- a/sandbox/src/scenario/package-assistant.ts
+++ b/sandbox/src/scenario/package-assistant.ts
@@ -1,5 +1,5 @@
 import ClientScript from "../ClientScript.ts";
-import {fakeClient} from "../index.ts";
+import {fakeClient} from "../fakeClient.ts";
 
 const table = " Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:\n" +
     " o============================================================================o\n" +

--- a/sandbox/src/scenario/team-events-demo.ts
+++ b/sandbox/src/scenario/team-events-demo.ts
@@ -1,5 +1,5 @@
 import ClientScript from "../ClientScript.ts";
-import { fakeClient } from "../index.ts";
+import { fakeClient } from "../fakeClient.ts";
 
 export default new ClientScript(fakeClient)
     .reset()


### PR DESCRIPTION
## Summary
- extract sandbox fake client logic into separate module
- update sandbox entrypoint to use the new fake client
- adjust scenario imports to reference the new module

## Testing
- `yarn --cwd client test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68618574e93c832abdb6ef9d3c634963