### PR TITLE
Emit restored map position on load

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -76,6 +76,10 @@ export default class MapHelper {
             Object.values(this.mapReader.roomIndex).forEach(room => this.hashes[room.hash] = room);
             const startId = this.savedRoomId ?? 1;
             this.renderRoomById(startId, false)
+            this.client.sendEvent('restoredPosition', {
+                id: startId,
+                room: this.mapReader.getRoomById(startId),
+            });
         })
 
         this.client.addEventListener('gmcp.room.info', (event: CustomEvent) => {

--- a/map/embedded.js
+++ b/map/embedded.js
@@ -34,6 +34,9 @@ class EmbeddedMap {
                 case "enterLocation":
                     this.renderRoomById(data.id)
                     break;
+                case "restoredPosition":
+                    this.renderRoomById(data.id)
+                    break;
                 case "leadTo":
                     this.leadTo(data)
                     break;


### PR DESCRIPTION
## Summary
- dispatch `restoredPosition` event when the map initializes
- update embedded map to handle the new event

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686eec21c2e0832a96c83427c152d09d