### PR TITLE
Make options tab contents scrollable

### DIFF
--- a/options/src/App.css
+++ b/options/src/App.css
@@ -2,6 +2,22 @@ html, body {
     max-width: 760px;
     width: 100%;
     min-height: 100%;
+    height: 100%;
     scrollbar-gutter: stable;
     margin: 5px;
+}
+
+#root {
+    height: 100%;
+}
+
+#root > div {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.tab-content {
+    flex: 1 1 auto;
+    overflow-y: auto;
 }

--- a/options/src/App.tsx
+++ b/options/src/App.tsx
@@ -11,7 +11,7 @@ function App() {
     const [tab, setTab] = useState<'settings' | 'npc' | 'file' | 'binds'>('settings')
 
     return (
-        <div className="p-2">
+        <div className="p-2 d-flex flex-column h-100">
             <Tabs activeKey={tab} onSelect={(k) => k && setTab(k as any)} className="mb-2">
                 <Tab eventKey="settings" title="Ustawienia">
                     <SettingsForm />


### PR DESCRIPTION
## Summary
- make the options window tabs fill available height and scroll when content is long

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686c4465cdb0832a926a03ef6043524d