### PR TITLE
Add mobile buttons toggle and adjust scale

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -128,6 +128,10 @@
                     <label class="form-label">Mobile button size (%)
                         <input id="ui-button-size" type="number" step="0.1" class="form-control" />
                     </label>
+                    <label class="form-label">
+                        <input id="ui-show-buttons" type="checkbox" class="form-check-input me-2" />
+                        Show on-screen buttons
+                    </label>
                     <label class="form-label">Map zoom
                         <input id="ui-map-scale" type="number" step="0.05" class="form-control" />
                     </label>

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -5,13 +5,15 @@ interface UiSettings {
     objectsFontSize: number;
     buttonSize: number;
     mapScale: number;
+    showButtons: boolean;
 }
 
 const defaultSettings: UiSettings = {
     contentFontSize: 0.775,
     objectsFontSize: 0.6,
     buttonSize: 1,
-    mapScale: 90,
+    mapScale: 1,
+    showButtons: true,
 };
 
 function apply(settings: UiSettings) {
@@ -33,6 +35,11 @@ function apply(settings: UiSettings) {
     if ((window as any).embedded?.renderer?.controls) {
         (window as any).embedded.renderer.controls.view.zoom = settings.mapScale;
         (window as any).embedded.refresh();
+    }
+    if ((window as any).clientExtension?.eventTarget) {
+        (window as any).clientExtension.eventTarget.dispatchEvent(
+            new CustomEvent('settings', { detail: { mobileDirectionButtons: settings.showButtons } })
+        );
     }
 }
 
@@ -63,6 +70,7 @@ export default function initUiSettings() {
     const objectsInput = modalEl.querySelector('#ui-objects-font') as HTMLInputElement;
     const buttonInput = modalEl.querySelector('#ui-button-size') as HTMLInputElement;
     const mapInput = modalEl.querySelector('#ui-map-scale') as HTMLInputElement;
+    const showButtonsInput = modalEl.querySelector('#ui-show-buttons') as HTMLInputElement;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
 
     let current = load();
@@ -70,6 +78,7 @@ export default function initUiSettings() {
     objectsInput.value = String(current.objectsFontSize);
     buttonInput.value = String(current.buttonSize);
     mapInput.value = String(current.mapScale);
+    showButtonsInput.checked = current.showButtons;
     apply(current);
 
     function read(): UiSettings {
@@ -78,6 +87,7 @@ export default function initUiSettings() {
             objectsFontSize: parseFloat(objectsInput.value) || defaultSettings.objectsFontSize,
             buttonSize: parseFloat(buttonInput.value) || defaultSettings.buttonSize,
             mapScale: parseFloat(mapInput.value) || defaultSettings.mapScale,
+            showButtons: showButtonsInput.checked,
         };
     }
 


### PR DESCRIPTION
## Summary
- add checkbox option to show mobile direction buttons
- adjust map zoom scale to use percentage format (100% = 1)
- dispatch setting change to mobile buttons handler

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686ec2fb4238832aa76b36aea4eaccc2