### PR TITLE
Update gate hotkey to Ctrl+2

### DIFF
--- a/client/src/scripts/gates.ts
+++ b/client/src/scripts/gates.ts
@@ -2,7 +2,7 @@ import Client from "../Client";
 import { FunctionalBind } from "./functionalBind";
 
 export default function initGates(client: Client) {
-    const bind = new FunctionalBind(client, { key: "F2", ctrl: true, label: "CTRL+F2" });
+    const bind = new FunctionalBind(client, { key: "Digit2", ctrl: true, label: "CTRL+2" });
     const knock = () => {
         Input.send("zastukaj we wrota");
     };

--- a/client/test/gates.test.ts
+++ b/client/test/gates.test.ts
@@ -24,7 +24,7 @@ describe('gates triggers', () => {
   });
 
   test('binding is set and callback sends command', () => {
-    expect(FunctionalBind).toHaveBeenCalledWith(client, { key: 'F2', ctrl: true, label: 'CTRL+F2' });
+    expect(FunctionalBind).toHaveBeenCalledWith(client, { key: 'Digit2', ctrl: true, label: 'CTRL+2' });
     expect(set).toHaveBeenCalledTimes(1);
     const initCb = set.mock.calls[0][1];
     initCb();


### PR DESCRIPTION
## Summary
- bind gate trigger to `Ctrl+2`
- update corresponding unit test

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6863adfdfb90832aa5e260264a868c3c