### PR TITLE
Add history overlay to web client

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -23,6 +23,8 @@
     <div id="main_text_output_msg_wrapper">
 
     </div>
+    <div id="history-overlay"></div>
+    <div id="history-divider"></div>
     <div id="char-state">
         <span id="char-state-text"></span>
         <span id="lamp-timer"></span>

--- a/web-client/src/historyOverlay.ts
+++ b/web-client/src/historyOverlay.ts
@@ -1,0 +1,80 @@
+// Overlay for scrolling history above the latest lines
+export default class HistoryOverlay {
+    private contentArea: HTMLElement;
+    private overlay: HTMLElement;
+    private divider: HTMLElement;
+    private visible = false;
+    private readonly bottomLines = 10;
+
+    constructor() {
+        const content = document.getElementById('main_text_output_msg_wrapper');
+        const overlay = document.getElementById('history-overlay');
+        const divider = document.getElementById('history-divider');
+        if (!content || !overlay || !divider) {
+            throw new Error('HistoryOverlay elements missing');
+        }
+        this.contentArea = content;
+        this.overlay = overlay;
+        this.divider = divider;
+        this.attachEvents();
+    }
+
+    private attachEvents() {
+        this.contentArea.addEventListener('scroll', () => {
+            const { scrollTop, scrollHeight, clientHeight } = this.contentArea;
+            if (!this.visible && scrollTop < scrollHeight - clientHeight) {
+                this.show();
+            }
+        });
+
+        this.overlay.addEventListener('scroll', () => {
+            const { scrollTop, scrollHeight, clientHeight } = this.overlay;
+            if (this.visible && scrollTop >= scrollHeight - clientHeight) {
+                this.hide();
+            }
+        });
+    }
+
+    private show() {
+        this.visible = true;
+        this.overlay.innerHTML = this.contentArea.innerHTML;
+        this.updateBottomHeight();
+        this.overlay.style.display = 'block';
+        this.divider.style.display = 'block';
+        this.overlay.scrollTop = this.contentArea.scrollTop;
+        this.contentArea.scrollTop = this.contentArea.scrollHeight;
+        this.overlay.style.pointerEvents = 'auto';
+    }
+
+    private hide() {
+        this.visible = false;
+        this.overlay.style.display = 'none';
+        this.divider.style.display = 'none';
+        this.overlay.style.pointerEvents = 'none';
+    }
+
+    private updateBottomHeight() {
+        const children = Array.from(this.contentArea.children);
+        const start = Math.max(0, children.length - this.bottomLines);
+        let bottomHeight = 0;
+        for (let i = start; i < children.length; i++) {
+            bottomHeight += (children[i] as HTMLElement).offsetHeight;
+        }
+        const rect = this.contentArea.getBoundingClientRect();
+        this.overlay.style.left = `${rect.left}px`;
+        this.overlay.style.right = `${window.innerWidth - rect.right}px`;
+        this.overlay.style.top = `${rect.top}px`;
+        const bottomOffset = window.innerHeight - rect.bottom + bottomHeight;
+        this.overlay.style.bottom = `${bottomOffset}px`;
+        this.divider.style.left = `${rect.left}px`;
+        this.divider.style.right = `${window.innerWidth - rect.right}px`;
+        this.divider.style.bottom = `${bottomOffset}px`;
+    }
+
+    public update() {
+        if (this.visible) {
+            this.overlay.innerHTML = this.contentArea.innerHTML;
+            this.updateBottomHeight();
+        }
+    }
+}

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -19,6 +19,9 @@ import { createElement } from 'react'
 import { createRoot} from 'react-dom/client'
 import Binds from "@options/src/Binds.tsx"
 import Npc from "@options/src/Npc.tsx"
+import HistoryOverlay from "./historyOverlay"
+
+let historyOverlay: HistoryOverlay | null = null;
 
 // Prevent tab sleep on mobile when switching tabs
 let noSleepInstance: NoSleep | null = null;
@@ -143,6 +146,9 @@ client.on('message', (message: string, type?: string) => {
                 break;
             }
         }
+        if (historyOverlay) {
+            historyOverlay.update();
+        }
         contentArea.scrollTop = contentArea.scrollHeight;
     }
 });
@@ -230,6 +236,8 @@ document.addEventListener('DOMContentLoaded', () => {
         preventTabSleep();
         console.log('Tab sleep prevention activated for mobile device');
     }
+
+    historyOverlay = new HistoryOverlay();
 
     const messageInput = document.getElementById('message-input') as HTMLInputElement;
     const sendButton = document.getElementById('send-button') as HTMLButtonElement;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -440,3 +440,24 @@ button:focus-visible {
   display: none;
 }
 
+#history-overlay {
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  overflow-y: auto;
+  display: none;
+  pointer-events: none;
+  z-index: 998;
+}
+
+#history-divider {
+  position: fixed;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background-color: rgba(255, 255, 255, 0.5);
+  display: none;
+  z-index: 999;
+}
+


### PR DESCRIPTION
## Summary
- implement scrollable history overlay keeping last 10 lines visible
- load overlay when scrolling away from bottom
- update overlay on new messages
- style and embed new overlay elements in HTML

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6871a2c8bb38832aa10cee9cf14e76f4