### PR TITLE
Fix mobile button text color

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -395,6 +395,7 @@ button:focus-visible {
   border: 1px solid #a0d0e0;
   border-radius: 4px;
   background-color: #87CEEB; /* Sky blue */
+  color: inherit;
   cursor: pointer;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- ensure `.mobile-button` inherits text color so theme colors apply correctly

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68736361dc1c832a8289c37d5b9d4b15