### PR TITLE
Fix build error due to ASI

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -169,8 +169,8 @@ initKillTrigger(client, aliases)
 
 import ItemCollector from './scripts/itemCollector'
 
-const itemCollector = new ItemCollector(client)
-(client as any).ItemCollector = itemCollector
+const itemCollector = new ItemCollector(client);
+(client as any).ItemCollector = itemCollector;
 
 aliases.push({
     pattern: /\/zbieraj_extra(.*)/,


### PR DESCRIPTION
## Summary
- ensure ItemCollector initialization line ends with a semicolon

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6872ac6a26cc832a83a010bc9cffcf85