### PR TITLE
Add bank deposit tracking

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -117,6 +117,7 @@ function connectToBackground(extensionId: string) {
         port.postMessage({type: 'GET_STORAGE', key: 'settings'})
         port.postMessage({type: 'GET_STORAGE', key: 'kill_counter'})
         port.postMessage({type: 'GET_STORAGE', key: 'containers'})
+        port.postMessage({type: 'GET_STORAGE', key: 'deposits'})
         isInitialConnection = false
     }
     port.onDisconnect.addListener(() => {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -209,8 +209,10 @@ import initContainers from "./scripts/prettyContainers"
 initContainers(client)
 
 import initBagManager from "./scripts/bagManager"
+import initDeposits from "./scripts/deposits"
 
 initBagManager(client, aliases)
+initDeposits(client, aliases)
 
 import initLvlCalc from "./scripts/lvlCalc"
 import initItemCondition from "./scripts/itemCondition"

--- a/client/src/scripts/deposits.ts
+++ b/client/src/scripts/deposits.ts
@@ -1,0 +1,72 @@
+import Client from "../Client";
+import { stripAnsiCodes } from "../Triggers";
+
+interface DepositInfo {
+    name: string;
+    items: string[] | null;
+}
+
+const deposits: Record<number, DepositInfo> = {};
+
+function isBankRoom(room: any): boolean {
+    return !!room?.userData?.bind && room.userData.bind.includes("depozyt");
+}
+
+export default function initDeposits(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
+    function update(items: string[] | null) {
+        const room = client.Map.currentRoom as any;
+        if (!isBankRoom(room)) {
+            return;
+        }
+        deposits[room.id] = {
+            name: room.name || `Bank ${room.id}`,
+            items,
+        };
+    }
+
+    const matchContents = (_raw: string, line: string) => {
+        return stripAnsiCodes(line).match(/^Twoj depozyt zawiera (.+)\.$/);
+    };
+    const matchEmpty = (_raw: string, line: string) => {
+        return stripAnsiCodes(line).match(/^Twoj depozyt jest pusty\./);
+    };
+    const matchNone = (_raw: string, line: string) => {
+        return stripAnsiCodes(line).match(/^Nie posiadasz wykupionego depozytu\./);
+    };
+
+    client.Triggers.registerTrigger(matchContents, (_r, _l, m) => {
+        const text = m[1].replace(/\.$/, "");
+        const items = text.split(/,\s*/).map(i => i.trim()).filter(Boolean);
+        update(items);
+        return undefined;
+    });
+    client.Triggers.registerTrigger(matchEmpty, () => { update([]); return undefined; });
+    client.Triggers.registerTrigger(matchNone, () => { update(null); return undefined; });
+
+    function printDeposits() {
+        const lines: string[] = [];
+        Object.values(deposits).forEach(({ name, items }) => {
+            let line: string;
+            if (items === null) {
+                line = `${name}: brak depozytu`;
+            } else if (items.length === 0) {
+                line = `${name}: (pusty)`;
+            } else {
+                line = `${name}: ${items.join(", ")}`;
+            }
+            lines.push(line);
+        });
+        if (lines.length === 0) {
+            client.println("Brak zapisanych depozytow.");
+        } else {
+            client.println(lines.join("\n"));
+        }
+    }
+
+    if (aliases) {
+        aliases.push({ pattern: /\/depozyt$/, callback: () => Input.send("przejrzyj depozyt") });
+        aliases.push({ pattern: /\/depozyty$/, callback: printDeposits });
+    }
+}
+
+export { deposits };

--- a/client/test/deposit.test.ts
+++ b/client/test/deposit.test.ts
@@ -1,0 +1,53 @@
+import initDeposits, { deposits } from '../src/scripts/deposits';
+import Triggers from '../src/Triggers';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+  Map = { currentRoom: { id: 1, name: 'Bank', userData: { bind: '/depozyt' } } } as any;
+  println = jest.fn();
+}
+
+describe('deposits', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+  let refresh: () => void;
+  let show: () => void;
+
+  beforeEach(() => {
+    (global as any).Input = { send: jest.fn() };
+    client = new FakeClient();
+    const aliases: { pattern: RegExp; callback: () => void }[] = [];
+    initDeposits((client as unknown) as any, aliases);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    refresh = aliases[0].callback;
+    show = aliases[1].callback;
+    Object.keys(deposits).forEach(k => delete deposits[parseInt(k)]);
+    jest.clearAllMocks();
+  });
+
+  test('refresh command sends query', () => {
+    refresh();
+    expect((global as any).Input.send).toHaveBeenCalledWith('przejrzyj depozyt');
+  });
+
+  test('parses deposit contents', () => {
+    parse('Twoj depozyt zawiera miecz, tarcza.');
+    expect(deposits[1].items).toEqual(['miecz', 'tarcza']);
+  });
+
+  test('handles empty deposit', () => {
+    parse('Twoj depozyt jest pusty.');
+    expect(deposits[1].items).toEqual([]);
+  });
+
+  test('handles no deposit', () => {
+    parse('Nie posiadasz wykupionego depozytu.');
+    expect(deposits[1].items).toBeNull();
+  });
+
+  test('prints deposits', () => {
+    parse('Twoj depozyt zawiera miecz.');
+    show();
+    expect(client.println).toHaveBeenCalledWith(expect.stringContaining('miecz'));
+  });
+});


### PR DESCRIPTION
## Summary
- implement deposit tracker and add /depozyt and /depozyty commands
- integrate deposit feature in main client initialization
- cover new functionality with unit tests

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68644f1a0f18832a97d4279afcb204fb