### PR TITLE
Add login modal to web client

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -44,7 +44,26 @@
                 <li><button class="w-100 p-1" id="docs-button">Docs</button></li>
             </ul>
         </div>
+        <button id="login-button">Login</button>
         <button id="connect-button">Connect</button>
+    </div>
+
+    <div id="login-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Login</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body d-flex flex-column gap-2">
+                    <input id="login-character" class="form-control" placeholder="Character">
+                    <input id="login-password" type="password" class="form-control" placeholder="Password">
+                </div>
+                <div class="modal-footer">
+                    <button id="login-submit" class="btn btn-primary">Login</button>
+                </div>
+            </div>
+        </div>
     </div>
 
     <!-- Mobile Direction Buttons (hidden by default) -->

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -242,12 +242,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const messageInput = document.getElementById('message-input') as HTMLInputElement;
     const sendButton = document.getElementById('send-button') as HTMLButtonElement;
     const connectButton = document.getElementById('connect-button') as HTMLButtonElement;
+    const loginButton = document.getElementById('login-button') as HTMLButtonElement | null;
     const menuButton = document.getElementById('menu-button') as HTMLButtonElement | null;
     const optionsButton = document.getElementById('options-button') as HTMLButtonElement;
 
     // Initialize Bootstrap modal
     const optionsModalElement = document.getElementById('options-modal');
     const optionsModal = optionsModalElement ? new Modal(optionsModalElement) : null;
+    const loginModalElement = document.getElementById('login-modal');
+    const loginModal = loginModalElement ? new Modal(loginModalElement) : null;
+    const loginCharacter = document.getElementById('login-character') as HTMLInputElement | null;
+    const loginPassword = document.getElementById('login-password') as HTMLInputElement | null;
+    const loginSubmit = document.getElementById('login-submit') as HTMLButtonElement | null;
 
     if (menuButton) {
         new Dropdown(menuButton);
@@ -263,6 +269,31 @@ document.addEventListener('DOMContentLoaded', () => {
     if (optionsButton && optionsModal) {
         optionsButton.addEventListener('click', () => {
             optionsModal.show();
+        });
+    }
+
+    if (loginButton && loginModal && loginSubmit) {
+        loginButton.addEventListener('click', () => {
+            loginModal.show();
+        });
+
+        loginSubmit.addEventListener('click', () => {
+            const character = loginCharacter?.value || '';
+            const password = loginPassword?.value || '';
+            loginModal.hide();
+
+            const sendCreds = () => {
+                if (character) Input.send(character);
+                if (password) Input.send(password);
+                client.off('client.connect', sendCreds);
+            };
+
+            if (!isConnected) {
+                client.on('client.connect', sendCreds);
+                client.connect();
+            } else {
+                sendCreds();
+            }
         });
     }
 

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -362,7 +362,8 @@ button:focus-visible {
 }
 
 #options-modal .modal-dialog,
-#docs-modal .modal-dialog {
+#docs-modal .modal-dialog,
+#login-modal .modal-dialog {
   margin-top: 5vh;
   margin-bottom: 5vh;
 }


### PR DESCRIPTION
## Summary
- add Login button and popup
- send credentials upon connecting
- style login modal like others

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686c4a64ab34832aa60b43a994874c12