### PR TITLE
Implement dynamic herb shop table width

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -186,9 +186,11 @@ initContainers(client)
 
 import initBagManager from './scripts/bagManager'
 import initDeposits from './scripts/deposits'
+import initHerbShop from './scripts/herbShop'
 
 initBagManager(client, aliases)
 initDeposits(client, aliases)
+initHerbShop(client)
 
 import initLvlCalc from './scripts/lvlCalc'
 import initItemCondition from './scripts/itemCondition'

--- a/client/src/scripts/herbShop.ts
+++ b/client/src/scripts/herbShop.ts
@@ -1,0 +1,43 @@
+import Client from "../Client";
+import { stripAnsiCodes } from "../Triggers";
+
+export default function initHerbShop(client: Client) {
+    let width = client.contentWidth;
+    client.addEventListener('contentWidth', (ev: CustomEvent) => {
+        width = ev.detail;
+    });
+
+    const NORMAL_WIDTH = 88;
+    const splitReg = /^\+-{58}\+-{4}\+-{4}\+-{4}\+-{4}\+-{7}\+$/;
+    const headerReg = /^\|\s*Nazwa towaru\s*\|\s*mt\s*\|\s*zl\s*\|\s*sr\s*\|\s*md\s*\|\s*Ilosc\s*\|$/;
+    const itemReg = /^\|\s*(.+?)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|$/;
+
+    const pad = (str: string, len: number) => str + " ".repeat(Math.max(0, len - stripAnsiCodes(str).length));
+
+    client.Triggers.registerTrigger(splitReg, () => {
+        if (width >= NORMAL_WIDTH) return undefined;
+        return `+${"-".repeat(Math.max(0, width - 2))}+`;
+    }, 'herb-shop');
+
+    client.Triggers.registerTrigger(headerReg, () => {
+        if (width >= NORMAL_WIDTH) return undefined;
+        const nameLine = `| ${pad('Nazwa towaru', width - 3)}|`;
+        const numbers = '| mt | zl | sr | md | Ilosc |';
+        const padded = numbers + ' '.repeat(Math.max(0, width - numbers.length));
+        return nameLine + '\n' + padded;
+    }, 'herb-shop');
+
+    client.Triggers.registerTrigger(itemReg, (_raw, _line, m) => {
+        if (width >= NORMAL_WIDTH) return undefined;
+        const name = m[1];
+        const mt = m[2];
+        const zl = m[3];
+        const sr = m[4];
+        const md = m[5];
+        const amount = m[6];
+        const nameLine = `| ${pad(name, width - 3)}|`;
+        const numbersBase = `| ${mt.padStart(2, ' ')} | ${zl.padStart(2, ' ')} | ${sr.padStart(2, ' ')} | ${md.padStart(2, ' ')} | ${amount.padStart(5, ' ')} |`;
+        const numbersLine = numbersBase + ' '.repeat(Math.max(0, width - numbersBase.length));
+        return nameLine + '\n' + numbersLine;
+    }, 'herb-shop');
+}

--- a/client/test/herbShop.test.ts
+++ b/client/test/herbShop.test.ts
@@ -1,0 +1,56 @@
+import initHerbShop from '../src/scripts/herbShop';
+import Triggers from '../src/Triggers';
+import { EventEmitter } from 'events';
+
+class FakeClient {
+  private emitter = new EventEmitter();
+  Triggers = new Triggers(({} as unknown) as any);
+  contentWidth = 40;
+
+  addEventListener(event: string, cb: any) {
+    this.emitter.on(event, cb);
+  }
+  removeEventListener(event: string, cb: any) {
+    this.emitter.off(event, cb);
+  }
+  dispatch(event: string, detail: any) {
+    this.emitter.emit(event, { detail });
+  }
+}
+
+describe('herb shop width adjustments', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initHerbShop((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+  });
+
+  const split = '+----------------------------------------------------------+----+----+----+----+-------+';
+  const header = '| Nazwa towaru                                             | mt | zl | sr | md | Ilosc |';
+  const item = '| rozgaleziona wzniesiona lodyga (jaskier)                 |  0 |  0 |  6 |  2 |   100 |';
+
+  test('adjusts split line', () => {
+    const result = parse(split);
+    expect(result).toBe('+'.padEnd(client.contentWidth - 1, '-') + '+');
+  });
+
+  test('splits header and item lines when narrow', () => {
+    const h = parse(header).split('\n');
+    expect(h[0]).toMatch(/Nazwa towaru/);
+    expect(h[1]).toMatch(/mt/);
+
+    const it = parse(item).split('\n');
+    expect(it[0]).toMatch(/jaskier/);
+    expect(it[1]).toMatch(/100/);
+  });
+
+  test('leaves lines unchanged when wide enough', () => {
+    client.contentWidth = 90;
+    client.dispatch('contentWidth', 90);
+    expect(parse(header)).toBe(header);
+    expect(parse(item)).toBe(item);
+  });
+});


### PR DESCRIPTION
## Summary
- adapt herb shop interface to narrow client widths
- hook the new handler into client main
- test herb shop table formatting

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687385073c9c832aab986ee688e23d8a