### PR TITLE
Add break item warnings

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -198,6 +198,7 @@ import initMagicKeys from './scripts/magicKeys'
 import initMagics from './scripts/magics'
 import registerGagTriggers from './scripts/gags'
 import initLeaderAttackWarning from './scripts/leaderAttackWarning'
+import initBreakItem from './scripts/breakItem'
 
 initLvlCalc(client, aliases)
 initItemCondition(client)
@@ -206,5 +207,6 @@ initObjectAliases(client, aliases)
 initMagicKeys(client)
 initMagics(client)
 initLeaderAttackWarning(client)
+initBreakItem(client)
 
 window['clientExtension'] = client

--- a/client/src/scripts/breakItem.ts
+++ b/client/src/scripts/breakItem.ts
@@ -22,6 +22,7 @@ export default function initBreakItem(client: Client) {
     entries.forEach(({ pattern, command }) => {
         client.Triggers.registerTrigger(pattern, (_raw, line) => {
             client.playSound("beep");
+            client.sendEvent('breakItem', { text: line, command });
             const label = command ? ` >> ${command}` : " >> Sprzet zniszczony";
             client.FunctionalBind.set(label, () => {
                 if (command) {

--- a/client/src/scripts/breakItem.ts
+++ b/client/src/scripts/breakItem.ts
@@ -1,0 +1,34 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+export default function initBreakItem(client: Client) {
+    const COLOR = findClosestColor("#ff6347");
+    const tag = "break-item";
+
+    type Entry = { pattern: RegExp; command?: string };
+
+    const entries: Entry[] = [
+        { pattern: /^Nagle (\w+) rozpruwa sie\.(?:.*)/ },
+        { pattern: /^Niestety zbyt mocnym ruchem rozrywasz (?:\w+ )+(\w+), drac go na bezwartosciowe pasy materialu\.$/ },
+        { pattern: /^Probujesz zalozyc (?:\w+ )+line(?: z hakiem)?, ale ta peka ci w rekach ze starosci\.$/ },
+        { pattern: /^Czujesz, ze (?:\w+ )+(\w+) po prostu rozpada ci sie w rekach\.$/ },
+        { pattern: /^(?:[A-Z][a-z]+) (?:[a-z]+ ){1,3}peka(?:ja)?!$/, command: "odloz zniszczona bron" },
+        { pattern: /^(?:[A-Z][a-z]+) (?:[a-z]+ ){1,3}rozpada(?:ja)? sie!$/, command: "odloz zniszczona zbroje" },
+        { pattern: /^(?:[A-Z][a-z-]+ ?){1,3} ((?:[A-Z][a-z]+ |(?:\w+ ){3,4}))rozpada(?:ja)? sie!/, command: "odloz zniszczona zbroje" },
+    ];
+
+    const format = (line: string) => `\n\n${client.prefix(line, colorString("[  SPRZET  ] ", COLOR))}\n\n`;
+
+    entries.forEach(({ pattern, command }) => {
+        client.Triggers.registerTrigger(pattern, (_raw, line) => {
+            client.playSound("beep");
+            const label = command ? ` >> ${command}` : " >> Sprzet zniszczony";
+            client.FunctionalBind.set(label, () => {
+                if (command) {
+                    client.sendCommand(command);
+                }
+            }, true);
+            return format(line);
+        }, tag);
+    });
+}

--- a/client/test/breakItem.test.ts
+++ b/client/test/breakItem.test.ts
@@ -7,6 +7,7 @@ class FakeClient {
   FunctionalBind = { set: jest.fn() } as any;
   playSound = jest.fn();
   sendCommand = jest.fn();
+  sendEvent = jest.fn();
   prefix = (line: string, prefix: string) => prefix + line;
 }
 
@@ -25,6 +26,7 @@ describe('break item triggers', () => {
     const line = 'Nagle topor rozpruwa sie.';
     const result = parse(line);
     expect(client.playSound).toHaveBeenCalledTimes(1);
+    expect(client.sendEvent).toHaveBeenCalledWith('breakItem', { text: line, command: undefined });
     const color = findClosestColor('#ff6347');
     const expected = `\n\n${client.prefix(line, colorString('[  SPRZET  ] ', color))}\n\n`;
     expect(result).toBe(expected);

--- a/client/test/breakItem.test.ts
+++ b/client/test/breakItem.test.ts
@@ -1,0 +1,53 @@
+import initBreakItem from '../src/scripts/breakItem';
+import Triggers from '../src/Triggers';
+import { colorString, findClosestColor } from '../src/Colors';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+  FunctionalBind = { set: jest.fn() } as any;
+  playSound = jest.fn();
+  sendCommand = jest.fn();
+  prefix = (line: string, prefix: string) => prefix + line;
+}
+
+describe('break item triggers', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initBreakItem((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    jest.clearAllMocks();
+  });
+
+  test('replaces line and beeps', () => {
+    const line = 'Nagle topor rozpruwa sie.';
+    const result = parse(line);
+    expect(client.playSound).toHaveBeenCalledTimes(1);
+    const color = findClosestColor('#ff6347');
+    const expected = `\n\n${client.prefix(line, colorString('[  SPRZET  ] ', color))}\n\n`;
+    expect(result).toBe(expected);
+    expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
+  });
+
+  test('binds weapon command', () => {
+    const line = 'Miecz bojowy peka!';
+    parse(line);
+    const call = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
+    expect(call[0]).toContain('odloz zniszczona bron');
+    const cb = call[1] as Function;
+    cb();
+    expect(client.sendCommand).toHaveBeenCalledWith('odloz zniszczona bron');
+  });
+
+  test('binds armor command', () => {
+    const line = 'Stalowa zbroja rozpada sie!';
+    parse(line);
+    const call = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
+    expect(call[0]).toContain('odloz zniszczona zbroje');
+    const cb = call[1] as Function;
+    cb();
+    expect(client.sendCommand).toHaveBeenCalledWith('odloz zniszczona zbroje');
+  });
+});

--- a/sandbox/src/Controls.tsx
+++ b/sandbox/src/Controls.tsx
@@ -18,6 +18,7 @@ import lampDemo from "./scenario/lamp-demo.ts";
 import depositDemo from "./scenario/deposit-demo.ts";
 import stunDemo from "./scenario/stun-demo.ts";
 import inviteDemo from "./scenario/invite-demo.ts";
+import breakItemDemo from "./scenario/break-item-demo.ts";
 
 // Demo mapping for localStorage persistence
 export const demoMap = {
@@ -36,7 +37,8 @@ export const demoMap = {
     'lampDemo': lampDemo,
     'depositDemo': depositDemo,
     'stunDemo': stunDemo,
-    'inviteDemo': inviteDemo
+    'inviteDemo': inviteDemo,
+    'breakItemDemo': breakItemDemo
 };
 
 function runDemo(demoName: string) {
@@ -138,6 +140,13 @@ export function Controls() {
                         onClick={() => runDemo('lampDemo')}
                     >
                         Lamp Demo
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => runDemo('breakItemDemo')}
+                    >
+                        Break Item Demo
                     </Button>
                     <Button
                         size="sm"

--- a/sandbox/src/scenario/break-item-demo.ts
+++ b/sandbox/src/scenario/break-item-demo.ts
@@ -1,0 +1,8 @@
+import ClientScript from "../ClientScript.ts";
+import { fakeClient } from "../fakeClient.ts";
+
+export default new ClientScript(fakeClient)
+    .reset()
+    .fake("Nagle topor rozpruwa sie.")
+    .fake("Miecz bojowy peka!")
+    .fake("Stalowa zbroja rozpada sie!");

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -28,6 +28,7 @@
     <div id="char-state" data-emoji-labels="0">
         <span id="char-state-text"></span>
         <span id="lamp-timer"></span>
+        <span id="break-item-warning"></span>
     </div>
     <div id="objects-list"></div>
     <span id="content-width-measure" style="visibility:hidden;position:absolute;white-space:pre">M</span>

--- a/web-client/src/BreakItemWarning.ts
+++ b/web-client/src/BreakItemWarning.ts
@@ -1,0 +1,38 @@
+import ArkadiaClient from "./ArkadiaClient.ts";
+
+interface Data {
+  text: string;
+  command?: string;
+}
+
+export default class BreakItemWarning {
+  private container: HTMLElement | null;
+  private client: typeof ArkadiaClient;
+  private command: string | null = null;
+  constructor(client: typeof ArkadiaClient) {
+    this.client = client;
+    this.container = document.getElementById("break-item-warning");
+    if (this.container) {
+      this.container.addEventListener("click", () => {
+        if (this.command) {
+          this.client.sendCommand(this.command);
+        }
+        this.update(null);
+      });
+    }
+    client.on("breakItem", (data: Data) => this.update(data));
+  }
+
+  private update(data: Data | null) {
+    if (!this.container) return;
+    if (!data) {
+      this.container.style.display = "none";
+      this.container.textContent = "";
+      this.command = null;
+      return;
+    }
+    this.container.textContent = data.text;
+    this.command = data.command ?? null;
+    this.container.style.display = "block";
+  }
+}

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -6,6 +6,7 @@ import { Modal, Dropdown } from 'bootstrap';
 import CharState from "./CharState";
 import ObjectList from "./ObjectList";
 import LampTimer from "./LampTimer";
+import BreakItemWarning from "./BreakItemWarning";
 
 import "@client/src/main.ts"
 import MockPort from "./MockPort.ts";
@@ -72,6 +73,9 @@ const port = new MockPort();
 window.clientExtension.connect(port as any, true);
 window.clientExtension.addEventListener('lampTimer', (ev: CustomEvent<number | null>) => {
     client.emit('lampTimer', ev.detail);
+});
+window.clientExtension.addEventListener('breakItem', (ev: CustomEvent<any>) => {
+    client.emit('breakItem', ev.detail);
 });
 
 const progressContainer = document.getElementById('map-progress-container')!;
@@ -534,6 +538,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Display character state and lamp timer
     new CharState(client);
     new LampTimer(client);
+    new BreakItemWarning(client);
     new ObjectList(window.clientExtension as any);
 
     // Initialize mobile direction buttons

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -110,6 +110,12 @@ h1 {
   color: tomato;
 }
 
+#break-item-warning {
+  display: none;
+  color: tomato;
+  cursor: pointer;
+}
+
 #objects-list {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Summary
- alert about broken equipment
- run auto-drop commands for broken weapon or armor
- test break item patterns

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68737855d9a0832a8002e6a122172b6a