### PR TITLE
Remove extra functional binds

### DIFF
--- a/client/src/scripts/gates.ts
+++ b/client/src/scripts/gates.ts
@@ -1,27 +1,13 @@
 import Client from "../Client";
-import { FunctionalBind, formatLabel } from "./functionalBind";
 
 export default function initGates(client: Client) {
-    const bind = new FunctionalBind(client, { key: "Digit2", ctrl: true, label: "CTRL+2" });
-    client.addEventListener('settings', (ev: CustomEvent) => {
-        const opts = ev.detail?.binds?.gates;
-        if (opts) {
-            bind.updateOptions({
-                key: opts.key,
-                ctrl: opts.ctrl,
-                alt: opts.alt,
-                shift: opts.shift,
-                label: formatLabel(opts)
-            });
-        }
-    });
     const knock = () => {
         Input.send("zastukaj we wrota");
     };
-    bind.set(null, knock);
+    client.FunctionalBind.set(null, knock);
 
     const showMessage = () => {
-        bind.set("zastukaj we wrota", knock);
+        client.FunctionalBind.set("zastukaj we wrota", knock);
         return undefined;
     };
 

--- a/client/src/scripts/itemCollector.ts
+++ b/client/src/scripts/itemCollector.ts
@@ -1,10 +1,8 @@
 import Client from "../Client";
-import { FunctionalBind, formatLabel } from "./functionalBind";
 
 export default class ItemCollector {
     private client: Client;
     private checkBody = false;
-    private bind: FunctionalBind;
 
     modes = [
         "monety",
@@ -24,20 +22,7 @@ export default class ItemCollector {
 
     constructor(client: Client) {
         this.client = client;
-        this.bind = new FunctionalBind(client, { key: "Digit3", ctrl: true, label: "CTRL+3" });
-        this.client.addEventListener('settings', (ev: CustomEvent) => {
-            const o = ev.detail?.binds?.collector;
-            if (o) {
-                this.bind.updateOptions({
-                    key: o.key,
-                    ctrl: o.ctrl,
-                    alt: o.alt,
-                    shift: o.shift,
-                    label: formatLabel(o)
-                });
-            }
-        });
-        this.bind.set(null, () => this.keyPressed(true));
+        this.client.FunctionalBind.set(null, () => this.keyPressed(true));
         this.client.addEventListener("settings", (ev: CustomEvent) => {
             const s = ev.detail || {};
             if (typeof s.collectMode === "number") {
@@ -88,7 +73,7 @@ export default class ItemCollector {
 
     killedAction() {
         if (this.currentMode !== 7 || this.extra.length > 0) {
-            this.bind.set("wez z ciala", () => this.keyPressed(true));
+            this.client.FunctionalBind.set("wez z ciala", () => this.keyPressed(true));
             this.checkBody = true;
         }
     }
@@ -98,7 +83,7 @@ export default class ItemCollector {
             (this.currentMode === 4 || this.currentMode === 5 || this.currentMode === 6 || this.extra.length > 0) &&
             this.client.TeamManager.isInTeam(name)
         ) {
-            this.bind.set("wez z ciala", () => this.keyPressed(true));
+            this.client.FunctionalBind.set("wez z ciala", () => this.keyPressed(true));
             this.checkBody = true;
         }
     }

--- a/client/test/gates.test.ts
+++ b/client/test/gates.test.ts
@@ -1,13 +1,10 @@
 import Triggers from '../src/Triggers';
 
-const set = jest.fn();
-const FunctionalBind = jest.fn().mockImplementation(() => ({ set, newMessage: jest.fn() }));
-jest.mock('../src/scripts/functionalBind', () => ({ FunctionalBind }));
-
 import initGates from '../src/scripts/gates';
 
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
+  FunctionalBind = { set: jest.fn(), clear: jest.fn(), newMessage: jest.fn() };
   addEventListener = jest.fn();
 }
 
@@ -18,22 +15,20 @@ describe('gates triggers', () => {
   beforeEach(() => {
     (global as any).Input = { send: jest.fn() };
     client = new FakeClient();
-    set.mockClear();
-    FunctionalBind.mockClear();
+    jest.clearAllMocks();
     initGates((client as unknown) as any);
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
   });
 
   test('binding is set and callback sends command', () => {
-    expect(FunctionalBind).toHaveBeenCalledWith(client, { key: 'Digit2', ctrl: true, label: 'CTRL+2' });
-    expect(set).toHaveBeenCalledTimes(1);
-    const initCb = set.mock.calls[0][1];
+    expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
+    const initCb = (client.FunctionalBind.set as jest.Mock).mock.calls[0][1];
     initCb();
     expect((global as any).Input.send).toHaveBeenCalledWith('zastukaj we wrota');
 
     parse('Probujesz otworzyc masywne wrota.');
-    expect(set).toHaveBeenCalledTimes(2);
-    const [label, cb] = set.mock.calls[1];
+    expect(client.FunctionalBind.set).toHaveBeenCalledTimes(2);
+    const [label, cb] = (client.FunctionalBind.set as jest.Mock).mock.calls[1];
     expect(label).toBe('zastukaj we wrota');
     cb();
     expect((global as any).Input.send).toHaveBeenCalledTimes(2);
@@ -41,7 +36,7 @@ describe('gates triggers', () => {
 
   test('niewielka furtka pattern', () => {
     parse('Probujesz otworzyc niewielka furtke.');
-    expect(set).toHaveBeenCalledTimes(2);
+    expect(client.FunctionalBind.set).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/options/src/Binds.tsx
+++ b/options/src/Binds.tsx
@@ -11,14 +11,10 @@ interface Bind {
 
 interface BindSettings {
     main: Bind;
-    gates: Bind;
-    collector: Bind;
 }
 
 const defaultBinds: BindSettings = {
     main: { key: 'BracketRight' },
-    gates: { key: 'Digit2', ctrl: true },
-    collector: { key: 'Digit3', ctrl: true },
 };
 
 function label(bind: Bind) {
@@ -40,7 +36,10 @@ function Binds() {
 
     useEffect(() => {
         storage.getItem('settings').then(res => {
-            setBinds({ ...defaultBinds, ...(res.settings?.binds || {}) });
+            setBinds({
+                ...defaultBinds,
+                main: res.settings?.binds?.main || defaultBinds.main,
+            });
         });
     }, []);
 
@@ -52,13 +51,13 @@ function Binds() {
 
     function save() {
             storage.getItem('settings').then(res => {
-                const settings = { ...(res.settings || {}), binds };
+                const settings = { ...(res.settings || {}), binds: { main: binds.main } };
                 storage.setItem('settings', settings).then(() => {
-                if (chrome.runtime) {
-                    window.close();
-                } else {
-                    window.dispatchEvent(new Event('close-options'));
-                }
+                    if (chrome.runtime) {
+                        window.close();
+                    } else {
+                        window.dispatchEvent(new Event('close-options'));
+                    }
             });
         });
     }
@@ -74,28 +73,6 @@ function Binds() {
                     className="w-40"
                     value={label(binds.main)}
                     onKeyDown={ev => handleCapture('main', ev)}
-                />
-            </Form.Group>
-            <Form.Group className="d-flex align-items-center gap-2">
-                <Form.Label className="w-32 mb-0">Wrota</Form.Label>
-                <Form.Control
-                    type="text"
-                    readOnly
-                    size="sm"
-                    className="w-40"
-                    value={label(binds.gates)}
-                    onKeyDown={ev => handleCapture('gates', ev)}
-                />
-            </Form.Group>
-            <Form.Group className="d-flex align-items-center gap-2">
-                <Form.Label className="w-32 mb-0">Zbieranie</Form.Label>
-                <Form.Control
-                    type="text"
-                    readOnly
-                    size="sm"
-                    className="w-40"
-                    value={label(binds.collector)}
-                    onKeyDown={ev => handleCapture('collector', ev)}
                 />
             </Form.Group>
             <Button className="mt-2 w-auto" onClick={save}>Zapisz</Button>


### PR DESCRIPTION
## Summary
- drop separate gates and collector bindings and rely on the main one
- keep only the default bind option in Options UI
- update tests for gates triggers

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686eece51c38832a97c5b64ec098036f