### PR TITLE
Improve shop layout

### DIFF
--- a/client/src/scripts/shop.ts
+++ b/client/src/scripts/shop.ts
@@ -41,6 +41,12 @@ export function formatItem(
         ? `${coloredCosts} Ilosc: ${amount}`
         : coloredCosts;
 
+    const combined = `${name} ${numbersContent}`;
+    const fitsSingleLine = stripAnsiCodes(combined).length <= width - 3;
+    if (fitsSingleLine) {
+        return `| ${pad(combined, width - 3)}|`;
+    }
+
     const nameLine = `| ${pad(name, width - 3)}|`;
     const numbersLine = `| ${pad(numbersContent, width - 3)}|`;
     return nameLine + '\n' + numbersLine;

--- a/client/test/armorShop.test.ts
+++ b/client/test/armorShop.test.ts
@@ -1,5 +1,5 @@
 import initArmorShop from '../src/scripts/armorShop';
-import Triggers from '../src/Triggers';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
 import { EventEmitter } from 'events';
 
 class FakeClient {
@@ -45,6 +45,14 @@ describe('armor shop width adjustments', () => {
     const it = parse(item).split('\n');
     expect(it[0]).toMatch(/rycerska/);
     expect(it[1]).toMatch(/\//);
+  });
+
+  test('keeps item on one line when there is room', () => {
+    client.contentWidth = 50;
+    client.dispatch('contentWidth', 50);
+    const result = parse(item);
+    expect(result).not.toMatch(/\n/);
+    expect(stripAnsiCodes(result)).toMatch(/0\/2\/7\/6/);
   });
 
   test('leaves lines unchanged when wide enough', () => {

--- a/client/test/herbShop.test.ts
+++ b/client/test/herbShop.test.ts
@@ -1,5 +1,5 @@
 import initHerbShop from '../src/scripts/herbShop';
-import Triggers from '../src/Triggers';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
 import { EventEmitter } from 'events';
 
 class FakeClient {
@@ -45,6 +45,14 @@ describe('herb shop width adjustments', () => {
     const it = parse(item).split('\n');
     expect(it[0]).toMatch(/jaskier/);
     expect(it[1]).toMatch(/\//);
+  });
+
+  test('keeps item on one line when there is room', () => {
+    client.contentWidth = 70;
+    client.dispatch('contentWidth', 70);
+    const result = parse(item);
+    expect(result).not.toMatch(/\n/);
+    expect(stripAnsiCodes(result)).toMatch(/Ilosc/);
   });
 
   test('leaves lines unchanged when wide enough', () => {


### PR DESCRIPTION
## Summary
- adjust shop logic so numeric details stay on the first line when possible
- test that armor and herb shop items remain on one line when there's enough room

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6873de170318832a95aaa92fdbf68d98