### PR TITLE
Enable initial map refresh

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -88,6 +88,8 @@ export default class MapHelper {
         this.client.addEventListener('refreshPositionWhenAble', () => {
             this.refreshPosition = true;
         });
+
+        this.client.sendEvent('refreshPositionWhenAble');
     }
 
     parseCommand(command) {


### PR DESCRIPTION
## Summary
- ensure map refresh is triggered at startup

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686ee190d66c832a8e39c3433e201084