### PR TITLE
Implement local storage change events for options

### DIFF
--- a/sandbox/src/MockPort.ts
+++ b/sandbox/src/MockPort.ts
@@ -1,3 +1,5 @@
+import storage from "@options/src/storage.ts";
+
 export default class MockPort {
     listeners: Array<(msg: any) => void> = [];
     onMessage = {
@@ -5,6 +7,17 @@ export default class MockPort {
             this.listeners.push(cb);
         }
     };
+
+    constructor() {
+        storage.onChanged?.addListener(changes => {
+            Object.entries(changes).forEach(([key, {newValue}]) => {
+                this.dispatch({storage: {key, value: newValue}});
+                if (key === 'settings' || key === 'npc') {
+                    this.dispatch({[key]: newValue});
+                }
+            });
+        });
+    }
 
     private dispatch(message: any) {
         this.listeners.forEach(l => l(message));

--- a/web-client/src/MockPort.ts
+++ b/web-client/src/MockPort.ts
@@ -1,3 +1,5 @@
+import storage from "@options/src/storage.ts";
+
 export default class MockPort {
     listeners: Array<(msg: any) => void> = [];
     onMessage = {
@@ -5,6 +7,17 @@ export default class MockPort {
             this.listeners.push(cb);
         }
     };
+
+    constructor() {
+        storage.onChanged?.addListener(changes => {
+            Object.entries(changes).forEach(([key, {newValue}]) => {
+                this.dispatch({storage: {key, value: newValue}});
+                if (key === 'settings' || key === 'npc') {
+                    this.dispatch({[key]: newValue});
+                }
+            });
+        });
+    }
 
     private dispatch(message: any) {
         this.listeners.forEach(l => l(message));


### PR DESCRIPTION
## Summary
- enhance options local storage to emit change events similar to `chrome.storage`
- propagate storage change events through web `MockPort` so client listeners behave the same as with the background script

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_686b82aa4ae8832a8409d869f124dd74