### PR TITLE
Add warning when target differs from leader

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -197,6 +197,7 @@ import initObjectAliases from './scripts/objectAliases'
 import initMagicKeys from './scripts/magicKeys'
 import initMagics from './scripts/magics'
 import registerGagTriggers from './scripts/gags'
+import initLeaderAttackWarning from './scripts/leaderAttackWarning'
 
 initLvlCalc(client, aliases)
 initItemCondition(client)
@@ -204,5 +205,6 @@ initInvite(client)
 initObjectAliases(client, aliases)
 initMagicKeys(client)
 initMagics(client)
+initLeaderAttackWarning(client)
 
 window['clientExtension'] = client

--- a/client/src/scripts/leaderAttackWarning.ts
+++ b/client/src/scripts/leaderAttackWarning.ts
@@ -1,0 +1,36 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+export default function initLeaderAttackWarning(client: Client) {
+    const RED = findClosestColor("#ff0000");
+    const PADDING = 4; // two spaces on each side
+
+    function getLeaderTargetId(): string | undefined {
+        const leader = client.TeamManager.getLeader();
+        if (!leader) return undefined;
+        const data = client.TeamManager.getAccumulatedObjectsData() as Record<string, any>;
+        for (const obj of Object.values(data)) {
+            if (obj && obj.desc === leader) {
+                const target = (obj as any).attack_num;
+                if (typeof target === 'number' || typeof target === 'string') {
+                    return String(target);
+                }
+            }
+        }
+        return undefined;
+    }
+
+    function check() {
+        const myTarget = client.TeamManager.getAttackTargetId();
+        const leaderTarget = getLeaderTargetId();
+        if (myTarget && leaderTarget && myTarget !== leaderTarget) {
+            const text = "Atakujesz inny cel";
+            const width = text.length + PADDING;
+            const line = "=".repeat(width);
+            const message = `${line}\n  ${text}  \n${line}`;
+            client.println(colorString(message, RED));
+        }
+    }
+
+    client.addEventListener('teamLeaderTargetNoAvatar', check);
+}

--- a/client/test/TeamManager.test.ts
+++ b/client/test/TeamManager.test.ts
@@ -173,4 +173,5 @@ describe('TeamManager', () => {
     expect(manager.getAttackTargetId()).toBe('1');
     expect(manager.getDefenseTargetId()).toBe('2');
   });
+
 });

--- a/client/test/leaderAttackWarning.test.ts
+++ b/client/test/leaderAttackWarning.test.ts
@@ -1,0 +1,64 @@
+import initLeaderAttackWarning from '../src/scripts/leaderAttackWarning';
+import { stripAnsiCodes } from '../src/Triggers';
+import { EventEmitter } from 'events';
+
+class FakeClient {
+  private emitter = new EventEmitter();
+  TeamManager = {
+    getAttackTargetId: jest.fn(),
+    getLeader: jest.fn(),
+    getAccumulatedObjectsData: jest.fn()
+  };
+  println = jest.fn();
+  addEventListener(event: string, cb: any) {
+    this.emitter.on(event, cb);
+  }
+  removeEventListener(event: string, cb: any) {
+    this.emitter.off(event, cb);
+  }
+  sendEvent(type: string, detail?: any) {
+    this.emitter.emit(type, { detail });
+  }
+}
+
+describe('leader attack warning', () => {
+  let client: FakeClient;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initLeaderAttackWarning((client as unknown) as any);
+  });
+
+  test('prints warning when targets differ', () => {
+    client.TeamManager.getAttackTargetId.mockReturnValue('2');
+    client.TeamManager.getLeader.mockReturnValue('Leader');
+    client.TeamManager.getAccumulatedObjectsData.mockReturnValue({ '10': { desc: 'Leader', attack_num: '1' } });
+    client.sendEvent('teamLeaderTargetNoAvatar');
+    expect(client.println).toHaveBeenCalledTimes(1);
+    const text = stripAnsiCodes(client.println.mock.calls[0][0]);
+    expect(text).toContain('Atakujesz inny cel');
+  });
+
+  test('does not print when targets match', () => {
+    client.TeamManager.getAttackTargetId.mockReturnValue('1');
+    client.TeamManager.getLeader.mockReturnValue('Leader');
+    client.TeamManager.getAccumulatedObjectsData.mockReturnValue({ '10': { desc: 'Leader', attack_num: '1' } });
+    client.sendEvent('teamLeaderTargetNoAvatar');
+    expect(client.println).not.toHaveBeenCalled();
+  });
+
+  test('prints again after state changes', () => {
+    client.TeamManager.getAttackTargetId.mockReturnValue('2');
+    client.TeamManager.getLeader.mockReturnValue('Leader');
+    client.TeamManager.getAccumulatedObjectsData.mockReturnValue({ '10': { desc: 'Leader', attack_num: '1' } });
+    client.sendEvent('teamLeaderTargetNoAvatar');
+    client.sendEvent('teamLeaderTargetNoAvatar');
+    expect(client.println).toHaveBeenCalledTimes(2);
+    client.TeamManager.getAttackTargetId.mockReturnValue('1');
+    client.sendEvent('teamLeaderTargetNoAvatar');
+    expect(client.println).toHaveBeenCalledTimes(2);
+    client.TeamManager.getAttackTargetId.mockReturnValue('2');
+    client.sendEvent('teamLeaderTargetNoAvatar');
+    expect(client.println).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary
- warn player when attacking a different target than team leader
- simplify logic to listen only to `teamLeaderTargetNoAvatar`
- avoid blank lines in `TeamManager`
- adjust tests for new behavior

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_68736b604ac0832a988e3750b98d6a47