### PR TITLE
Move emoji labels to UI settings

### DIFF
--- a/options/src/Settings.tsx
+++ b/options/src/Settings.tsx
@@ -28,7 +28,6 @@ interface Settings {
     packageHelper: boolean;
     replaceMap: boolean;
     inlineCompassRose: boolean;
-    emojiLabels: boolean;
     prettyContainers: boolean;
     containerColumns: number;
     collectMode: number;
@@ -44,7 +43,6 @@ function SettingsForm() {
         packageHelper: false,
         replaceMap: false,
         inlineCompassRose: false,
-        emojiLabels: false,
         prettyContainers: true,
         containerColumns: 2,
         collectMode: 3,
@@ -188,14 +186,6 @@ function SettingsForm() {
                         label="Róża wiatrów"
                         checked={settings.inlineCompassRose}
                         onChange={e => onChangeSetting(s => s.inlineCompassRose = e.target.checked)}
-                        className="me-2"
-                    />
-                    <Form.Check
-                        type="checkbox"
-                        id="emojiLabels"
-                        label="Emoji w stanie postaci"
-                        checked={settings.emojiLabels}
-                        onChange={e => onChangeSetting(s => s.emojiLabels = e.target.checked)}
                         className="me-2"
                     />
                 </div>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -156,6 +156,10 @@
                         <input id="ui-show-buttons" type="checkbox" class="form-check-input me-2" />
                         Show on-screen buttons
                     </label>
+                    <label class="form-label">
+                        <input id="ui-emoji-labels" type="checkbox" class="form-check-input me-2" />
+                        Emoji labels in char state
+                    </label>
                     <label class="form-label">Map zoom
                         <input id="ui-map-scale" type="number" step="0.05" min="0.05" class="form-control" />
                     </label>

--- a/web-client/src/CharState.ts
+++ b/web-client/src/CharState.ts
@@ -118,6 +118,15 @@ export default class CharState {
       }
     });
 
+    const ext: any = (window as any).clientExtension;
+    if (ext?.addEventListener) {
+      ext.addEventListener('uiSettings', (ev: CustomEvent) => {
+        if (typeof ev.detail?.emojiLabels === 'boolean') {
+          this.applyLabelMode(ev.detail.emojiLabels);
+        }
+      });
+    }
+
     this.client.on(
       "gmcp.char.state",
       (state: Partial<CharStateData>) => this.update(state),

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -7,6 +7,7 @@ interface UiSettings {
     mapScale: number;
     showButtons: boolean;
     mapHeight: number;
+    emojiLabels: boolean;
 }
 
 const defaultSettings: UiSettings = {
@@ -16,6 +17,7 @@ const defaultSettings: UiSettings = {
     mapScale: 0.30,
     showButtons: true,
     mapHeight: typeof window !== 'undefined' && window.innerWidth < 768 ? 25 : 30,
+    emojiLabels: false,
 };
 
 function apply(settings: UiSettings) {
@@ -56,7 +58,7 @@ function apply(settings: UiSettings) {
     }
     if ((window as any).clientExtension?.eventTarget) {
         (window as any).clientExtension.eventTarget.dispatchEvent(
-            new CustomEvent('uiSettings', { detail: { mobileDirectionButtons: settings.showButtons } })
+            new CustomEvent('uiSettings', { detail: { mobileDirectionButtons: settings.showButtons, emojiLabels: settings.emojiLabels } })
         );
     }
 }
@@ -70,7 +72,7 @@ function load(): UiSettings {
                 const value = Math.abs(parseFloat(parsed.mapScale));
                 return value > 0 ? value : defaultSettings.mapScale;
             })();
-            return { ...defaultSettings, ...parsed, mapScale };
+            return { ...defaultSettings, ...parsed, mapScale, emojiLabels: !!parsed.emojiLabels };
         }
     } catch {
         // ignore malformed data
@@ -94,6 +96,7 @@ export default function initUiSettings() {
     const mapInput = modalEl.querySelector('#ui-map-scale') as HTMLInputElement;
     const mapHeightInput = modalEl.querySelector('#ui-map-height') as HTMLInputElement;
     const showButtonsInput = modalEl.querySelector('#ui-show-buttons') as HTMLInputElement;
+    const emojiLabelsInput = modalEl.querySelector('#ui-emoji-labels') as HTMLInputElement;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
 
     let current = load();
@@ -103,6 +106,7 @@ export default function initUiSettings() {
     mapInput.value = String(current.mapScale);
     mapHeightInput.value = String(current.mapHeight);
     showButtonsInput.checked = current.showButtons;
+    emojiLabelsInput.checked = current.emojiLabels;
     apply(current);
 
     function read(): UiSettings {
@@ -120,6 +124,7 @@ export default function initUiSettings() {
             mapScale,
             mapHeight: parseFloat(mapHeightInput.value) || defaultSettings.mapHeight,
             showButtons: showButtonsInput.checked,
+            emojiLabels: emojiLabelsInput.checked,
         };
     }
 


### PR DESCRIPTION
## Summary
- move emoji toggle from options into UI settings
- emit emojiLabels value with UI settings updates
- listen for uiSettings events in CharState

## Testing
- `yarn --cwd client test` *(fails: this.Map.move is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6872f8342fd0832a85a86a9abf330b69