### PR TITLE
Fix attack highlight and color helper

### DIFF
--- a/client/src/Colors.ts
+++ b/client/src/Colors.ts
@@ -274,6 +274,9 @@ export function encloseColor(string: string, colorCode: number) {
 
 export function colorString(rawLine: string, string: string, colorCode: number) {
     const matchIndex = rawLine.indexOf(string)
+    if (matchIndex === -1) {
+        return rawLine
+    }
     return rawLine.substring(0, matchIndex) + color(colorCode) + string + RESET + rawLine.substring(matchIndex + string.length)
 }
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -171,10 +171,12 @@ client.Triggers.registerTrigger('Wykonuje komende \'idz ', (): undefined => {
 import initShips from "./scripts/ships"
 import initBuses from "./scripts/buses"
 import initGates from "./scripts/gates"
+import initAttackBeep from "./scripts/attackBeep"
 
 initShips(client)
 initBuses(client)
 initGates(client)
+initAttackBeep(client)
 
 import initKillTrigger from "./scripts/kill"
 

--- a/client/src/scripts/attackBeep.ts
+++ b/client/src/scripts/attackBeep.ts
@@ -1,0 +1,38 @@
+import Client from "../Client";
+import {colorString, encloseColor, findClosestColor} from "../Colors";
+
+const RED = findClosestColor("#ff0000");
+
+function highlightAttack(line: string, upper?: string) {
+    if (upper && line.includes(upper)) {
+        line = line.replace(upper, upper.toUpperCase());
+    }
+    return encloseColor(line, RED);
+}
+
+function highlightPhrase(line: string) {
+    const phrase = "atakuje cie";
+    const colored = colorString(line, phrase, RED);
+    return colored.replace(phrase, phrase.toUpperCase());
+}
+
+export default function initAttackBeep(client: Client) {
+    const tag = "attackBeep";
+    const beep = (raw: string, _line: string, matches: RegExpMatchArray): string => {
+        client.playSound("beep");
+        const upper = (matches.groups && (matches.groups as any).upper) as string | undefined;
+        return highlightAttack(raw, upper);
+    };
+
+    [
+        /(?<name>.*) atakuje cie!/,
+        /(?<name>.*) atakuje cie nie dajac ci czasu na skontrowanie swojego ataku!/,
+        /^Ku twojemu zdumieniu, (?<name>.*) pojawil sie nagle tuz obok ciebie!/,
+        /^Oczy (?<name>.*) zachodza woalem rytualnego transu, gdy jak blyskawica rzuca sie on na ciebie, rozniecajac burze Tanca Smierci!/,
+        /^W oczach (?<name>.*) rozpala sie swiety ogien nienawisci i z imieniem Morra na ustach (?<upper>rzuca sie do walki z toba)!/,
+        /^\w+(?: \w+){0,4} z determinacja i pewnoscia siebie unosi swoja bron i (?<upper>naciera na ciebie)!/,
+        /^\w+(?: \w+){0,4} z pierwotna wsciekloscia (?<upper>rzuca sie na ciebie), rozpoczynajac walke!/
+    ].forEach(p => client.Triggers.registerTrigger(p, beep, tag));
+
+    client.Triggers.registerTrigger(/^atakuje cie!$/, (_r, line) => highlightPhrase(line), tag);
+}

--- a/client/test/attackBeep.test.ts
+++ b/client/test/attackBeep.test.ts
@@ -1,0 +1,45 @@
+import initAttackBeep from '../src/scripts/attackBeep';
+import Triggers from '../src/Triggers';
+import {findClosestColor} from '../src/Colors';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+  playSound = jest.fn();
+}
+
+describe('attack beep triggers', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initAttackBeep((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    jest.clearAllMocks();
+  });
+
+  test('beeps and highlights on attack', () => {
+    const result = parse('Wojownik atakuje cie!');
+    expect(client.playSound).toHaveBeenCalledTimes(1);
+    const prefix = `\x1B[22;38;5;${findClosestColor('#ff0000') + 1}m`;
+    expect(result.startsWith(prefix)).toBe(true);
+    expect(result).toContain('Wojownik atakuje cie!');
+    expect(result.endsWith('\x1B[0m')).toBe(true);
+  });
+
+  test('uppercases selected phrase', () => {
+    const line = 'W oczach Eamon rozpala sie swiety ogien nienawisci i z imieniem Morra na ustach rzuca sie do walki z toba!';
+    const result = parse(line);
+    expect(result).toContain('RZUCA SIE DO WALKI Z TOBA');
+  });
+
+  test('does not beep on plain phrase trigger', () => {
+    const result = parse('atakuje cie!');
+    expect(client.playSound).not.toHaveBeenCalled();
+    const prefix = `\x1B[22;38;5;${findClosestColor('#ff0000') + 1}m`;
+    expect(result.startsWith(prefix)).toBe(true);
+    expect(result).toContain('ATAKUJE CIE');
+    expect(result.includes('\x1B[0m')).toBe(true);
+    expect(result.endsWith('!')).toBe(true);
+  });
+});

--- a/client/test/colorString.test.ts
+++ b/client/test/colorString.test.ts
@@ -1,0 +1,8 @@
+import { colorString } from '../src/Colors';
+
+describe('colorString', () => {
+  test('returns input when substring missing', () => {
+    const input = 'some text';
+    expect(colorString(input, 'missing', 1)).toBe(input);
+  });
+});

--- a/options/src/Settings.tsx
+++ b/options/src/Settings.tsx
@@ -23,6 +23,7 @@ const collectMoneyOptions = ["wszystkie", "srebrne", "zlote"]
 
 interface Settings {
     guilds: string[];
+    enemyGuilds: string[];
     packageHelper: boolean;
     replaceMap: boolean;
     inlineCompassRose: boolean;
@@ -37,6 +38,7 @@ function SettingsForm() {
 
     const [settings, setSettings] = useState<Settings>({
         guilds: [],
+        enemyGuilds: [],
         packageHelper: false,
         replaceMap: false,
         inlineCompassRose: false,
@@ -48,6 +50,7 @@ function SettingsForm() {
     })
 
     const allSelected = settings.guilds.length === guilds.length
+    const allEnemySelected = settings.enemyGuilds.length === guilds.length
     const [extraInput, setExtraInput] = useState<string>('')
 
     function onChangeSetting(modifier: (settings: Settings) => void) {
@@ -71,6 +74,22 @@ function SettingsForm() {
         setSettings(prev => ({
             ...prev,
             guilds: event.target.checked ? [...guilds] : []
+        }))
+    }
+
+    function onChangeEnemy(event: ChangeEvent<HTMLInputElement>, guild: string) {
+        setSettings(prev => {
+            const enemyGuilds = event.target.checked
+                ? [...prev.enemyGuilds, guild]
+                : prev.enemyGuilds.filter(g => g !== guild)
+            return {...prev, enemyGuilds}
+        })
+    }
+
+    function onChangeAllEnemy(event: ChangeEvent<HTMLInputElement>) {
+        setSettings(prev => ({
+            ...prev,
+            enemyGuilds: event.target.checked ? [...guilds] : []
         }))
     }
 
@@ -117,6 +136,38 @@ function SettingsForm() {
                                     onChange={event => onChange(event, guild)}
                                     className="checkbox checkbox-sm mx-1"
                                     checked={settings.guilds.indexOf(guild) != -1}
+                                />
+                                {guild}
+                            </label>
+                        ))}
+                    </div>
+                </div>
+                <div className="mb-4 border border-secondary rounded-box p-3 bg-neutral/10">
+                    <div className="flex items-center justify-between mb-2">
+                        <h5 className="font-bold">Gildie wrogów (alarm ataku)</h5>
+                        <label className="flex items-center gap-1" key="all-enemy-guilds">
+                            <input
+                                type="checkbox"
+                                id="enemy-guild-all"
+                                name="enemy-guild-all"
+                                onChange={event => onChangeAllEnemy(event)}
+                                className="checkbox checkbox-sm mx-1"
+                                checked={allEnemySelected}
+                            />
+                            Wszystkie
+                        </label>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                        {guilds.map(guild => (
+                            <label className="flex items-center gap-1 w-20" key={`enemy-${guild}`}>
+                                <input
+                                    type="checkbox"
+                                    id={`enemy-guild-${guild}`}
+                                    name="enemy-guild"
+                                    value={guild}
+                                    onChange={event => onChangeEnemy(event, guild)}
+                                    className="checkbox checkbox-sm mx-1"
+                                    checked={settings.enemyGuilds.indexOf(guild) != -1}
                                 />
                                 {guild}
                             </label>

--- a/sandbox/src/Controls.tsx
+++ b/sandbox/src/Controls.tsx
@@ -13,6 +13,7 @@ import compassDemo from "./scenario/compass-demo.ts";
 import containersDemo from "./scenario/containers-demo.ts";
 import inventoryDemo from "./scenario/inventory-demo.ts";
 import lvlCalcDemo from "./scenario/lvl-calc-demo.ts";
+import attackBeepDemo from "./scenario/attack-beep-demo.ts";
 
 
 export function Controls() {
@@ -87,6 +88,13 @@ export function Controls() {
                         onClick={() => shipsDemo.run()}
                     >
                         Ships Demo
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => attackBeepDemo.run()}
+                    >
+                        Attack Beep Demo
                     </Button>
                     <Button
                         size="sm"

--- a/sandbox/src/scenario/attack-beep-demo.ts
+++ b/sandbox/src/scenario/attack-beep-demo.ts
@@ -1,0 +1,16 @@
+import ClientScript from "../ClientScript.ts";
+import { fakeClient } from "../fakeClient.ts";
+
+const lines = [
+    "Wojownik atakuje cie!",
+    "W oczach Eamon rozpala sie swiety ogien nienawisci i z imieniem Morra na ustach rzuca sie do walki z toba!",
+    "Ku twojemu zdumieniu, potwor pojawil sie nagle tuz obok ciebie!"
+];
+
+function pick() {
+    return lines[Math.floor(Math.random() * lines.length)];
+}
+
+export default new ClientScript(fakeClient)
+    .reset()
+    .call(() => fakeClient.fake(pick()));


### PR DESCRIPTION
## Summary
- avoid highlighting bug when substring is missing
- uppercase attack phrase before coloring
- test colorString fallback behavior

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_68645ecb59e0832abbfede546f726bbd