### PR TITLE
Fix dropdown menu z-index on mobile

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -263,7 +263,7 @@ button:focus-visible {
     padding: 0.75vh 2vw;
     position: sticky;
     bottom: 0;
-    z-index: 10;
+    z-index: 1102;
   }
 
   #message-input {


### PR DESCRIPTION
## Summary
- raise z-index of input area on mobile to keep dropdown menu above mobile direction buttons

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686eeddeb05c832ab88ea815297b7955