### PR TITLE
Add GMCP message label column in sandbox

### DIFF
--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -65,18 +65,6 @@ iframe {
     font-size: 12px;
 }
 
-.gmcp-event::after {
-    content: "GMCP";
-    position: absolute;
-    top: 0;
-    right: 0;
-    background-color: #555;
-    color: #fff;
-    font-size: 10px;
-    padding: 2px 4px;
-    border-bottom-left-radius: 3px;
-    line-height: 1;
-}
 
 .gmcp-msg {
     padding: 5px;
@@ -84,18 +72,6 @@ iframe {
     position: relative;
 }
 
-.gmcp-msg::after {
-    content: attr(data-gmcp-type);
-    position: absolute;
-    top: 0;
-    right: 0;
-    background-color: #555;
-    color: #fff;
-    font-size: 10px;
-    padding: 2px 4px;
-    border-bottom-left-radius: 3px;
-    line-height: 1;
-}
 
 /* GMCP type labels in a left column */
 #main_text_output_msg_wrapper.show-gmcp-column .gmcp-msg {
@@ -118,9 +94,6 @@ iframe {
     height: 100%;
 }
 
-#main_text_output_msg_wrapper.show-gmcp-column .gmcp-msg::after {
-    display: none;
-}
 
 #panel_buttons_bottom {
     height: 25px;

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -67,8 +67,8 @@ iframe {
 
 
 .gmcp-msg {
-    padding: 5px;
-    margin: 2px 0;
+    padding: 0px;
+    margin: 0px 0;
     position: relative;
 }
 
@@ -81,7 +81,7 @@ iframe {
 #main_text_output_msg_wrapper.show-gmcp-column .gmcp-msg::before {
     content: attr(data-gmcp-type);
     position: absolute;
-    top: 0;
+    top: 7px;
     left: 0;
     width: 80px;
     height: 1.2em;
@@ -90,7 +90,7 @@ iframe {
     justify-content: flex-end;
     padding-right: 6px;
     font-size: 10px;
-    color: #aaa;
+    color: #ccc;
 }
 
 #main_text_output_msg_wrapper.show-gmcp-column .gmcp-msg::after {
@@ -100,6 +100,11 @@ iframe {
     bottom: 0;
     left: 86px;
     border-right: 1px solid #444;
+}
+
+.output_msg {
+    padding-bottom: 2px;
+    padding-top: 2px;
 }
 
 

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -105,11 +105,10 @@ iframe {
 }
 
 #main_text_output_msg_wrapper.show-gmcp-column .gmcp-msg::before {
-    content: attr(data-gmcp-type);
+    content: attr(data-gmcp-type) " |";
     color: #aaa;
     font-size: 10px;
-    padding: 0 4px;
-    border-right: 1px solid #555;
+    padding-right: 4px;
     min-width: 80px;
     text-align: right;
     margin-right: 6px;

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -97,6 +97,28 @@ iframe {
     line-height: 1;
 }
 
+/* GMCP type labels in a left column */
+#main_text_output_msg_wrapper.show-gmcp-column .gmcp-msg {
+    display: flex;
+    align-items: flex-start;
+    padding-left: 0;
+}
+
+#main_text_output_msg_wrapper.show-gmcp-column .gmcp-msg::before {
+    content: attr(data-gmcp-type);
+    color: #aaa;
+    font-size: 10px;
+    padding: 0 4px;
+    border-right: 1px solid #555;
+    min-width: 80px;
+    text-align: right;
+    margin-right: 6px;
+}
+
+#main_text_output_msg_wrapper.show-gmcp-column .gmcp-msg::after {
+    display: none;
+}
+
 #panel_buttons_bottom {
     height: 25px;
     margin-top: 5px;

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -100,18 +100,22 @@ iframe {
 /* GMCP type labels in a left column */
 #main_text_output_msg_wrapper.show-gmcp-column .gmcp-msg {
     display: flex;
-    align-items: flex-start;
+    align-items: stretch;
     padding-left: 0;
 }
 
 #main_text_output_msg_wrapper.show-gmcp-column .gmcp-msg::before {
