### PR TITLE
Implement opposite highlight for char state

### DIFF
--- a/web-client/src/CharState.ts
+++ b/web-client/src/CharState.ts
@@ -86,15 +86,18 @@ export default class CharState {
         this.config[key].default === undefined ||
         this.state[key] !== this.config[key].default,
     );
-    this.text.textContent = entries
+    this.text.innerHTML = entries
       .map((key) => {
         let value = this.state[key] as number;
-        const { max, label, transform } = this.config[key];
+        const { max, label, transform, default: def } = this.config[key];
         let maxValue = max;
         if (transform && typeof value === "number") {
           ({ value, max: maxValue } = transform(value, maxValue));
         }
-        return `${label}: [${value}/${maxValue}]`;
+        const opposite = def !== undefined ? (def > 0 ? 0 : maxValue) : null;
+        const highlight = opposite !== null && value === opposite;
+        const text = `${label}: [${value}/${maxValue}]`;
+        return highlight ? `<span style="color:tomato">${text}</span>` : text;
       })
       .join(" ");
   }


### PR DESCRIPTION
## Summary
- highlight extreme char state values in red

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6872aefe9154832ab77e27d6d8d5264a