### PR TITLE
Fix vertical drag direction for mobile buttons

### DIFF
--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -377,7 +377,7 @@ export default class MobileDirectionButtons {
 
         // Calculate new position (from right and top)
         const deltaX = this.initialX - this.currentX;
-        const deltaY = this.initialY - this.currentY;
+        const deltaY = this.currentY - this.initialY;
 
         const newRight = this.offsetX + deltaX;
         const newTop = this.offsetY + deltaY;
@@ -458,7 +458,7 @@ export default class MobileDirectionButtons {
 
         // Calculate new position (from right and top)
         const deltaX = this.initialX - this.currentX;
-        const deltaY = this.initialY - this.currentY;
+        const deltaY = this.currentY - this.initialY;
 
         const newRight = this.offsetX + deltaX;
         const newTop = this.offsetY + deltaY;


### PR DESCRIPTION
## Summary
- correct deltaY calculation so dragging down moves buttons down

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687395658da0832a911955dbbf33e20e