### PR TITLE
Fix default settings injection

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -65,6 +65,12 @@ function loadIframe(tabId) {
     chrome.scripting.executeScript({
         target: {tabId: tabId},
         func: async () => {
+            const defaultSettings = {
+                prettyContainers: true,
+                collectMode: 3,
+                collectMoneyType: 1,
+                collectExtra: []
+            }
 
             let download = async (url, ttl) => {
                 return chrome.storage.local.get(url).then(item => {


### PR DESCRIPTION
## Summary
- define `defaultSettings` in injected script so background doesn't crash

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6863ac1e8538832a95e280ca006ec2c4