### PR TITLE
Fix mobile top button spacing

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -312,7 +312,7 @@ button:focus-visible {
 .mobile-top-buttons {
   display: flex;
   justify-content: center;
-  gap: 3px;
+  gap: 5px;
   margin-bottom: 5px;
 }
 


### PR DESCRIPTION
## Summary
- make `mobile-top-buttons` gap consistent with directional buttons

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686ee2afc900832aac8e1ef77f926306