### PR TITLE
Add mobile attack selectors

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -179,13 +179,15 @@
 
     <!-- Mobile Direction Buttons (hidden by default) -->
     <div id="mobile-direction-buttons" class="mobile-direction-buttons">
+        <div class="mobile-attack-buttons">
+            <button class="mobile-button mobile-button-text top-button" id="z-list-toggle">/z</button>
+            <button class="mobile-button mobile-button-text top-button" id="zas-list-toggle">/zas</button>
+        </div>
         <div class="mobile-top-buttons">
             <button class="mobile-button mobile-button-text top-button" id="bracket-right-button">]</button>
             <button class="mobile-button mobile-button-text top-button" id="button-1">wesprzyj</button>
             <button class="mobile-button mobile-button-text top-button" id="button-2">/zz</button>
             <button class="mobile-button mobile-button-text top-button" id="button-3">/za</button>
-            <button class="mobile-button mobile-button-text top-button" id="z-list-toggle">/z</button>
-            <button class="mobile-button mobile-button-text top-button" id="zas-list-toggle">/zas</button>
         </div>
         <div class="mobile-direction-main">
             <div class="mobile-direction-grid">

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -184,6 +184,8 @@
             <button class="mobile-button mobile-button-text top-button" id="button-1">wesprzyj</button>
             <button class="mobile-button mobile-button-text top-button" id="button-2">/zz</button>
             <button class="mobile-button mobile-button-text top-button" id="button-3">/za</button>
+            <button class="mobile-button mobile-button-text top-button" id="z-list-toggle">/z</button>
+            <button class="mobile-button mobile-button-text top-button" id="zas-list-toggle">/zas</button>
         </div>
         <div class="mobile-direction-main">
             <div class="mobile-direction-grid">
@@ -203,6 +205,8 @@
                 <button class="mobile-button mobile-button-text direction-button" id="special-exit-button" title="">3</button>
             </div>
         </div>
+        <div id="z-buttons-list" class="mobile-z-buttons"></div>
+        <div id="zas-buttons-list" class="mobile-z-buttons"></div>
     </div>
 
 </div>

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -487,6 +487,16 @@ export default class MobileDirectionButtons {
         if (this.zasList) this.zasList.style.display = 'none';
     }
 
