### PR TITLE
Fix attack beep tests

### DIFF
--- a/client/test/attackBeep.test.ts
+++ b/client/test/attackBeep.test.ts
@@ -29,7 +29,7 @@ describe('attack beep triggers', () => {
     expect(client.playSound).toHaveBeenCalledTimes(1);
     const prefix = `\x1B[22;38;5;${findClosestColor('#ff0000') + 1}m`;
     expect(result.startsWith(prefix)).toBe(true);
-    expect(result).toContain('Wojownik atakuje cie!');
+    expect(result).toContain('Wojownik ATAKUJE CIE!');
     expect(result.endsWith('\x1B[0m')).toBe(true);
   });
 
@@ -46,6 +46,6 @@ describe('attack beep triggers', () => {
     expect(result.startsWith(prefix)).toBe(true);
     expect(result).toContain('ATAKUJE CIE');
     expect(result.includes('\x1B[0m')).toBe(true);
-    expect(result.endsWith('!')).toBe(true);
+    expect(result.endsWith('\x1B[0m')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- update tests for attack beep highlighting

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686f97898eb4832aa298ce6a206eb951