### PR TITLE
Add fullscreen button

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
 <div id="main-container">
+    <button id="fullscreen-button" title="Fullscreen">⛶</button>
     <div id="iframe-container">
         <canvas id="map" resize="true"></canvas>
         <div id="map-progress-container" class="position-absolute top-50 start-50 translate-middle w-75">

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -402,6 +402,17 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initialize mobile direction buttons
     new MobileDirectionButtons(window.clientExtension);
 
+    const fullscreenButton = document.getElementById('fullscreen-button') as HTMLButtonElement | null;
+    if (fullscreenButton) {
+        fullscreenButton.addEventListener('click', () => {
+            if (!document.fullscreenElement) {
+                document.documentElement.requestFullscreen().catch(err => console.error('Failed to enter fullscreen:', err));
+            } else {
+                document.exitFullscreen().catch(err => console.error('Failed to exit fullscreen:', err));
+            }
+        });
+    }
+
     const rootElement = document.getElementById('options');
     if (rootElement) {
         createRoot(rootElement).render(createElement(Settings));

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -404,3 +404,19 @@ button:focus-visible {
   gap: 1vw;
   z-index: 1000;
 }
+
+#fullscreen-button {
+  position: fixed;
+  top: 5px;
+  right: 5px;
+  z-index: 1001;
+  background: rgba(0, 0, 0, 0.5);
+  color: white;
+  border: 1px solid silver;
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+}
+
+#fullscreen-button:hover {
+  background: rgba(0, 0, 0, 0.7);
+}


### PR DESCRIPTION
## Summary
- add fullscreen button element in the web client UI
- style the fullscreen button so it appears in the top-right corner
- allow toggling fullscreen mode from the button

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686eb9d7681c832aa990bc39a5de424f