### PR TITLE
Add UI settings popup to web client

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -46,6 +46,9 @@
                     <button class="w-100 p-1" id="options-button">Ustawienia</button>
                 </li>
                 <li>
+                    <button class="w-100 p-1" id="ui-settings-button">UI</button>
+                </li>
+                <li>
                     <button class="w-100 p-1" id="docs-button">Docs</button>
                 </li>
             </ul>
@@ -75,6 +78,34 @@
                 </div>
             </div>
         </form>
+    </div>
+
+    <div id="ui-settings-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">UI Settings</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body d-flex flex-column gap-2">
+                    <label class="form-label">Content font size (rem)
+                        <input id="ui-content-font" type="number" step="0.1" class="form-control" />
+                    </label>
+                    <label class="form-label">Objects list font size (rem)
+                        <input id="ui-objects-font" type="number" step="0.1" class="form-control" />
+                    </label>
+                    <label class="form-label">Button font size (rem)
+                        <input id="ui-button-size" type="number" step="0.1" class="form-control" />
+                    </label>
+                    <label class="form-label">Map zoom
+                        <input id="ui-map-scale" type="number" step="0.05" class="form-control" />
+                    </label>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" id="ui-settings-save">Save</button>
+                </div>
+            </div>
+        </div>
     </div>
 
     <!-- Mobile Direction Buttons (hidden by default) -->

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -402,6 +402,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initialize mobile direction buttons
     new MobileDirectionButtons(window.clientExtension);
 
+    initUiSettings();
+
     const rootElement = document.getElementById('options');
     if (rootElement) {
         createRoot(rootElement).render(createElement(Settings));
@@ -422,3 +424,4 @@ window.client = client
 
 import MobileDirectionButtons from "./scripts/mobileDirectionButtons"
 import Settings from "@options/src/Settings.tsx";
+import initUiSettings from "./uiSettings";

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -1,0 +1,91 @@
+import Modal from "bootstrap/js/dist/modal";
+
+interface UiSettings {
+    contentFontSize: number;
+    objectsFontSize: number;
+    buttonSize: number;
+    mapScale: number;
+}
+
+const defaultSettings: UiSettings = {
+    contentFontSize: 0.775,
+    objectsFontSize: 0.6,
+    buttonSize: 1,
+    mapScale: 0.30,
+};
+
+function apply(settings: UiSettings) {
+    const content = document.getElementById('main_text_output_msg_wrapper');
+    if (content) {
+        content.style.fontSize = settings.contentFontSize + 'rem';
+    }
+    const objects = document.getElementById('objects-list');
+    if (objects) {
+        objects.style.fontSize = settings.objectsFontSize + 'rem';
+    }
+    document.querySelectorAll<HTMLButtonElement>('button').forEach(btn => {
+        btn.style.fontSize = settings.buttonSize + 'rem';
+    });
+    if ((window as any).embedded?.renderer?.controls) {
+        (window as any).embedded.renderer.controls.view.zoom = settings.mapScale;
+        (window as any).embedded.refresh();
+    }
+}
+
+function load(): UiSettings {
+    try {
+        const raw = localStorage.getItem('uiSettings');
+        if (raw) {
+            const parsed = JSON.parse(raw);
+            return { ...defaultSettings, ...parsed };
+        }
+    } catch {
+        // ignore malformed data
+    }
+    return { ...defaultSettings };
+}
+
+function save(settings: UiSettings) {
+    localStorage.setItem('uiSettings', JSON.stringify(settings));
+}
+
+export default function initUiSettings() {
+    const button = document.getElementById('ui-settings-button') as HTMLButtonElement | null;
+    const modalEl = document.getElementById('ui-settings-modal');
+    if (!button || !modalEl) return;
+
+    const modal = new Modal(modalEl);
+    const contentInput = modalEl.querySelector('#ui-content-font') as HTMLInputElement;
+    const objectsInput = modalEl.querySelector('#ui-objects-font') as HTMLInputElement;
+    const buttonInput = modalEl.querySelector('#ui-button-size') as HTMLInputElement;
+    const mapInput = modalEl.querySelector('#ui-map-scale') as HTMLInputElement;
+    const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
+
+    let current = load();
+    contentInput.value = String(current.contentFontSize);
+    objectsInput.value = String(current.objectsFontSize);
+    buttonInput.value = String(current.buttonSize);
+    mapInput.value = String(current.mapScale);
+    apply(current);
+
+    function read(): UiSettings {
+        return {
+            contentFontSize: parseFloat(contentInput.value) || defaultSettings.contentFontSize,
+            objectsFontSize: parseFloat(objectsInput.value) || defaultSettings.objectsFontSize,
+            buttonSize: parseFloat(buttonInput.value) || defaultSettings.buttonSize,
+            mapScale: parseFloat(mapInput.value) || defaultSettings.mapScale,
+        };
+    }
+
+    saveBtn.addEventListener('click', () => {
+        current = read();
+        save(current);
+        apply(current);
+        modal.hide();
+    });
+
+    button.addEventListener('click', () => {
+        modal.show();
+    });
+}
+

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -11,7 +11,7 @@ const defaultSettings: UiSettings = {
     contentFontSize: 0.775,
     objectsFontSize: 0.6,
     buttonSize: 1,
-    mapScale: 0.30,
+    mapScale: 90,
 };
 
 function apply(settings: UiSettings) {


### PR DESCRIPTION
## Summary
- add dropdown menu entry for web client UI options
- implement `uiSettings.ts` for controlling fonts, button size and map zoom
- call `initUiSettings` in web client
- place UI settings modal markup in `index.html`

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_686e977bddc0832a899359fe8623923e