### PR TITLE
Fix settings restore mobile buttons

### DIFF
--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -45,8 +45,12 @@ export default class MobileDirectionButtons {
 
         // Listen for settings changes
         this.client.addEventListener("settings", (event: CustomEvent) => {
+            const detail = event.detail || {};
+            if (!Object.prototype.hasOwnProperty.call(detail, "mobileDirectionButtons")) {
+                return;
+            }
             // Only disable if explicitly set to false
-            const disabled = event.detail.mobileDirectionButtons === false;
+            const disabled = detail.mobileDirectionButtons === false;
             if (disabled) {
                 this.disable();
             } else {


### PR DESCRIPTION
## Summary
- ignore settings events that do not specify `mobileDirectionButtons`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686ee70ca9d4832a8bef164f16e74b06