### PR TITLE
Add map height UI setting

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -144,6 +144,9 @@
                     <label class="form-label">Map zoom
                         <input id="ui-map-scale" type="number" step="0.05" class="form-control" />
                     </label>
+                    <label class="form-label">Map height (vh)
+                        <input id="ui-map-height" type="number" step="1" class="form-control" />
+                    </label>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-primary" id="ui-settings-save">Save</button>

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -6,6 +6,7 @@ interface UiSettings {
     buttonSize: number;
     mapScale: number;
     showButtons: boolean;
+    mapHeight: number;
 }
 
 const defaultSettings: UiSettings = {
@@ -14,6 +15,7 @@ const defaultSettings: UiSettings = {
     buttonSize: 1,
     mapScale: 0.30,
     showButtons: true,
+    mapHeight: typeof window !== 'undefined' && window.innerWidth < 768 ? 25 : 30,
 };
 
 function apply(settings: UiSettings) {
@@ -28,6 +30,12 @@ function apply(settings: UiSettings) {
     const objects = document.getElementById('objects-list');
     if (objects) {
         objects.style.fontSize = settings.objectsFontSize + 'rem';
+    }
+    const iframeContainer = document.getElementById('iframe-container');
+    if (iframeContainer) {
+        const height = settings.mapHeight + 'vh';
+        (iframeContainer as HTMLElement).style.height = height;
+        (iframeContainer as HTMLElement).style.maxHeight = height;
     }
     document.querySelectorAll<HTMLButtonElement>('.mobile-button').forEach(btn => {
         const baseSize = 36; // default width/height in px
@@ -74,6 +82,7 @@ export default function initUiSettings() {
     const objectsInput = modalEl.querySelector('#ui-objects-font') as HTMLInputElement;
     const buttonInput = modalEl.querySelector('#ui-button-size') as HTMLInputElement;
     const mapInput = modalEl.querySelector('#ui-map-scale') as HTMLInputElement;
+    const mapHeightInput = modalEl.querySelector('#ui-map-height') as HTMLInputElement;
     const showButtonsInput = modalEl.querySelector('#ui-show-buttons') as HTMLInputElement;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
 
@@ -82,6 +91,7 @@ export default function initUiSettings() {
     objectsInput.value = String(current.objectsFontSize);
     buttonInput.value = String(current.buttonSize);
     mapInput.value = String(current.mapScale);
+    mapHeightInput.value = String(current.mapHeight);
     showButtonsInput.checked = current.showButtons;
     apply(current);
 
@@ -91,6 +101,7 @@ export default function initUiSettings() {
             objectsFontSize: parseFloat(objectsInput.value) || defaultSettings.objectsFontSize,
             buttonSize: parseFloat(buttonInput.value) || defaultSettings.buttonSize,
             mapScale: parseFloat(mapInput.value) || defaultSettings.mapScale,
+            mapHeight: parseFloat(mapHeightInput.value) || defaultSettings.mapHeight,
             showButtons: showButtonsInput.checked,
         };
     }


### PR DESCRIPTION
## Summary
- add `mapHeight` option to UI settings
- allow user to set map container height

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686fa2ecfeb4832a9f588ce3f96e68f1