### PR TITLE
Store GMCP attack/defense target IDs

### DIFF
--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -18,6 +18,8 @@ export default class TeamManager {
     private leader?: string;
     private tag = 'teamManager';
     private accumulatedObjectsData = {}
+    private attackTargetId?: string
+    private defenseTargetId?: string
 
     constructor(client: Client) {
         this.client = client;
@@ -29,10 +31,26 @@ export default class TeamManager {
         }
     }
 
-    private handleObjectsData(data: Record<number,ObjectData>) {
-        Object.assign(this.accumulatedObjectsData, data)
+    private handleObjectsData(data: Record<number, ObjectData>) {
+        Object.entries(data).forEach(([id, obj]) => {
+            this.accumulatedObjectsData[id] = { ...(this.accumulatedObjectsData as any)[id], ...obj };
 
-        Object.values(data).forEach(obj => {
+            if (typeof obj.attack_target === 'boolean') {
+                if (obj.attack_target) {
+                    this.attackTargetId = id;
+                } else if (this.attackTargetId === id) {
+                    this.attackTargetId = undefined;
+                }
+            }
+
+            if (typeof obj.defense_target === 'boolean') {
+                if (obj.defense_target) {
+                    this.defenseTargetId = id;
+                } else if (this.defenseTargetId === id) {
+                    this.defenseTargetId = undefined;
+                }
+            }
+
             if (obj && obj.living && obj.team) {
                 const name = obj.desc;
                 if (name) {
@@ -114,6 +132,14 @@ export default class TeamManager {
 
     getAccumulatedObjectsData() {
         return this.accumulatedObjectsData
+    }
+
+    getAttackTargetId() {
+        return this.attackTargetId;
+    }
+
+    getDefenseTargetId() {
+        return this.defenseTargetId;
     }
 
 

--- a/client/test/TeamManager.test.ts
+++ b/client/test/TeamManager.test.ts
@@ -56,4 +56,13 @@ describe('TeamManager', () => {
     expect(members).toEqual(expect.arrayContaining(['Vesper', 'Pablo', 'Opeteh']));
     expect(manager.isInTeam('Pablo')).toBe(true);
   });
+
+  test('stores attack and defense target ids', () => {
+    client.sendEvent('gmcp.objects.data', {
+      '1': { desc: 'Bob', living: true, team: true, attack_target: true },
+      '2': { desc: 'Alice', living: true, team: true, defense_target: true },
+    });
+    expect(manager.getAttackTargetId()).toBe('1');
+    expect(manager.getDefenseTargetId()).toBe('2');
+  });
 });


### PR DESCRIPTION
## Summary
- track attack_target and defense_target object ids when parsing team data
- expose getters for attack and defense target ids
- test storing of attack and defense targets

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686c51d2eaa8832ab69b0b4fd89fea85