### PR TITLE
Fix threshold for red HP color

### DIFF
--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -100,7 +100,7 @@ export default class ObjectList {
             let bar = "";
             if (typeof obj.state === "number") {
                 const hp = Math.max(0, Math.min(6, obj.state));
-                const color = hp < 2 ? "tomato" : (hp < 4 ? "yellow" : "springgreen");
+                const color = hp < 3 ? "tomato" : (hp < 4 ? "yellow" : "springgreen");
                 const filled = "#".repeat(hp + 1);
                 const empty = "-".repeat(6 - hp);
                 bar = `[<span style="color:${color}">${filled}${empty}</span>]`;


### PR DESCRIPTION
## Summary
- adjust HP threshold for red highlight in the objects list

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6873f9e6d9e4832a801c60b2c004a6d1