### PR TITLE
Implement alias management popup

### DIFF
--- a/client/src/userAliases.ts
+++ b/client/src/userAliases.ts
@@ -1,0 +1,50 @@
+export interface UserAlias { pattern: string; command: string }
+export interface AliasEntry { pattern: RegExp; callback: (m: RegExpMatchArray) => void }
+
+let userAliasEntries: AliasEntry[] = []
+let sendRaw: (cmd: string) => void = () => {}
+
+function escapeRegExp(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function applyUserAliases(list: UserAlias[]) {
+    userAliasEntries = list.map(a => {
+        const regex = new RegExp("^" + escapeRegExp(a.pattern) + "(?:\\s+(.*))?$")
+        return {
+            pattern: regex,
+            callback: (m: RegExpMatchArray) => {
+                const rest = m[1] ? " " + m[1] : ""
+                sendRaw(a.command + rest)
+            }
+        }
+    })
+}
+
+function loadUserAliases() {
+    try {
+        const raw = localStorage.getItem('aliases')
+        if (raw) {
+            const arr = JSON.parse(raw) as UserAlias[]
+            applyUserAliases(arr)
+        }
+    } catch {}
+}
+
+export function getUserAliasEntries(): AliasEntry[] {
+    return userAliasEntries
+}
+
+export function initUserAliasHandling(sendFn: (cmd: string) => void) {
+    sendRaw = sendFn
+    loadUserAliases()
+    window.addEventListener('aliases-changed', (ev: Event) => {
+        const detail = (ev as CustomEvent<UserAlias[]>).detail
+        if (Array.isArray(detail)) applyUserAliases(detail)
+    })
+    window.addEventListener('storage', (ev: StorageEvent) => {
+        if (ev.key === 'aliases' && ev.newValue) {
+            try { applyUserAliases(JSON.parse(ev.newValue)) } catch {}
+        }
+    })
+}

--- a/options/src/AliasForm.tsx
+++ b/options/src/AliasForm.tsx
@@ -1,0 +1,46 @@
+import {useEffect, useState} from 'react'
+import {Button, Form} from 'react-bootstrap'
+
+export interface AliasFormProps {
+    initial?: { pattern: string; command: string }
+    onSave: (pattern: string, command: string) => void
+    onCancel?: () => void
+}
+
+function AliasForm({initial, onSave, onCancel}: AliasFormProps) {
+    const [pattern, setPattern] = useState('')
+    const [command, setCommand] = useState('')
+
+    useEffect(() => {
+        setPattern(initial?.pattern ?? '')
+        setCommand(initial?.command ?? '')
+    }, [initial])
+
+    const handleSave = () => {
+        if (!pattern.trim() || !command.trim()) return
+        onSave(pattern.trim(), command.trim())
+        setPattern('')
+        setCommand('')
+    }
+
+    return (
+        <Form className="d-flex flex-column gap-2">
+            <Form.Group>
+                <Form.Label>Pattern</Form.Label>
+                <Form.Control type="text" size="sm" value={pattern} onChange={e => setPattern(e.target.value)} />
+            </Form.Group>
+            <Form.Group>
+                <Form.Label>Command</Form.Label>
+                <Form.Control type="text" size="sm" value={command} onChange={e => setCommand(e.target.value)} />
+            </Form.Group>
+            <div className="d-flex gap-2">
+                <Button size="sm" variant="primary" onClick={handleSave}>{initial ? 'Save Changes' : 'Create'}</Button>
+                {initial && onCancel && (
+                    <Button size="sm" variant="secondary" onClick={onCancel}>Cancel</Button>
+                )}
+            </div>
+        </Form>
+    )
+}
+
+export default AliasForm

--- a/options/src/AliasList.tsx
+++ b/options/src/AliasList.tsx
@@ -1,0 +1,36 @@
+import {Button, Table} from 'react-bootstrap'
+
+export interface AliasDef {
+    pattern: string;
+    command: string;
+}
+
+interface Props {
+    aliases: AliasDef[];
+    onEdit: (index: number) => void;
+    onRemove: (index: number) => void;
+}
+
+function AliasList({aliases, onEdit, onRemove}: Props) {
+    return (
+        <Table bordered size="sm" className="table-zebra">
+            <tbody className="align-middle">
+            {aliases.map((a, i) => (
+                <tr key={i}>
+                    <td className="w-25">{a.pattern}</td>
+                    <td>{a.command}</td>
+                    <td className="w-25 text-end">
+                        <Button variant="secondary" size="sm" className="me-1" onClick={() => onEdit(i)}>Edit</Button>
+                        <Button variant="danger" size="sm" onClick={() => onRemove(i)}>Remove</Button>
+                    </td>
+                </tr>
+            ))}
+            {aliases.length === 0 && (
+                <tr><td colSpan={3} className="text-center">No aliases</td></tr>
+            )}
+            </tbody>
+        </Table>
+    )
+}
+
+export default AliasList

--- a/options/src/Aliases.tsx
+++ b/options/src/Aliases.tsx
@@ -1,0 +1,95 @@
+import {useEffect, useState} from "react";
+import {Button, Form, Table} from 'react-bootstrap';
+import storage from "./storage";
+
+interface AliasDef {
+    pattern: string;
+    command: string;
+}
+
+function Aliases() {
+    const [aliases, setAliases] = useState<AliasDef[]>([]);
+    const [pattern, setPattern] = useState('');
+    const [command, setCommand] = useState('');
+    const [editIndex, setEditIndex] = useState<number | null>(null);
+
+    useEffect(() => {
+        storage.getItem('aliases').then((value: { aliases: AliasDef[] }) => {
+            if (value && value.aliases) {
+                setAliases(value.aliases);
+            }
+        });
+    }, []);
+
+    function persist(updated: AliasDef[]) {
+        setAliases(updated);
+        storage.setItem('aliases', updated).then(() => {
+            if (!chrome.runtime) {
+                window.dispatchEvent(new CustomEvent('aliases-changed', { detail: updated }));
+            }
+        });
+    }
+
+    function save() {
+        if (!pattern.trim() || !command.trim()) return;
+        if (aliases.some((a, i) => a.pattern === pattern && i !== editIndex)) return;
+        const updated = [...aliases];
+        if (editIndex === null) {
+            updated.push({ pattern: pattern.trim(), command: command.trim() });
+        } else {
+            updated[editIndex] = { pattern: pattern.trim(), command: command.trim() };
+        }
+        setPattern('');
+        setCommand('');
+        setEditIndex(null);
+        persist(updated);
+    }
+
+    function startEdit(index: number) {
+        const a = aliases[index];
+        setPattern(a.pattern);
+        setCommand(a.command);
+        setEditIndex(index);
+    }
+
+    function remove(index: number) {
+        if (!confirm('Are you sure you want to delete this alias?')) return;
+        const updated = aliases.filter((_, i) => i !== index);
+        persist(updated);
+    }
+
+    return (
+        <div className="m-2 d-flex flex-column gap-3">
+            <Table bordered size="sm" className="table-zebra">
+                <tbody className="align-middle">
+                {aliases.map((a, i) => (
+                    <tr key={i}>
+                        <td className="w-25">{a.pattern}</td>
+                        <td>{a.command}</td>
+                        <td className="w-25 text-end">
+                            <Button variant="secondary" size="sm" className="me-1" onClick={() => startEdit(i)}>Edit</Button>
+                            <Button variant="danger" size="sm" onClick={() => remove(i)}>Remove</Button>
+                        </td>
+                    </tr>
+                ))}
+                {aliases.length === 0 && (
+                    <tr><td colSpan={3} className="text-center">No aliases</td></tr>
+                )}
+                </tbody>
+            </Table>
+            <Form className="d-flex flex-column gap-2">
+                <Form.Group>
+                    <Form.Label>Pattern</Form.Label>
+                    <Form.Control type="text" size="sm" value={pattern} onChange={e => setPattern(e.target.value)} />
+                </Form.Group>
+                <Form.Group>
+                    <Form.Label>Command</Form.Label>
+                    <Form.Control type="text" size="sm" value={command} onChange={e => setCommand(e.target.value)} />
+                </Form.Group>
+                <Button size="sm" variant="primary" onClick={save}>{editIndex === null ? 'Create' : 'Save Changes'}</Button>
+            </Form>
+        </div>
+    );
+}
+
+export default Aliases;

--- a/options/src/Aliases.tsx
+++ b/options/src/Aliases.tsx
@@ -1,16 +1,10 @@
 import {useEffect, useState} from "react";
-import {Button, Form, Table} from 'react-bootstrap';
 import storage from "./storage";
-
-interface AliasDef {
-    pattern: string;
-    command: string;
-}
+import AliasForm from "./AliasForm";
+import AliasList, { AliasDef } from "./AliasList";
 
 function Aliases() {
     const [aliases, setAliases] = useState<AliasDef[]>([]);
-    const [pattern, setPattern] = useState('');
-    const [command, setCommand] = useState('');
     const [editIndex, setEditIndex] = useState<number | null>(null);
 
     useEffect(() => {
@@ -30,25 +24,19 @@ function Aliases() {
         });
     }
 
-    function save() {
-        if (!pattern.trim() || !command.trim()) return;
+    function save(pattern: string, command: string) {
         if (aliases.some((a, i) => a.pattern === pattern && i !== editIndex)) return;
         const updated = [...aliases];
         if (editIndex === null) {
-            updated.push({ pattern: pattern.trim(), command: command.trim() });
+            updated.push({ pattern, command });
         } else {
-            updated[editIndex] = { pattern: pattern.trim(), command: command.trim() };
+            updated[editIndex] = { pattern, command };
         }
-        setPattern('');
-        setCommand('');
         setEditIndex(null);
         persist(updated);
     }
 
     function startEdit(index: number) {
-        const a = aliases[index];
-        setPattern(a.pattern);
-        setCommand(a.command);
         setEditIndex(index);
     }
 
@@ -60,34 +48,12 @@ function Aliases() {
 
     return (
         <div className="m-2 d-flex flex-column gap-3">
-            <Table bordered size="sm" className="table-zebra">
-                <tbody className="align-middle">
-                {aliases.map((a, i) => (
-                    <tr key={i}>
-                        <td className="w-25">{a.pattern}</td>
-                        <td>{a.command}</td>
-                        <td className="w-25 text-end">
-                            <Button variant="secondary" size="sm" className="me-1" onClick={() => startEdit(i)}>Edit</Button>
-                            <Button variant="danger" size="sm" onClick={() => remove(i)}>Remove</Button>
-                        </td>
-                    </tr>
-                ))}
-                {aliases.length === 0 && (
-                    <tr><td colSpan={3} className="text-center">No aliases</td></tr>
-                )}
-                </tbody>
-            </Table>
-            <Form className="d-flex flex-column gap-2">
-                <Form.Group>
-                    <Form.Label>Pattern</Form.Label>
-                    <Form.Control type="text" size="sm" value={pattern} onChange={e => setPattern(e.target.value)} />
-                </Form.Group>
-                <Form.Group>
-                    <Form.Label>Command</Form.Label>
-                    <Form.Control type="text" size="sm" value={command} onChange={e => setCommand(e.target.value)} />
-                </Form.Group>
-                <Button size="sm" variant="primary" onClick={save}>{editIndex === null ? 'Create' : 'Save Changes'}</Button>
-            </Form>
+            <AliasList aliases={aliases} onEdit={startEdit} onRemove={remove} />
+            <AliasForm
+                initial={editIndex !== null ? aliases[editIndex] : undefined}
+                onSave={save}
+                onCancel={() => setEditIndex(null)}
+            />
         </div>
     );
 }

--- a/options/src/App.tsx
+++ b/options/src/App.tsx
@@ -5,10 +5,11 @@ import SettingsForm from "./Settings.tsx";
 import Npc from "./Npc.tsx";
 import SettingsFile from "./SettingsFile";
 import Binds from "./Binds";
+import Aliases from "./Aliases";
 
 
 function App() {
-    const [tab, setTab] = useState<'settings' | 'npc' | 'file' | 'binds'>('settings')
+    const [tab, setTab] = useState<'settings' | 'npc' | 'file' | 'binds' | 'aliases'>('settings')
 
     return (
         <div className="p-2 d-flex flex-column h-100">
@@ -24,6 +25,9 @@ function App() {
                 </Tab>
                 <Tab eventKey="binds" title="Bindowanie">
                     <Binds />
+                </Tab>
+                <Tab eventKey="aliases" title="Aliasy">
+                    <Aliases />
                 </Tab>
             </Tabs>
         </div>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -68,6 +68,19 @@
             </div>
         </div>
     </div>
+    <div id="aliases-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Aliasy</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="aliases-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
     <div id="input-area">
         <input type="search" id="message-input" autocomplete="false" autocapitalize="off" spellcheck="false"/>
         <button id="send-button">➢</button>
@@ -82,6 +95,9 @@
                 </li>
                 <li>
                     <button class="w-100 p-1" id="binds-button">Bindowanie</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="aliases-button">Aliasy</button>
                 </li>
                 <li>
                     <button class="w-100 p-1" id="npc-button">Odbiorcy paczek</button>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -19,6 +19,7 @@ import { createElement } from 'react'
 import { createRoot} from 'react-dom/client'
 import Binds from "@options/src/Binds.tsx"
 import Npc from "@options/src/Npc.tsx"
+import Aliases from "@options/src/Aliases.tsx"
 
 // Prevent tab sleep on mobile when switching tabs
 let noSleepInstance: NoSleep | null = null;
@@ -241,6 +242,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const menuButton = document.getElementById('menu-button') as HTMLButtonElement | null;
     const optionsButton = document.getElementById('options-button') as HTMLButtonElement;
     const bindsButton = document.getElementById('binds-button') as HTMLButtonElement | null;
+    const aliasesButton = document.getElementById('aliases-button') as HTMLButtonElement | null;
     const npcButton = document.getElementById('npc-button') as HTMLButtonElement | null;
     wakeLockButton = document.getElementById('wake-lock-button') as HTMLButtonElement | null;
     updateWakeLockButton();
@@ -250,6 +252,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const optionsModal = optionsModalElement ? new Modal(optionsModalElement) : null;
     const bindsModalElement = document.getElementById('binds-modal');
     const bindsModal = bindsModalElement ? new Modal(bindsModalElement) : null;
+    const aliasesModalElement = document.getElementById('aliases-modal');
+    const aliasesModal = aliasesModalElement ? new Modal(aliasesModalElement) : null;
     const npcModalElement = document.getElementById('npc-modal');
     const npcModal = npcModalElement ? new Modal(npcModalElement) : null;
     const loginModalElement = document.getElementById('login-modal');
@@ -269,6 +273,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (bindsModal) {
             bindsModal.hide();
         }
+        if (aliasesModal) {
+            aliasesModal.hide();
+        }
         if (npcModal) {
             npcModal.hide();
         }
@@ -284,6 +291,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (bindsButton && bindsModal) {
         bindsButton.addEventListener('click', () => {
             bindsModal.show();
+        });
+    }
+
+    if (aliasesButton && aliasesModal) {
+        aliasesButton.addEventListener('click', () => {
+            aliasesModal.show();
         });
     }
 
@@ -459,6 +472,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const npcRoot = document.getElementById('npc-options');
     if (npcRoot) {
         createRoot(npcRoot).render(createElement(Npc));
+    }
+
+    const aliasesRoot = document.getElementById('aliases-options');
+    if (aliasesRoot) {
+        createRoot(aliasesRoot).render(createElement(Aliases));
     }
 });
 


### PR DESCRIPTION
## Summary
- create React component for alias list management
- expose alias management tab in options page
- add modal and menu button for aliases in the web client
- render alias manager modal via React
- load and apply saved aliases at runtime

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6871ae2e6df4832a83bdd9a98f23eadd