### PR TITLE
Fix beep playback when triggered rapidly

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -155,10 +155,14 @@ export default class Client {
         if (!sound) {
             return
         }
-        if (sound.state() === 'loaded') {
+        const play = () => {
+            sound.stop()
             sound.play()
+        }
+        if (sound.state() === 'loaded') {
+            play()
         } else {
-            sound.once('load', () => sound.play())
+            sound.once('load', play)
             sound.load()
         }
     }


### PR DESCRIPTION
## Summary
- force beep sound to restart on each play
- mock `Howl` in tests and verify consecutive beeps

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686318e99e34832aa5ceb976598db110