### PR TITLE
Fix negative zoom handling

### DIFF
--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -101,7 +101,7 @@ export default function initUiSettings() {
             objectsFontSize: parseFloat(objectsInput.value) || defaultSettings.objectsFontSize,
             buttonSize: parseFloat(buttonInput.value) || defaultSettings.buttonSize,
             mapScale: (() => {
-                const value = parseFloat(mapInput.value);
+                const value = Math.abs(parseFloat(mapInput.value));
                 return value > 0 ? value : defaultSettings.mapScale;
             })(),
             mapHeight: parseFloat(mapHeightInput.value) || defaultSettings.mapHeight,


### PR DESCRIPTION
## Summary
- prevent negative values in map zoom settings by flipping to positive before saving

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687032140810832a9ba4d4db0a0f6ed2