### PR TITLE
Sync deposit pretty container columns

### DIFF
--- a/client/src/scripts/deposits.ts
+++ b/client/src/scripts/deposits.ts
@@ -33,6 +33,11 @@ export default function initDeposits(client: Client, aliases?: { pattern: RegExp
         client.port?.postMessage({ type: "SET_STORAGE", key: STORAGE_KEY, value: deposits });
     };
 
+    let columns = 1;
+    client.addEventListener('settings', (ev: CustomEvent) => {
+        columns = ev.detail.containerColumns ?? columns;
+    });
+
     function update(items: ContainerItem[] | null) {
         const room = client.Map.currentRoom as any;
         if (!isBankRoom(room)) {
@@ -63,8 +68,7 @@ export default function initDeposits(client: Client, aliases?: { pattern: RegExp
         const text = (m.groups?.content || m[1]).replace(/\.$/, "");
         const items = parseItems(text);
         update(items);
-        //todo should follow pretty containers settings
-        client.print(prettyPrintContainer(m as RegExpMatchArray, 1, 'DEPOZYT', 5));
+        client.print(prettyPrintContainer(m as RegExpMatchArray, columns, 'DEPOZYT', 5));
         return undefined;
     });
     client.Triggers.registerTrigger(matchEmpty, () => { update([] as ContainerItem[]); return undefined; });

--- a/client/test/deposit.test.ts
+++ b/client/test/deposit.test.ts
@@ -1,5 +1,11 @@
+jest.mock('../src/scripts/prettyContainers', () => {
+  const actual = jest.requireActual('../src/scripts/prettyContainers');
+  return { ...actual, prettyPrintContainer: jest.fn(() => 'table') };
+});
+
 import initDeposits, { deposits } from '../src/scripts/deposits';
 import Triggers, { stripAnsiCodes } from '../src/Triggers';
+import { prettyPrintContainer } from '../src/scripts/prettyContainers';
 import { EventEmitter } from 'events';
 
 class FakeClient {
@@ -115,5 +121,11 @@ describe('deposits', () => {
     const printed = stripAnsiCodes(client.println.mock.calls[0][0]);
     expect(printed).toContain('  5 | mieczy');
     expect(printed).toContain('wie | monet');
+  });
+
+  test('uses column setting for pretty print', () => {
+    client.dispatch('settings', { containerColumns: 3 });
+    parse('Twoj depozyt zawiera miecz.');
+    expect(prettyPrintContainer).toHaveBeenCalledWith(expect.anything(), 3, 'DEPOZYT', 5);
   });
 });


### PR DESCRIPTION
## Summary
- respect container column setting when printing deposits
- test that deposit pretty print uses column settings

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6871ad1ac350832a8c1cc910dc6651ab