### PR TITLE
Fix Client test for updated event

### DIFF
--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -122,7 +122,7 @@ test('onLine sends printed messages after line and restores Output.send', () => 
   expect(originalOutputSend).not.toHaveBeenCalled();
 
   originalOutputSend(result);
-  client.sendEvent('output-sent');
+  client.sendEvent('line-sent');
 
   expect(originalOutputSend).toHaveBeenNthCalledWith(1, 'processed');
   expect(originalOutputSend).toHaveBeenNthCalledWith(2, 'printed', undefined);


### PR DESCRIPTION
## Summary
- update onLine test to dispatch `line-sent` after printing

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68718dd93c70832ab2014e56d44dbbc2