### PR TITLE
Fix extra items text on options screen

### DIFF
--- a/options/src/Settings.tsx
+++ b/options/src/Settings.tsx
@@ -36,6 +36,7 @@ function SettingsForm() {
     })
 
     const allSelected = settings.guilds.length === guilds.length
+    const [extraInput, setExtraInput] = useState<string>('')
 
     function onChangeSetting(modifier: (settings: Settings) => void) {
         setSettings(prev => {
@@ -206,14 +207,33 @@ function SettingsForm() {
                         </label>
                         <div>
                             <span className="mr-1">Dodatkowe przedmioty:</span>
-                            <input id="extraItem" type="text" className="input input-bordered input-sm mr-1 w-40" />
-                            <button className="btn btn-sm" onClick={() => {
-                                const input = document.getElementById('extraItem') as HTMLInputElement;
-                                if (input.value) {
-                                    onChangeSetting(s => s.collectExtra = [...s.collectExtra, input.value]);
-                                    input.value = '';
-                                }
-                            }}>Dodaj</button>
+                            <input
+                                id="extraItem"
+                                type="text"
+                                className="input input-bordered input-sm mr-1 w-40"
+                                value={extraInput}
+                                onChange={e => setExtraInput(e.target.value)}
+                                onKeyDown={e => {
+                                    if (e.key === 'Enter') {
+                                        e.preventDefault();
+                                        if (extraInput.trim()) {
+                                            onChangeSetting(s => s.collectExtra = [...s.collectExtra, extraInput.trim()]);
+                                            setExtraInput('');
+                                        }
+                                    }
+                                }}
+                            />
+                            <button
+                                className="btn btn-sm"
+                                onClick={() => {
+                                    if (extraInput.trim()) {
+                                        onChangeSetting(s => s.collectExtra = [...s.collectExtra, extraInput.trim()]);
+                                        setExtraInput('');
+                                    }
+                                }}
+                            >
+                                Dodaj
+                            </button>
                         </div>
                         <ul className="list-disc pl-5">
                             {settings.collectExtra.map(item => (


### PR DESCRIPTION
## Summary
- fix the `Dodatkowe przedmioty` field in options to store input value
- allow pressing *Enter* to add an extra item

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68639bf765a8832ab8e3668967f36274