### PR TITLE
Fix mobile dragging for objects list

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -79,6 +79,7 @@ h1 {
   background-color: rgba(0, 0, 0, 0.4);
   border: 0.1vh solid rgba(255, 255, 255, 0.1);
   cursor: move;
+  touch-action: none;
   white-space: pre;
   z-index: 10;
 }


### PR DESCRIPTION
## Summary
- disable default touch behavior for the objects list so dragging works on mobile

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686d9994a70c832a8ad31d87a4727eb9