### PR TITLE
Fix z-index for options popup

### DIFF
--- a/options/index.html
+++ b/options/index.html
@@ -9,5 +9,11 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <style>
+      #root {
+        position: relative;
+        z-index: 10000;
+      }
+    </style>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the options popup stays above mobile controls

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686edae9f544832a8e6f2726f878fb94