### PR TITLE
Allow /wem or /wlm alias without slash

### DIFF
--- a/client/src/scripts/bagManager.ts
+++ b/client/src/scripts/bagManager.ts
@@ -200,7 +200,7 @@ export default function initBagManager(
         aliases.push({ pattern: /\/wzp (.*)/, callback: (m: RegExpMatchArray) => containerAction(client, "other", "take", m[1]) });
         aliases.push({ pattern: /\/wlp$/, callback: () => containerAction(client, "other", "put", "pocztowa paczke") });
         aliases.push({ pattern: /\/wep$/, callback: () => containerAction(client, "other", "take", "pocztowa paczke") });
-        aliases.push({ pattern: /\/wem$/, callback: () => containerAction(client, "money", "take", "monety") });
-        aliases.push({ pattern: /\/wlm$/, callback: () => containerAction(client, "money", "put", "monety") });
+        aliases.push({ pattern: /\/?wem$/, callback: () => containerAction(client, "money", "take", "monety") });
+        aliases.push({ pattern: /\/?wlm$/, callback: () => containerAction(client, "money", "put", "monety") });
     }
 }

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -15,7 +15,7 @@ Poniższa lista opisuje dostępne aliasy w rozszerzeniu:
 - **/pojemniki** - wyświetla bieżące ustawienia menedżera pojemników.
 - **/wdp _przedmioty_** - wkłada podane przedmioty do ustawionego pojemnika.
 - **/wzp _przedmioty_** - wyjmuje podane przedmioty z ustawionego pojemnika.
-- **/wem** - wyjmuje monety z pojemnika na pieniądze.
-- **/wlm** - wkłada monety do pojemnika na pieniądze.
+- **/wem** (lub **wem**) - wyjmuje monety z pojemnika na pieniądze.
+- **/wlm** (lub **wlm**) - wkłada monety do pojemnika na pieniądze.
 - **/wlp** - wkłada pocztową paczkę do ustawionego pojemnika.
 - **/wep** - wyjmuje pocztową paczkę z ustawionego pojemnika.

--- a/docs/BAG_MANAGER.md
+++ b/docs/BAG_MANAGER.md
@@ -14,7 +14,7 @@ Ustawienia są zapisywane w pamięci przeglądarki i wczytywane po ponownym uruc
 
 - `/wdp przedmiot[, ...]` – wkłada podane przedmioty do pojemnika typu **other**.
 - `/wzp przedmiot[, ...]` – wyjmuje podane przedmioty z pojemnika typu **other**.
-- `/wem` – wyjmuje monety z pojemnika typu **money**.
-- `/wlm` – wkłada monety do pojemnika typu **money**.
+- `/wem` (lub `wem`) – wyjmuje monety z pojemnika typu **money**.
+- `/wlm` (lub `wlm`) – wkłada monety do pojemnika typu **money**.
 - `/wlp` – wkłada pocztową paczkę do ustawionego pojemnika.
 - `/wep` – wyjmuje pocztową paczkę z ustawionego pojemnika.


### PR DESCRIPTION
## Summary
- allow `/wem` and `/wlm` aliases to work without the leading slash
- document the new alias forms

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6862c1d85dac832ab207d1d13a246f92