### PR TITLE
Make functional bind output clickable

### DIFF
--- a/client/src/scripts/functionalBind.ts
+++ b/client/src/scripts/functionalBind.ts
@@ -73,7 +73,9 @@ export class FunctionalBind {
         this.functionalBind = callback;
         if (this.currentPrintable === printable) {
             if (printable && !this.printedInMessage) {
-                this.client.println(`\t${color(49)}bind ${color(222)}${this.label}${color(49)}: ${printable}`);
+                const line = `\t${color(49)}bind ${color(222)}${this.label}${color(49)}: ${printable}`;
+                const clickable = this.client.OutputHandler.makeClickable(line, printable, callback);
+                this.client.println(clickable);
                 this.printedInMessage = true;
             }
             return;
@@ -82,7 +84,9 @@ export class FunctionalBind {
         this.printedInMessage = true;
         this.button?.remove();
         if (printable) {
-            this.client.println(`\t${color(49)}bind ${color(222)}${this.label}${color(49)}: ${printable}`);
+            const line = `\t${color(49)}bind ${color(222)}${this.label}${color(49)}: ${printable}`;
+            const clickable = this.client.OutputHandler.makeClickable(line, printable, callback);
+            this.client.println(clickable);
             this.button = this.client.createButton(printable, callback);
         }
     }

--- a/client/test/FunctionalBind.test.ts
+++ b/client/test/FunctionalBind.test.ts
@@ -1,0 +1,21 @@
+import { FunctionalBind } from '../src/scripts/functionalBind';
+import { color } from '../src/Colors';
+
+describe('FunctionalBind clickable text', () => {
+  test('set makes printed text clickable', () => {
+    const client = {
+      addEventListener: jest.fn(),
+      println: jest.fn(),
+      createButton: jest.fn(() => ({ remove: jest.fn() })),
+      OutputHandler: { makeClickable: jest.fn(() => 'clickable') },
+    } as any;
+
+    const fb = new FunctionalBind(client);
+    const cb = jest.fn();
+    fb.set('cmd', cb);
+
+    const expectedLine = `\t${color(49)}bind ${color(222)}]${color(49)}: cmd`;
+    expect(client.OutputHandler.makeClickable).toHaveBeenCalledWith(expectedLine, 'cmd', cb);
+    expect(client.println).toHaveBeenCalledWith('clickable');
+  });
+});


### PR DESCRIPTION
## Summary
- make functional bind output clickable by using `OutputHandler.makeClickable`
- add unit test for clickable functional bind text

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686edab4e8f0832ab3a5218458779517