### PR TITLE
Refactor package assistant trigger

### DIFF
--- a/client/test/PackageHelper.test.ts
+++ b/client/test/PackageHelper.test.ts
@@ -35,7 +35,7 @@ describe('PackageHelper', () => {
     client.OutputHandler.makeClickable.mockReturnValue('click');
 
     const rawLine = " |1. Bob 1/2/3 5";
-    const packageLineRegex = /^ \|.*?(?<number>\d+)?\. (?<name>.*?)(?:, (?<city>[\w' ]+?))?\s+(?<gold>\d+)\/\s?(?<silver>\d+)\/\s?(?<copper>\d+)\s+(?:nieogr|(?<time>\d+))/;
+    const packageLineRegex = /^ \|\s*(?<heavy>\*)?\s*(?<number>\d+)\. (?<name>.*?)(?:, (?<city>[\w' ]+?))?\s+(?<gold>\d+)\/\s?(?<silver>\d+)\/\s?(?<copper>\d+)\s+(?:nieogr\.|(?<time>\d+))/;
     const match = rawLine.match(packageLineRegex)!;
     const result = cb(rawLine, '', match);
 
@@ -75,5 +75,28 @@ describe('PackageHelper', () => {
     expect(helper.currentPackage).toEqual({ name: 'Bob', time: undefined });
     expect(client.Triggers.registerOneTimeTrigger).toHaveBeenCalledTimes(2);
     expect(helper.deliveryTrigger).toBe('delivery');
+  });
+
+  test('packageTableCallback simplifies output when width is small', () => {
+    client.contentWidth = 50;
+    client.OutputHandler.makeClickable.mockImplementation((l) => l);
+
+    const cb = helper['packageTableCallback']();
+    const raw =
+      'Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:\n' +
+      ' |   1. Bob                     0/ 1/ 2        nieogr.\n' +
+      " | * 2. Tom, Foo                1/ 2/ 3        5\n" +
+      'Symbolem * oznaczono przesylki ciezkie.';
+
+    const result = cb(raw);
+    const lines = result.split('\n').map(l => l.replace(/\x1B\[[0-9;]*m/g, ''));
+    expect(lines[1]).toBe('1. Bob');
+    expect(lines[2]).toBe('  0/1/2 nieogr.');
+    expect(lines[3]).toBe('* 2. Tom, Foo');
+    expect(lines[4]).toBe('  1/2/3 5');
+    expect(helper['packages']).toEqual([
+      { name: 'Bob', time: undefined },
+      { name: 'Tom', time: '5' },
+    ]);
   });
 });

--- a/client/test/PackageHelper.test.ts
+++ b/client/test/PackageHelper.test.ts
@@ -79,7 +79,7 @@ describe('PackageHelper', () => {
 
   test('packageTableCallback simplifies output when width is small', () => {
     client.contentWidth = 50;
-    client.OutputHandler.makeClickable.mockImplementation((l) => l);
+    client.OutputHandler.makeClickable.mockImplementation(l => l);
 
     const cb = helper['packageTableCallback']();
     const raw =
@@ -90,6 +90,7 @@ describe('PackageHelper', () => {
 
     const result = cb(raw);
     const lines = result.split('\n').map(l => l.replace(/\x1B\[[0-9;]*m/g, ''));
+    expect(lines[0]).toBe('Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:');
     expect(lines[1]).toBe('1. Bob');
     expect(lines[2]).toBe('  0/1/2 nieogr.');
     expect(lines[3]).toBe('* 2. Tom, Foo');


### PR DESCRIPTION
## Summary
- use multiline trigger for reading package tables
- remove end trigger and per-line triggers
- highlight packages from multiline output

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68737f138c30832a80e8d012bc3913ec