### PR TITLE
Add semicolon command separator

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -40,7 +40,7 @@ Input.send = (command?: string) => {
         return false
     })
     if (!isAlias) {
-        cmd.split("#").forEach(subcommand => {
+        cmd.split(/[#;]/).forEach(subcommand => {
             client.sendCommand(subcommand);
         })
     }


### PR DESCRIPTION
## Summary
- allow semicolons as command separators in the web client

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_686fa22ea254832ab112c792ea767162