### PR TITLE
Fix lamp timer reset

### DIFF
--- a/client/src/scripts/lamp.ts
+++ b/client/src/scripts/lamp.ts
@@ -47,7 +47,6 @@ export default function initLamp(client: Client) {
 
     function resetTimer() {
         seconds = DEFAULT_TIME
-        processCounter()
     }
 
     function takeBottle() {


### PR DESCRIPTION
## Summary
- update lamp logic so refilling no longer activates the timer

## Testing
- `yarn --cwd client test` *(fails: this.Map.move is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6872ff6a9b04832ab61b33576e9a146a