### PR TITLE
Fix tests for container environment

### DIFF
--- a/client/test/TeamManager.test.ts
+++ b/client/test/TeamManager.test.ts
@@ -1,18 +1,20 @@
 import TeamManager from '../src/TeamManager';
 import Triggers from '../src/Triggers';
 
+import { EventEmitter } from 'events';
+
 class FakeClient {
-  eventTarget = new EventTarget();
+  private emitter = new EventEmitter();
   Triggers = new Triggers({} as any);
-  addEventListener(event: string, cb: any, options?: any) {
-    this.eventTarget.addEventListener(event, cb, options);
-    return () => this.eventTarget.removeEventListener(event, cb, options);
+  addEventListener(event: string, cb: any, _options?: any) {
+    this.emitter.on(event, cb);
+    return () => this.emitter.off(event, cb);
   }
   removeEventListener(event: string, cb: any) {
-    this.eventTarget.removeEventListener(event, cb);
+    this.emitter.off(event, cb);
   }
   sendEvent(type: string, detail?: any) {
-    this.eventTarget.dispatchEvent(new CustomEvent(type, { detail }));
+    this.emitter.emit(type, { detail });
   }
 }
 

--- a/client/test/kill.test.ts
+++ b/client/test/kill.test.ts
@@ -1,8 +1,10 @@
 import initKillTrigger, { parseName, formatSessionTable, formatLifetimeTable } from '../src/scripts/kill';
 import Triggers, { stripAnsiCodes } from '../src/Triggers';
 
+import { EventEmitter } from 'events';
+
 class FakeClient {
-  eventTarget = new EventTarget();
+  private emitter = new EventEmitter();
   Triggers = new Triggers(({} as unknown) as any);
   TeamManager = { isInTeam: jest.fn() };
   prefix = (line: string, prefix: string) => prefix + line;
@@ -10,13 +12,13 @@ class FakeClient {
   port = { postMessage: jest.fn() } as any;
 
   addEventListener(event: string, cb: any) {
-    this.eventTarget.addEventListener(event, cb);
+    this.emitter.on(event, cb);
   }
   removeEventListener(event: string, cb: any) {
-    this.eventTarget.removeEventListener(event, cb);
+    this.emitter.off(event, cb);
   }
   dispatch(event: string, detail: any) {
-    this.eventTarget.dispatchEvent(new CustomEvent(event, { detail }));
+    this.emitter.emit(event, { detail });
   }
 }
 


### PR DESCRIPTION
## Summary
- avoid `EventTarget` in Jest tests
- update kill and team manager tests to use Node's `EventEmitter`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6861b60b3f20832aaccb19d785854528