### PR TITLE
Fix ship boarding trigger for ferry

### DIFF
--- a/client/src/scripts/ships.ts
+++ b/client/src/scripts/ships.ts
@@ -54,7 +54,7 @@ export default function initShips(client: Client) {
     client.Triggers.registerTrigger(/^(?!Ktos|Jakis|Jakas).*(Doplynelismy.*(Mozna|w calej swej)|Marynarze sprawnie cumuja)/, disembark, "ships");
 
     [
-        /^[a-zA-Z]+ [a-z]+ prom[^a-z]$/,
+        /^[a-zA-Z]+ [a-z]+ prom(?:$|[^a-z])/,
         /^Prom(\.|,| i)/,
         /^Barka(\.|,| i)/,
     ].forEach(p => client.Triggers.registerTrigger(p, board(true), "ships"));

--- a/client/test/attackBeep.test.ts
+++ b/client/test/attackBeep.test.ts
@@ -5,6 +5,7 @@ import {findClosestColor} from '../src/Colors';
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
   playSound = jest.fn();
+  addEventListener = jest.fn();
 }
 
 describe('attack beep triggers', () => {
@@ -15,6 +16,11 @@ describe('attack beep triggers', () => {
     client = new FakeClient();
     initAttackBeep((client as unknown) as any);
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    // initialize with some enemy guilds so beeping is enabled
+    const handler = client.addEventListener.mock.calls[0]?.[1];
+    if (handler) {
+      handler({ detail: { enemyGuilds: ['foo'] } } as any);
+    }
     jest.clearAllMocks();
   });
 

--- a/client/test/ships.test.ts
+++ b/client/test/ships.test.ts
@@ -65,4 +65,12 @@ describe('ships triggers', () => {
     parse('Tratwa przybija do brzegu.');
     expect(client.FunctionalBind.set).not.toHaveBeenCalled();
   });
+
+  test('prom without punctuation binds and beeps', () => {
+    parse('Szeroki zielony prom');
+    expect(client.playSound).toHaveBeenCalledTimes(1);
+    expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
+    const [label] = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
+    expect(label).toBe('wem;kup bilet;wsiadz na statek;wlm');
+  });
 });


### PR DESCRIPTION
## Summary
- handle ferry names without punctuation
- test that a ferry with no punctuation still binds
- fix attack beep tests after enemy guild settings change

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68654dde15d4832a968576e4ad70b1ad