### PR TITLE
Expose binds and npc configuration in web client

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -36,6 +36,32 @@
             </div>
         </div>
     </div>
+    <div id="binds-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Bindowanie</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="binds-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="npc-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Odbiorcy paczek</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="npc-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
     <div id="input-area">
         <input type="text" id="message-input" autocomplete="off" autocapitalize="off" spellcheck="false"/>
         <button id="send-button">➢</button>
@@ -44,6 +70,12 @@
             <ul class="dropdown-menu dropdown-menu-end mb-1 gap-2">
                 <li>
                     <button class="w-100 p-1" id="options-button">Ustawienia</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="binds-button">Bindowanie</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="npc-button">Odbiorcy paczek</button>
                 </li>
                 <li>
                     <button class="w-100 p-1" id="docs-button">Docs</button>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -15,7 +15,9 @@ const client = ArkadiaClient
 
 import { createElement } from 'react'
 import { createRoot} from 'react-dom/client'
-import App from "@options/src/App.tsx"
+import Settings from "@options/src/Settings.tsx"
+import Binds from "@options/src/Binds.tsx"
+import Npc from "@options/src/Npc.tsx"
 
 // Prevent tab sleep on mobile when switching tabs
 let noSleepAudio: HTMLAudioElement | null = null;
@@ -248,10 +250,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const loginButton = document.getElementById('login-button') as HTMLButtonElement | null;
     const menuButton = document.getElementById('menu-button') as HTMLButtonElement | null;
     const optionsButton = document.getElementById('options-button') as HTMLButtonElement;
+    const bindsButton = document.getElementById('binds-button') as HTMLButtonElement | null;
+    const npcButton = document.getElementById('npc-button') as HTMLButtonElement | null;
 
     // Initialize Bootstrap modal
     const optionsModalElement = document.getElementById('options-modal');
     const optionsModal = optionsModalElement ? new Modal(optionsModalElement) : null;
+    const bindsModalElement = document.getElementById('binds-modal');
+    const bindsModal = bindsModalElement ? new Modal(bindsModalElement) : null;
+    const npcModalElement = document.getElementById('npc-modal');
+    const npcModal = npcModalElement ? new Modal(npcModalElement) : null;
     const loginModalElement = document.getElementById('login-modal');
     const loginModal = loginModalElement ? new Modal(loginModalElement) : null;
     const loginCharacter = document.getElementById('login-character') as HTMLInputElement | null;
@@ -266,12 +274,30 @@ document.addEventListener('DOMContentLoaded', () => {
         if (optionsModal) {
             optionsModal.hide();
         }
+        if (bindsModal) {
+            bindsModal.hide();
+        }
+        if (npcModal) {
+            npcModal.hide();
+        }
     });
 
     // Add event listener to options button
     if (optionsButton && optionsModal) {
         optionsButton.addEventListener('click', () => {
             optionsModal.show();
+        });
+    }
+
+    if (bindsButton && bindsModal) {
+        bindsButton.addEventListener('click', () => {
+            bindsModal.show();
+        });
+    }
+
+    if (npcButton && npcModal) {
+        npcButton.addEventListener('click', () => {
+            npcModal.show();
         });
     }
 
@@ -406,6 +432,16 @@ document.addEventListener('DOMContentLoaded', () => {
     if (rootElement) {
         createRoot(rootElement).render(createElement(Settings));
     }
+
+    const bindsRoot = document.getElementById('binds-options');
+    if (bindsRoot) {
+        createRoot(bindsRoot).render(createElement(Binds));
+    }
+
+    const npcRoot = document.getElementById('npc-options');
+    if (npcRoot) {
+        createRoot(npcRoot).render(createElement(Npc));
+    }
 });
 
 // Add resize event listener to check if device becomes mobile-sized
@@ -421,4 +457,3 @@ window.addEventListener('resize', () => {
 window.client = client
 
 import MobileDirectionButtons from "./scripts/mobileDirectionButtons"
-import Settings from "@options/src/Settings.tsx";


### PR DESCRIPTION
## Summary
- show binds and npc modals in web client menu
- render Settings, Binds and NPC forms separately in respective modals

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_686e96c0d630832ab91fd1bb99e359a4