### PR TITLE
Add object list overlay in web client

### DIFF
--- a/client/src/ObjectManager.ts
+++ b/client/src/ObjectManager.ts
@@ -82,7 +82,7 @@ export default class ObjectManager {
                 num,
                 desc: obj.desc,
                 state: obj.state ?? obj.hp,
-                attack_target: obj.attack_target,
+                attack_num: obj.attack_num,
                 avatar_target: obj.avatar_target,
             };
         });
@@ -92,7 +92,7 @@ export default class ObjectManager {
                 num: this.playerNum,
                 desc: obj.desc,
                 state: obj.state ?? obj.hp,
-                attack_target: obj.attack_target,
+                attack_num: obj.attack_num,
                 avatar_target: obj.avatar_target,
             });
         }

--- a/client/test/ObjectManager.test.ts
+++ b/client/test/ObjectManager.test.ts
@@ -28,7 +28,7 @@ describe('ObjectManager', () => {
     client.sendEvent('gmcp.objects.data', {
       '1': { desc: 'Goblin', hp: 5, attack_target: true, avatar_target: true },
     });
-    client.sendEvent('gmcp.object.nums', ['1']);
+    client.sendEvent('gmcp.objects.nums', ['1']);
     expect(manager.getObjectsOnLocation()).toEqual([
       { num: '1', desc: 'Goblin', state: 5, attack_target: true, avatar_target: true },
     ]);
@@ -38,7 +38,7 @@ describe('ObjectManager', () => {
     client.sendEvent('gmcp.objects.data', {
       '2': { desc: 'Orc', hp: 10 },
     });
-    client.sendEvent('gmcp.object.nums', { nums: [2] });
+    client.sendEvent('gmcp.objects.nums', { nums: [2] });
     expect(manager.getObjectsOnLocation()).toEqual([
       { num: '2', desc: 'Orc', state: 10, attack_target: undefined, avatar_target: undefined },
     ]);
@@ -47,7 +47,7 @@ describe('ObjectManager', () => {
   test('includes player from char info and state', () => {
     client.sendEvent('gmcp.char.info', { object_num: 99, name: 'Hero' });
     client.sendEvent('gmcp.char.state', { hp: 50 });
-    client.sendEvent('gmcp.object.nums', []);
+    client.sendEvent('gmcp.objects.nums', []);
     expect(manager.getObjectsOnLocation()).toEqual([
       { num: '99', desc: 'Hero', state: 50, attack_target: undefined, avatar_target: undefined },
     ]);
@@ -55,7 +55,7 @@ describe('ObjectManager', () => {
 
   test('sets avatar target flag', () => {
     client.sendEvent('gmcp.objects.data', { '1': { desc: 'Ogre', avatar_target: true } });
-    client.sendEvent('gmcp.object.nums', ['1']);
+    client.sendEvent('gmcp.objects.nums', ['1']);
     expect(manager.getObjectsOnLocation()).toEqual([
       { num: '1', desc: 'Ogre', state: undefined, attack_target: undefined, avatar_target: true },
     ]);

--- a/client/test/ObjectManager.test.ts
+++ b/client/test/ObjectManager.test.ts
@@ -26,11 +26,11 @@ describe('ObjectManager', () => {
 
   test('stores nums and data and returns objects', () => {
     client.sendEvent('gmcp.objects.data', {
-      '1': { desc: 'Goblin', hp: 5, attack_target: true, avatar_target: true },
+      '1': { desc: 'Goblin', hp: 5, attack_num: true, avatar_target: true },
     });
     client.sendEvent('gmcp.objects.nums', ['1']);
     expect(manager.getObjectsOnLocation()).toEqual([
-      { num: '1', desc: 'Goblin', state: 5, attack_target: true, avatar_target: true },
+      { num: '1', desc: 'Goblin', state: 5, attack_num: true, avatar_target: true },
     ]);
   });
 
@@ -40,7 +40,7 @@ describe('ObjectManager', () => {
     });
     client.sendEvent('gmcp.objects.nums', { nums: [2] });
     expect(manager.getObjectsOnLocation()).toEqual([
-      { num: '2', desc: 'Orc', state: 10, attack_target: undefined, avatar_target: undefined },
+      { num: '2', desc: 'Orc', state: 10, attack_num: undefined, avatar_target: undefined },
     ]);
   });
 
@@ -49,7 +49,7 @@ describe('ObjectManager', () => {
     client.sendEvent('gmcp.char.state', { hp: 50 });
     client.sendEvent('gmcp.objects.nums', []);
     expect(manager.getObjectsOnLocation()).toEqual([
-      { num: '99', desc: 'Hero', state: 50, attack_target: undefined, avatar_target: undefined },
+      { num: '99', desc: 'Hero', state: 50, attack_num: undefined, avatar_target: undefined },
     ]);
   });
 
@@ -57,7 +57,7 @@ describe('ObjectManager', () => {
     client.sendEvent('gmcp.objects.data', { '1': { desc: 'Ogre', avatar_target: true } });
     client.sendEvent('gmcp.objects.nums', ['1']);
     expect(manager.getObjectsOnLocation()).toEqual([
-      { num: '1', desc: 'Ogre', state: undefined, attack_target: undefined, avatar_target: true },
+      { num: '1', desc: 'Ogre', state: undefined, attack_num: undefined, avatar_target: true },
     ]);
   });
 });

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -22,6 +22,7 @@
 
     </div>
     <div id="char-state"></div>
+    <div id="objects-list"></div>
     <div id="options-modal" class="modal fade" tabindex="-1">
         <div class="modal-dialog modal-lg modal-dialog-scrollable">
             <div class="modal-content">

--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -26,7 +26,11 @@ export default class ObjectList {
                 const hp = Math.max(0, Math.min(6, obj.state));
                 bar = `[${"#".repeat(hp)}${"-".repeat(6 - hp)}]`;
             }
-            return `${num} ${desc} ${bar}`.trim();
+            const attackers = objects
+                .filter((o: any) => o.attack_num === num)
+                .map((o: any) => o.num);
+            const arrow = attackers.length ? ` <- ${attackers.join(" ")}` : "";
+            return `${num} ${desc} ${bar}${arrow}`.trim();
         });
         this.container.textContent = lines.join("\n");
     }

--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -1,0 +1,33 @@
+import Client from "@client/src/Client";
+
+export default class ObjectList {
+    private client: Client;
+    private container: HTMLElement | null;
+
+    constructor(client: Client) {
+        this.client = client;
+        this.container = document.getElementById("objects-list");
+        this.client.addEventListener("gmcp.objects.nums", () => this.render());
+        this.client.addEventListener("gmcp.objects.data", () => this.render());
+        this.client.addEventListener("gmcp.char.state", () => this.render());
+        this.render();
+    }
+
+    private render() {
+        if (!this.container) return;
+        const manager = (window as any).clientExtension?.ObjectManager;
+        if (!manager) return;
+        const objects = manager.getObjectsOnLocation();
+        const lines = objects.map((obj: any) => {
+            const num = obj.num;
+            const desc = obj.desc || "";
+            let bar = "";
+            if (typeof obj.state === "number") {
+                const hp = Math.max(0, Math.min(6, obj.state));
+                bar = `[${"#".repeat(hp)}${"-".repeat(6 - hp)}]`;
+            }
+            return `${num} ${desc} ${bar}`.trim();
+        });
+        this.container.textContent = lines.join("\n");
+    }
+}

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -4,6 +4,7 @@ import ArkadiaClient from "./ArkadiaClient.ts";
 import "./plugin.ts"
 import { Modal, Dropdown } from 'bootstrap';
 import CharState from "./CharState";
+import ObjectList from "./ObjectList";
 
 import "@client/src/main.ts"
 import MockPort from "./MockPort.ts";
@@ -396,6 +397,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Display character state
     new CharState(client);
+    new ObjectList(window.clientExtension as any);
 
     // Initialize mobile direction buttons
     new MobileDirectionButtons(window.clientExtension);

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -69,6 +69,18 @@ h1 {
   border-top: 0.1vh solid rgba(255, 255, 255, 0.1);
 }
 
+#objects-list {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 0.5vh 1vh;
+  font-family: monospace;
+  font-size: 0.8rem;
+  background-color: rgba(0, 0, 0, 0.4);
+  white-space: pre;
+  z-index: 10;
+}
+
 #app {
   max-width: 90vw;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- show objects on location using `ObjectManager`
- integrate overlay with main page and style
- update ObjectManager tests for new event name

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686d85b8247c832a8d7ef11582de8377