### PR TITLE
Add map loading progress bar in sandbox

### DIFF
--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -10,7 +10,11 @@
 (window as any).Gmcp = { parse_option_subnegotiation: jest.fn() };
 const parseCommand = jest.fn((cmd: string) => `parsed:${cmd}`);
 
-jest.mock('../src/main', () => ({ rawSend: jest.fn() }));
+jest.mock('../src/main', () => ({
+  __esModule: true,
+  rawInputSend: jest.fn((cmd: string) => (window as any).Input.send(cmd)),
+  rawOutputSend: jest.fn(),
+}));
 
 import Client from '../src/Client';
 import { Howl } from 'howler';
@@ -36,7 +40,6 @@ jest.mock('../src/scripts/functionalBind', () => ({
     newMessage: jest.fn(),
   })),
 }));
-jest.mock('../src/main', () => ({ __esModule: true, rawSend: jest.fn() }));
 
 
 jest.mock('../src/MapHelper', () => {

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -16,8 +16,13 @@
             <div id="root"></div>
         </div>
         <div class="right-column h-100">
-            <div id="map" class="border w-100 h-50 mb-2">
+            <div id="map" class="border w-100 h-50 mb-2 position-relative">
                 <iframe id="cm-frame" src="embedded.html"></iframe>
+                <div id="map-progress-container" class="position-absolute top-50 start-50 translate-middle w-75">
+                    <div class="progress">
+                        <div id="map-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%"></div>
+                    </div>
+                </div>
             </div>
             <div id="sandbox-buttons"></div>
         </div>

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -112,3 +112,7 @@ iframe {
     height: 25px;
     margin-top: 5px;
 }
+
+#map-progress-container {
+    pointer-events: none;
+}

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -26,11 +26,25 @@ if (!localStorage.getItem('kill_counter')) {
 
 fakeClient.eventTarget.dispatchEvent(new CustomEvent("npc", {detail: npc}));
 const frame: HTMLIFrameElement = document.getElementById("cm-frame")! as HTMLIFrameElement;
+const progressContainer = document.getElementById('map-progress-container')!;
+const progressBar = document.getElementById('map-progress-bar') as HTMLElement;
+
+progressContainer.style.display = 'none';
+
+function updateProgress(p: number) {
+    progressContainer.style.display = 'block';
+    progressBar.style.width = `${p}%`;
+}
+
+const mapPromise = loadMapData(updateProgress);
+const colorsPromise = loadColors();
 
 // Load map data and colors asynchronously
-Promise.all([loadMapData(), loadColors()])
+Promise.all([mapPromise, colorsPromise])
     .then(([mapData, colors]) => {
         console.log('Map data and colors loaded successfully');
+
+        progressContainer.style.display = 'none';
 
         // Send map data to iframe
         frame.contentWindow?.postMessage({mapData, colors}, '*');
@@ -44,6 +58,7 @@ Promise.all([loadMapData(), loadColors()])
         }));
     })
     .catch(error => {
+        progressContainer.style.display = 'none';
         console.error('Failed to load map data or colors:', error);
     });
 


### PR DESCRIPTION
## Summary
- display progress bar when loading map data in sandbox
- support progress callback in `loadMapData`
- wire progress handling into sandbox index script
- expose map progress bar styles
- fix Client.test mock for `rawInputSend`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6869c864b434832a94052df66967b7d4