### PR TITLE
Revert color helper change

### DIFF
--- a/client/src/Colors.ts
+++ b/client/src/Colors.ts
@@ -17,9 +17,6 @@ export function color(colorCode:number) {
     return `\x1B[22;38;5;${colorCode}m`
 }
 
-// A single reset is enough here. When the output processor rewrites
-// "\x1b[0m" to the last color code, the ANSI parser detects this and closes
-// the current span so the color does not leak beyond the string.
 export function colorString(string: string, colorCode: number) {
     return color(colorCode) + string + RESET;
 }

--- a/web-client/src/ansiParser.ts
+++ b/web-client/src/ansiParser.ts
@@ -29,22 +29,7 @@ function handleColorChange(
     }
 
     if (colorIndex >= 0 && colorIndex < palette.length) {
-        const color = palette[colorIndex];
-        const lastColor =
-            spanStartIndices.length === currentSpanCount + 1
-                ? activeColors[currentSpanCount]
-                : undefined;
-
-        if (lastColor === color) {
-            // A reset with no previous color gets rewritten to the same color.
-            // Close the current span and do not reopen a new one so the color
-            // is cleared.
-            activeColors.splice(currentSpanCount, 1);
-            spanStartIndices.splice(currentSpanCount, 1);
-            return;
-        }
-
-        activeColors.push(color);
+        activeColors.push(palette[colorIndex]);
         spanStartIndices.push(matchPos);
     }
 }


### PR DESCRIPTION
## Summary
- revert "Remove double reset in color helpers (#286)" commit

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6873ae4622cc832abe388eb7cde9dacd