### PR TITLE
Add content width detection

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -24,6 +24,7 @@ export default class Client {
     ObjectManager = new ObjectManager(this)
     inlineCompassRose = new InlineCompassRose(this)
     panel = document.getElementById("panel_buttons_bottom")
+    contentWidth = 0
     sounds: Record<string, Howl> = {
         beep: new Howl({
             src: beepSound,
@@ -39,6 +40,10 @@ export default class Client {
                 this.eventTarget.dispatchEvent(new CustomEvent(data.type, {detail: data.payload}))
             }
         })
+
+        this.updateContentWidth()
+        window.addEventListener('resize', () => this.updateContentWidth())
+        this.addEventListener('uiSettings', () => this.updateContentWidth())
 
 
         Object.values(this.sounds).forEach((sound) => sound.load())
@@ -205,5 +210,22 @@ export default class Client {
 
     prefix(rawLine: string, prefix: string) {
         return prefix + rawLine;
+    }
+
+    updateContentWidth() {
+        const content = document.getElementById('main_text_output_msg_wrapper') as HTMLElement | null
+        const measure = document.getElementById('content-width-measure') as HTMLElement | null
+        if (!content || !measure) {
+            return
+        }
+        const style = window.getComputedStyle(content)
+        measure.style.fontFamily = style.fontFamily
+        measure.style.fontSize = style.fontSize
+        const charWidth = measure.getBoundingClientRect().width
+        const width = content.clientWidth
+        if (charWidth > 0 && width > 0) {
+            this.contentWidth = Math.floor(width / charWidth)
+            this.sendEvent('contentWidth', this.contentWidth)
+        }
     }
 }

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -53,6 +53,7 @@ beforeEach(() => {
   document.body.innerHTML = '<div id="panel_buttons_bottom"></div><iframe id="cm-frame"></iframe>';
   (window as any).Output = { flush_buffer: jest.fn(), send: jest.fn() };
   (window as any).Text = { parse_patterns: jest.fn((v: any) => v) };
+  (window as any).postMessage = jest.fn();
 });
 
 test('createEvent returns object with type and data', () => {
@@ -202,5 +203,19 @@ test('playSound restarts sound when called twice', () => {
 
   expect(sound.stop).toHaveBeenCalledTimes(2);
   expect(sound.play).toHaveBeenCalledTimes(2);
+});
+
+test('updateContentWidth measures characters per line', () => {
+  document.body.innerHTML =
+    '<div id="panel_buttons_bottom"></div>' +
+    '<div id="main_text_output_msg_wrapper"></div>' +
+    '<span id="content-width-measure">M</span>';
+  const wrapper = document.getElementById('main_text_output_msg_wrapper')!;
+  Object.defineProperty(wrapper, 'clientWidth', { value: 100, configurable: true });
+  const measure = document.getElementById('content-width-measure')!;
+  (measure as any).getBoundingClientRect = jest.fn(() => ({ width: 10 }));
+  const client = new Client();
+  client.updateContentWidth();
+  expect(client.contentWidth).toBe(10);
 });
 

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -25,6 +25,7 @@
     </div>
     <div id="char-state"></div>
     <div id="objects-list"></div>
+    <span id="content-width-measure" style="visibility:hidden;position:absolute;white-space:pre">M</span>
     <div id="options-modal" class="modal fade" tabindex="-1">
         <div class="modal-dialog modal-lg modal-dialog-scrollable">
             <div class="modal-content">


### PR DESCRIPTION
## Summary
- add hidden span for width measurement
- compute content width in `Client`
- expose helper to recompute width on resize and settings
- test the new content width calculation

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687191a3a0d0832ab9bdbb1fafd2bebb