### PR TITLE
Fix reconnect credentials

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -124,7 +124,7 @@
                         <input id="login-password" type="password" class="form-control" placeholder="Password">
                         <label class="form-label">
                             <input id="login-remember-password" type="checkbox" class="form-check-input me-2">
-                            Remember password (stored locally, may be insecure)
+                            Remember credentials (stored locally, may be insecure)
                         </label>
                     </div>
                     <div class="modal-footer">

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -128,6 +128,13 @@ class ArkadiaClient {
     }
 
     /**
+     * Manually set the stored character for automatic credential sending
+     */
+    setStoredCharacter(character: string | null): void {
+        this.userCommand = character;
+    }
+
+    /**
      * Send a message through the WebSocket
      */
     send(message: string): void {

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -13,7 +13,7 @@ import NoSleep from 'nosleep.js';
 import { loadMapData, loadColors } from "./mapDataLoader.ts";
 import { loadNpcData } from "./npcDataLoader.ts";
 import "@map/embedded.js"
-import { savePassword, getPassword, clearPassword } from "./passwordStore";
+import { savePassword, getPassword, clearPassword, saveCharacter, getCharacter, clearCharacter } from "./passwordStore";
 const client = ArkadiaClient
 
 import { createElement } from 'react'
@@ -379,11 +379,12 @@ document.addEventListener('DOMContentLoaded', () => {
             loginModal.hide();
 
             if (rememberPassword && rememberPassword.checked && password) {
-                try { await savePassword(password); } catch {}
+                try { await savePassword(password); await saveCharacter(character); } catch {}
             } else {
-                try { await clearPassword(); } catch {}
+                try { await clearPassword(); await clearCharacter(); } catch {}
             }
             client.setStoredPassword(password || null);
+            client.setStoredCharacter(character || null);
 
             const sendCreds = () => {
                 if (character) Input.send(character);
@@ -493,9 +494,13 @@ document.addEventListener('DOMContentLoaded', () => {
     if (reconnectButton) {
         reconnectButton.addEventListener('click', async () => {
             try {
-                const stored = await getPassword();
-                if (stored) {
-                    client.setStoredPassword(stored);
+                const storedPass = await getPassword();
+                const storedChar = await getCharacter();
+                if (storedPass) {
+                    client.setStoredPassword(storedPass);
+                }
+                if (storedChar) {
+                    client.setStoredCharacter(storedChar);
                 }
             } catch {}
             client.connect(false);

--- a/web-client/src/passwordStore.ts
+++ b/web-client/src/passwordStore.ts
@@ -87,3 +87,86 @@ export async function clearPassword() {
         request.onerror = () => reject(new Error('Failed to open IndexedDB'));
     });
 }
+
+export async function saveCharacter(character: string) {
+    return new Promise<void>((resolve, reject) => {
+        if (!isIndexedDBSupported()) {
+            reject(new Error('IndexedDB is not supported'));
+            return;
+        }
+
+        const request = indexedDB.open(DB_NAME, 1);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+                db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+            }
+        };
+        request.onsuccess = () => {
+            const db = request.result;
+            const tx = db.transaction([STORE_NAME], 'readwrite');
+            const store = tx.objectStore(STORE_NAME);
+            const putReq = store.put({ id: 'character', value: character });
+            putReq.onsuccess = () => resolve();
+            putReq.onerror = () => reject(new Error('Failed to store character'));
+        };
+        request.onerror = () => reject(new Error('Failed to open IndexedDB'));
+    });
+}
+
+export async function getCharacter() {
+    return new Promise<string | null>((resolve, reject) => {
+        if (!isIndexedDBSupported()) {
+            resolve(null);
+            return;
+        }
+
+        const request = indexedDB.open(DB_NAME, 1);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+                db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+            }
+        };
+        request.onsuccess = () => {
+            const db = request.result;
+            const tx = db.transaction([STORE_NAME], 'readonly');
+            const store = tx.objectStore(STORE_NAME);
+            const getReq = store.get('character');
+            getReq.onsuccess = () => {
+                if (getReq.result) {
+                    resolve(getReq.result.value as string);
+                } else {
+                    resolve(null);
+                }
+            };
+            getReq.onerror = () => reject(new Error('Failed to get character'));
+        };
+        request.onerror = () => reject(new Error('Failed to open IndexedDB'));
+    });
+}
+
+export async function clearCharacter() {
+    return new Promise<void>((resolve, reject) => {
+        if (!isIndexedDBSupported()) {
+            resolve();
+            return;
+        }
+        const request = indexedDB.open(DB_NAME, 1);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+                db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+            }
+        };
+        request.onsuccess = () => {
+            const db = request.result;
+            const tx = db.transaction([STORE_NAME], 'readwrite');
+            const store = tx.objectStore(STORE_NAME);
+            const delReq = store.delete('character');
+            delReq.onsuccess = () => resolve();
+            delReq.onerror = () => reject(new Error('Failed to delete character'));
+        };
+        request.onerror = () => reject(new Error('Failed to open IndexedDB'));
+    });
+}


### PR DESCRIPTION
## Summary
- store login character in IndexedDB alongside password
- expose `setStoredCharacter` on `ArkadiaClient`
- remember both character and password from login form
- load stored credentials on reconnect
- update dialog wording

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6872bc9e3848832a8bfcf17cd98019dd