-    content: attr(data-gmcp-type) " |";
+    content: attr(data-gmcp-type);
     color: #aaa;
     font-size: 10px;
-    padding-right: 4px;
+    padding-right: 6px;
     min-width: 80px;
     text-align: right;
     margin-right: 6px;
+    border-right: 1px solid #444;
+    display: flex;
+    align-items: center;
+    height: 100%;
 }
 
 #main_text_output_msg_wrapper.show-gmcp-column .gmcp-msg::after {

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -75,23 +75,31 @@ iframe {
 
 /* GMCP type labels in a left column */
 #main_text_output_msg_wrapper.show-gmcp-column .gmcp-msg {
-    display: flex;
-    align-items: stretch;
-    padding-left: 0;
+    padding-left: 92px;
 }
 
 #main_text_output_msg_wrapper.show-gmcp-column .gmcp-msg::before {
     content: attr(data-gmcp-type);
-    color: #aaa;
-    font-size: 10px;
-    padding-right: 6px;
-    min-width: 80px;
-    text-align: right;
-    margin-right: 6px;
-    border-right: 1px solid #444;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 80px;
+    height: 1.2em;
     display: flex;
     align-items: center;
-    height: 100%;
+    justify-content: flex-end;
+    padding-right: 6px;
+    font-size: 10px;
+    color: #aaa;
+}
+
+#main_text_output_msg_wrapper.show-gmcp-column .gmcp-msg::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 86px;
+    border-right: 1px solid #444;
 }
 
 

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -59,8 +59,8 @@ wrapper.addEventListener('contextmenu', (ev) => {
     menu.style.border = '1px solid #555';
     menu.style.cursor = 'pointer';
     menu.textContent = wrapper.classList.contains('show-gmcp-column')
-        ? 'Hide GMCP type column'
-        : 'Show GMCP type column';
+        ? 'Hide GMCP column'
+        : 'Show GMCP column';
     document.body.appendChild(menu);
 
     const removeMenu = () => {

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -33,3 +33,49 @@ window.dispatchEvent(new CustomEvent("map-ready", {
 fakeClient.eventTarget.dispatchEvent(new CustomEvent("gmcp.room.info", {
     detail: {map: {x: 80, y: 89, z: 0, name: "Wissenland"}}
 }));
+
+const wrapper = document.getElementById('main_text_output_msg_wrapper')!;
+
+function applyGmcpColumn() {
+    if (localStorage.getItem('gmcpColumn') === '1') {
+        wrapper.classList.add('show-gmcp-column');
+    } else {
+        wrapper.classList.remove('show-gmcp-column');
+    }
+}
+
+applyGmcpColumn();
+
+wrapper.addEventListener('contextmenu', (ev) => {
+    ev.preventDefault();
+    const menu = document.createElement('div');
+    menu.style.position = 'fixed';
+    menu.style.top = `${ev.clientY}px`;
+    menu.style.left = `${ev.clientX}px`;
+    menu.style.background = '#333';
+    menu.style.color = '#fff';
+    menu.style.padding = '4px 8px';
+    menu.style.fontSize = '12px';
+    menu.style.border = '1px solid #555';
+    menu.style.cursor = 'pointer';
+    menu.textContent = wrapper.classList.contains('show-gmcp-column')
+        ? 'Hide GMCP type column'
+        : 'Show GMCP type column';
+    document.body.appendChild(menu);
+
+    const removeMenu = () => {
+        menu.remove();
+        document.removeEventListener('click', removeMenu);
+    };
+
+    menu.addEventListener('click', () => {
+        if (wrapper.classList.toggle('show-gmcp-column')) {
+            localStorage.setItem('gmcpColumn', '1');
+        } else {
+            localStorage.removeItem('gmcpColumn');
+        }
+        removeMenu();
+    });
+
+    document.addEventListener('click', removeMenu);
+});


### PR DESCRIPTION
## Summary
- support left column view of GMCP message type in sandbox
- add context menu option to toggle the column

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6861b1617b10832aacab74cc590228bf