### PR TITLE
Move progress bar to sandbox client

### DIFF
--- a/sandbox/client.html
+++ b/sandbox/client.html
@@ -11,6 +11,11 @@
 <div id="main-container">
     <div id="iframe-container">
         <canvas id="map" resize="true"></canvas>
+        <div id="map-progress-container" class="position-absolute top-50 start-50 translate-middle w-75">
+            <div class="progress">
+                <div id="map-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%"></div>
+            </div>
+        </div>
     </div>
     <div id="main_text_output_msg_wrapper">
 

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -18,11 +18,6 @@
         <div class="right-column h-100">
             <div id="map" class="border w-100 h-50 mb-2 position-relative">
                 <iframe id="cm-frame" src="embedded.html"></iframe>
-                <div id="map-progress-container" class="position-absolute top-50 start-50 translate-middle w-75">
-                    <div class="progress">
-                        <div id="map-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%"></div>
-                    </div>
-                </div>
             </div>
             <div id="sandbox-buttons"></div>
         </div>

--- a/sandbox/src/client/main.ts
+++ b/sandbox/src/client/main.ts
@@ -110,14 +110,26 @@ loadNpcData().then(npc => {
 const port = new MockPort();
 window.clientExtension.connect(port as any, true);
 
+const progressContainer = document.getElementById('map-progress-container')!;
+const progressBar = document.getElementById('map-progress-bar') as HTMLElement;
+
+progressContainer.style.display = 'none';
+
+function updateProgress(p: number) {
+    progressContainer.style.display = 'block';
+    progressBar.style.width = `${p}%`;
+}
+
 // Load map data and colors asynchronously
-let mapDataPromise = loadMapData();
+let mapDataPromise = loadMapData(updateProgress);
 let colorsPromise = loadColors();
 
 // When both are loaded, dispatch events
 Promise.all([mapDataPromise, colorsPromise])
     .then(([mapData, colors]) => {
         console.log('Map data and colors loaded successfully');
+
+        progressContainer.style.display = 'none';
 
         // Dispatch map-ready event
         window.dispatchEvent(new CustomEvent("map-ready", {
@@ -130,6 +142,7 @@ Promise.all([mapDataPromise, colorsPromise])
         window.postMessage({mapData, colors}, '*');
     })
     .catch(error => {
+        progressContainer.style.display = 'none';
         console.error('Failed to load map data or colors:', error);
     });
 

--- a/sandbox/src/client/style.css
+++ b/sandbox/src/client/style.css
@@ -299,3 +299,7 @@ button:focus-visible {
 .mobile-button.no-click {
   pointer-events: none; /* Disable click events */
 }
+
+#map-progress-container {
+  pointer-events: none;
+}

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -112,7 +112,3 @@ iframe {
     height: 25px;
     margin-top: 5px;
 }
-
-#map-progress-container {
-    pointer-events: none;
-}

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -28,25 +28,14 @@ if (!localStorage.getItem('kill_counter')) {
 }
 
 const frame: HTMLIFrameElement = document.getElementById("cm-frame")! as HTMLIFrameElement;
-const progressContainer = document.getElementById('map-progress-container')!;
-const progressBar = document.getElementById('map-progress-bar') as HTMLElement;
 
-progressContainer.style.display = 'none';
-
-function updateProgress(p: number) {
-    progressContainer.style.display = 'block';
-    progressBar.style.width = `${p}%`;
-}
-
-const mapPromise = loadMapData(updateProgress);
+const mapPromise = loadMapData();
 const colorsPromise = loadColors();
 
 // Load map data and colors asynchronously
 Promise.all([mapPromise, colorsPromise])
     .then(([mapData, colors]) => {
         console.log('Map data and colors loaded successfully');
-
-        progressContainer.style.display = 'none';
 
         // Send map data to iframe
         frame.contentWindow?.postMessage({mapData, colors}, '*');
@@ -60,7 +49,6 @@ Promise.all([mapPromise, colorsPromise])
         }));
     })
     .catch(error => {
-        progressContainer.style.display = 'none';
         console.error('Failed to load map data or colors:', error);
     });
 


### PR DESCRIPTION
## Summary
- show map loading progress in sandbox client page instead of index
- remove progress bar logic from index scripts
- keep styling for progress bar with new CSS rule

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686a32b87da0832a999ea6c6b2143fba