### PR TITLE
Implement IndexedDB caching for NPCs in sandbox

### DIFF
--- a/sandbox/src/client/main.ts
+++ b/sandbox/src/client/main.ts
@@ -5,7 +5,7 @@ import "@client/src/main.ts"
 import MockPort from "../MockPort.ts";
 import { loadMapData, loadColors } from "../mapDataLoader.ts";
 
-import npc from "../npc.json";
+import { loadNpcData } from "../npcDataLoader.ts";
 // Import map data and colors asynchronously instead of bundling them
 // import mapData from "../../../data/mapExport.json";
 // import colors from "../../../data/colors.json";
@@ -102,8 +102,11 @@ const defaultSettings = {
     collectExtra: []
 }
 
-localStorage.setItem('npc', JSON.stringify(npc))
 localStorage.setItem('settings', JSON.stringify(defaultSettings))
+
+loadNpcData().then(npc => {
+    window.clientExtension.eventTarget.dispatchEvent(new CustomEvent("npc", {detail: npc}))
+})
 
 const port = new MockPort();
 window.clientExtension.connect(port as any, true);
@@ -130,8 +133,6 @@ Promise.all([mapDataPromise, colorsPromise])
     .catch(error => {
         console.error('Failed to load map data or colors:', error);
     });
-
-window.clientExtension.eventTarget.dispatchEvent(new CustomEvent("npc", {detail: npc}))
 
 
 // Set up message event listener for UI updates

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -1,8 +1,8 @@
 import "./sandbox.ts"
 import "@client/src/main.ts"
 
-import npc from "./npc.json";
 import { loadMapData, loadColors } from "./mapDataLoader.ts";
+import { loadNpcData } from "./npcDataLoader.ts";
 import { fakeClient } from "./fakeClient.ts";
 import { demoMap } from "./Controls.tsx";
 
@@ -17,14 +17,16 @@ const defaultSettings = {
     collectExtra: []
 }
 
-localStorage.setItem('npc', JSON.stringify(npc))
 localStorage.setItem('settings', JSON.stringify(defaultSettings))
+
+loadNpcData().then(npc => {
+    fakeClient.eventTarget.dispatchEvent(new CustomEvent("npc", {detail: npc}));
+});
 
 if (!localStorage.getItem('kill_counter')) {
     localStorage.setItem('kill_counter', JSON.stringify({}))
 }
 
-fakeClient.eventTarget.dispatchEvent(new CustomEvent("npc", {detail: npc}));
 const frame: HTMLIFrameElement = document.getElementById("cm-frame")! as HTMLIFrameElement;
 
 // Load map data and colors asynchronously

--- a/sandbox/src/npcDataLoader.ts
+++ b/sandbox/src/npcDataLoader.ts
@@ -1,0 +1,119 @@
+// This file provides a way to load NPC data asynchronously similar to map data loading.
+
+function isIndexedDBSupported() {
+  return 'indexedDB' in window;
+}
+
+async function storeNpcInIndexedDB(data: any) {
+  return new Promise<void>((resolve, reject) => {
+    if (!isIndexedDBSupported()) {
+      reject(new Error('IndexedDB is not supported'));
+      return;
+    }
+
+    const request = indexedDB.open('ArkadiaNpcDB', 1);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains('npcData')) {
+        db.createObjectStore('npcData', { keyPath: 'id' });
+      }
+    };
+
+    request.onsuccess = () => {
+      const db = request.result;
+      const transaction = db.transaction(['npcData'], 'readwrite');
+      const store = transaction.objectStore('npcData');
+
+      const storeRequest = store.put({ id: 'npc', data });
+      storeRequest.onsuccess = () => resolve();
+      storeRequest.onerror = () => reject(new Error('Failed to store data in IndexedDB'));
+    };
+
+    request.onerror = () => {
+      reject(new Error('Failed to open IndexedDB'));
+    };
+  });
+}
+
+async function getNpcFromIndexedDB() {
+  return new Promise<any>((resolve, reject) => {
+    if (!isIndexedDBSupported()) {
+      resolve(null);
+      return;
+    }
+
+    const request = indexedDB.open('ArkadiaNpcDB', 1);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains('npcData')) {
+        db.createObjectStore('npcData', { keyPath: 'id' });
+      }
+    };
+
+    request.onsuccess = () => {
+      const db = request.result;
+      const transaction = db.transaction(['npcData'], 'readonly');
+      const store = transaction.objectStore('npcData');
+
+      const getRequest = store.get('npc');
+      getRequest.onsuccess = () => {
+        if (getRequest.result) {
+          resolve(getRequest.result.data);
+        } else {
+          resolve(null);
+        }
+      };
+      getRequest.onerror = () => {
+        reject(new Error('Failed to get data from IndexedDB'));
+      };
+    };
+
+    request.onerror = () => {
+      reject(new Error('Failed to open IndexedDB'));
+    };
+  });
+}
+
+export async function loadNpcData() {
+  try {
+    const indexedData = await getNpcFromIndexedDB();
+    if (indexedData) {
+      localStorage.setItem('npc', JSON.stringify(indexedData));
+      return indexedData;
+    }
+  } catch (e) {
+    console.warn('Failed to load NPCs from IndexedDB, falling back to localStorage:', e);
+  }
+
+  const cached = localStorage.getItem('npc');
+  if (cached) {
+    try {
+      return JSON.parse(cached);
+    } catch {
+      console.error('Failed to parse cached npc data');
+    }
+  }
+
+  try {
+    const response = await fetch('./data/npc.json');
+    const data = await response.json();
+    try {
+      await storeNpcInIndexedDB(data);
+      console.log('Successfully stored NPC data in IndexedDB');
+    } catch (e) {
+      console.warn('Failed to store NPC data in IndexedDB, falling back to localStorage:', e);
+      try {
+        localStorage.setItem('npc', JSON.stringify(data));
+      } catch (lsErr) {
+        console.error('Failed to cache NPC data in localStorage:', lsErr);
+      }
+    }
+    localStorage.setItem('npc', JSON.stringify(data));
+    return data;
+  } catch (e) {
+    console.error('Failed to load npc data:', e);
+    throw e;
+  }
+}


### PR DESCRIPTION
## Summary
- load NPC data asynchronously using IndexedDB cache
- update sandbox bootstrapping to use the new NPC loader
- send NPC info once loaded in the sandbox client

## Testing
- `yarn --cwd client test` *(fails: rawInputSend is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6869ca80cc0c832a888b671e1b579177