### PR TITLE
Enhance container config view

### DIFF
--- a/client/src/OutputHandler.ts
+++ b/client/src/OutputHandler.ts
@@ -38,6 +38,24 @@ export default class OutputHandler {
                             this.clickerCallbacks[callbackIndex]?.apply(null)
                         }
                     })
+                    if (msg.textContent && msg.textContent.indexOf("{click:") > -1) {
+                        msg.style.cursor = "pointer"
+                        msg.style.textDecoration = " underline"
+                        msg.style.textDecorationStyle = "dotted"
+                        msg.style.textDecorationSkipInk = "auto"
+                        const clickIndex = msg.textContent.indexOf("{click:")
+                        const clickTitleSeparator = msg.textContent.indexOf(":", clickIndex + 7)
+                        const closerIndex = msg.textContent.indexOf("}", clickIndex)
+                        const hasTitle = clickTitleSeparator > clickIndex && clickTitleSeparator < closerIndex
+                        if (hasTitle) {
+                            msg.title = msg.textContent.substring(clickTitleSeparator + 1, closerIndex)
+                        }
+                        const callbackIndex = msg.textContent.substring(clickIndex + 7, hasTitle ? clickTitleSeparator : closerIndex)
+                        msg.textContent = msg.textContent.substring(0, clickIndex) + msg.textContent.substring(closerIndex + 1)
+                        msg.onclick = () => {
+                            this.clickerCallbacks[callbackIndex]?.apply(null)
+                        }
+                    }
                 }
             }
         })

--- a/client/src/scripts/bagManager.ts
+++ b/client/src/scripts/bagManager.ts
@@ -104,7 +104,40 @@ function containerAction(
 }
 
 function showConfig(client: Client) {
-    const lines = availableTypes.map((t) => `${t}: ${containerConfig[t]}`);
+    const pairs = availableTypes.map((t) => [t, containerConfig[t]]);
+
+    const headerColor = findClosestColor("#7cfc00");
+    const typeColor = findClosestColor("#cfb530");
+    const bagColor = findClosestColor("#87ceeb");
+
+    const headers = ["typ", "pojemnik"];
+    const col1Width = Math.max(...pairs.map(([t]) => t.length), headers[0].length);
+    const col2Width = Math.max(...pairs.map(([, b]) => b.length), headers[1].length);
+
+    const visible = (str: string) => stripAnsiCodes(str).length;
+    const pad = (str: string, len: number) => str + " ".repeat(Math.max(0, len - visible(str)));
+    const center = (str: string, len: number) => {
+        const l = visible(str);
+        const left = Math.floor((len - l) / 2);
+        return " ".repeat(left) + str + " ".repeat(len - l - left);
+    };
+
+    const width = col1Width + col2Width + 7;
+    const horiz1 = "-".repeat(col1Width + 2);
+    const horiz2 = "-".repeat(col2Width + 2);
+
+    const lines: string[] = [];
+    lines.push(`/${"-".repeat(width - 2)}\\`);
+    lines.push(`|${center(encloseColor("POJEMNIKI", headerColor), width - 2)}|`);
+    lines.push(`+${horiz1}+${horiz2}+`);
+    lines.push(`| ${pad(headers[0], col1Width)} | ${pad(headers[1], col2Width)} |`);
+    lines.push(`+${horiz1}+${horiz2}+`);
+    pairs.forEach(([t, b]) => {
+        const type = encloseColor(t, typeColor);
+        const bag = encloseColor(b, bagColor);
+        lines.push(`| ${pad(type, col1Width)} | ${pad(bag, col2Width)} |`);
+    });
+    lines.push(`\\${"-".repeat(width - 2)}/`);
     client.println(lines.join("\n"));
 }
 


### PR DESCRIPTION
## Summary
- color table for `/pojemniki` command
- fix OutputHandler to parse click markers in plain text

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6861c1818f08832aa8e20d8d3624b5d9