### PR TITLE
Sanitize Polish letters before command processing

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,6 +1,7 @@
 import Client from "./Client";
 import People from "./People";
 import registerLuaGagTriggers from "./scripts/./luaGags";
+import { stripPolishCharacters } from "./stripPolishCharacters";
 import Port = chrome.runtime.Port;
 
 const gmcpParseOption = Gmcp.parse_option_subnegotiation
@@ -32,6 +33,9 @@ Gmcp.parse_option_subnegotiation = (match) => {
     gmcpParseOption(match)
 }
 Input.send = (command?: string) => {
+    if (command) {
+        command = stripPolishCharacters(command)
+    }
     client.sendCommand(command ?? '')
 }
 

--- a/client/src/stripPolishCharacters.ts
+++ b/client/src/stripPolishCharacters.ts
@@ -1,0 +1,23 @@
+export const stripPolishCharacters = (input: string): string => {
+    const map: Record<string, string> = {
+        'ą': 'a',
+        'ć': 'c',
+        'ę': 'e',
+        'ł': 'l',
+        'ń': 'n',
+        'ó': 'o',
+        'ś': 's',
+        'ż': 'z',
+        'ź': 'z',
+        'Ą': 'A',
+        'Ć': 'C',
+        'Ę': 'E',
+        'Ł': 'L',
+        'Ń': 'N',
+        'Ó': 'O',
+        'Ś': 'S',
+        'Ż': 'Z',
+        'Ź': 'Z',
+    };
+    return Array.from(input).map(ch => map[ch] || ch).join('');
+};


### PR DESCRIPTION
## Summary
- sanitize Polish characters in incoming commands
- add helper function to strip Polish diacritics

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6873a5e03ca8832aaf52ca511fde4e0f