### PR TITLE
Fix duplicate functional bind buttons

### DIFF
--- a/client/src/scripts/functionalBind.ts
+++ b/client/src/scripts/functionalBind.ts
@@ -42,6 +42,7 @@ export class FunctionalBind {
 
     set(printable: string | null, callback: () => void) {
         this.functionalBind = callback;
+        this.button?.remove();
         if (printable) {
             this.client.println(`\t${color(49)}bind ${color(222)}${this.label}${color(49)}: ${printable}`);
             this.button = this.client.createButton(printable, callback);


### PR DESCRIPTION
## Summary
- ensure `FunctionalBind` removes old button when setting a new one

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6863909f7ae0832a95c74eae85ccb0bf