+    private applyButtonSize(btn: HTMLButtonElement) {
+        const ref = this.container.querySelector('.mobile-button') as HTMLButtonElement | null;
+        if (ref) {
+            const styles = window.getComputedStyle(ref);
+            btn.style.width = styles.width;
+            btn.style.height = styles.height;
+            btn.style.fontSize = styles.fontSize;
+        }
+    }
+
     private renderZList() {
         if (!this.zList) return;
         this.zList.innerHTML = '';
@@ -497,6 +507,7 @@ export default class MobileDirectionButtons {
         nums.forEach((n: string) => {
             const b = document.createElement('button');
             b.className = 'mobile-button';
+            this.applyButtonSize(b);
             b.textContent = n;
             b.addEventListener('click', () => {
                 this.client.sendCommand(`/z ${n}`);
@@ -516,6 +527,7 @@ export default class MobileDirectionButtons {
         letters.forEach((l: string) => {
             const b = document.createElement('button');
             b.className = 'mobile-button';
+            this.applyButtonSize(b);
             b.textContent = l;
             b.addEventListener('click', () => {
                 this.client.sendCommand(`/zas ${l}`);

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -6,6 +6,10 @@ export default class MobileDirectionButtons {
     private readonly container: HTMLDivElement;
     private readonly messageInput: HTMLInputElement | null = null;
     private readonly contentArea: HTMLElement | null = null;
+    private readonly zList: HTMLDivElement | null = null;
+    private readonly zasList: HTMLDivElement | null = null;
+    private readonly zToggle: HTMLButtonElement | null = null;
+    private readonly zasToggle: HTMLButtonElement | null = null;
     private enabled = false;
     private isMobile = false;
 
@@ -26,6 +30,10 @@ export default class MobileDirectionButtons {
         this.container = document.getElementById('mobile-direction-buttons') as HTMLDivElement;
         this.messageInput = document.getElementById('message-input') as HTMLInputElement;
         this.contentArea = document.getElementById('main_text_output_msg_wrapper');
+        this.zList = document.getElementById('z-buttons-list') as HTMLDivElement;
+        this.zasList = document.getElementById('zas-buttons-list') as HTMLDivElement;
+        this.zToggle = document.getElementById('z-list-toggle') as HTMLButtonElement;
+        this.zasToggle = document.getElementById('zas-list-toggle') as HTMLButtonElement;
 
         if (!this.container) {
             console.error('Mobile direction buttons container not found');
@@ -116,6 +124,30 @@ export default class MobileDirectionButtons {
             button3.addEventListener('click', () => {
                 if (window.clientExtension.TeamManager.getAttackTargetId()) {
                     client.sendCommand(`zaslon ob_${window.clientExtension.TeamManager.getAttackTargetId()}`)
+                }
+            });
+        }
+
+        if (this.zToggle) {
+            this.zToggle.addEventListener('click', () => {
+                if (this.zList && this.zList.style.display === 'flex') {
+                    this.hideLists();
+                } else {
+                    this.hideLists();
+                    this.renderZList();
+                    if (this.zList) this.zList.style.display = 'flex';
+                }
+            });
+        }
+
+        if (this.zasToggle) {
+            this.zasToggle.addEventListener('click', () => {
+                if (this.zasList && this.zasList.style.display === 'flex') {
+                    this.hideLists();
+                } else {
+                    this.hideLists();
+                    this.renderZasList();
+                    if (this.zasList) this.zasList.style.display = 'flex';
                 }
             });
         }
@@ -448,5 +480,48 @@ export default class MobileDirectionButtons {
                 this.contentArea.scrollTop = this.contentArea.scrollHeight;
             }
         }, 100);
+    }
+
+    private hideLists() {
+        if (this.zList) this.zList.style.display = 'none';
+        if (this.zasList) this.zasList.style.display = 'none';
+    }
+
+    private renderZList() {
+        if (!this.zList) return;
+        this.zList.innerHTML = '';
+        const objects = (window as any).clientExtension?.ObjectManager?.getObjectsOnLocation?.() || [];
+        const nums = Array.from(new Set(objects
+            .filter((o: any) => /^[0-9]+$/.test(o.shortcut))
+            .map((o: any) => o.shortcut)));
+        nums.forEach((n: string) => {
+            const b = document.createElement('button');
+            b.className = 'mobile-button';
+            b.textContent = n;
+            b.addEventListener('click', () => {
+                this.client.sendCommand(`/z ${n}`);
+                this.hideLists();
+            });
+            this.zList!.appendChild(b);
+        });
+    }
+
+    private renderZasList() {
+        if (!this.zasList) return;
+        this.zasList.innerHTML = '';
+        const objects = (window as any).clientExtension?.ObjectManager?.getObjectsOnLocation?.() || [];
+        const letters = Array.from(new Set(objects
+            .filter((o: any) => /^[A-Z]$/.test(o.shortcut))
+            .map((o: any) => o.shortcut)));
+        letters.forEach((l: string) => {
+            const b = document.createElement('button');
+            b.className = 'mobile-button';
+            b.textContent = l;
+            b.addEventListener('click', () => {
+                this.client.sendCommand(`/zas ${l}`);
+                this.hideLists();
+            });
+            this.zasList!.appendChild(b);
+        });
     }
 }

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -130,24 +130,24 @@ export default class MobileDirectionButtons {
 
         if (this.zToggle) {
             this.zToggle.addEventListener('click', () => {
-                if (this.zList && this.zList.style.display === 'flex') {
+                if (this.zList && this.zList.style.display === 'grid') {
                     this.hideLists();
                 } else {
                     this.hideLists();
                     this.renderZList();
-                    if (this.zList) this.zList.style.display = 'flex';
+                    if (this.zList) this.zList.style.display = 'grid';
                 }
             });
         }
 
         if (this.zasToggle) {
             this.zasToggle.addEventListener('click', () => {
-                if (this.zasList && this.zasList.style.display === 'flex') {
+                if (this.zasList && this.zasList.style.display === 'grid') {
                     this.hideLists();
                 } else {
                     this.hideLists();
                     this.renderZasList();
-                    if (this.zasList) this.zasList.style.display = 'flex';
+                    if (this.zasList) this.zasList.style.display = 'grid';
                 }
             });
         }

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -360,6 +360,13 @@ button:focus-visible {
   margin-bottom: 5px;
 }
 
+.mobile-attack-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 5px;
+  margin-bottom: 5px;
+}
+
 .mobile-direction-main {
   display: flex;
 }
@@ -422,7 +429,7 @@ button:focus-visible {
 .mobile-z-buttons {
   position: absolute;
   right: 100%;
-  top: 0;
+  top: 82px;
   display: none;
   flex-direction: column;
   gap: 3px;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -431,6 +431,7 @@ button:focus-visible {
   right: 100%;
   top: 0;
   display: none;
+  grid-template-columns: 1fr;
   grid-auto-rows: 36px;
   gap: 5px;
 }

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -419,6 +419,15 @@ button:focus-visible {
   pointer-events: none; /* Disable click events */
 }
 
+.mobile-z-buttons {
+  position: absolute;
+  right: 100%;
+  top: 0;
+  display: none;
+  flex-direction: column;
+  gap: 3px;
+}
+
 #map-progress-container {
   pointer-events: none;
 }

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -362,7 +362,7 @@ button:focus-visible {
 
 .mobile-attack-buttons {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 5px;
   margin-bottom: 5px;
 }
@@ -429,10 +429,10 @@ button:focus-visible {
 .mobile-z-buttons {
   position: absolute;
   right: 100%;
-  top: 82px;
+  top: 0;
   display: none;
-  flex-direction: column;
-  gap: 3px;
+  grid-auto-rows: 36px;
+  gap: 5px;
 }
 
 #map-progress-container {


### PR DESCRIPTION
## Summary
- expand mobile direction panel with /z and /zas buttons
- add containers for selectable numbers and letters
- populate those buttons from objects list in web client

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6872982307b8832a9c849a4ac8a7159f