### PR TITLE
Precompute color codes

### DIFF
--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -13,6 +13,9 @@ const tag = "packageHelper";
 const pickCommand = "wybierz paczke"
 const packageLineRegex = /^ \|.*?(?<number>\d+)?\. (?<name>.*?)(?:, (?<city>[\w' ]+?))?\s+(?<gold>\d+)\/\s?(?<silver>\d+)\/\s?(?<copper>\d+)\s+(?:nieogr|(?<time>\d+))/
 
+const KNOWN_NPC_COLOR = findClosestColor('#63ba41');
+const UNKNOWN_NPC_COLOR = findClosestColor('#aaaaaa');
+
 export default class PackageHelper {
 
     private client: Client
@@ -94,7 +97,8 @@ export default class PackageHelper {
             const index = matches.groups.number
             const name = matches.groups.name
             this.packages.push({name: name, time: matches.groups.time})
-            return this.client.OutputHandler.makeClickable(colorString(rawLine, name, this.npc[name] ? findClosestColor('#63ba41') : findClosestColor("#aaaaaa")), name, () => {
+            const colorCode = this.npc[name] ? KNOWN_NPC_COLOR : UNKNOWN_NPC_COLOR;
+            return this.client.OutputHandler.makeClickable(colorString(rawLine, name, colorCode), name, () => {
                 Input.send("wybierz paczke " + index)
             }, "wybierz paczke " + index)
         };

--- a/client/src/scripts/bagManager.ts
+++ b/client/src/scripts/bagManager.ts
@@ -4,6 +4,10 @@ import {encloseColor, findClosestColor} from "../Colors";
 
 const STORAGE_KEY = "containers";
 
+const HEADER_COLOR = findClosestColor("#7cfc00");
+const TYPE_COLOR = findClosestColor("#cfb530");
+const BAG_COLOR = findClosestColor("#87ceeb");
+
 const availableTypes = ["money", "gems", "food", "other"] as const;
 
 const bagInBiernik: Record<string, string> = {
@@ -106,9 +110,9 @@ function containerAction(
 function showConfig(client: Client) {
     const pairs = availableTypes.map((t) => [t, containerConfig[t]]);
 
-    const headerColor = findClosestColor("#7cfc00");
-    const typeColor = findClosestColor("#cfb530");
-    const bagColor = findClosestColor("#87ceeb");
+    const headerColor = HEADER_COLOR;
+    const typeColor = TYPE_COLOR;
+    const bagColor = BAG_COLOR;
 
     const headers = ["typ", "pojemnik"];
     const col1Width = Math.max(...pairs.map(([t]) => t.length), headers[0].length);
@@ -148,10 +152,10 @@ function showInterface(client: Client, bags: string[]) {
         let line = `Ustaw ${bag} jako:`;
         availableTypes.forEach((type) => {
             const text = `${type}`;
-            line += " [ " + encloseColor(client.OutputHandler.makeClickable(text, text, () => setContainer(type, bag, client)), findClosestColor("#cfb530")) + " ]";
+            line += " [ " + encloseColor(client.OutputHandler.makeClickable(text, text, () => setContainer(type, bag, client)), TYPE_COLOR) + " ]";
         });
         const allText = `wszystkie`;
-        line += " [ " + encloseColor(client.OutputHandler.makeClickable(allText, allText, () => setAll(bag, client)), findClosestColor("#cfb530")) + " ]";
+        line += " [ " + encloseColor(client.OutputHandler.makeClickable(allText, allText, () => setAll(bag, client)), TYPE_COLOR) + " ]";
         lines.push(line);
     });
     client.println(lines.join("\n"));

--- a/client/src/scripts/gags.ts
+++ b/client/src/scripts/gags.ts
@@ -19,6 +19,11 @@ const gagColors = {
     "npc": "#fffaf0",
     "npc_spece": "#fffaf0"
 };
+const gagColorCodes: Record<string, number> = Object.fromEntries(
+    Object.entries(gagColors).map(([k, v]) => [k, findClosestColor(v)])
+) as Record<string, number>;
+const OWN_HIT_COLOR = findClosestColor('#2db92d');
+const DAMAGE_COLOR = findClosestColor('#ff9933');
 const combatTypes = ["combat.avatar", "combat.team", "combat.others"]
 
 class EmptyMatches extends Array<string> implements RegExpMatchArray {
@@ -59,7 +64,7 @@ function gagOwnSpec(rawLine: string, power: string, totalPower: string) {
 }
 
 function gagPrefix(rawLine: string, prefix: string, type: string) {
-    return client.prefix(rawLine, encloseColor(`[${prefix}] `, findClosestColor(gagColors[type])));
+    return client.prefix(rawLine, encloseColor(`[${prefix}] `, gagColorCodes[type]));
 }
 
 function gagSpec(rawLine: string, prefix: string, power: string, totalPower: string, kind: string) {
@@ -181,7 +186,7 @@ function gagOwnRegularHits(rawLine: string, matches: RegExpMatchArray | { index:
         return rawLine
     }
 
-    rawLine = colorString(rawLine, matches[0], findClosestColor('#2db92d'))
+    rawLine = colorString(rawLine, matches[0], OWN_HIT_COLOR)
 
 
     return gag(rawLine, power, "6", "moje_ciosy")
@@ -195,7 +200,7 @@ function color_hit(rawLine: string, matches: RegExpMatchArray, value: string, ty
 
 
     if (matches.groups.target) {
-        rawLine = colorString(rawLine, matches.groups.damage + " cie", findClosestColor('#ff9933'))
+        rawLine = colorString(rawLine, matches.groups.damage + " cie", DAMAGE_COLOR)
     } else {
         target = "innych_ciosy"
     }

--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -12,6 +12,14 @@ type KillCounts = Record<string, KillEntry>;
 
 const STORAGE_KEY = "kill_counter";
 
+const KILL_HEADER_COLOR = findClosestColor("#7cfc00");
+const KILL_MY_COLOR = findClosestColor("#ffff00");
+const KILL_TOTAL_COLOR = findClosestColor("#778899");
+const KILL_UPPER_COLOR = findClosestColor("#ffa500");
+const KILL_LOWER_COLOR = findClosestColor("#7cfc00");
+const KILL_PINK_COLOR = findClosestColor("#ffc0cb");
+const KILL_PREFIX_COLOR = findClosestColor("#ff6347");
+
 const twoWordNames = [
     "czarnego orka",
     "dzikiego orka",
@@ -95,9 +103,9 @@ function formatSessionTable(counts: KillCounts): string {
     const RIGHT_PADDING = 5;
     const CONTENT_WIDTH = WIDTH - LEFT_PADDING - RIGHT_PADDING;
 
-    const HEADER_COLOR = findClosestColor("#7cfc00");
-    const MY_COLOR = findClosestColor("#ffff00");
-    const TOTAL_COLOR = findClosestColor("#778899");
+    const HEADER_COLOR = KILL_HEADER_COLOR;
+    const MY_COLOR = KILL_MY_COLOR;
+    const TOTAL_COLOR = KILL_TOTAL_COLOR;
 
     const pad = createPad(WIDTH, LEFT_PADDING, RIGHT_PADDING);
     const header = createHeader(WIDTH, 2, HEADER_COLOR);
@@ -156,10 +164,10 @@ function formatLifetimeTable(counts: KillCounts): string {
     const INNER = WIDTH - 2;
     const CONTENT_WIDTH = INNER - LEFT_PADDING - RIGHT_PADDING;
 
-    const HEADER_COLOR = findClosestColor("#7cfc00");
-    const UPPER_COLOR = findClosestColor("#ffa500");
-    const LOWER_COLOR = findClosestColor("#7cfc00");
-    const PINK_COLOR = findClosestColor("#ffc0cb");
+    const HEADER_COLOR = KILL_HEADER_COLOR;
+    const UPPER_COLOR = KILL_UPPER_COLOR;
+    const LOWER_COLOR = KILL_LOWER_COLOR;
+    const PINK_COLOR = KILL_PINK_COLOR;
 
     const pad = createPad(INNER, LEFT_PADDING, RIGHT_PADDING);
     const header = createHeader(WIDTH, 4, HEADER_COLOR);
@@ -267,7 +275,7 @@ export default function init(
     };
 
     const formatPrefix = (line: string, entry: KillEntry | null, label: string) => {
-        const color = findClosestColor("#ff6347");
+        const color = KILL_PREFIX_COLOR;
         const counts = entry
             ? ` (${entry.mySession} / ${entry.mySession + entry.teamSession})`
             : "";

--- a/client/src/scripts/prettyContainers.ts
+++ b/client/src/scripts/prettyContainers.ts
@@ -2,6 +2,12 @@ import Client from "../Client";
 import {encloseColor, findClosestColor} from "../Colors";
 import {stripAnsiCodes} from "../Triggers";
 
+const GROUP_NAME_COLOR = findClosestColor('#557C99');
+const MITHRIL_COLOR = findClosestColor('#afeeee');
+const GOLD_COLOR = findClosestColor('#FFD700');
+const SILVER_COLOR = findClosestColor('#C0C0C0');
+const COPPER_COLOR = findClosestColor('#8B4513');
+
 export type GroupDefinition = {
     name: string;
     filter: (item: string) => boolean;
@@ -122,7 +128,7 @@ export function formatTable(title: string, groups: Record<string, ContainerItem[
         let gLine = '|';
         for (let c = 0; c < columns; c++) {
             const grp = pair[c];
-            gLine += cell(encloseColor(grp ? grp[0] : '', findClosestColor('#557C99')));
+            gLine += cell(encloseColor(grp ? grp[0] : '', GROUP_NAME_COLOR));
             gLine += c === columns - 1 ? '' : ' | ';
         }
         gLine += '|';
@@ -227,10 +233,10 @@ const defs = [
 ]
 
 const defaultTransforms: TransformDefinition[] = [
-    { check: (item: string) => item.match("mithryl\\w+ monet") != null, transform: (item) => encloseColor(item, findClosestColor("#afeeee"))},
-    { check: (item: string) => item.match("zlot\\w+ monet") != null, transform: (item) => encloseColor(item, findClosestColor("#FFD700"))},
-    { check: (item: string) => item.match("srebrn\\w+") != null, transform: (item) => encloseColor(item, findClosestColor("#C0C0C0"))},
-    { check: (item: string) => item.match("miedzian\\w+ monet") != null, transform: (item) => encloseColor(item, findClosestColor("#8B4513"))}
+    { check: (item: string) => item.match("mithryl\\w+ monet") != null, transform: (item) => encloseColor(item, MITHRIL_COLOR)},
+    { check: (item: string) => item.match("zlot\\w+ monet") != null, transform: (item) => encloseColor(item, GOLD_COLOR)},
+    { check: (item: string) => item.match("srebrn\\w+") != null, transform: (item) => encloseColor(item, SILVER_COLOR)},
+    { check: (item: string) => item.match("miedzian\\w+ monet") != null, transform: (item) => encloseColor(item, COPPER_COLOR)}
 ]
 
 


### PR DESCRIPTION
## Summary
- move calls to `findClosestColor` into constants for PackageHelper
- precompute color values for bag manager
- cache gag color values and other color constants
- cache kill counter colors
- precompute colors for pretty containers

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68624029207c832a9c3ec4252771a8f6