### PR TITLE
Fix auth overlay visibility

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -167,7 +167,7 @@ function updateConnectButtons() {
     const displayValue = connectButton.style.display;
     document.getElementById('login-button').style.display = displayValue;
     if (authOverlay) {
-        authOverlay.style.display = displayValue;
+        authOverlay.style.display = isConnected ? 'none' : 'block';
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure the auth overlay appears when disconnected

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687197d47274832aa4fb1926bac8ab76