### PR TITLE
Implement bag manager aliases and clickable text fix

### DIFF
--- a/client/src/OutputHandler.ts
+++ b/client/src/OutputHandler.ts
@@ -17,8 +17,23 @@ export default class OutputHandler {
                 if (!element) {
                     return;
                 }
-                const msg = element.querySelector(".output_msg_text")
+                const msg = element.querySelector(".output_msg_text") as HTMLElement | null
                 if (msg) {
+                    const plainMatch = msg.textContent?.match(/\{click:(\d+)(?::([^}]+))?}/)
+                    if (plainMatch) {
+                        msg.textContent = msg.textContent?.replace(plainMatch[0], "") || ""
+                        msg.style.cursor = "pointer"
+                        msg.style.textDecoration = " underline"
+                        msg.style.textDecorationStyle = "dotted"
+                        msg.style.textDecorationSkipInk = "auto"
+                        if (plainMatch[2]) {
+                            msg.title = plainMatch[2]
+                        }
+                        const index = parseInt(plainMatch[1])
+                        msg.onclick = () => {
+                            this.clickerCallbacks[index]?.apply(null)
+                        }
+                    }
                     const elements: HTMLElement[] = Array.from(msg.querySelectorAll("span")) as HTMLElement[]
                     elements.filter(el => el.textContent.indexOf("click:") > -1).forEach(el => {
                         el.style.cursor = "pointer"
@@ -35,7 +50,7 @@ export default class OutputHandler {
                         const callbackIndex = el.textContent.substring(clickIndex + 7, hasTitle ? clickTitleSeparator : closerIndex)
                         el.textContent = el.textContent.substring(0, clickIndex) + el.textContent.substring(closerIndex + 1)
                         el.onclick = () => {
-                            this.clickerCallbacks[callbackIndex]?.apply()
+                            this.clickerCallbacks[callbackIndex]?.apply(null)
                         }
                     })
                 }

--- a/client/src/scripts/bagManager.ts
+++ b/client/src/scripts/bagManager.ts
@@ -88,14 +88,24 @@ function containerAction(
         return;
     }
     const forms = getBagForms(bag);
-    const cmds = [
-        `otworz ${forms.pronoun_b} ${forms.biernik}`,
-        action === "put"
-            ? `wloz ${item} do ${forms.pronoun_d} ${forms.dopelniacz}`
-            : `wez ${item} ze ${forms.pronoun_d} ${forms.dopelniacz}`,
-        `zamknij ${forms.pronoun_b} ${forms.biernik}`,
-    ];
-    cmds.forEach((c) => Input.send(c));
+    const items = item
+        .split(",")
+        .map((i) => i.trim())
+        .filter((i) => i.length);
+    Input.send(`otworz ${forms.pronoun_b} ${forms.biernik}`);
+    items.forEach((it) =>
+        Input.send(
+            action === "put"
+                ? `wloz ${it} do ${forms.pronoun_d} ${forms.dopelniacz}`
+                : `wez ${it} ze ${forms.pronoun_d} ${forms.dopelniacz}`
+        )
+    );
+    Input.send(`zamknij ${forms.pronoun_b} ${forms.biernik}`);
+}
+
+function showConfig(client: Client) {
+    const lines = availableTypes.map((t) => `${t}: ${containerConfig[t]}`);
+    client.println(lines.join("\n"));
 }
 
 function showInterface(client: Client, bags: string[]) {
@@ -147,8 +157,11 @@ export default function initBagManager(
 
     if (aliases) {
         aliases.push({ pattern: /\/pojemnik$/, callback: () => configure(client) });
+        aliases.push({ pattern: /\/pojemniki$/, callback: () => showConfig(client) });
         aliases.push({ pattern: /\/wdp (.*)/, callback: (m: RegExpMatchArray) => containerAction(client, "other", "put", m[1]) });
         aliases.push({ pattern: /\/wzp (.*)/, callback: (m: RegExpMatchArray) => containerAction(client, "other", "take", m[1]) });
+        aliases.push({ pattern: /\/wlp$/, callback: () => containerAction(client, "other", "put", "pocztowa paczke") });
+        aliases.push({ pattern: /\/wep$/, callback: () => containerAction(client, "other", "take", "pocztowa paczke") });
         aliases.push({ pattern: /\/wem$/, callback: () => containerAction(client, "money", "take", "monety") });
         aliases.push({ pattern: /\/wlm$/, callback: () => containerAction(client, "money", "put", "monety") });
     }


### PR DESCRIPTION
## Summary
- support comma-separated items and config printing in bag manager
- add /pojemniki, /wlp, /wep aliases
- enable clickable text without spans in OutputHandler

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6861bba094ec832a9f680e6b06c64abb