### PR TITLE
Handle initial ANSI resets

### DIFF
--- a/client/test/ansiParser.test.ts
+++ b/client/test/ansiParser.test.ts
@@ -1,0 +1,8 @@
+import { parseAnsiPatterns } from '../../web-client/src/ansiParser';
+
+describe('parseAnsiPatterns', () => {
+  test('reset with no previous color opens inherit span', () => {
+    const result = parseAnsiPatterns('\x1b[0mfoo');
+    expect(result).toBe('<span style="color: inherit">foo</span>');
+  });
+});

--- a/web-client/src/ansiParser.ts
+++ b/web-client/src/ansiParser.ts
@@ -88,6 +88,9 @@ export function parseAnsiPatterns(input: string): string {
                     activeColors.splice(currentSpanCount, 1);
                     spanStartIndices.splice(currentSpanCount, 1);
                 }
+            } else {
+                activeColors.push("inherit");
+                spanStartIndices.push(matchPos);
             }
         } else if (ansiSequence.startsWith("22;38;5;")) {
             // 256-color mode


### PR DESCRIPTION
## Summary
- handle reset sequences when no color previously set by starting an `inherit` span
- test parser behavior for reset before any color

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6873b7774fe8832a897e1fa136896090