### PR TITLE
Move docs modal to sandbox client

### DIFF
--- a/sandbox/client.html
+++ b/sandbox/client.html
@@ -24,6 +24,7 @@
         <input type="text" id="message-input" autocomplete="off" autocapitalize="off" spellcheck="false" />
         <button id="send-button">➢</button>
         <button id="connect-button">Connect</button>
+        <button id="docs-button">Docs</button>
     </div>
 
     <!-- Mobile Direction Buttons (hidden by default) -->
@@ -49,5 +50,6 @@
 </div>
 <script type="module" src="/src/client/plugin.ts"></script>
 <script type="module" src="/src/client/main.ts"></script>
+<script type="module" src="/src/client/docs.ts"></script>
 </body>
 </html>

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "ansi-to-html": "^0.7.2",
     "bootstrap": "^5.3.7",
+    "marked": "^16.0.0",
     "react": "^19.1.0",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.1.0",

--- a/sandbox/src/client/docs.ts
+++ b/sandbox/src/client/docs.ts
@@ -1,0 +1,54 @@
+import {marked} from "marked";
+import aliasesMd from "../../../docs/ALIASES.md?raw";
+import bagManagerMd from "../../../docs/BAG_MANAGER.md?raw";
+
+interface DocDef { key: string; title: string; md: string; }
+const docs: DocDef[] = [
+    { key: 'aliases', title: 'Aliasy', md: aliasesMd },
+    { key: 'bag', title: 'Mened\u017cer pojemnik\u00f3w', md: bagManagerMd },
+];
+
+function createModal() {
+    const modal = document.createElement('div');
+    modal.id = 'docs-modal';
+    modal.className = 'hidden';
+    modal.innerHTML = `
+<div class="docs-modal-content">
+  <div class="docs-nav">
+    ${docs.map(d => `<button data-key="${d.key}">${d.title}</button>`).join('')}
+    <button id="docs-close">X</button>
+  </div>
+  <div id="docs-content" class="docs-content"></div>
+</div>`;
+    document.body.appendChild(modal);
+    return modal;
+}
+
+function initDocs() {
+    const docsButton = document.getElementById('docs-button') as HTMLButtonElement | null;
+    if (!docsButton) return;
+
+    const modal = createModal();
+    const content = modal.querySelector('#docs-content') as HTMLElement;
+    const closeBtn = modal.querySelector('#docs-close') as HTMLButtonElement;
+    const navButtons = Array.from(modal.querySelectorAll('.docs-nav button[data-key]')) as HTMLButtonElement[];
+
+    function showDoc(key: string) {
+        const doc = docs.find(d => d.key === key);
+        if (!doc) return;
+        content.innerHTML = marked.parse(doc.md);
+        modal.classList.remove('hidden');
+    }
+
+    navButtons.forEach(btn => {
+        btn.addEventListener('click', () => showDoc(btn.dataset.key!));
+    });
+
+    closeBtn.addEventListener('click', () => {
+        modal.classList.add('hidden');
+    });
+
+    docsButton.addEventListener('click', () => showDoc(docs[0].key));
+}
+
+document.addEventListener('DOMContentLoaded', initDocs);

--- a/sandbox/src/client/docs.ts
+++ b/sandbox/src/client/docs.ts
@@ -33,10 +33,11 @@ function initDocs() {
     const closeBtn = modal.querySelector('#docs-close') as HTMLButtonElement;
     const navButtons = Array.from(modal.querySelectorAll('.docs-nav button[data-key]')) as HTMLButtonElement[];
 
-    function showDoc(key: string) {
+    async function showDoc(key: string) {
         const doc = docs.find(d => d.key === key);
         if (!doc) return;
-        content.innerHTML = marked.parse(doc.md);
+        const html = await marked.parse(doc.md);
+        content.innerHTML = html as string;
         modal.classList.remove('hidden');
     }
 

--- a/sandbox/src/client/style.css
+++ b/sandbox/src/client/style.css
@@ -309,9 +309,9 @@ button:focus-visible {
   inset: 0;
   background: rgba(0, 0, 0, 0.8);
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  padding: 2vh;
+  padding: 8vh 2vh 2vh;
   z-index: 10000;
 }
 #docs-modal.hidden {
@@ -322,15 +322,23 @@ button:focus-visible {
   border: 1px solid #444;
   padding: 2vh;
   max-height: 90vh;
-  overflow-y: auto;
+  overflow: hidden;
   width: 90vw;
+  display: flex;
+  gap: 2vw;
 }
 .docs-nav {
   display: flex;
+  flex-direction: column;
   gap: 1vmin;
-  margin-bottom: 1em;
+  min-width: 20vw;
 }
 .docs-nav button {
+  width: 100%;
+}
+
+.docs-content {
   flex: 1;
+  overflow-y: auto;
 }
 

--- a/sandbox/src/client/style.css
+++ b/sandbox/src/client/style.css
@@ -303,3 +303,34 @@ button:focus-visible {
 #map-progress-container {
   pointer-events: none;
 }
+
+#docs-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2vh;
+  z-index: 10000;
+}
+#docs-modal.hidden {
+  display: none;
+}
+.docs-modal-content {
+  background: #1a1a1a;
+  border: 1px solid #444;
+  padding: 2vh;
+  max-height: 90vh;
+  overflow-y: auto;
+  width: 90vw;
+}
+.docs-nav {
+  display: flex;
+  gap: 1vmin;
+  margin-bottom: 1em;
+}
+.docs-nav button {
+  flex: 1;
+}
+

--- a/sandbox/src/types/md.d.ts
+++ b/sandbox/src/types/md.d.ts
@@ -1,0 +1,4 @@
+declare module "*.md?raw" {
+    const content: string;
+    export default content;
+}

--- a/sandbox/yarn.lock
+++ b/sandbox/yarn.lock
@@ -1359,6 +1359,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+marked@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-16.0.0.tgz#0c48e79782f26224f8ce34878644d8c320ad599f"
+  integrity sha512-MUKMXDjsD/eptB7GPzxo4xcnLS6oo7/RHimUMHEDRhUooPwmN9BEpMl7AEOJv3bmso169wHI2wUF9VQgL7zfmA==
+
 merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"


### PR DESCRIPTION
## Summary
- remove DocsModal component from sandbox
- add docs button and script in sandbox client page
- style simple modal and load markdown using marked

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_686acdde174c832a8549ee9447215213