### PR TITLE
Fix PackageHelper test

### DIFF
--- a/client/test/PackageHelper.test.ts
+++ b/client/test/PackageHelper.test.ts
@@ -42,7 +42,7 @@ describe('PackageHelper', () => {
     expect(helper['packages']).toEqual([{ name: 'Bob', time: '5' }]);
     expect(client.OutputHandler.makeClickable).toHaveBeenCalledTimes(1);
     const call = client.OutputHandler.makeClickable.mock.calls[0];
-    const expectedColor = colorString(rawLine, 'Bob', findClosestColor('#AAA'));
+    const expectedColor = colorString(rawLine, 'Bob', findClosestColor('#aaaaaa'));
     expect(call[0]).toBe(expectedColor);
     expect(call[1]).toBe('Bob');
     expect(call[3]).toBe('wybierz paczke 1');


### PR DESCRIPTION
## Summary
- update expected color in PackageHelper tests

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6861d1d97fac832a9a1f96276f5f043b