### PR TITLE
Fix auth overlay z-index

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -453,7 +453,7 @@ button:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 1vw;
-  z-index: 1000;
+  z-index: 1011;
 }
 
 #auth-overlay {
@@ -462,7 +462,7 @@ button:focus-visible {
   background-color: rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
-  z-index: 999;
+  z-index: 1010;
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- overlay should cover mobile buttons, so raise z-index
- ensure auth buttons stay on top

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687296bf1820832ab15d7733ff67c995