### PR TITLE
Add docs for default binds

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -157,12 +157,14 @@ import initBuses from './scripts/buses'
 import initGates from './scripts/gates'
 import initAttackBeep from './scripts/attackBeep'
 import initLamp from './scripts/lamp'
+import initBinds from './scripts/binds'
 
 initShips(client)
 initBuses(client)
 initGates(client)
 initAttackBeep(client)
 initLamp(client)
+initBinds(client, aliases)
 
 import initKillTrigger from './scripts/kill'
 initKillTrigger(client, aliases)

--- a/client/src/scripts/binds.ts
+++ b/client/src/scripts/binds.ts
@@ -1,0 +1,18 @@
+import Client from "../Client";
+import { formatLabel } from "./functionalBind";
+
+export default function initBinds(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
+    function printBinds() {
+        const main = client.FunctionalBind.getLabel();
+        const lamp = formatLabel(client.lampBind);
+        const lines = [
+            `Domy\u015Blny: ${main}`,
+            `Nape\u0142nij lamp\u0119: ${lamp}`,
+        ];
+        client.println(lines.join("\n"));
+    }
+
+    if (aliases) {
+        aliases.push({ pattern: /\/binds$/, callback: printBinds });
+    }
+}

--- a/client/test/binds.test.ts
+++ b/client/test/binds.test.ts
@@ -1,0 +1,21 @@
+import initBinds from '../src/scripts/binds';
+
+class FakeClient {
+  FunctionalBind = { getLabel: jest.fn(() => ']') };
+  lampBind = { key: 'Digit4', ctrl: true };
+  println = jest.fn();
+}
+
+describe('binds alias', () => {
+  test('prints current binds', () => {
+    const client = new FakeClient();
+    const aliases: { pattern: RegExp; callback: () => void }[] = [];
+    initBinds((client as unknown) as any, aliases);
+    const show = aliases[0].callback;
+    show();
+    expect(client.println).toHaveBeenCalledTimes(1);
+    const printed = client.println.mock.calls[0][0];
+    expect(printed).toContain('Domy\u015Blny: ]');
+    expect(printed).toContain('Nape\u0142nij lamp\u0119: CTRL+4');
+  });
+});

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -30,3 +30,4 @@ Poniższa lista opisuje dostępne aliasy w rozszerzeniu:
 - **/za** - zasłania cel oznaczony jako cel obrony.
 - **/zap** - wykonuje polecenie `zapal lampe`.
 - **/zg** - wykonuje polecenie `zgas lampe`.
+- **/binds** - wyświetla aktualnie ustawione skróty klawiaturowe.

--- a/docs/BINDS.md
+++ b/docs/BINDS.md
@@ -1,0 +1,9 @@
+# Bindowanie
+
+Rozszerzenie umożliwia ustawienie kilku skrótów klawiaturowych. Domyślne bindy to:
+
+- **Domyślny** – klawisz `]` (BracketRight). Używany do wykonywania akcji kontekstowych, np. zbierania łupów z ciała czy powtarzania poleceń pojawiających się w komunikatach.
+- **Napełnij lampę** – `CTRL+4`. Skrót wysyła komendę `napelnij lampe olejem`.
+
+Bindy można modyfikować w zakładce **Bindowanie** na stronie opcji rozszerzenia.
+Aktualnie ustawione skróty możesz też wypisać w grze komendą `/binds`.


### PR DESCRIPTION
## Summary
- document current keybinds in new `BINDS.md`
- add `/binds` alias to print currently configured keys
- test the `/binds` alias

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6872aaa0e0d0832ab361688003a02bd6