### PR TITLE
Center auth buttons

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -45,6 +45,9 @@
                 <li><button class="w-100 p-1" id="docs-button">Docs</button></li>
             </ul>
         </div>
+    </div>
+
+    <div id="auth-buttons">
         <button id="login-button">Login</button>
         <button id="connect-button">Connect</button>
     </div>

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -376,3 +376,13 @@ button:focus-visible {
 .modal-dialog {
   max-height: 85%;
 }
+
+#auth-buttons {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  gap: 1vw;
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- move Login and Connect buttons out of the input bar
- position auth buttons in the middle of the screen

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686c66daaef4832a9fb5063152a48fb2