### PR TITLE
Add magics coloring

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -197,6 +197,7 @@ import initItemCondition from "./scripts/itemCondition"
 import initInvite from "./scripts/invite"
 import initObjectAliases from "./scripts/objectAliases"
 import initMagicKeys from "./scripts/magicKeys"
+import initMagics from "./scripts/magics"
 import registerGagTriggers from "./scripts/gags";
 
 initLvlCalc(client, aliases)
@@ -204,5 +205,6 @@ initItemCondition(client)
 initInvite(client)
 initObjectAliases(client, aliases)
 initMagicKeys(client)
+initMagics(client)
 
 window["clientExtension"] = client

--- a/client/src/scripts/magics.ts
+++ b/client/src/scripts/magics.ts
@@ -1,0 +1,18 @@
+import Client from "../Client";
+import { colorStringInLine, findClosestColor } from "../Colors";
+import loadMagics from "./magicsLoader";
+
+export default async function initMagics(client: Client) {
+    const tag = "magics";
+    try {
+        const magics = await loadMagics();
+        const colorCode = findClosestColor('#B22222');
+        magics.forEach((pattern: string) => {
+            client.Triggers.registerTrigger(pattern, (raw) => {
+                return colorStringInLine(raw, pattern, colorCode);
+            }, tag);
+        });
+    } catch (e) {
+        console.error("Failed to load magics", e);
+    }
+}

--- a/client/src/scripts/magicsLoader.ts
+++ b/client/src/scripts/magicsLoader.ts
@@ -1,0 +1,127 @@
+export const MAGICS_URL = "https://raw.githubusercontent.com/tjurczyk/arkadia-data/refs/heads/master/magics_data.json";
+
+function isIndexedDBSupported() {
+    return typeof indexedDB !== 'undefined';
+}
+
+async function storeInIndexedDB(data: string[]) {
+    return new Promise<void>((resolve, reject) => {
+        if (!isIndexedDBSupported()) {
+            reject(new Error('IndexedDB is not supported'));
+            return;
+        }
+
+        const request = indexedDB.open('ArkadiaMagicsDB', 1);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains('magics')) {
+                db.createObjectStore('magics', { keyPath: 'id' });
+            }
+        };
+
+        request.onsuccess = () => {
+            const db = request.result;
+            const transaction = db.transaction(['magics'], 'readwrite');
+            const store = transaction.objectStore('magics');
+
+            const storeRequest = store.put({ id: 'magics', data });
+            storeRequest.onsuccess = () => resolve();
+            storeRequest.onerror = () => reject(new Error('Failed to store data in IndexedDB'));
+        };
+
+        request.onerror = () => {
+            reject(new Error('Failed to open IndexedDB'));
+        };
+    });
+}
+
+async function getFromIndexedDB() {
+    return new Promise<string[] | null>((resolve, reject) => {
+        if (!isIndexedDBSupported()) {
+            resolve(null);
+            return;
+        }
+
+        const request = indexedDB.open('ArkadiaMagicsDB', 1);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains('magics')) {
+                db.createObjectStore('magics', { keyPath: 'id' });
+            }
+        };
+
+        request.onsuccess = () => {
+            const db = request.result;
+            const transaction = db.transaction(['magics'], 'readonly');
+            const store = transaction.objectStore('magics');
+
+            const getRequest = store.get('magics');
+            getRequest.onsuccess = () => {
+                if (getRequest.result) {
+                    resolve(getRequest.result.data as string[]);
+                } else {
+                    resolve(null);
+                }
+            };
+            getRequest.onerror = () => reject(new Error('Failed to get data from IndexedDB'));
+        };
+
+        request.onerror = () => {
+            reject(new Error('Failed to open IndexedDB'));
+        };
+    });
+}
+
+export default async function loadMagics(): Promise<string[]> {
+    try {
+        const indexed = await getFromIndexedDB();
+        if (indexed) {
+            localStorage.setItem('magics', JSON.stringify(indexed));
+            return indexed;
+        }
+    } catch (e) {
+        console.warn('Failed to load magics from IndexedDB, falling back to localStorage:', e);
+    }
+
+    const cached = localStorage.getItem('magics');
+    if (cached) {
+        try {
+            return JSON.parse(cached);
+        } catch {
+            console.error('Failed to parse cached magics');
+        }
+    }
+
+    try {
+        const response = await fetch(MAGICS_URL);
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+        const data = await response.json();
+        const magicsObj = data?.magics;
+        if (!magicsObj || typeof magicsObj !== 'object') {
+            throw new Error('Invalid data format');
+        }
+        const magics: string[] = [];
+        for (const value of Object.values(magicsObj)) {
+            if (value && Array.isArray((value as any).regexps)) {
+                magics.push(...(value as any).regexps);
+            }
+        }
+        try {
+            await storeInIndexedDB(magics);
+            console.log('Successfully stored magics in IndexedDB');
+        } catch (e) {
+            console.warn('Failed to store magics in IndexedDB, falling back to localStorage:', e);
+        }
+        try {
+            localStorage.setItem('magics', JSON.stringify(magics));
+        } catch (lsErr) {
+            console.error('Failed to cache magics in localStorage:', lsErr);
+        }
+        return magics;
+    } catch (e) {
+        console.error('Failed to load magics:', e);
+        return [];
+    }
+}

--- a/client/test/magics.test.ts
+++ b/client/test/magics.test.ts
@@ -1,0 +1,25 @@
+import initMagics from '../src/scripts/magics';
+import { colorStringInLine, findClosestColor } from '../src/Colors';
+
+describe('magics', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        (global as any).fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ magics: { a: { regexps: ['alpha'] }, b: { regexps: ['beta'] } } })
+        });
+    });
+
+    test('registers triggers from remote list', async () => {
+        const client = { Triggers: { registerTrigger: jest.fn() } } as any;
+        await initMagics(client);
+        expect(fetch).toHaveBeenCalled();
+        expect(localStorage.getItem('magics')).not.toBeNull();
+        expect(client.Triggers.registerTrigger).toHaveBeenCalledTimes(2);
+        const call = client.Triggers.registerTrigger.mock.calls[0];
+        const pattern = call[0];
+        const callback = call[1];
+        const colored = colorStringInLine('alpha test', pattern, findClosestColor('#B22222'));
+        expect(callback('alpha test', 'alpha test', {} as any)).toBe(colored);
+    });
+});


### PR DESCRIPTION
## Summary
- download list of magical weapons from arkadia-data
- highlight lines matching magic weapon patterns in brick red
- expose magics initializer in main script
- cover magics colorization with tests

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6871b78acd54832ab029d2914761f15f