### PR TITLE
Fix settings popup closing on save

### DIFF
--- a/options/src/Binds.tsx
+++ b/options/src/Binds.tsx
@@ -51,11 +51,13 @@ function Binds() {
     }
 
     function save() {
-        storage.getItem('settings').then(res => {
-            const settings = { ...(res.settings || {}), binds };
-            storage.setItem('settings', settings).then(() => {
+            storage.getItem('settings').then(res => {
+                const settings = { ...(res.settings || {}), binds };
+                storage.setItem('settings', settings).then(() => {
                 if (chrome.runtime) {
                     window.close();
+                } else {
+                    window.dispatchEvent(new Event('close-options'));
                 }
             });
         });

--- a/options/src/Settings.tsx
+++ b/options/src/Settings.tsx
@@ -98,6 +98,8 @@ function SettingsForm() {
         storage.setItem("settings", settings)
         if (chrome.runtime) {
             window.close()
+        } else {
+            window.dispatchEvent(new Event('close-options'))
         }
     }
 

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -266,6 +266,12 @@ document.addEventListener('DOMContentLoaded', () => {
         new Dropdown(menuButton);
     }
 
+    window.addEventListener('close-options', () => {
+        if (optionsModal) {
+            optionsModal.hide();
+        }
+    });
+
     // Add event listener to options button
     if (optionsButton && optionsModal) {
         optionsButton.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- close settings modal when saving settings in web client
- dispatch `close-options` event from Settings and Binds
- listen for `close-options` in web client

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686b830ff0a4832abf5a9cc8e6fda56b