### PR TITLE
Make gate knock bind always active

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -169,9 +169,11 @@ client.Triggers.registerTrigger('Wykonuje komende \'idz ', (): undefined => {
 
 import initShips from "./scripts/ships"
 import initBuses from "./scripts/buses"
+import initGates from "./scripts/gates"
 
 initShips(client)
 initBuses(client)
+initGates(client)
 
 import initKillTrigger from "./scripts/kill"
 

--- a/client/src/scripts/gates.ts
+++ b/client/src/scripts/gates.ts
@@ -1,0 +1,26 @@
+import Client from "../Client";
+import { FunctionalBind } from "./functionalBind";
+
+export default function initGates(client: Client) {
+    const bind = new FunctionalBind(client, { key: "F2", ctrl: true, label: "CTRL+F2" });
+    const knock = () => {
+        Input.send("zastukaj we wrota");
+    };
+    bind.set(null, knock);
+
+    const showMessage = () => {
+        bind.set("zastukaj we wrota", knock);
+        return undefined;
+    };
+
+    const patterns = [
+        /^Probujesz otworzyc .*wrota.*/,
+        /^Probujesz otworzyc .*drzwiczki.*/,
+        /^Probujesz otworzyc .*krate.*/,
+        /^Probujesz otworzyc .*brame.*/,
+        /^Probujesz otworzyc niewielka furtke.*/,
+    ];
+
+    patterns.forEach(p => client.Triggers.registerTrigger(p, showMessage, "gates"));
+}
+

--- a/client/test/gates.test.ts
+++ b/client/test/gates.test.ts
@@ -1,0 +1,46 @@
+import Triggers from '../src/Triggers';
+
+const set = jest.fn();
+const FunctionalBind = jest.fn().mockImplementation(() => ({ set }));
+jest.mock('../src/scripts/functionalBind', () => ({ FunctionalBind }));
+
+import initGates from '../src/scripts/gates';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+}
+
+describe('gates triggers', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    (global as any).Input = { send: jest.fn() };
+    client = new FakeClient();
+    set.mockClear();
+    FunctionalBind.mockClear();
+    initGates((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+  });
+
+  test('binding is set and callback sends command', () => {
+    expect(FunctionalBind).toHaveBeenCalledWith(client, { key: 'F2', ctrl: true, label: 'CTRL+F2' });
+    expect(set).toHaveBeenCalledTimes(1);
+    const initCb = set.mock.calls[0][1];
+    initCb();
+    expect((global as any).Input.send).toHaveBeenCalledWith('zastukaj we wrota');
+
+    parse('Probujesz otworzyc masywne wrota.');
+    expect(set).toHaveBeenCalledTimes(2);
+    const [label, cb] = set.mock.calls[1];
+    expect(label).toBe('zastukaj we wrota');
+    cb();
+    expect((global as any).Input.send).toHaveBeenCalledTimes(2);
+  });
+
+  test('niewielka furtka pattern', () => {
+    parse('Probujesz otworzyc niewielka furtke.');
+    expect(set).toHaveBeenCalledTimes(2);
+  });
+});
+


### PR DESCRIPTION
## Summary
- create dedicated CTRL+F2 bind for knocking on gates
- only display bind message when closed gate patterns are detected
- adjust tests for the new behaviour

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6863a75d2414832aa7efc42b8a782a26