### PR TITLE
Reset functional bind message per line

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -3,7 +3,7 @@ import PackageHelper from "./PackageHelper";
 import MapHelper from "./MapHelper";
 import InlineCompassRose from "./scripts/inlineCompassRose";
 import {Howl} from "howler"
-import {FunctionalBind} from "./scripts/functionalBind";
+import {FunctionalBind, LINE_START_EVENT} from "./scripts/functionalBind";
 import OutputHandler from "./OutputHandler";
 import {rawSend} from "./main";
 import TeamManager from "./TeamManager";
@@ -65,6 +65,7 @@ export default class Client {
     }
 
     onLine(line: string, type: string) {
+        this.eventTarget.dispatchEvent(new CustomEvent(LINE_START_EVENT));
         const buffer: { out: string, type?: string }[] = [];
         const originalOutputSend = Output.send;
         Output.send = (out: string, outputType?: string): any => {

--- a/client/src/scripts/functionalBind.ts
+++ b/client/src/scripts/functionalBind.ts
@@ -1,6 +1,8 @@
 import {color} from "../Colors";
 import Client from "../Client";
 
+export const LINE_START_EVENT = 'line-start';
+
 export interface FunctionalBindOptions {
     key?: string;
     label?: string;
@@ -15,6 +17,7 @@ export class FunctionalBind {
     private functionalBind = () => {};
     private button?: HTMLInputElement;
     private currentPrintable: string | null = null;
+    private printedInMessage = false;
     private key: string;
     private label: string;
     private ctrl: boolean;
@@ -39,14 +42,25 @@ export class FunctionalBind {
                 ev.preventDefault();
             }
         })
+
+        this.client.addEventListener(LINE_START_EVENT, () => this.newMessage());
+    }
+
+    newMessage() {
+        this.printedInMessage = false;
     }
 
     set(printable: string | null, callback: () => void) {
         this.functionalBind = callback;
         if (this.currentPrintable === printable) {
+            if (printable && !this.printedInMessage) {
+                this.client.println(`\t${color(49)}bind ${color(222)}${this.label}${color(49)}: ${printable}`);
+                this.printedInMessage = true;
+            }
             return;
         }
         this.currentPrintable = printable;
+        this.printedInMessage = true;
         this.button?.remove();
         if (printable) {
             this.client.println(`\t${color(49)}bind ${color(222)}${this.label}${color(49)}: ${printable}`);
@@ -57,6 +71,7 @@ export class FunctionalBind {
     clear() {
         this.functionalBind = () => {};
         this.currentPrintable = null;
+        this.printedInMessage = false;
         this?.button?.remove();
     }
 

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -29,7 +29,13 @@ jest.mock('howler', () => {
 jest.mock('../src/Triggers', () => ({ __esModule: true, default: jest.fn().mockImplementation(() => ({ parseLine: jest.fn((l: string) => l) })) }));
 jest.mock('../src/PackageHelper', () => ({ __esModule: true, default: jest.fn() }));
 jest.mock('../src/OutputHandler', () => ({ __esModule: true, default: jest.fn() }));
-jest.mock('../src/scripts/functionalBind', () => ({ FunctionalBind: jest.fn() }));
+jest.mock('../src/scripts/functionalBind', () => ({
+  FunctionalBind: jest.fn().mockImplementation(() => ({
+    set: jest.fn(),
+    clear: jest.fn(),
+    newMessage: jest.fn(),
+  })),
+}));
 jest.mock('../src/main', () => ({ __esModule: true, rawSend: jest.fn() }));
 
 

--- a/client/test/PackageHelper.test.ts
+++ b/client/test/PackageHelper.test.ts
@@ -24,7 +24,7 @@ describe('PackageHelper', () => {
       println: jest.fn(),
       Map: { currentRoom: { id: 123 } },
       port: { postMessage: jest.fn() },
-      FunctionalBind: { set: jest.fn(), clear: jest.fn() },
+      FunctionalBind: { set: jest.fn(), clear: jest.fn(), newMessage: jest.fn() },
     };
     helper = new PackageHelper(client);
   });

--- a/client/test/buses.test.ts
+++ b/client/test/buses.test.ts
@@ -3,7 +3,7 @@ import Triggers from '../src/Triggers';
 
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
-  FunctionalBind = { set: jest.fn(), clear: jest.fn() };
+  FunctionalBind = { set: jest.fn(), clear: jest.fn(), newMessage: jest.fn() };
   playSound = jest.fn();
 }
 

--- a/client/test/gates.test.ts
+++ b/client/test/gates.test.ts
@@ -1,7 +1,7 @@
 import Triggers from '../src/Triggers';
 
 const set = jest.fn();
-const FunctionalBind = jest.fn().mockImplementation(() => ({ set }));
+const FunctionalBind = jest.fn().mockImplementation(() => ({ set, newMessage: jest.fn() }));
 jest.mock('../src/scripts/functionalBind', () => ({ FunctionalBind }));
 
 import initGates from '../src/scripts/gates';

--- a/client/test/ships.test.ts
+++ b/client/test/ships.test.ts
@@ -3,7 +3,7 @@ import Triggers from '../src/Triggers';
 
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
-  FunctionalBind = { set: jest.fn(), clear: jest.fn() };
+  FunctionalBind = { set: jest.fn(), clear: jest.fn(), newMessage: jest.fn() };
   playSound = jest.fn();
   sendEvent = jest.fn();
 }


### PR DESCRIPTION
## Summary
- ensure functional bind message can display again on a new line using an event
- `FunctionalBind` listens for a new `line-start` event
- dispatch that event from `Client.onLine`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6864601235a8832aaa36c77b50c09639