### PR TITLE
Add dynamic magic key coloring

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -196,11 +196,13 @@ import initLvlCalc from "./scripts/lvlCalc"
 import initItemCondition from "./scripts/itemCondition"
 import initInvite from "./scripts/invite"
 import initObjectAliases from "./scripts/objectAliases"
+import initMagicKeys from "./scripts/magicKeys"
 import registerGagTriggers from "./scripts/gags";
 
 initLvlCalc(client, aliases)
 initItemCondition(client)
 initInvite(client)
 initObjectAliases(client, aliases)
+initMagicKeys(client)
 
 window["clientExtension"] = client

--- a/client/src/scripts/magicKeyLoader.ts
+++ b/client/src/scripts/magicKeyLoader.ts
@@ -1,0 +1,121 @@
+export const MAGIC_KEYS_URL = "https://raw.githubusercontent.com/tjurczyk/arkadia-data/refs/heads/master/magic_keys.json";
+
+function isIndexedDBSupported() {
+    return typeof indexedDB !== 'undefined';
+}
+
+async function storeInIndexedDB(data: string[]) {
+    return new Promise<void>((resolve, reject) => {
+        if (!isIndexedDBSupported()) {
+            reject(new Error('IndexedDB is not supported'));
+            return;
+        }
+
+        const request = indexedDB.open('ArkadiaMagicKeysDB', 1);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains('magicKeys')) {
+                db.createObjectStore('magicKeys', { keyPath: 'id' });
+            }
+        };
+
+        request.onsuccess = () => {
+            const db = request.result;
+            const transaction = db.transaction(['magicKeys'], 'readwrite');
+            const store = transaction.objectStore('magicKeys');
+
+            const storeRequest = store.put({ id: 'keys', data });
+            storeRequest.onsuccess = () => resolve();
+            storeRequest.onerror = () => reject(new Error('Failed to store data in IndexedDB'));
+        };
+
+        request.onerror = () => {
+            reject(new Error('Failed to open IndexedDB'));
+        };
+    });
+}
+
+async function getFromIndexedDB() {
+    return new Promise<string[] | null>((resolve, reject) => {
+        if (!isIndexedDBSupported()) {
+            resolve(null);
+            return;
+        }
+
+        const request = indexedDB.open('ArkadiaMagicKeysDB', 1);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains('magicKeys')) {
+                db.createObjectStore('magicKeys', { keyPath: 'id' });
+            }
+        };
+
+        request.onsuccess = () => {
+            const db = request.result;
+            const transaction = db.transaction(['magicKeys'], 'readonly');
+            const store = transaction.objectStore('magicKeys');
+
+            const getRequest = store.get('keys');
+            getRequest.onsuccess = () => {
+                if (getRequest.result) {
+                    resolve(getRequest.result.data as string[]);
+                } else {
+                    resolve(null);
+                }
+            };
+            getRequest.onerror = () => reject(new Error('Failed to get data from IndexedDB'));
+        };
+
+        request.onerror = () => {
+            reject(new Error('Failed to open IndexedDB'));
+        };
+    });
+}
+
+export default async function loadMagicKeys(): Promise<string[]> {
+    try {
+        const indexed = await getFromIndexedDB();
+        if (indexed) {
+            localStorage.setItem('magic_keys', JSON.stringify(indexed));
+            return indexed;
+        }
+    } catch (e) {
+        console.warn('Failed to load magic keys from IndexedDB, falling back to localStorage:', e);
+    }
+
+    const cached = localStorage.getItem('magic_keys');
+    if (cached) {
+        try {
+            return JSON.parse(cached);
+        } catch {
+            console.error('Failed to parse cached magic keys');
+        }
+    }
+
+    try {
+        const response = await fetch(MAGIC_KEYS_URL);
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+        const data = await response.json();
+        if (!Array.isArray(data?.magic_keys)) {
+            throw new Error('Invalid data format');
+        }
+        const keys: string[] = data.magic_keys;
+        try {
+            await storeInIndexedDB(keys);
+            console.log('Successfully stored magic keys in IndexedDB');
+        } catch (e) {
+            console.warn('Failed to store magic keys in IndexedDB, falling back to localStorage:', e);
+        }
+        try {
+            localStorage.setItem('magic_keys', JSON.stringify(keys));
+        } catch (lsErr) {
+            console.error('Failed to cache magic keys in localStorage:', lsErr);
+        }
+        return keys;
+    } catch (e) {
+        console.error('Failed to load magic keys:', e);
+        return [];
+    }
+}

--- a/client/src/scripts/magicKeys.ts
+++ b/client/src/scripts/magicKeys.ts
@@ -1,0 +1,18 @@
+import Client from "../Client";
+import { colorStringInLine, findClosestColor } from "../Colors";
+import loadMagicKeys from "./magicKeyLoader";
+
+export default async function initMagicKeys(client: Client) {
+    const tag = "magicKeys";
+    try {
+        const keys = await loadMagicKeys();
+        const colorCode = findClosestColor("#00ff7f");
+        keys.forEach((pattern: string) => {
+            client.Triggers.registerTrigger(pattern, (raw) => {
+                return colorStringInLine(raw, pattern, colorCode);
+            }, tag);
+        });
+    } catch (e) {
+        console.error("Failed to load magic keys", e);
+    }
+}

--- a/client/test/magicKeys.test.ts
+++ b/client/test/magicKeys.test.ts
@@ -1,0 +1,25 @@
+import initMagicKeys from '../src/scripts/magicKeys';
+import { colorStringInLine, findClosestColor } from '../src/Colors';
+
+describe('magic keys', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        (global as any).fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ magic_keys: ['alpha', 'beta'] })
+        });
+    });
+
+    test('registers triggers from remote list', async () => {
+        const client = { Triggers: { registerTrigger: jest.fn() } } as any;
+        await initMagicKeys(client);
+        expect(fetch).toHaveBeenCalled();
+        expect(localStorage.getItem('magic_keys')).not.toBeNull();
+        expect(client.Triggers.registerTrigger).toHaveBeenCalledTimes(2);
+        const call = client.Triggers.registerTrigger.mock.calls[0];
+        const pattern = call[0];
+        const callback = call[1];
+        const colored = colorStringInLine('alpha test', pattern, findClosestColor('#00ff7f'));
+        expect(callback('alpha test', 'alpha test', {} as any)).toBe(colored);
+    });
+});


### PR DESCRIPTION
## Summary
- fetch magic key list from arkadia-data repo
- color magic keys in spring green at runtime
- test registering of magic key triggers

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6871aef11230832a97e80fb3dc66375c