### PR TITLE
Fix sandbox click processing

### DIFF
--- a/sandbox/src/client/main.ts
+++ b/sandbox/src/client/main.ts
@@ -37,17 +37,19 @@ window.dispatchEvent(new CustomEvent("map-ready", {
 
 // Set up message event listener for UI updates
 client.on('message', (message: string) => {
-    // Get the content area element
     const contentArea = document.getElementById('main_text_output_msg_wrapper');
     if (contentArea) {
-        // Create a new div for the message
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('output_msg');
+
         const messageDiv = document.createElement('div');
-        messageDiv.innerHTML = message
+        messageDiv.innerHTML = message;
         messageDiv.classList.add('output_msg_text');
         messageDiv.style.borderRadius = '4px';
         messageDiv.style.whiteSpace = 'pre-wrap';
 
-        contentArea.appendChild(messageDiv);
+        wrapper.appendChild(messageDiv);
+        contentArea.appendChild(wrapper);
         contentArea.scrollTop = contentArea.scrollHeight;
     }
 });


### PR DESCRIPTION
## Summary
- ensure sandbox client's output handler wraps text in `.output_msg` with `.output_msg_text`

## Testing
- `yarn --cwd client test` *(fails: TypeError `(0 , main_1.rawInputSend) is not a function`)*

------
https://chatgpt.com/codex/tasks/task_e_6868f88abab0832a97e6c92e6b917b28