### PR TITLE
Improve shop layout

### DIFF
--- a/client/src/scripts/shop.ts
+++ b/client/src/scripts/shop.ts
@@ -37,11 +37,19 @@ export function formatItem(
 
     const coloredCosts = costs.map((c, i) => colorString(c === "" ? "0" : c, colors[i])).join('/');
 
-    const numbersContent = amount && amount !== '1'
-        ? `${coloredCosts} Ilosc: ${amount}`
-        : coloredCosts;
+    const amountPrefix = amount ? `${amount.padStart(3)}| ` : "";
+    const namePart = `${amountPrefix}${name}`;
+    const numbersContent = coloredCosts;
 
-    const nameLine = `| ${pad(name, width - 3)}|`;
+    const combined = `${namePart} ${numbersContent}`;
+    const strippedLen = stripAnsiCodes(combined).length;
+    const fitsSingleLine = strippedLen <= width - 4;
+    if (fitsSingleLine) {
+        const spaces = " ".repeat(Math.max(0, width - 3 - strippedLen - 1));
+        return `| ${namePart} ${numbersContent}${spaces} |`;
+    }
+
+    const nameLine = `| ${pad(namePart, width - 3)}|`;
     const numbersLine = `| ${pad(numbersContent, width - 3)}|`;
     return nameLine + '\n' + numbersLine;
 }

--- a/client/test/armorShop.test.ts
+++ b/client/test/armorShop.test.ts
@@ -1,5 +1,5 @@
 import initArmorShop from '../src/scripts/armorShop';
-import Triggers from '../src/Triggers';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
 import { EventEmitter } from 'events';
 
 class FakeClient {
@@ -45,6 +45,14 @@ describe('armor shop width adjustments', () => {
     const it = parse(item).split('\n');
     expect(it[0]).toMatch(/rycerska/);
     expect(it[1]).toMatch(/\//);
+  });
+
+  test('keeps item on one line when there is room', () => {
+    client.contentWidth = 50;
+    client.dispatch('contentWidth', 50);
+    const result = parse(item);
+    expect(result).not.toMatch(/\n/);
+    expect(stripAnsiCodes(result)).toMatch(/0\/2\/7\/6/);
   });
 
   test('leaves lines unchanged when wide enough', () => {

--- a/client/test/herbShop.test.ts
+++ b/client/test/herbShop.test.ts
@@ -1,5 +1,5 @@
 import initHerbShop from '../src/scripts/herbShop';
-import Triggers from '../src/Triggers';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
 import { EventEmitter } from 'events';
 
 class FakeClient {
@@ -43,8 +43,19 @@ describe('herb shop width adjustments', () => {
     expect(h[1]).toMatch(/mt/);
 
     const it = parse(item).split('\n');
+    expect(it[0]).toMatch(/\|\s*100\|/);
     expect(it[0]).toMatch(/jaskier/);
     expect(it[1]).toMatch(/\//);
+  });
+
+  test('keeps item on one line when there is room', () => {
+    client.contentWidth = 70;
+    client.dispatch('contentWidth', 70);
+    const result = parse(item);
+    expect(result).not.toMatch(/\n/);
+    const stripped = stripAnsiCodes(result);
+    expect(stripped).toMatch(/^\|\s*100\|/);
+    expect(stripped).toMatch(/0\/0\/6\/2\s*\|$/);
   });
 
   test('leaves lines unchanged when wide enough', () => {


### PR DESCRIPTION
## Summary
- adjust item formatting so quantity precedes the name and prices are aligned
- update herb shop test expectations

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6873de170318832a95aaa92fdbf68d98