### PR TITLE
Add configurable key binds

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -3,7 +3,7 @@ import PackageHelper from "./PackageHelper";
 import MapHelper from "./MapHelper";
 import InlineCompassRose from "./scripts/inlineCompassRose";
 import {Howl} from "howler"
-import {FunctionalBind, LINE_START_EVENT} from "./scripts/functionalBind";
+import {FunctionalBind, LINE_START_EVENT, formatLabel} from "./scripts/functionalBind";
 import OutputHandler from "./OutputHandler";
 import {rawSend} from "./main";
 import TeamManager from "./TeamManager";
@@ -37,6 +37,19 @@ export default class Client {
 
 
         Object.values(this.sounds).forEach((sound) => sound.load())
+
+        this.addEventListener('settings', (ev: CustomEvent) => {
+            const bind = ev.detail?.binds?.main
+            if (bind) {
+                this.FunctionalBind.updateOptions({
+                    key: bind.key,
+                    ctrl: bind.ctrl,
+                    alt: bind.alt,
+                    shift: bind.shift,
+                    label: formatLabel(bind)
+                })
+            }
+        })
     }
 
     connect(port: chrome.runtime.Port) {

--- a/client/src/scripts/functionalBind.ts
+++ b/client/src/scripts/functionalBind.ts
@@ -11,6 +11,25 @@ export interface FunctionalBindOptions {
     shift?: boolean;
 }
 
+export function formatLabel(options: FunctionalBindOptions) {
+    let key = options.key ?? '';
+    if (key.startsWith('Digit')) {
+        key = key.substring(5);
+    } else if (key.startsWith('Key')) {
+        key = key.substring(3);
+    } else if (key === 'BracketRight') {
+        key = ']';
+    } else if (key === 'BracketLeft') {
+        key = '[';
+    }
+    const parts = [] as string[];
+    if (options.ctrl) parts.push('CTRL');
+    if (options.alt) parts.push('ALT');
+    if (options.shift) parts.push('SHIFT');
+    parts.push(key);
+    return parts.join('+');
+}
+
 export class FunctionalBind {
 
     private client: Client;
@@ -73,6 +92,20 @@ export class FunctionalBind {
         this.currentPrintable = null;
         this.printedInMessage = false;
         this?.button?.remove();
+    }
+
+    updateOptions(options: FunctionalBindOptions = {}) {
+        if (options.key) {
+            this.key = options.key;
+        }
+        if (options.label) {
+            this.label = options.label;
+        } else if (options.key) {
+            this.label = options.key === 'BracketRight' ? ']' : options.key;
+        }
+        if (options.ctrl !== undefined) this.ctrl = !!options.ctrl;
+        if (options.alt !== undefined) this.alt = !!options.alt;
+        if (options.shift !== undefined) this.shift = !!options.shift;
     }
 
 }

--- a/client/src/scripts/gates.ts
+++ b/client/src/scripts/gates.ts
@@ -1,8 +1,20 @@
 import Client from "../Client";
-import { FunctionalBind } from "./functionalBind";
+import { FunctionalBind, formatLabel } from "./functionalBind";
 
 export default function initGates(client: Client) {
     const bind = new FunctionalBind(client, { key: "Digit2", ctrl: true, label: "CTRL+2" });
+    client.addEventListener('settings', (ev: CustomEvent) => {
+        const opts = ev.detail?.binds?.gates;
+        if (opts) {
+            bind.updateOptions({
+                key: opts.key,
+                ctrl: opts.ctrl,
+                alt: opts.alt,
+                shift: opts.shift,
+                label: formatLabel(opts)
+            });
+        }
+    });
     const knock = () => {
         Input.send("zastukaj we wrota");
     };

--- a/client/src/scripts/itemCollector.ts
+++ b/client/src/scripts/itemCollector.ts
@@ -1,5 +1,5 @@
 import Client from "../Client";
-import { FunctionalBind } from "./functionalBind";
+import { FunctionalBind, formatLabel } from "./functionalBind";
 
 export default class ItemCollector {
     private client: Client;
@@ -25,6 +25,18 @@ export default class ItemCollector {
     constructor(client: Client) {
         this.client = client;
         this.bind = new FunctionalBind(client, { key: "Digit3", ctrl: true, label: "CTRL+3" });
+        this.client.addEventListener('settings', (ev: CustomEvent) => {
+            const o = ev.detail?.binds?.collector;
+            if (o) {
+                this.bind.updateOptions({
+                    key: o.key,
+                    ctrl: o.ctrl,
+                    alt: o.alt,
+                    shift: o.shift,
+                    label: formatLabel(o)
+                });
+            }
+        });
         this.bind.set(null, () => this.keyPressed(true));
         this.client.addEventListener("settings", (ev: CustomEvent) => {
             const s = ev.detail || {};

--- a/client/test/gates.test.ts
+++ b/client/test/gates.test.ts
@@ -8,6 +8,7 @@ import initGates from '../src/scripts/gates';
 
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
+  addEventListener = jest.fn();
 }
 
 describe('gates triggers', () => {

--- a/extension/background.js
+++ b/extension/background.js
@@ -2,7 +2,12 @@ const defaultSettings = {
     prettyContainers: true,
     collectMode: 3,
     collectMoneyType: 1,
-    collectExtra: []
+    collectExtra: [],
+    binds: {
+        main: { key: 'BracketRight' },
+        gates: { key: 'Digit2', ctrl: true },
+        collector: { key: 'Digit3', ctrl: true }
+    }
 }
 
 chrome.commands.onCommand.addListener(shortcut => {
@@ -69,7 +74,12 @@ function loadIframe(tabId) {
                 prettyContainers: true,
                 collectMode: 3,
                 collectMoneyType: 1,
-                collectExtra: []
+                collectExtra: [],
+                binds: {
+                    main: { key: 'BracketRight' },
+                    gates: { key: 'Digit2', ctrl: true },
+                    collector: { key: 'Digit3', ctrl: true }
+                }
             }
 
             let download = async (url, ttl) => {

--- a/options/src/App.tsx
+++ b/options/src/App.tsx
@@ -3,10 +3,11 @@ import {useState} from "react";
 import SettingsForm from "./Settings.tsx";
 import Npc from "./Npc.tsx";
 import SettingsFile from "./SettingsFile";
+import Binds from "./Binds";
 
 
 function App() {
-    const [tab, setTab] = useState<'settings' | 'npc' | 'file'>('settings')
+    const [tab, setTab] = useState<'settings' | 'npc' | 'file' | 'binds'>('settings')
 
     return (
         <div className="p-2">
@@ -29,10 +30,17 @@ function App() {
                 >
                     Plik ustawień
                 </button>
+                <button
+                    className={`cursor-pointer px-4 py-2 font-medium ${tab === 'binds' ? 'border-b-2 border-blue-500' : ''}`}
+                    onClick={() => setTab('binds')}
+                >
+                    Bindowanie
+                </button>
             </div>
             {tab === 'settings' && <SettingsForm />}
             {tab === 'npc' && <Npc />}
             {tab === 'file' && <SettingsFile />}
+            {tab === 'binds' && <Binds />}
         </div>
     )
 }

--- a/options/src/Binds.tsx
+++ b/options/src/Binds.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState, KeyboardEvent } from "react";
+import storage from "./storage";
+
+interface Bind {
+    key: string;
+    ctrl?: boolean;
+    alt?: boolean;
+    shift?: boolean;
+}
+
+interface BindSettings {
+    main: Bind;
+    gates: Bind;
+    collector: Bind;
+}
+
+const defaultBinds: BindSettings = {
+    main: { key: 'BracketRight' },
+    gates: { key: 'Digit2', ctrl: true },
+    collector: { key: 'Digit3', ctrl: true },
+};
+
+function label(bind: Bind) {
+    let key = bind.key;
+    if (key.startsWith('Digit')) key = key.substring(5);
+    else if (key.startsWith('Key')) key = key.substring(3);
+    else if (key === 'BracketRight') key = ']';
+    else if (key === 'BracketLeft') key = '[';
+    const parts: string[] = [];
+    if (bind.ctrl) parts.push('CTRL');
+    if (bind.alt) parts.push('ALT');
+    if (bind.shift) parts.push('SHIFT');
+    parts.push(key);
+    return parts.join('+');
+}
+
+function Binds() {
+    const [binds, setBinds] = useState<BindSettings>(defaultBinds);
+
+    useEffect(() => {
+        storage.getItem('settings').then(res => {
+            setBinds({ ...defaultBinds, ...(res.settings?.binds || {}) });
+        });
+    }, []);
+
+    function handleCapture(name: keyof BindSettings, ev: KeyboardEvent<HTMLInputElement>) {
+        ev.preventDefault();
+        const { code, ctrlKey, altKey, shiftKey } = ev;
+        setBinds(prev => ({ ...prev, [name]: { key: code, ctrl: ctrlKey, alt: altKey, shift: shiftKey } }));
+    }
+
+    function save() {
+        storage.getItem('settings').then(res => {
+            const settings = { ...(res.settings || {}), binds };
+            storage.setItem('settings', settings).then(() => {
+                if (chrome.runtime) {
+                    window.close();
+                }
+            });
+        });
+    }
+
+    return (
+        <div className="m-2 flex flex-col gap-3">
+            <label className="flex items-center gap-2">
+                <span className="w-32">Domyślny</span>
+                <input
+                    type="text"
+                    readOnly
+                    className="input input-bordered input-sm w-40"
+                    value={label(binds.main)}
+                    onKeyDown={ev => handleCapture('main', ev)}
+                />
+            </label>
+            <label className="flex items-center gap-2">
+                <span className="w-32">Wrota</span>
+                <input
+                    type="text"
+                    readOnly
+                    className="input input-bordered input-sm w-40"
+                    value={label(binds.gates)}
+                    onKeyDown={ev => handleCapture('gates', ev)}
+                />
+            </label>
+            <label className="flex items-center gap-2">
+                <span className="w-32">Zbieranie</span>
+                <input
+                    type="text"
+                    readOnly
+                    className="input input-bordered input-sm w-40"
+                    value={label(binds.collector)}
+                    onKeyDown={ev => handleCapture('collector', ev)}
+                />
+            </label>
+            <button className="btn btn-primary mt-2" onClick={save}>Zapisz</button>
+        </div>
+    );
+}
+
+export default Binds;


### PR DESCRIPTION
## Summary
- make FunctionalBind updateable and expose label formatter
- allow editing binds in options UI
- support new binds in client modules
- expose binds via extension default settings

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686468dce540832abb9f8b11897e8b9d