### PR TITLE
Fix sendCommand splitting

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -115,7 +115,9 @@ export default class Client {
 
     sendCommand(command: string) {
         this.eventTarget.dispatchEvent(new CustomEvent('command', {detail: command}))
-        rawInputSend(this.Map.parseCommand(command))
+        command.split(/[#;]/).forEach(part => {
+            rawInputSend(this.Map.parseCommand(part))
+        })
     }
 
     onLine(line: string, type: string) {

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -92,11 +92,13 @@ test('createButton creates button attached to panel', () => {
   expect(panel?.contains(button)).toBe(true);
 });
 
-test('sendCommand dispatches event and sends parsed command', () => {
+test('sendCommand dispatches event and splits commands', () => {
   const client = new Client();
-  client.sendCommand('test');
-  expect(parseCommand).toHaveBeenCalledWith('test');
-  expect((window as any).Input.send).toHaveBeenCalledWith('parsed:test');
+  client.sendCommand('foo#bar');
+  expect(parseCommand).toHaveBeenNthCalledWith(1, 'foo');
+  expect(parseCommand).toHaveBeenNthCalledWith(2, 'bar');
+  expect((window as any).Input.send).toHaveBeenNthCalledWith(1, 'parsed:foo');
+  expect((window as any).Input.send).toHaveBeenNthCalledWith(2, 'parsed:bar');
 });
 
 test('sendCommand allows empty command', () => {


### PR DESCRIPTION
## Summary
- split commands containing `#` or `;` in `sendCommand`
- update tests for new behaviour

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6872cca668a4832a87d757d44eed4f7d