### PR TITLE
Refactor auth overlay with inline login

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -108,31 +108,17 @@
         </div>
     </div>
 
-    <div id="auth-overlay"></div>
-    <div id="auth-buttons">
-        <div id="connecting-spinner" class="spinner-border text-light" role="status"></div>
-        <button id="login-button">Login</button>
-        <button id="connect-button">Connect</button>
-    </div>
-
-    <div id="login-modal" class="modal fade" tabindex="-1">
-        <form id="login-form">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title">Login</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <div class="modal-body d-flex flex-column gap-2">
-                        <input id="login-character" class="form-control" placeholder="Character">
-                        <input id="login-password" type="password" class="form-control" placeholder="Password">
-                    </div>
-                    <div class="modal-footer">
-                        <button id="login-submit" class="btn btn-primary" type="submit">Login</button>
-                    </div>
-                </div>
-            </div>
-        </form>
+    <div id="auth-overlay">
+        <div id="auth-panel">
+            <div id="connecting-spinner" class="spinner-border text-light" role="status"></div>
+            <button id="connect-button">Connect</button>
+            <div class="auth-or">- OR -</div>
+            <form id="login-form" class="d-flex flex-column gap-2">
+                <input id="login-character" class="form-control" placeholder="Character">
+                <input id="login-password" type="password" class="form-control" placeholder="Password">
+                <button id="login-submit" class="btn btn-primary" type="submit">Login</button>
+            </form>
+        </div>
     </div>
 
     <div id="ui-settings-modal" class="modal fade" tabindex="-1">

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -219,7 +219,7 @@ let isConnecting = false;
 // Function to update the connect button state
 function updateConnectButtons() {
     const connectButton = document.getElementById('connect-button') as HTMLButtonElement;
-    const loginButton = document.getElementById('login-button') as HTMLButtonElement | null;
+    const loginForm = document.getElementById('login-form') as HTMLFormElement | null;
     const authOverlay = document.getElementById('auth-overlay') as HTMLElement | null;
     const spinner = document.getElementById('connecting-spinner') as HTMLElement | null;
 
@@ -235,8 +235,8 @@ function updateConnectButtons() {
     }
 
 
-    if (loginButton) {
-        loginButton.style.display = (!isConnected && !isConnecting) ? '' : 'none';
+    if (loginForm) {
+        loginForm.style.display = (!isConnected && !isConnecting) ? 'flex' : 'none';
     }
 
     if (spinner) {
@@ -244,7 +244,7 @@ function updateConnectButtons() {
     }
 
     if (authOverlay) {
-        authOverlay.style.display = isConnected ? 'none' : (isConnecting ? 'none' : 'block');
+        authOverlay.style.display = isConnected ? 'none' : 'flex';
     }
 }
 
@@ -314,7 +314,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const messageInput = document.getElementById('message-input') as HTMLInputElement;
     const sendButton = document.getElementById('send-button') as HTMLButtonElement;
     const connectButton = document.getElementById('connect-button') as HTMLButtonElement;
-    const loginButton = document.getElementById('login-button') as HTMLButtonElement | null;
     const menuButton = document.getElementById('menu-button') as HTMLButtonElement | null;
     const optionsButton = document.getElementById('options-button') as HTMLButtonElement;
     const bindsButton = document.getElementById('binds-button') as HTMLButtonElement | null;
@@ -329,8 +328,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const bindsModal = bindsModalElement ? new Modal(bindsModalElement) : null;
     const npcModalElement = document.getElementById('npc-modal');
     const npcModal = npcModalElement ? new Modal(npcModalElement) : null;
-    const loginModalElement = document.getElementById('login-modal');
-    const loginModal = loginModalElement ? new Modal(loginModalElement) : null;
     const loginCharacter = document.getElementById('login-character') as HTMLInputElement | null;
     const loginPassword = document.getElementById('login-password') as HTMLInputElement | null;
     const loginForm = document.getElementById('login-form') as HTMLFormElement | null;
@@ -380,16 +377,11 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    if (loginButton && loginModal && loginForm) {
-        loginButton.addEventListener('click', () => {
-            loginModal.show();
-        });
-
+    if (loginForm) {
         loginForm.addEventListener('submit', async (e) => {
             e.preventDefault();
             const character = loginCharacter?.value || '';
             const password = loginPassword?.value || '';
-            loginModal.hide();
 
             // Password persistence removed
             client.setStoredPassword(password || null);

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -474,7 +474,6 @@ button:focus-visible {
 
 #options-modal .modal-dialog,
 #docs-modal .modal-dialog,
-#login-modal .modal-dialog,
 #debug-modal .modal-dialog {
   margin-top: 5vh;
   margin-bottom: 5vh;
@@ -484,14 +483,11 @@ button:focus-visible {
   max-height: 85%;
 }
 
-#auth-buttons {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+#auth-panel {
   display: flex;
   flex-direction: column;
   gap: 1vw;
+  align-items: center;
   z-index: 1011;
 }
 
@@ -508,5 +504,19 @@ button:focus-visible {
   -webkit-backdrop-filter: blur(2px);
   z-index: 1010;
   display: none;
+  align-items: center;
+  justify-content: center;
+}
+
+#login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1vh;
+  width: 200px;
+}
+
+.auth-or {
+  color: #fff;
+  text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- inline login form in the auth overlay
- simplify login handling in `main.ts`
- update styles for new auth panel layout

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6873e357eb88832a9fd93e82b235b87e