### PR TITLE
Add ObjectManager

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -7,6 +7,7 @@ import {FunctionalBind, LINE_START_EVENT, formatLabel} from "./scripts/functiona
 import OutputHandler from "./OutputHandler";
 import {rawSend} from "./main";
 import TeamManager from "./TeamManager";
+import ObjectManager from "./ObjectManager";
 import {beepSound} from "./sounds";
 import { attachGmcpListener } from "./gmcp";
 
@@ -22,6 +23,7 @@ export default class Client {
     Map = new MapHelper(this)
     OutputHandler = new OutputHandler(this)
     TeamManager = new TeamManager(this)
+    ObjectManager = new ObjectManager(this)
     inlineCompassRose = new InlineCompassRose(this)
     panel = document.getElementById("panel_buttons_bottom")
     sounds: Record<string, Howl> = {

--- a/client/src/ObjectManager.ts
+++ b/client/src/ObjectManager.ts
@@ -1,0 +1,54 @@
+import Client from "./Client";
+
+export interface ObjectData {
+    desc?: string;
+    hp?: number;
+    attack_num?: boolean | number;
+    attack_target?: boolean;
+    state?: any;
+    [key: string]: any;
+}
+
+export default class ObjectManager {
+    private client: Client;
+    private nums: string[] = [];
+    private data: Record<string, ObjectData> = {};
+
+    constructor(client: Client) {
+        this.client = client;
+        this.client.addEventListener('gmcp.object.nums', (e: CustomEvent) => {
+            this.handleNums(e.detail);
+        });
+        this.client.addEventListener('gmcp.objects.data', (e: CustomEvent) => {
+            this.handleData(e.detail);
+        });
+    }
+
+    private handleNums(detail: any) {
+        if (Array.isArray(detail)) {
+            this.nums = detail.map(String);
+        } else if (detail && Array.isArray(detail.nums)) {
+            this.nums = detail.nums.map(String);
+        } else if (detail && Array.isArray(detail.objects)) {
+            this.nums = detail.objects.map(String);
+        }
+    }
+
+    private handleData(detail: Record<string, ObjectData>) {
+        if (detail && typeof detail === 'object') {
+            Object.assign(this.data, detail);
+        }
+    }
+
+    getObjectsOnLocation() {
+        return this.nums.map(num => {
+            const obj = this.data[num] || {};
+            return {
+                num,
+                desc: obj.desc,
+                state: obj.state ?? obj.hp,
+                attack_target: obj.attack_target,
+            };
+        });
+    }
+}

--- a/client/test/ObjectManager.test.ts
+++ b/client/test/ObjectManager.test.ts
@@ -1,0 +1,46 @@
+import ObjectManager from '../src/ObjectManager';
+import { EventEmitter } from 'events';
+
+class FakeClient {
+  private emitter = new EventEmitter();
+  addEventListener(event: string, cb: any) {
+    this.emitter.on(event, cb);
+    return () => this.emitter.off(event, cb);
+  }
+  removeEventListener(event: string, cb: any) {
+    this.emitter.off(event, cb);
+  }
+  sendEvent(type: string, detail?: any) {
+    this.emitter.emit(type, { detail });
+  }
+}
+
+describe('ObjectManager', () => {
+  let client: FakeClient;
+  let manager: ObjectManager;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    manager = new ObjectManager((client as unknown) as any);
+  });
+
+  test('stores nums and data and returns objects', () => {
+    client.sendEvent('gmcp.objects.data', {
+      '1': { desc: 'Goblin', hp: 5, attack_target: true },
+    });
+    client.sendEvent('gmcp.object.nums', ['1']);
+    expect(manager.getObjectsOnLocation()).toEqual([
+      { num: '1', desc: 'Goblin', state: 5, attack_target: true },
+    ]);
+  });
+
+  test('supports nums property object', () => {
+    client.sendEvent('gmcp.objects.data', {
+      '2': { desc: 'Orc', hp: 10 },
+    });
+    client.sendEvent('gmcp.object.nums', { nums: [2] });
+    expect(manager.getObjectsOnLocation()).toEqual([
+      { num: '2', desc: 'Orc', state: 10, attack_target: undefined },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- create `ObjectManager` class to track location objects via gmcp
- expose ObjectManager from Client
- test object management behaviour

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686d7b78ab20832abb857561803b69eb