### PR TITLE
Listen for GMCP events

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -8,6 +8,7 @@ import OutputHandler from "./OutputHandler";
 import {rawSend} from "./main";
 import TeamManager from "./TeamManager";
 import {beepSound} from "./sounds";
+import { attachGmcpListener } from "./gmcp";
 
 const originalSend = Input.send
 
@@ -31,6 +32,7 @@ export default class Client {
     }
 
     constructor() {
+        attachGmcpListener(this);
         window.addEventListener('message', ({data: data}) => {
             this.eventTarget.dispatchEvent(new CustomEvent(data.type, {detail: data.payload}))
         })

--- a/client/src/gmcp.ts
+++ b/client/src/gmcp.ts
@@ -8,3 +8,12 @@ export function setGmcp(path: string, value: any) {
     }
     obj[parts[parts.length - 1]] = value;
 }
+
+export function attachGmcpListener(target: { addEventListener: Function }) {
+    target.addEventListener('gmcp', (event: CustomEvent<{ path: string; value: any }>) => {
+        const { path, value } = event.detail || {};
+        if (typeof path === 'string') {
+            setGmcp(path, value);
+        }
+    });
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,7 +1,6 @@
 import Client from "./Client";
 import People from "./People";
 import registerGagTriggers from "./scripts/gags";
-import {setGmcp} from "./gmcp";
 import Port = chrome.runtime.Port;
 
 const gmcpParseOption = Gmcp.parse_option_subnegotiation
@@ -17,7 +16,7 @@ Gmcp.parse_option_subnegotiation = (match) => {
     if (message.substring(0, 1) === 'É') {
         const [type, data] = [message.substring(1, message.indexOf(" ")), message.substring(message.indexOf(" "))]
         const parsed = JSON.parse(data)
-        setGmcp(type, parsed)
+        client.sendEvent('gmcp', { path: type, value: parsed })
         client.sendEvent(`gmcp.${type}`, parsed)
         if (type === "gmcp_msgs") {
             let text = atob(parsed.text)

--- a/client/test/attachGmcpListener.test.ts
+++ b/client/test/attachGmcpListener.test.ts
@@ -1,0 +1,26 @@
+import { gmcp, attachGmcpListener } from '../src/gmcp';
+import { EventEmitter } from 'events';
+
+class FakeClient {
+  private emitter = new EventEmitter();
+  addEventListener(event: string, cb: any) {
+    this.emitter.on(event, cb);
+    return () => this.emitter.off(event, cb);
+  }
+  sendEvent(type: string, detail?: any) {
+    this.emitter.emit(type, { detail });
+  }
+}
+
+describe('attachGmcpListener', () => {
+  beforeEach(() => {
+    (window as any).gmcp = {};
+  });
+
+  test('updates gmcp on gmcp event', () => {
+    const client = new FakeClient();
+    attachGmcpListener(client as any);
+    client.sendEvent('gmcp', { path: 'room.info', value: { id: 5 } });
+    expect(gmcp.room.info).toEqual({ id: 5 });
+  });
+});


### PR DESCRIPTION
## Summary
- listen for GMCP events via new `gmcp` event
- hook GMCP listener inside `Client` constructor
- update GMCP data on `gmcp` events
- add tests for GMCP listener

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6869ca45f770832a9ce43fe95be8c67c