### PR TITLE
Color item evaluation value

### DIFF
--- a/client/src/scripts/itemCondition.ts
+++ b/client/src/scripts/itemCondition.ts
@@ -33,7 +33,8 @@ export function processItemCondition(rawLine: string, phrase: string): string {
         if (found) {
             const colorCode = COLORS[condition.color] ?? COLORS.red;
             const colored = encloseColor(phrase, colorCode);
-            const replaced = `${colored} ${condition.replacement}`;
+            const coloredValue = encloseColor(condition.replacement, colorCode);
+            const replaced = `${colored} ${coloredValue}`;
             return rawLine.replace(phrase, replaced);
         }
     }


### PR DESCRIPTION
## Summary
- color the bracketed value alongside the phrase during item evaluation

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6863a2c7d088832a86a15023b5b26d45