### PR TITLE
docs: add bag manager

### DIFF
--- a/client/src/OutputHandler.ts
+++ b/client/src/OutputHandler.ts
@@ -20,9 +20,6 @@ export default class OutputHandler {
                 const msg = element.querySelector(".output_msg_text") as HTMLElement | null
                 if (msg) {
                     const elements: HTMLElement[] = Array.from(msg.querySelectorAll("span")) as HTMLElement[]
-                    if (elements.length === 0 && msg.textContent?.indexOf("{click:") > -1) {
-                        elements.push(msg)
-                    }
                     elements.filter(el => el.textContent.indexOf("click:") > -1).forEach(el => {
                         el.style.cursor = "pointer"
                         el.style.textDecoration = " underline"

--- a/client/src/OutputHandler.ts
+++ b/client/src/OutputHandler.ts
@@ -20,6 +20,9 @@ export default class OutputHandler {
                 const msg = element.querySelector(".output_msg_text") as HTMLElement | null
                 if (msg) {
                     const elements: HTMLElement[] = Array.from(msg.querySelectorAll("span")) as HTMLElement[]
+                    if (elements.length === 0 && msg.textContent?.indexOf("{click:") > -1) {
+                        elements.push(msg)
+                    }
                     elements.filter(el => el.textContent.indexOf("click:") > -1).forEach(el => {
                         el.style.cursor = "pointer"
                         el.style.textDecoration = " underline"

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -11,3 +11,11 @@ Poniższa lista opisuje dostępne aliasy w rozszerzeniu:
 - **/zlok** - wymusza odświeżenie bieżącej pozycji na mapie.
 - **/zabici** - pokazuje tabelę z liczbą twoich zabitych istot w bieżącej sesji.
 - **/zabici2** - wyświetla podsumowanie liczby zabitych istot.
+- **/pojemnik** - uruchamia konfigurację menedżera pojemników.
+- **/pojemniki** - wyświetla bieżące ustawienia menedżera pojemników.
+- **/wdp _przedmioty_** - wkłada podane przedmioty do ustawionego pojemnika.
+- **/wzp _przedmioty_** - wyjmuje podane przedmioty z ustawionego pojemnika.
+- **/wem** - wyjmuje monety z pojemnika na pieniądze.
+- **/wlm** - wkłada monety do pojemnika na pieniądze.
+- **/wlp** - wkłada pocztową paczkę do ustawionego pojemnika.
+- **/wep** - wyjmuje pocztową paczkę z ustawionego pojemnika.

--- a/docs/BAG_MANAGER.md
+++ b/docs/BAG_MANAGER.md
@@ -1,0 +1,20 @@
+# Menedżer pojemników
+
+Menedżer pojemników pozwala przypisać wybrane torby, plecaki i inne pojemniki do określonych typów przedmiotów. Dzięki temu możesz szybko odkładać i wyjmować rzeczy z odpowiedniego miejsca.
+
+Ustawienia są zapisywane w pamięci przeglądarki i wczytywane po ponownym uruchomieniu klienta.
+
+## Konfiguracja
+
+1. Wpisz alias `/pojemnik` aby przeszukać ekwipunek i wyświetlić listę znalezionych pojemników.
+2. Kliknij nazwę typu przy wybranym pojemniku, aby przypisać go do danego typu lub wybierz `wszystkie`, by używać go dla wszystkich kategorii.
+3. Aktualne przypisania możesz sprawdzić poleceniem `/pojemniki`.
+
+## Aliasy
+
+- `/wdp przedmiot[, ...]` – wkłada podane przedmioty do pojemnika typu **other**.
+- `/wzp przedmiot[, ...]` – wyjmuje podane przedmioty z pojemnika typu **other**.
+- `/wem` – wyjmuje monety z pojemnika typu **money**.
+- `/wlm` – wkłada monety do pojemnika typu **money**.
+- `/wlp` – wkłada pocztową paczkę do ustawionego pojemnika.
+- `/wep` – wyjmuje pocztową paczkę z ustawionego pojemnika.


### PR DESCRIPTION
## Summary
- document bag manager aliases
- describe how to use the bag manager
- fix OutputHandler to handle clickable text without span

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6861c0335310832aa46323c7606c004a