### PR TITLE
Add deposit sandbox demo

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -101,9 +101,13 @@ export default class MapHelper {
                     return direction
                 }
             }
-            const allExits = Object.assign({}, this.currentRoom.exits, this.currentRoom.specialExits);
+            const allExits = Object.assign(
+                {},
+                this.currentRoom.exits ?? {},
+                this.currentRoom.specialExits ?? {}
+            );
             const potentialExit = getLongDir(direction);
-            if (!this.currentRoom.exits[potentialExit]) {
+            if (!this.currentRoom.exits || !this.currentRoom.exits[potentialExit]) {
                 const exits = Object.entries(allExits).filter(([_, id]) => {
                     const target = this.mapReader.getRoomById(id);
                     return this.findRoomByExit(this.currentRoom, target, getLongDir(direction));

--- a/sandbox/src/Controls.tsx
+++ b/sandbox/src/Controls.tsx
@@ -13,6 +13,7 @@ import compassDemo from "./scenario/compass-demo.ts";
 import containersDemo from "./scenario/containers-demo.ts";
 import inventoryDemo from "./scenario/inventory-demo.ts";
 import lvlCalcDemo from "./scenario/lvl-calc-demo.ts";
+import depositDemo from "./scenario/deposit-demo.ts";
 
 
 export function Controls() {
@@ -66,6 +67,13 @@ export function Controls() {
                         onClick={() => inventoryDemo.run()}
                     >
                         Inventory Demo
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => depositDemo.run()}
+                    >
+                        Deposit Demo
                     </Button>
                     <Button
                         size="sm"

--- a/sandbox/src/scenario/deposit-demo.ts
+++ b/sandbox/src/scenario/deposit-demo.ts
@@ -1,0 +1,11 @@
+import ClientScript from "../ClientScript.ts";
+import { fakeClient } from "../fakeClient.ts";
+
+export default new ClientScript(fakeClient)
+    .reset()
+    .call(() => {
+        fakeClient.Map.currentRoom = { id: 1, name: 'Bank', userData: { bind: '/depozyt' } } as any;
+    })
+    .send('/depozyt')
+    .fake('Twoj depozyt zawiera miecz, tarcza.')
+    .send('/depozyty');


### PR DESCRIPTION
## Summary
- create deposit-demo sandbox scenario
- add Deposit Demo button in sandbox controls
- fix MapHelper crash for rooms without exits

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_686467e199e0832aa7541bf15bdfc352