### PR TITLE
Fix IDE warning in tests by adding tsconfig

### DIFF
--- a/client/test/tsconfig.json
+++ b/client/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "../src",
+    "**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a `tsconfig.json` for the test directory so IDE uses ES2021 target

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6862538db7b8832abc4340362f525822