### PR TITLE
Allow empty commands in client

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -28,18 +28,19 @@ Gmcp.parse_option_subnegotiation = (match) => {
     }
     gmcpParseOption(match)
 }
-Input.send = (command: string) => {
+Input.send = (command?: string) => {
+    const cmd = command ?? ""
     const isAlias = aliases.find(alias => {
-        const matches = command.match(alias.pattern)
+        const matches = cmd.match(alias.pattern)
         if (matches) {
-            Output.send("→ " + command, "command")
+            Output.send("→ " + cmd, "command")
             alias.callback(matches);
             return true;
         }
         return false
     })
-    if (!isAlias && command !== undefined) {
-        command.split("#").forEach(subcommand => {
+    if (!isAlias) {
+        cmd.split("#").forEach(subcommand => {
             client.sendCommand(subcommand);
         })
     }

--- a/client/src/types/global.d.ts
+++ b/client/src/types/global.d.ts
@@ -1,5 +1,5 @@
 interface ClientInput {
-    send(command: string): void;
+    send(command?: string): void;
 }
 
 declare var Input: ClientInput;

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -95,6 +95,13 @@ test('sendCommand dispatches event and sends parsed command', () => {
   expect((window as any).Input.send).toHaveBeenCalledWith('parsed:test');
 });
 
+test('sendCommand allows empty command', () => {
+  const client = new Client();
+  client.sendCommand('');
+  expect(parseCommand).toHaveBeenCalledWith('');
+  expect((window as any).Input.send).toHaveBeenCalledWith('parsed:');
+});
+
 test('onLine sends printed messages after line and restores Output.send', () => {
   const client = new Client();
   const originalOutputSend = (window as any).Output.send;

--- a/sandbox/src/types/globals.d.ts
+++ b/sandbox/src/types/globals.d.ts
@@ -1,7 +1,7 @@
 import Client from "@client/src/Client.ts";
 
 interface ClientInput {
-    send(command: string): void;
+    send(command?: string): void;
 }
 
 interface ClientOutput {


### PR DESCRIPTION
## Summary
- allow empty command in Input.send by defaulting to an empty string
- update typings for optional command parameter
- test that sending empty command works

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686e9e0028b4832abeca370b3a11a494