### PR TITLE
Add container settings

### DIFF
--- a/client/src/scripts/prettyContainers.ts
+++ b/client/src/scripts/prettyContainers.ts
@@ -235,10 +235,29 @@ const defaultTransforms: TransformDefinition[] = [
 
 
 export default function initContainers(client: Client) {
-    defaultContainerPatterns.forEach(pattern => {
-        client.Triggers.registerTrigger(pattern, (_, __, matches): undefined => {
-            client.print(prettyPrintContainer(matches, 2, "POJEMNIK", 5))
+    const tag = 'prettyContainers';
+    let enabled = false;
+    let columns = 2;
+
+    const register = () => {
+        client.Triggers.removeByTag(tag);
+        defaultContainerPatterns.forEach(pattern => {
+            client.Triggers.registerTrigger(pattern, (_, __, matches): undefined => {
+                client.print(prettyPrintContainer(matches, columns, 'POJEMNIK', 5));
+            }, tag);
         });
-    })
+    };
+
+    client.addEventListener('settings', (ev: CustomEvent) => {
+        columns = ev.detail.containerColumns ?? columns;
+        const shouldEnable = !!ev.detail.prettyContainers;
+        if (shouldEnable && !enabled) {
+            enabled = true;
+            register();
+        } else if (!shouldEnable && enabled) {
+            client.Triggers.removeByTag(tag);
+            enabled = false;
+        }
+    });
 }
 

--- a/options/src/Settings.tsx
+++ b/options/src/Settings.tsx
@@ -115,6 +115,11 @@ function SettingsForm() {
                             />
                             Róża wiatrów
                         </label>
+                    </div>
+                </div>
+                <div className="mb-4 border border-info/40 rounded-box p-3 bg-neutral/10">
+                    <h5 className="font-bold mb-2">Pojemniki</h5>
+                    <div className="flex flex-wrap gap-4">
                         <label className="flex items-center gap-1">
                             <input
                                 type="checkbox"

--- a/options/src/Settings.tsx
+++ b/options/src/Settings.tsx
@@ -14,6 +14,8 @@ interface Settings {
     packageHelper: boolean;
     replaceMap: boolean;
     inlineCompassRose: boolean;
+    prettyContainers: boolean;
+    containerColumns: number;
 }
 
 function SettingsForm() {
@@ -23,6 +25,8 @@ function SettingsForm() {
         packageHelper: false,
         replaceMap: false,
         inlineCompassRose: false,
+        prettyContainers: true,
+        containerColumns: 2,
     })
 
     function onChangeSetting(modifier: (settings: Settings) => void) {
@@ -110,6 +114,30 @@ function SettingsForm() {
                                 checked={settings.inlineCompassRose}
                             />
                             Róża wiatrów
+                        </label>
+                        <label className="flex items-center gap-1">
+                            <input
+                                type="checkbox"
+                                id="prettyContainers"
+                                name="prettyContainers"
+                                onChange={event => onChangeSetting((s) => s.prettyContainers = event.target.checked)}
+                                className="mx-1 checkbox checkbox-sm"
+                                checked={settings.prettyContainers}
+                            />
+                            Formatuj pojemniki
+                        </label>
+                        <label className="flex items-center gap-1">
+                            <span className="mr-1">Kolumny:</span>
+                            <input
+                                type="number"
+                                min="1"
+                                max="4"
+                                id="containerColumns"
+                                name="containerColumns"
+                                onChange={event => onChangeSetting((s) => s.containerColumns = parseInt(event.target.value) || 1)}
+                                className="mx-1 input input-bordered input-sm w-16"
+                                value={settings.containerColumns}
+                            />
                         </label>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add options for container feature configuration
- allow enabling/disabling pretty container output with custom columns

## Testing
- `corepack prepare yarn@1.22.19 --activate`
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6861ec5e8d7c832a9e1dbdda6be9c1cf