### PR TITLE
Fix password auto-send on reconnect

### DIFF
--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -86,9 +86,9 @@ class ArkadiaClient {
                 this.emit('open', event);
                 this.emit('client.connect');
                 if (!this.lastConnectManual && this.userCommand && this.passwordCommand) {
-                    this.send(this.userCommand);
+                    this.sendRaw(this.userCommand);
                     if (this.passwordCommand !== this.userCommand) {
-                        this.send(this.passwordCommand);
+                        this.sendRaw(this.passwordCommand);
                     }
                 }
             };
@@ -154,6 +154,26 @@ class ArkadiaClient {
         try {
             this.socket.send(btoa(message + "\r\n"));
             // Only echo commands if we've received the first GMCP event
+            if (this.receivedFirstGmcp && message) {
+                Output.send("-> " + message);
+            }
+        } catch (error) {
+            console.error('Error sending message:', error);
+            this.emit('error', error);
+        }
+    }
+
+    /**
+     * Send a message without updating stored credentials
+     */
+    private sendRaw(message: string): void {
+        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+            console.error('WebSocket is not connected');
+            return;
+        }
+
+        try {
+            this.socket.send(btoa(message + "\r\n"));
             if (this.receivedFirstGmcp && message) {
                 Output.send("-> " + message);
             }


### PR DESCRIPTION
## Summary
- send stored credentials without updating them

## Testing
- `yarn --cwd client test` *(fails: this.Map.move is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6872ff2d13c4832aa1d98eec6e922521