### PR TITLE
Add attack beep triggers

### DIFF
--- a/client/src/Colors.ts
+++ b/client/src/Colors.ts
@@ -274,6 +274,9 @@ export function encloseColor(string: string, colorCode: number) {
 
 export function colorString(rawLine: string, string: string, colorCode: number) {
     const matchIndex = rawLine.indexOf(string)
+    if (matchIndex === -1) {
+        return rawLine
+    }
     return rawLine.substring(0, matchIndex) + color(colorCode) + string + RESET + rawLine.substring(matchIndex + string.length)
 }
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -171,10 +171,12 @@ client.Triggers.registerTrigger('Wykonuje komende \'idz ', (): undefined => {
 import initShips from "./scripts/ships"
 import initBuses from "./scripts/buses"
 import initGates from "./scripts/gates"
+import initAttackBeep from "./scripts/attackBeep"
 
 initShips(client)
 initBuses(client)
 initGates(client)
+initAttackBeep(client)
 
 import initKillTrigger from "./scripts/kill"
 

--- a/client/src/scripts/attackBeep.ts
+++ b/client/src/scripts/attackBeep.ts
@@ -4,11 +4,10 @@ import {colorString, encloseColor, findClosestColor} from "../Colors";
 const RED = findClosestColor("#ff0000");
 
 function highlightAttack(line: string, upper?: string) {
-    let colored = encloseColor(line, RED);
-    if (upper && colored.includes(upper)) {
-        colored = colored.replace(upper, upper.toUpperCase());
+    if (upper && line.includes(upper)) {
+        line = line.replace(upper, upper.toUpperCase());
     }
-    return colored;
+    return encloseColor(line, RED);
 }
 
 function highlightPhrase(line: string) {

--- a/client/src/scripts/attackBeep.ts
+++ b/client/src/scripts/attackBeep.ts
@@ -1,9 +1,17 @@
 import Client from "../Client";
-import {colorString, findClosestColor} from "../Colors";
+import {colorString, encloseColor, findClosestColor} from "../Colors";
 
 const RED = findClosestColor("#ff0000");
 
-function highlightAttack(line: string) {
+function highlightAttack(line: string, upper?: string) {
+    let colored = encloseColor(line, RED);
+    if (upper && colored.includes(upper)) {
+        colored = colored.replace(upper, upper.toUpperCase());
+    }
+    return colored;
+}
+
+function highlightPhrase(line: string) {
     const phrase = "atakuje cie";
     const colored = colorString(line, phrase, RED);
     return colored.replace(phrase, phrase.toUpperCase());
@@ -11,20 +19,21 @@ function highlightAttack(line: string) {
 
 export default function initAttackBeep(client: Client) {
     const tag = "attackBeep";
-    const beep = (_: string, line: string): string => {
+    const beep = (raw: string, _line: string, matches: RegExpMatchArray): string => {
         client.playSound("beep");
-        return highlightAttack(line);
+        const upper = (matches.groups && (matches.groups as any).upper) as string | undefined;
+        return highlightAttack(raw, upper);
     };
 
     [
-        /(.*) atakuje cie!/,
-        /(.*) atakuje cie nie dajac ci czasu na skontrowanie swojego ataku!/,
-        /^Ku twojemu zdumieniu, (.*) pojawil sie nagle tuz obok ciebie!/,
-        /^Oczy (.*) zachodza woalem rytualnego transu, gdy jak blyskawica rzuca sie on na ciebie, rozniecajac burze Tanca Smierci!/,
-        /^W oczach (.*) rozpala sie swiety ogien nienawisci i z imieniem Morra na ustach (rzuca sie do walki z toba)!/,
-        /^\w+(?: \w+){0,4} z determinacja i pewnoscia siebie unosi swoja bron i (naciera na ciebie)!/,
-        /^\w+(?: \w+){0,4} z pierwotna wsciekloscia (rzuca sie na ciebie), rozpoczynajac walke!/
+        /(?<name>.*) atakuje cie!/,
+        /(?<name>.*) atakuje cie nie dajac ci czasu na skontrowanie swojego ataku!/,
+        /^Ku twojemu zdumieniu, (?<name>.*) pojawil sie nagle tuz obok ciebie!/,
+        /^Oczy (?<name>.*) zachodza woalem rytualnego transu, gdy jak blyskawica rzuca sie on na ciebie, rozniecajac burze Tanca Smierci!/,
+        /^W oczach (?<name>.*) rozpala sie swiety ogien nienawisci i z imieniem Morra na ustach (?<upper>rzuca sie do walki z toba)!/,
+        /^\w+(?: \w+){0,4} z determinacja i pewnoscia siebie unosi swoja bron i (?<upper>naciera na ciebie)!/,
+        /^\w+(?: \w+){0,4} z pierwotna wsciekloscia (?<upper>rzuca sie na ciebie), rozpoczynajac walke!/
     ].forEach(p => client.Triggers.registerTrigger(p, beep, tag));
 
-    client.Triggers.registerTrigger("atakuje cie!", (_r, line) => highlightAttack(line), tag);
+    client.Triggers.registerTrigger(/^atakuje cie!$/, (_r, line) => highlightPhrase(line), tag);
 }

--- a/client/src/scripts/attackBeep.ts
+++ b/client/src/scripts/attackBeep.ts
@@ -1,0 +1,30 @@
+import Client from "../Client";
+import {colorString, findClosestColor} from "../Colors";
+
+const RED = findClosestColor("#ff0000");
+
+function highlightAttack(line: string) {
+    const phrase = "atakuje cie";
+    const colored = colorString(line, phrase, RED);
+    return colored.replace(phrase, phrase.toUpperCase());
+}
+
+export default function initAttackBeep(client: Client) {
+    const tag = "attackBeep";
+    const beep = (_: string, line: string): string => {
+        client.playSound("beep");
+        return highlightAttack(line);
+    };
+
+    [
+        /(.*) atakuje cie!/,
+        /(.*) atakuje cie nie dajac ci czasu na skontrowanie swojego ataku!/,
+        /^Ku twojemu zdumieniu, (.*) pojawil sie nagle tuz obok ciebie!/,
+        /^Oczy (.*) zachodza woalem rytualnego transu, gdy jak blyskawica rzuca sie on na ciebie, rozniecajac burze Tanca Smierci!/,
+        /^W oczach (.*) rozpala sie swiety ogien nienawisci i z imieniem Morra na ustach (rzuca sie do walki z toba)!/,
+        /^\w+(?: \w+){0,4} z determinacja i pewnoscia siebie unosi swoja bron i (naciera na ciebie)!/,
+        /^\w+(?: \w+){0,4} z pierwotna wsciekloscia (rzuca sie na ciebie), rozpoczynajac walke!/
+    ].forEach(p => client.Triggers.registerTrigger(p, beep, tag));
+
+    client.Triggers.registerTrigger("atakuje cie!", (_r, line) => highlightAttack(line), tag);
+}

--- a/client/test/attackBeep.test.ts
+++ b/client/test/attackBeep.test.ts
@@ -1,0 +1,33 @@
+import initAttackBeep from '../src/scripts/attackBeep';
+import Triggers from '../src/Triggers';
+import {findClosestColor} from '../src/Colors';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+  playSound = jest.fn();
+}
+
+describe('attack beep triggers', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initAttackBeep((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    jest.clearAllMocks();
+  });
+
+  test('beeps and highlights on attack', () => {
+    const result = parse('Wojownik atakuje cie!');
+    expect(client.playSound).toHaveBeenCalledTimes(1);
+    const prefix = `\x1B[22;38;5;${findClosestColor('#ff0000') + 1}m`;
+    expect(result).toContain(prefix + 'ATAKUJE CIE');
+  });
+
+  test('does not beep on plain phrase trigger', () => {
+    const result = parse('atakuje cie!');
+    expect(client.playSound).not.toHaveBeenCalled();
+    expect(result).toContain('ATAKUJE CIE');
+  });
+});

--- a/client/test/attackBeep.test.ts
+++ b/client/test/attackBeep.test.ts
@@ -22,12 +22,24 @@ describe('attack beep triggers', () => {
     const result = parse('Wojownik atakuje cie!');
     expect(client.playSound).toHaveBeenCalledTimes(1);
     const prefix = `\x1B[22;38;5;${findClosestColor('#ff0000') + 1}m`;
-    expect(result).toContain(prefix + 'ATAKUJE CIE');
+    expect(result.startsWith(prefix)).toBe(true);
+    expect(result).toContain('Wojownik atakuje cie!');
+    expect(result.endsWith('\x1B[0m')).toBe(true);
+  });
+
+  test('uppercases selected phrase', () => {
+    const line = 'W oczach Eamon rozpala sie swiety ogien nienawisci i z imieniem Morra na ustach rzuca sie do walki z toba!';
+    const result = parse(line);
+    expect(result).toContain('RZUCA SIE DO WALKI Z TOBA');
   });
 
   test('does not beep on plain phrase trigger', () => {
     const result = parse('atakuje cie!');
     expect(client.playSound).not.toHaveBeenCalled();
+    const prefix = `\x1B[22;38;5;${findClosestColor('#ff0000') + 1}m`;
+    expect(result.startsWith(prefix)).toBe(true);
     expect(result).toContain('ATAKUJE CIE');
+    expect(result.includes('\x1B[0m')).toBe(true);
+    expect(result.endsWith('!')).toBe(true);
   });
 });

--- a/client/test/colorString.test.ts
+++ b/client/test/colorString.test.ts
@@ -1,0 +1,8 @@
+import { colorString } from '../src/Colors';
+
+describe('colorString', () => {
+  test('returns input when substring missing', () => {
+    const input = 'some text';
+    expect(colorString(input, 'missing', 1)).toBe(input);
+  });
+});

--- a/sandbox/src/Controls.tsx
+++ b/sandbox/src/Controls.tsx
@@ -13,6 +13,7 @@ import compassDemo from "./scenario/compass-demo.ts";
 import containersDemo from "./scenario/containers-demo.ts";
 import inventoryDemo from "./scenario/inventory-demo.ts";
 import lvlCalcDemo from "./scenario/lvl-calc-demo.ts";
+import attackBeepDemo from "./scenario/attack-beep-demo.ts";
 
 
 export function Controls() {
@@ -87,6 +88,13 @@ export function Controls() {
                         onClick={() => shipsDemo.run()}
                     >
                         Ships Demo
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => attackBeepDemo.run()}
+                    >
+                        Attack Beep Demo
                     </Button>
                     <Button
                         size="sm"

--- a/sandbox/src/scenario/attack-beep-demo.ts
+++ b/sandbox/src/scenario/attack-beep-demo.ts
@@ -1,0 +1,16 @@
+import ClientScript from "../ClientScript.ts";
+import { fakeClient } from "../fakeClient.ts";
+
+const lines = [
+    "Wojownik atakuje cie!",
+    "W oczach Eamon rozpala sie swiety ogien nienawisci i z imieniem Morra na ustach rzuca sie do walki z toba!",
+    "Ku twojemu zdumieniu, potwor pojawil sie nagle tuz obok ciebie!"
+];
+
+function pick() {
+    return lines[Math.floor(Math.random() * lines.length)];
+}
+
+export default new ClientScript(fakeClient)
+    .reset()
+    .call(() => fakeClient.fake(pick()));


### PR DESCRIPTION
## Summary
- highlight attack messages and beep
- test attack beep triggers
- add Attack Beep demo in sandbox

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_68645ecb59e0832abbfede546f726bbd