### PR TITLE
Limit output history to 1000 elements

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -133,6 +133,15 @@ client.on('message', (message: string, type?: string) => {
 
         wrapper.appendChild(messageDiv);
         contentArea.appendChild(wrapper);
+        const maxElements = 1000;
+        while (contentArea.childElementCount > maxElements) {
+            const first = contentArea.firstElementChild;
+            if (first) {
+                contentArea.removeChild(first);
+            } else {
+                break;
+            }
+        }
         contentArea.scrollTop = contentArea.scrollHeight;
     }
 });


### PR DESCRIPTION
## Summary
- cap DOM output in web client at 1000 entries

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68713163e294832ab2f060a7044f343f