### PR TITLE
Add bus travel triggers

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -168,8 +168,10 @@ client.Triggers.registerTrigger('Wykonuje komende \'idz ', (): undefined => {
 
 
 import initShips from "./scripts/ships"
+import initBuses from "./scripts/buses"
 
 initShips(client)
+initBuses(client)
 
 import initKillTrigger from "./scripts/kill"
 

--- a/client/src/scripts/buses.ts
+++ b/client/src/scripts/buses.ts
@@ -74,8 +74,8 @@ export default function initBuses(client: Client) {
 
     client.Triggers.registerTrigger(/.*i wsiada do.*powozu/, boardPowoz, "buses");
 
-    client.Triggers.registerTrigger(/^.* siada w .*bryczce\.$/, boardBryczka, "buses");
-    client.Triggers.registerTrigger(/^.* zsiada z .*bryczki\.$/, exitBryczka, "buses");
-    client.Triggers.registerTrigger(/^.* siada na .*wozie\.$/, boardBryczka, "buses");
-    client.Triggers.registerTrigger(/^.* zsiada z .*wozu\.$/, exitBryczka, "buses");
+    client.Triggers.registerTrigger(/^.*siada w .*bryczce\.$/, boardBryczka, "buses");
+    client.Triggers.registerTrigger(/^.*zsiada z .*bryczki\.$/, exitBryczka, "buses");
+    client.Triggers.registerTrigger(/^.*siada na .*wozie\.$/, boardBryczka, "buses");
+    client.Triggers.registerTrigger(/^.*zsiada z .*wozu\.$/, exitBryczka, "buses");
 }

--- a/client/src/scripts/buses.ts
+++ b/client/src/scripts/buses.ts
@@ -59,7 +59,7 @@ export default function initBuses(client: Client) {
 
     const boardPowozPatterns: Array<RegExp | string> = [
         /.*(?:po)?woz.*powoli zatrzymuje sie\./,
-        /Kupiecki stojacy (po|)woz/,
+        /^Kupiecki stojacy (po|)woz$/,
         "Drewniany stojacy woz",
         "Otwarty stojacy powoz",
         "Kupiecki stojacy woz z plandeka",

--- a/client/src/scripts/buses.ts
+++ b/client/src/scripts/buses.ts
@@ -1,0 +1,81 @@
+import Client from "../Client";
+
+const DILIZANS_CMDS = ["wem", "wsiadz do dylizansu", "wlm"];
+const DILIZANS_LABEL = DILIZANS_CMDS.join(";");
+
+const POWOZ_CMDS = ["wem", "wsiadz do wozu", "wsiadz do powozu", "wlm"];
+const POWOZ_LABEL = POWOZ_CMDS.join(";");
+
+const BRYCZKA_CMDS = ["wem", "usiadz na bryczce", "wlm"];
+const BRYCZKA_LABEL = BRYCZKA_CMDS.join(";");
+
+function bindBus(client: Client, commands: string[], label: string, beep: boolean) {
+    if (beep) {
+        client.playSound("beep");
+    }
+    client.FunctionalBind.set(label, () => {
+        commands.forEach(cmd => Input.send(cmd));
+    });
+}
+
+export default function initBuses(client: Client) {
+    const boardDylizans = () => {
+        bindBus(client, DILIZANS_CMDS, DILIZANS_LABEL, false);
+        return undefined;
+    };
+    const exitPowozPatterns: Array<RegExp | string> = [
+        /.*owoz cicho skrzypiac zatrzymuje sie\.$/,
+        /.*kolysanie ustaje w koncu i woz zatrzymuje sie\.$/,
+        /.*Powoli pojazd zaczyna tracic predkosc.*/,
+        "Woz cicho skrzypiac zatrzymuje sie.",
+        "Otwarty jadacy powoz powoli zatrzymuje sie.",
+    ];
+
+    const boardPowoz = (_raw: string, line: string) => {
+        if (line.includes("powoli rusza w droge")) return undefined;
+        if (exitPowozPatterns.some(p => typeof p === "string" ? line === p : p.test(line))) {
+            return undefined;
+        }
+        bindBus(client, POWOZ_CMDS, POWOZ_LABEL, false);
+        return undefined;
+    };
+
+    const exitPowoz = () => {
+        bindBus(client, ["wyjscie"], "wyjscie", true);
+        return undefined;
+    };
+    const boardBryczka = () => {
+        bindBus(client, BRYCZKA_CMDS, BRYCZKA_LABEL, false);
+        return undefined;
+    };
+    const exitBryczka = () => {
+        bindBus(client, ["wstan"], "wstan", false);
+        return undefined;
+    };
+
+    client.Triggers.registerTrigger(/.*dylizans powoli zatrzymuje sie.*/, boardDylizans, "buses");
+    client.Triggers.registerTrigger(/.*i wsiada do.*dylizansu/, boardDylizans, "buses");
+    client.Triggers.registerTrigger(/[A-Za-z]+ stojacy dylizans/, boardDylizans, "buses");
+
+    const boardPowozPatterns: Array<RegExp | string> = [
+        /.*(?:po)?woz.*powoli zatrzymuje sie\./,
+        /Kupiecki stojacy (po|)woz/,
+        "Drewniany stojacy woz",
+        "Otwarty stojacy powoz",
+        "Kupiecki stojacy woz z plandeka",
+    ];
+    boardPowozPatterns.forEach(p =>
+        client.Triggers.registerTrigger(p, boardPowoz, "buses")
+    );
+
+    exitPowozPatterns.forEach(p =>
+        client.Triggers.registerTrigger(p, exitPowoz, "buses")
+    );
+
+    client.Triggers.registerTrigger(/.*i wsiada do.*powozu/, boardPowoz, "buses");
+
+    client.Triggers.registerTrigger(/^.* siada w .*bryczce\.$/, boardBryczka, "buses");
+    client.Triggers.registerTrigger(/^.* zsiada z .*bryczki\.$/, exitBryczka, "buses");
+    client.Triggers.registerTrigger(/^.* siada na .*wozie\.$/, boardBryczka, "buses");
+    client.Triggers.registerTrigger(/^.* zsiada z .*wozu\.$/, exitBryczka, "buses");
+}

--- a/client/test/buses.test.ts
+++ b/client/test/buses.test.ts
@@ -1,0 +1,43 @@
+import initBuses from '../src/scripts/buses';
+import Triggers from '../src/Triggers';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+  FunctionalBind = { set: jest.fn(), clear: jest.fn() };
+  playSound = jest.fn();
+}
+
+describe('buses triggers', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    (global as any).Input = { send: jest.fn() };
+    client = new FakeClient();
+    initBuses((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    jest.clearAllMocks();
+  });
+
+  test('exit trigger binds command and beeps', () => {
+    parse('Otwarty jadacy powoz powoli zatrzymuje sie.');
+    expect(client.playSound).toHaveBeenCalledTimes(1);
+    expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
+    const [label, callback] = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
+    expect(label).toBe('wyjscie');
+    callback();
+    expect((global as any).Input.send).toHaveBeenCalledWith('wyjscie');
+  });
+
+  test('boarding trigger binds commands', () => {
+    parse('dylizans powoli zatrzymuje sie.');
+    expect(client.playSound).not.toHaveBeenCalled();
+    expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
+    const [label, callback] = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
+    expect(label).toBe('wem;wsiadz do dylizansu;wlm');
+    callback();
+    expect((global as any).Input.send).toHaveBeenNthCalledWith(1, 'wem');
+    expect((global as any).Input.send).toHaveBeenNthCalledWith(2, 'wsiadz do dylizansu');
+    expect((global as any).Input.send).toHaveBeenNthCalledWith(3, 'wlm');
+  });
+});

--- a/client/test/buses.test.ts
+++ b/client/test/buses.test.ts
@@ -40,4 +40,9 @@ describe('buses triggers', () => {
     expect((global as any).Input.send).toHaveBeenNthCalledWith(2, 'wsiadz do dylizansu');
     expect((global as any).Input.send).toHaveBeenNthCalledWith(3, 'wlm');
   });
+
+  test('woz z plandeka triggers once', () => {
+    parse('Kupiecki stojacy woz z plandeka');
+    expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
+  });
 });

