### PR TITLE
Implement auth overlay

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -98,6 +98,7 @@
         </div>
     </div>
 
+    <div id="auth-overlay"></div>
     <div id="auth-buttons">
         <button id="login-button">Login</button>
         <button id="connect-button">Connect</button>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -143,6 +143,7 @@ let isConnected = false;
 // Function to update the connect button state
 function updateConnectButtons() {
     const connectButton = document.getElementById('connect-button') as HTMLButtonElement;
+    const authOverlay = document.getElementById('auth-overlay') as HTMLElement | null;
     if (connectButton) {
         if (isConnected) {
             connectButton.style.display = 'none'; // Hide button when connected
@@ -153,7 +154,11 @@ function updateConnectButtons() {
             connectButton.classList.remove('connected');
         }
     }
-    document.getElementById('login-button').style.display = connectButton.style.display;
+    const displayValue = connectButton.style.display;
+    document.getElementById('login-button').style.display = displayValue;
+    if (authOverlay) {
+        authOverlay.style.display = displayValue;
+    }
 }
 
 // Handle client connect event

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -409,7 +409,16 @@ button:focus-visible {
   left: 50%;
   transform: translate(-50%, -50%);
   display: flex;
+  flex-direction: column;
   gap: 1vw;
   z-index: 1000;
+}
+
+#auth-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 999;
+  display: none;
 }
 


### PR DESCRIPTION
## Summary
- overlay the page with a semi-transparent background while login and connect buttons are visible
- place login and connect buttons in a column for better readability

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_68714073a914832a8fda91869f4e08b4