### PR TITLE
Refactor: centralize shop colors

### DIFF
--- a/client/src/scripts/armorShop.ts
+++ b/client/src/scripts/armorShop.ts
@@ -1,53 +1,22 @@
 import Client from "../Client";
-import { colorString, findClosestColor } from "../Colors";
-import { stripAnsiCodes } from "../Triggers";
-
-const MITHRIL_COLOR = findClosestColor('#afeeee');
-const GOLD_COLOR = findClosestColor('#FFD700');
-const SILVER_COLOR = findClosestColor('#C0C0C0');
-const COPPER_COLOR = findClosestColor('#8B4513');
+import initShop, { ShopOptions, formatItem } from "./shop";
 
 export default function initArmorShop(client: Client) {
-    let width = client.contentWidth;
-    client.addEventListener('contentWidth', (ev: CustomEvent) => {
-        width = ev.detail;
-    });
+    const options: ShopOptions = {
+        normalWidth: 75,
+        tag: 'armor-shop',
+        splitReg: /^-{75}$/,
+        headerReg: /^\|\s*Nazwa towaru\s*\|\s*Mithryl\s*\|\s*Zloto\s*\|\s*Srebro\s*\|\s*Miedz\s*\|$/,
+        itemReg: /^\|\s*(.+?)\s*\|\s*(\d*)\s*\|\s*(\d*)\s*\|\s*(\d*)\s*\|\s*(\d*)\s*\|$/,
+        makeSplit: (width) => "-".repeat(Math.max(0, width)),
+        makeHeader: (width, pad) => {
+            const nameLine = `| ${pad('Nazwa towaru', width - 3)}|`;
+            const numbers = `| ${pad('Mithryl Zloto Srebro Miedz', width - 3)} |`;
+            const padded = numbers + ' '.repeat(Math.max(0, width - numbers.length));
+            return nameLine + '\n' + padded;
+        },
+        makeItem: (width, pad, m) => formatItem(width, pad, m)
+    };
 
-    const NORMAL_WIDTH = 75;
-    const splitReg = /^-{75}$/;
-    const headerReg = /^\|\s*Nazwa towaru\s*\|\s*Mithryl\s*\|\s*Zloto\s*\|\s*Srebro\s*\|\s*Miedz\s*\|$/;
-    const itemReg = /^\|\s*(.+?)\s*\|\s*(\d*)\s*\|\s*(\d*)\s*\|\s*(\d*)\s*\|\s*(\d*)\s*\|$/;
-
-    const pad = (str: string, len: number) => str + " ".repeat(Math.max(0, len - stripAnsiCodes(str).length));
-
-    client.Triggers.registerTrigger(splitReg, () => {
-        if (width >= NORMAL_WIDTH) return undefined;
-        return "-".repeat(Math.max(0, width));
-    }, 'armor-shop');
-
-    client.Triggers.registerTrigger(headerReg, () => {
-        if (width >= NORMAL_WIDTH) return undefined;
-        const nameLine = `| ${pad('Nazwa towaru', width - 3)}|`;
-        const numbers = `| ${pad('Mithryl Zloto Srebro Miedz', width - 3)} |`;
-        const padded = numbers + ' '.repeat(Math.max(0, width - numbers.length));
-        return nameLine + '\n' + padded;
-    }, 'armor-shop');
-
-    client.Triggers.registerTrigger(itemReg, (_raw, _line, m) => {
-        if (width >= NORMAL_WIDTH) return undefined;
-        const name = m[1];
-        const mith = m[2];
-        const zloto = m[3];
-        const srebro = m[4];
-        const miedz = m[5];
-        const nameLine = `| ${pad(name, width - 3)}|`;
-        const cost = [
-            colorString(mith, MITHRIL_COLOR),
-            colorString(zloto, GOLD_COLOR),
-            colorString(srebro, SILVER_COLOR),
-            colorString(miedz, COPPER_COLOR)
-        ].join('/')
-        const numbersLine = `| ${pad(cost, width - 3)}|`;
-        return nameLine + '\n' + numbersLine;
-    }, 'armor-shop');
+    initShop(client, options);
 }

--- a/client/src/scripts/herbShop.ts
+++ b/client/src/scripts/herbShop.ts
@@ -1,54 +1,26 @@
 import Client from "../Client";
