### PR TITLE
Add sticky footer to settings page

### DIFF
--- a/options/src/App.css
+++ b/options/src/App.css
@@ -4,3 +4,11 @@ html, body {
     scrollbar-gutter: stable;
     margin: 5px;
 }
+
+.sticky-footer {
+    position: sticky;
+    bottom: 0;
+    background-color: var(--bs-body-bg);
+    border-top: 1px solid var(--bs-border-color);
+    padding: 0.5rem 1rem;
+}

--- a/options/src/Settings.tsx
+++ b/options/src/Settings.tsx
@@ -287,7 +287,9 @@ function SettingsForm() {
                     )}
                 </div>
             </div>
-            <Button className="mt-2" onClick={handleSubmission}>Zapisz</Button>
+        </div>
+        <div className="sticky-footer text-end">
+            <Button onClick={handleSubmission}>Zapisz</Button>
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- add a `.sticky-footer` class in options styles
- use sticky footer with Save button in settings page

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686c407cade4832a91f963aae2423778