### PR TITLE
Add dropdown menu for options and docs

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -37,9 +37,14 @@
     <div id="input-area">
         <input type="text" id="message-input" autocomplete="off" autocapitalize="off" spellcheck="false"/>
         <button id="send-button">➢</button>
+        <div class="dropdown">
+            <button id="menu-button" class="dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">⋮</button>
+            <ul class="dropdown-menu dropdown-menu-end">
+                <li><button class="dropdown-item" id="options-button">Options</button></li>
+                <li><button class="dropdown-item" id="docs-button">Docs</button></li>
+            </ul>
+        </div>
         <button id="connect-button">Connect</button>
-        <button id="options-button">Options</button>
-        <button id="docs-button">Docs</button>
     </div>
 
     <!-- Mobile Direction Buttons (hidden by default) -->

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -2,7 +2,7 @@ import 'bootswatch/dist/darkly/bootstrap.min.css';
 import './style.css'
 import ArkadiaClient from "./ArkadiaClient.ts";
 import "./plugin.ts"
-import { Modal } from 'bootstrap';
+import { Modal, Dropdown } from 'bootstrap';
 
 import "@client/src/main.ts"
 import MockPort from "./MockPort.ts";
@@ -255,11 +255,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const messageInput = document.getElementById('message-input') as HTMLInputElement;
     const sendButton = document.getElementById('send-button') as HTMLButtonElement;
     const connectButton = document.getElementById('connect-button') as HTMLButtonElement;
+    const menuButton = document.getElementById('menu-button') as HTMLButtonElement | null;
     const optionsButton = document.getElementById('options-button') as HTMLButtonElement;
 
     // Initialize Bootstrap modal
     const optionsModalElement = document.getElementById('options-modal');
     const optionsModal = optionsModalElement ? new Modal(optionsModalElement) : null;
+
+    if (menuButton) {
+        new Dropdown(menuButton);
+    }
 
     // Add event listener to options button
     if (optionsButton && optionsModal) {


### PR DESCRIPTION
## Summary
- collapse `Options` and `Docs` buttons under a new dropdown next to the send button
- initialize dropdown in main script

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686b0ff4500c832ab18f7fc956c4d483