### PR TITLE
Show map download progress in KB

### DIFF
--- a/sandbox/src/client/main.ts
+++ b/sandbox/src/client/main.ts
@@ -115,9 +115,16 @@ const progressBar = document.getElementById('map-progress-bar') as HTMLElement;
 
 progressContainer.style.display = 'none';
 
-function updateProgress(p: number) {
+function updateProgress(p: number, loaded?: number, total?: number) {
     progressContainer.style.display = 'block';
     progressBar.style.width = `${p}%`;
+    if (loaded !== undefined && total !== undefined && total > 0) {
+        const loadedKb = Math.floor(loaded / 1024);
+        const totalKb = Math.ceil(total / 1024);
+        progressBar.textContent = `${loadedKb} / ${totalKb} KB`;
+    } else {
+        progressBar.textContent = `${Math.floor(p)}%`;
+    }
 }
 
 // Load map data and colors asynchronously

--- a/sandbox/src/mapDataLoader.ts
+++ b/sandbox/src/mapDataLoader.ts
@@ -102,7 +102,7 @@ async function getFromIndexedDB() {
  * Loads the map data asynchronously from a URL, IndexedDB, or local storage
  * @returns Promise that resolves with the map data
  */
-export async function loadMapData(onProgress?: (progress: number) => void) {
+export async function loadMapData(onProgress?: (progress: number, loaded?: number, total?: number) => void) {
   // Try to load from IndexedDB first
   try {
     const indexedDBData = await getFromIndexedDB();
@@ -144,7 +144,7 @@ export async function loadMapData(onProgress?: (progress: number) => void) {
         if (value) {
           chunks.push(value);
           received += value.length;
-          onProgress?.(Math.min(100, (received / total) * 100));
+          onProgress?.(Math.min(100, (received / total) * 100), received, total);
         }
       }
       const all = new Uint8Array(received);
@@ -156,7 +156,7 @@ export async function loadMapData(onProgress?: (progress: number) => void) {
       data = JSON.parse(new TextDecoder().decode(all));
     } else {
       data = await response.json();
-      onProgress?.(100);
+      onProgress?.(100, total || undefined, total || undefined);
     }
 
     // Try to store in IndexedDB first


### PR DESCRIPTION
## Summary
- extend map data loader progress callback to include bytes
- display downloaded kilobytes on progress bar in sandbox client

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686a38093ab8832a8f9869f3e4369bae