--- a/client/test/buses.test.ts
+++ b/client/test/buses.test.ts
@@ -45,4 +45,11 @@ describe('buses triggers', () => {
     parse('Kupiecki stojacy woz z plandeka');
     expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
   });
+
+  test('bryczka boarding triggers', () => {
+    parse('siada w malej bryczce.');
+    expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
+    const [label] = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
+    expect(label).toBe('wem;usiadz na bryczce;wlm');
+  });
 });

--- a/sandbox/src/Controls.tsx
+++ b/sandbox/src/Controls.tsx
@@ -6,6 +6,7 @@ import packageAssistant from "./scenario/package-assistant.ts";
 import killCounterDemo from "./scenario/kill-counter-demo.ts";
 import teamEventsDemo from "./scenario/team-events-demo.ts";
 import shipsDemo from "./scenario/ships-demo.ts";
+import busesDemo from "./scenario/buses-demo.ts";
 import combatDemo from "./scenario/combat-demo.ts";
 import compassDemo from "./scenario/compass-demo.ts";
 import containersDemo from "./scenario/containers-demo.ts";
@@ -78,6 +79,13 @@ export function Controls() {
                         onClick={() => shipsDemo.run()}
                     >
                         Ships Demo
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => busesDemo.run()}
+                    >
+                        Buses Demo
                     </Button>
                 </div>,
                 document.getElementById('sandbox-buttons')!,

--- a/sandbox/src/scenario/buses-demo.ts
+++ b/sandbox/src/scenario/buses-demo.ts
@@ -1,0 +1,22 @@
+import ClientScript from "../ClientScript.ts";
+import { fakeClient } from "../fakeClient.ts";
+
+const busTriggers = [
+    "dylizans powoli zatrzymuje sie.",
+    "i wsiada do powozu",
+    "i wsiada do dylizansu",
+    "Otwarty jadacy powoz powoli zatrzymuje sie.",
+    "Drewniany stojacy woz",
+    "Kupiecki stojacy woz z plandeka",
+    "siada w malej bryczce.",
+    "zsiada z malej bryczki.",
+];
+
+function pick() {
+    return busTriggers[Math.floor(Math.random() * busTriggers.length)];
+}
+
+export default new ClientScript(fakeClient)
+    .reset()
+    .call(() => fakeClient.FunctionalBind.clear())
+    .call(() => fakeClient.fake(pick()));


### PR DESCRIPTION
## Summary
- implement buses trigger bindings
- add Buses Demo button for sandbox
- provide sample bus scenario

## Testing
- `yarn --cwd client install`
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6862cd078e20832a97e425fc6016ecbf