### PR TITLE
Update mobile button scaling setting

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -125,7 +125,7 @@
                     <label class="form-label">Objects list font size (rem)
                         <input id="ui-objects-font" type="number" step="0.1" class="form-control" />
                     </label>
-                    <label class="form-label">Button font size (rem)
+                    <label class="form-label">Mobile button size (%)
                         <input id="ui-button-size" type="number" step="0.1" class="form-control" />
                     </label>
                     <label class="form-label">Map zoom

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -23,8 +23,12 @@ function apply(settings: UiSettings) {
     if (objects) {
         objects.style.fontSize = settings.objectsFontSize + 'rem';
     }
-    document.querySelectorAll<HTMLButtonElement>('button').forEach(btn => {
-        btn.style.fontSize = settings.buttonSize + 'rem';
+    document.querySelectorAll<HTMLButtonElement>('.mobile-button').forEach(btn => {
+        const baseSize = 36; // default width/height in px
+        const baseFont = btn.classList.contains('mobile-button-text') ? 9 : 14;
+        btn.style.width = baseSize * settings.buttonSize + 'px';
+        btn.style.height = baseSize * settings.buttonSize + 'px';
+        btn.style.fontSize = baseFont * settings.buttonSize + 'px';
     });
     if ((window as any).embedded?.renderer?.controls) {
         (window as any).embedded.renderer.controls.view.zoom = settings.mapScale;


### PR DESCRIPTION
## Summary
- rename button font size option to **Mobile button size (%)** in UI settings
- expand `uiSettings.apply` to scale mobile buttons' width, height, and font size

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686ebe35dad8832aad0ce9cb71f8b8e6