### PR TITLE
Implement multiline triggers

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -156,6 +156,7 @@ export default class Client {
             }
         }, {once: true})
 
+        line = this.Triggers.parseMultiline(line, type)
         let result = line.split('\n').map(partial => this.Triggers.parseLine(partial, type)).join('\n')
         const ansiRegex = /\x1b\[[0-9;]*m/g
         const restore: string[] = []

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -30,7 +30,13 @@ jest.mock('howler', () => {
   return { Howl: jest.fn(() => instance) };
 });
 
-jest.mock('../src/Triggers', () => ({ __esModule: true, default: jest.fn().mockImplementation(() => ({ parseLine: jest.fn((l: string) => l) })) }));
+jest.mock('../src/Triggers', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    parseLine: jest.fn((l: string) => l),
+    parseMultiline: jest.fn((l: string) => l),
+  })),
+}));
 jest.mock('../src/PackageHelper', () => ({ __esModule: true, default: jest.fn() }));
 jest.mock('../src/OutputHandler', () => ({ __esModule: true, default: jest.fn() }));
 jest.mock('../src/scripts/functionalBind', () => ({

--- a/client/test/Triggers.test.ts
+++ b/client/test/Triggers.test.ts
@@ -34,4 +34,15 @@ describe('Triggers', () => {
     triggers.parseLine('child', '');
     expect(childCb).not.toHaveBeenCalled();
   });
+
+  test('parseMultiline executes registered multiline trigger', () => {
+    const triggers = new Triggers({} as any);
+    const cb = jest.fn(() => 'changed');
+    triggers.registerMultilineTrigger(/foo\nbar/, cb);
+
+    const result = triggers.parseMultiline('foo\nbar', '');
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(result).toBe('changed');
+  });
 });


### PR DESCRIPTION
## Summary
- add ability to register multiline triggers
- process multiline triggers before splitting lines
- adjust tests

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68737cb1a084832aaa4b6bd6376d47e1