### PR TITLE
Add stun event demo

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -177,8 +177,10 @@ initBuses(client)
 initGates(client)
 
 import initKillTrigger from "./scripts/kill"
+import initStun from "./scripts/stun"
 
 initKillTrigger(client, aliases)
+initStun(client)
 
 import ItemCollector from "./scripts/itemCollector"
 

--- a/client/src/scripts/stun.ts
+++ b/client/src/scripts/stun.ts
@@ -1,0 +1,62 @@
+import Client from "../Client";
+import { encloseColor, findClosestColor } from "../Colors";
+
+export default function initStun(client: Client) {
+    const tag = "stun";
+    const STUN_COLOR = findClosestColor("#ff0000");
+    const NPC_COLOR = findClosestColor("#fffaf0");
+
+    const stunPrefix = (raw: string) =>
+        client.prefix(raw, encloseColor("[OGLUCH] ", STUN_COLOR)) +
+        "\n\n[   OGLUCH   ] ----- JESTES OGLUSZONY -----\n\n";
+    const endLine = "\n\n[   OGLUCH   ] ----- KONIEC OGLUCHA -----\n\n";
+    const golemPrefix = (raw: string) =>
+        client.prefix(raw, encloseColor("[OGLUCH] ", NPC_COLOR));
+
+    const startPatterns = [
+        /Powoli osuwasz sie na ziemie/,
+        /Potem robi sie ciemno/,
+        /Sila uderzania zamroczyla cie/,
+        /tak silnym, ze swiat przed twoimi oczami niknie/,
+        /Przymroczony tym uderzeniem czujesz jak nogi/,
+        /wali cie na odlew .* chwiejesz/,
+        /uderza cie w glowe i czujesz, ze tracisz przytomnosc/,
+        /Uderzenie w glowe oglusza cie i powala na ziemie\./,
+        /znienacka kopie cie w noge i kiedy tracisz rytm walki, przywala ci piescia prosto w nos\./,
+        /Ktos bez zastanowienia uderza cie piescia w szczeke, robiac to z taka sila, ze niemal powala cie na ziemie\./,
+        /silnym ciosem .* oglusza cie\b/,
+        /Gigantyczny drapiezny troll pochyla leb i szarzuje, by uderzyc cie kreconymi rogami prosto w klatke piersiowa\. Potezny cios odrzuca cie i wyrywa oddech z piersi\./,
+        /^(Saurgl|Posepny okrutny rycerz chaosu) pochyla glowe i z przerazliwa sila uderza dlugimi, ostro zakonczonymi rogami wyrastajacymi mu spod czarnego helmu\. Potezny cios odrzuca cie i wyrywa oddech z piersi\.$/,
+        / poteznym ciosem ogona oglusza cie\./,
+    ];
+
+    const endPatterns = [
+        /Powoli dochodzisz do siebie/,
+        /Czujesz jak slabosc po zadanym ciosie w glowe mija/,
+        /Udaje ci sie uwolnic z sieci/,
+        /Powoli odzyskujesz swobode ruchow/,
+    ];
+
+    const golemPatterns = [
+        /golem w mgnieniu oka uderza w [A-Za-z]+, a on.? wyrwan. z oslupienia, probuje ratowac sie krokiem w tyl\. Jednak wiele to nie pomaga i sila uderzenia odrzuca/,
+        /^Niespodziewanie kamienny golem wyciaga reke i uderza w glowe .*$/,
+    ];
+
+    startPatterns.forEach(p =>
+        client.Triggers.registerTrigger(p, (raw) => {
+            client.sendEvent("stunStart");
+            return stunPrefix(raw);
+        }, tag)
+    );
+
+    endPatterns.forEach(p =>
+        client.Triggers.registerTrigger(p, () => {
+            client.sendEvent("stunEnd");
+            return endLine;
+        }, tag)
+    );
+
+    golemPatterns.forEach(p =>
+        client.Triggers.registerTrigger(p, raw => golemPrefix(raw), tag)
+    );
+}

--- a/client/test/stun.test.ts
+++ b/client/test/stun.test.ts
@@ -1,0 +1,39 @@
+import initStun from '../src/scripts/stun';
+import Triggers from '../src/Triggers';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+  prefix = jest.fn((line: string, prefix: string) => prefix + line);
+  sendEvent = jest.fn();
+}
+
+describe('stun triggers', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initStun((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    jest.clearAllMocks();
+  });
+
+  test('stun start sends event and formats line', () => {
+    const result = parse('Powoli osuwasz sie na ziemie');
+    expect(client.sendEvent).toHaveBeenCalledWith('stunStart');
+    expect(result).toContain('[   OGLUCH   ] ----- JESTES OGLUSZONY -----');
+  });
+
+  test('stun end sends event', () => {
+    const result = parse('Powoli dochodzisz do siebie');
+    expect(client.sendEvent).toHaveBeenCalledWith('stunEnd');
+    expect(result).toContain('KONIEC OGLUCHA');
+  });
+
+  test('golem stun prefixes line without events', () => {
+    const line = 'golem w mgnieniu oka uderza w Bob, a on wyrwany z oslupienia, probuje ratowac sie krokiem w tyl. Jednak wiele to nie pomaga i sila uderzenia odrzuca';
+    const result = parse(line);
+    expect(result).toContain('[OGLUCH]');
+    expect(client.sendEvent).not.toHaveBeenCalled();
+  });
+});

--- a/sandbox/src/Controls.tsx
+++ b/sandbox/src/Controls.tsx
@@ -13,6 +13,7 @@ import compassDemo from "./scenario/compass-demo.ts";
 import containersDemo from "./scenario/containers-demo.ts";
 import inventoryDemo from "./scenario/inventory-demo.ts";
 import lvlCalcDemo from "./scenario/lvl-calc-demo.ts";
+import stunDemo from "./scenario/stun-demo.ts";
 
 
 export function Controls() {
@@ -94,6 +95,13 @@ export function Controls() {
                         onClick={() => busesDemo.run()}
                     >
                         Buses Demo
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => stunDemo.run()}
+                    >
+                        Stun Demo
                     </Button>
                 </div>,
                 document.getElementById('sandbox-buttons')!,

--- a/sandbox/src/scenario/stun-demo.ts
+++ b/sandbox/src/scenario/stun-demo.ts
@@ -1,0 +1,8 @@
+import ClientScript from "../ClientScript.ts";
+import { fakeClient } from "../fakeClient.ts";
+
+export default new ClientScript(fakeClient)
+    .reset()
+    .fake("Powoli osuwasz sie na ziemie")
+    .fake("Powoli dochodzisz do siebie")
+    .fake("golem w mgnieniu oka uderza w Bob, a on wyrwany z oslupienia, probuje ratowac sie krokiem w tyl. Jednak wiele to nie pomaga i sila uderzenia odrzuca");


### PR DESCRIPTION
## Summary
- add new Stun Demo to sandbox
- show stun start, end, and golem lines

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_68645e377ce8832aafb7dfbd2eada17c