### PR TITLE
Fix onLine reset color handling

### DIFF
--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -155,3 +155,13 @@ test('onLine restores color after inserting enclosed color', () => {
   expect(result).toBe(expected);
 });
 
+test('onLine preserves final reset at line end', () => {
+  const client = new Client();
+  const gray = '\x1b[22;38;5;8m';
+  const line = gray + 'gray text' + '\x1b[0m';
+
+  const result = client.onLine(line, '');
+
+  expect(result).toBe(line);
+});
+


### PR DESCRIPTION
## Summary
- improve handling of reset sequences in onLine
- add regression test for final reset

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6861cf76bd68832aa11d93cf83eb712d