### PR TITLE
Add object shortcut aliases

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -194,9 +194,11 @@ initDeposits(client, aliases)
 import initLvlCalc from "./scripts/lvlCalc"
 import initItemCondition from "./scripts/itemCondition"
 import initInvite from "./scripts/invite"
+import initObjectAliases from "./scripts/objectAliases"
 
 initLvlCalc(client, aliases)
 initItemCondition(client)
 initInvite(client)
+initObjectAliases(client, aliases)
 
 window["clientExtension"] = client

--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -1,0 +1,32 @@
+import Client from "../Client";
+
+export default function initObjectAliases(
+    client: Client,
+    aliases?: { pattern: RegExp; callback: Function }[]
+) {
+    function findByShortcut(short: string) {
+        const lower = short.toLowerCase();
+        return client
+            .ObjectManager
+            .getObjectsOnLocation()
+            .find(o => o.shortcut?.toLowerCase() === lower);
+    }
+
+    function exec(short: string, command: string) {
+        const obj = findByShortcut(short);
+        if (obj) {
+            Input.send(`${command} ${obj.num}`);
+        }
+    }
+
+    if (aliases) {
+        aliases.push({
+            pattern: /\/z ([A-Za-z0-9@]+)$/,
+            callback: (m: RegExpMatchArray) => exec(m[1], "zabij")
+        });
+        aliases.push({
+            pattern: /\/za ([A-Za-z0-9@]+)$/,
+            callback: (m: RegExpMatchArray) => exec(m[1], "zaslon")
+        });
+    }
+}

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -1,0 +1,34 @@
+import initObjectAliases from '../src/scripts/objectAliases';
+
+class FakeClient {
+  ObjectManager = {
+    getObjectsOnLocation: jest.fn(() => []),
+  };
+}
+
+describe('object aliases', () => {
+  let client: FakeClient;
+  let kill: (m: RegExpMatchArray) => void;
+  let shield: (m: RegExpMatchArray) => void;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    const aliases: { pattern: RegExp; callback: (m: RegExpMatchArray) => void }[] = [];
+    initObjectAliases((client as unknown) as any, aliases);
+    kill = aliases[0].callback as any;
+    shield = aliases[1].callback as any;
+    (global as any).Input = { send: jest.fn() };
+  });
+
+  test('kill alias sends zabij with object number', () => {
+    client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 5, shortcut: '1' }]);
+    kill(['', '1'] as unknown as RegExpMatchArray);
+    expect((global as any).Input.send).toHaveBeenCalledWith('zabij 5');
+  });
+
+  test('zaslon alias sends zaslon with object number', () => {
+    client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 7, shortcut: 'A' }]);
+    shield(['', 'A'] as unknown as RegExpMatchArray);
+    expect((global as any).Input.send).toHaveBeenCalledWith('zaslon 7');
+  });
+});


### PR DESCRIPTION
## Summary
- create object alias script for kill and shield commands
- register object aliases in main script
- test aliases for mapping shortcuts to object numbers

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686da27bcff4832a8adf6018c699667e