### PR TITLE
Fix map zoom validation

### DIFF
--- a/map/embedded.js
+++ b/map/embedded.js
@@ -17,7 +17,7 @@ class EmbeddedMap {
             const raw = localStorage.getItem('uiSettings')
             if (raw) {
                 const parsed = JSON.parse(raw)
-                if (typeof parsed.mapScale === 'number') {
+                if (typeof parsed.mapScale === 'number' && parsed.mapScale > 0) {
                     zoom = parsed.mapScale
                 }
             }

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -142,7 +142,7 @@
                         Show on-screen buttons
                     </label>
                     <label class="form-label">Map zoom
-                        <input id="ui-map-scale" type="number" step="0.05" class="form-control" />
+                        <input id="ui-map-scale" type="number" step="0.05" min="0.05" class="form-control" />
                     </label>
                     <label class="form-label">Map height (vh)
                         <input id="ui-map-height" type="number" step="1" class="form-control" />

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -100,7 +100,10 @@ export default function initUiSettings() {
             contentFontSize: parseFloat(contentInput.value) || defaultSettings.contentFontSize,
             objectsFontSize: parseFloat(objectsInput.value) || defaultSettings.objectsFontSize,
             buttonSize: parseFloat(buttonInput.value) || defaultSettings.buttonSize,
-            mapScale: parseFloat(mapInput.value) || defaultSettings.mapScale,
+            mapScale: (() => {
+                const value = parseFloat(mapInput.value);
+                return value > 0 ? value : defaultSettings.mapScale;
+            })(),
             mapHeight: parseFloat(mapHeightInput.value) || defaultSettings.mapHeight,
             showButtons: showButtonsInput.checked,
         };


### PR DESCRIPTION
## Summary
- ensure stored map zoom value is positive
- default to previous value when map zoom input is non-positive
- restrict map zoom input to positive numbers

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_686faacc61e0832ab338943830adc673