-import { colorString, findClosestColor } from "../Colors";
-import { stripAnsiCodes } from "../Triggers";
-
-const MITHRIL_COLOR = findClosestColor('#afeeee');
-const GOLD_COLOR = findClosestColor('#FFD700');
-const SILVER_COLOR = findClosestColor('#C0C0C0');
-const COPPER_COLOR = findClosestColor('#8B4513');
+import initShop, { ShopOptions, formatItem } from "./shop";
 
 export default function initHerbShop(client: Client) {
-    let width = client.contentWidth;
-    client.addEventListener('contentWidth', (ev: CustomEvent) => {
-        width = ev.detail;
-    });
+    const options: ShopOptions = {
+        normalWidth: 88,
+        tag: 'herb-shop',
+        splitReg: /^\+-{58}\+-{4}\+-{4}\+-{4}\+-{4}\+-{7}\+$/,
+        headerReg: /^\|\s*Nazwa towaru\s*\|\s*mt\s*\|\s*zl\s*\|\s*sr\s*\|\s*md\s*\|\s*Ilosc\s*\|$/,
+        itemReg: /^\|\s*(.+?)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|$/,
+        makeSplit: (width) => `+${"-".repeat(Math.max(0, width - 2))}+`,
+        makeHeader: (width, pad) => {
+            const nameLine = `| ${pad('Nazwa towaru', width - 3)}|`;
+            const numbersLine = `| ${pad('mt/zl/sr/md Ilosc', width - 3)}|`;
+            return nameLine + '\n' + numbersLine;
+        },
+        makeItem: (width, pad, m) => formatItem(
+            width,
+            pad,
+            m,
+            6
+        )
+    };
 
-    const NORMAL_WIDTH = 88;
-    const splitReg = /^\+-{58}\+-{4}\+-{4}\+-{4}\+-{4}\+-{7}\+$/;
-    const headerReg = /^\|\s*Nazwa towaru\s*\|\s*mt\s*\|\s*zl\s*\|\s*sr\s*\|\s*md\s*\|\s*Ilosc\s*\|$/;
-    const itemReg = /^\|\s*(.+?)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|$/;
-
-    const pad = (str: string, len: number) => str + " ".repeat(Math.max(0, len - stripAnsiCodes(str).length));
-
-    client.Triggers.registerTrigger(splitReg, () => {
-        if (width >= NORMAL_WIDTH) return undefined;
-        return `+${"-".repeat(Math.max(0, width - 2))}+`;
-    }, 'herb-shop');
-
-    client.Triggers.registerTrigger(headerReg, () => {
-        if (width >= NORMAL_WIDTH) return undefined;
-        const nameLine = `| ${pad('Nazwa towaru', width - 3)}|`;
-        const numbersLine = `| ${pad('mt/zl/sr/md Ilosc', width - 3)}|`;
-        return nameLine + '\n' + numbersLine;
-    }, 'herb-shop');
-
-    client.Triggers.registerTrigger(itemReg, (_raw, _line, m) => {
-        if (width >= NORMAL_WIDTH) return undefined;
-        const name = m[1];
-        const mt = m[2];
-        const zl = m[3];
-        const sr = m[4];
-        const md = m[5];
-        const amount = m[6];
-        const nameLine = `| ${pad(name, width - 3)}|`;
-        const cost = [
-            colorString(mt, MITHRIL_COLOR),
-            colorString(zl, GOLD_COLOR),
-            colorString(sr, SILVER_COLOR),
-            colorString(md, COPPER_COLOR)
-        ].join('/')
-        const numbersContent = `${cost} Ilosc ${amount}`;
-        const numbersLine = `| ${pad(numbersContent, width - 3)}|`;
-        return nameLine + '\n' + numbersLine;
-    }, 'herb-shop');
+    initShop(client, options);
 }

--- a/client/src/scripts/shop.ts
+++ b/client/src/scripts/shop.ts
@@ -1,0 +1,71 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+import { stripAnsiCodes } from "../Triggers";
+
+export interface ShopOptions {
+    normalWidth: number;
+    tag: string;
+    splitReg: RegExp;
+    headerReg: RegExp;
+    itemReg: RegExp;
+    makeSplit: (width: number) => string;
+    makeHeader: (width: number, pad: (s: string, len: number) => string) => string;
+    makeItem: (width: number, pad: (s: string, len: number) => string, match: RegExpMatchArray) => string;
+}
+
+export const MITHRIL_COLOR = findClosestColor('#afeeee');
+export const GOLD_COLOR = findClosestColor('#FFD700');
+export const SILVER_COLOR = findClosestColor('#C0C0C0');
+export const COPPER_COLOR = findClosestColor('#8B4513');
+export const CURRENCY_COLORS = [
+    MITHRIL_COLOR,
+    GOLD_COLOR,
+    SILVER_COLOR,
+    COPPER_COLOR,
+] as const;
+
+export function formatItem(
+    width: number,
+    pad: (s: string, len: number) => string,
+    match: RegExpMatchArray,
+    amountIndex?: number,
+    colors: readonly number[] = CURRENCY_COLORS
+): string {
+    const name = match[1];
+    const costs = match.slice(2, 6);
+    const amount = typeof amountIndex === 'number' ? match[amountIndex] : undefined;
+
+    const coloredCosts = costs.map((c, i) => colorString(c, colors[i])).join('/');
+
+    const numbersContent = amount && amount !== '1'
+        ? `${coloredCosts} Ilosc ${amount}`
+        : coloredCosts;
+
+    const nameLine = `| ${pad(name, width - 3)}|`;
+    const numbersLine = `| ${pad(numbersContent, width - 3)}|`;
+    return nameLine + '\n' + numbersLine;
+}
+
+export default function initShop(client: Client, opts: ShopOptions) {
+    let width = client.contentWidth;
+    client.addEventListener('contentWidth', (ev: CustomEvent) => {
+        width = ev.detail;
+    });
+
+    const pad = (str: string, len: number) => str + " ".repeat(Math.max(0, len - stripAnsiCodes(str).length));
+
+    client.Triggers.registerTrigger(opts.splitReg, () => {
+        if (width >= opts.normalWidth) return undefined;
+        return opts.makeSplit(width);
+    }, opts.tag);
+
+    client.Triggers.registerTrigger(opts.headerReg, () => {
+        if (width >= opts.normalWidth) return undefined;
+        return opts.makeHeader(width, pad);
+    }, opts.tag);
+
+    client.Triggers.registerTrigger(opts.itemReg, (_raw, _line, m) => {
+        if (width >= opts.normalWidth) return undefined;
+        return opts.makeItem(width, pad, m);
+    }, opts.tag);
+}


### PR DESCRIPTION
## Summary
- share currency color constants in `shop.ts`
- default to shared colors in `formatItem`
- simplify armor and herb shop modules

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6873c04ceb9c832aab2f5d8666bcb7c4