### PR TITLE
Adjust sandbox layout

### DIFF
--- a/sandbox/src/client/style.css
+++ b/sandbox/src/client/style.css
@@ -49,7 +49,9 @@ h1 {
   flex: 1;
   overflow-y: auto;
   padding: 1rem;
+  padding-bottom: 5rem;
   font-family: monospace;
+  font-size: 0.85rem;
 }
 
 #app {
@@ -145,7 +147,8 @@ button:focus-visible {
 }
 
 #iframe-container {
-  position: relative;
+  position: sticky;
+  top: 0;
   width: 100%;
   height: 300px;
   max-height: 30vh;
@@ -156,6 +159,7 @@ iframe {
   width: 100%;
   height: 100%;
   border: none;
+  opacity: 0.7;
 }
 
 /* Mobile-specific styles */
@@ -173,6 +177,7 @@ iframe {
   #main_text_output_msg_wrapper {
     padding: 0.75rem;
     font-size: 14px;
+    padding-bottom: 5rem;
     -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */
   }
 


### PR DESCRIPTION
## Summary
- tweak sandbox layout so map stays visible
- show map with some transparency
- reduce font in output
- add padding so text isn't hidden behind sticky input

## Testing
- `yarn --cwd client test` *(fails: rawInputSend is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_686822ba1914832a87f122e6ed2ff0a1