### PR TITLE
Fix ship board bind when on ship

### DIFF
--- a/client/src/scripts/ships.ts
+++ b/client/src/scripts/ships.ts
@@ -1,5 +1,7 @@
 import Client from "../Client";
 
+let onShip = false;
+
 const BOARD_CMDS = [
     "wem",
     "kup bilet",
@@ -13,21 +15,27 @@ function bindShip(client: Client, commands: string[], label: string, beep: boole
         client.playSound("beep");
     }
     client.FunctionalBind.set(label, () => {
-        commands.forEach(cmd => Input.send(cmd));
         if (commands.length === 1 && commands[0] === "zejdz ze statku") {
             client.sendEvent("refreshPositionWhenAble");
+            onShip = false;
+        } else {
+            onShip = true;
         }
+        commands.forEach(cmd => Input.send(cmd));
     });
 }
 
 export default function initShips(client: Client) {
+    onShip = false;
     const board = (beep: boolean) => (
         _raw: string,
         _line: string,
         _matches: RegExpMatchArray,
         _type: string
     ) => {
-        bindShip(client, BOARD_CMDS, BOARD_LABEL, beep);
+        if (!onShip) {
+            bindShip(client, BOARD_CMDS, BOARD_LABEL, beep);
+        }
         return undefined;
     };
     const disembark = () => {

--- a/client/test/ships.test.ts
+++ b/client/test/ships.test.ts
@@ -56,4 +56,13 @@ describe('ships triggers', () => {
     expect((global as any).Input.send).toHaveBeenCalledWith('zejdz ze statku');
     expect(client.sendEvent).toHaveBeenCalledWith('refreshPositionWhenAble');
   });
+
+  test('does not bind boarding command when already on ship', () => {
+    parse('Tratwa przybija do brzegu.');
+    const [, boardCallback] = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
+    boardCallback();
+    client.FunctionalBind.set.mockClear();
+    parse('Tratwa przybija do brzegu.');
+    expect(client.FunctionalBind.set).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- track whether player is already on a ship
- avoid setting board bind after docking
- trigger refreshPositionWhenAble before executing disembark commands
- test for the new behaviour

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6863a764a724832ab0ec8fb28d62aa5b