### PR TITLE
Fix lamp timer display

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -69,6 +69,9 @@ loadNpcData().then(npc => {
 
 const port = new MockPort();
 window.clientExtension.connect(port as any, true);
+window.clientExtension.addEventListener('lampTimer', (ev: CustomEvent<number | null>) => {
+    client.emit('lampTimer', ev.detail);
+});
 
 const progressContainer = document.getElementById('map-progress-container')!;
 const progressBar = document.getElementById('map-progress-bar') as HTMLElement;


### PR DESCRIPTION
## Summary
- forward lampTimer events from client extension to Arkadia client so the footer timer works

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6871a3629404832aa5e704221022f992