### PR TITLE
Add /zap alias for team invites

### DIFF
--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -46,5 +46,9 @@ export default function initObjectAliases(
                 }
             }
         });
+        aliases.push({
+            pattern: /\/zap ([0-9]+)$/,
+            callback: (m: RegExpMatchArray) => exec(m[1], "zapros")
+        });
     }
 }

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -17,6 +17,7 @@ describe('object aliases', () => {
   let shield: (m: RegExpMatchArray) => void;
   let killTarget: () => void;
   let shieldTarget: () => void;
+  let invite: (m: RegExpMatchArray) => void;
 
   beforeEach(() => {
     client = new FakeClient();
@@ -26,6 +27,7 @@ describe('object aliases', () => {
     shield = aliases[1].callback as any;
     killTarget = aliases[2].callback as any;
     shieldTarget = aliases[3].callback as any;
+    invite = aliases[4].callback as any;
     (global as any).Input = { send: jest.fn() };
   });
 
@@ -51,5 +53,11 @@ describe('object aliases', () => {
     client.TeamManager.getDefenseTargetId.mockReturnValue('15');
     shieldTarget();
     expect(client.sendCommand).toHaveBeenCalledWith('zaslon ob_15');
+  });
+
+  test('zap alias sends zapros with object number', () => {
+    client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 8, shortcut: '2' }]);
+    invite(['', '2'] as unknown as RegExpMatchArray);
+    expect(client.sendCommand).toHaveBeenCalledWith('zapros ob_8');
   });
 });

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -29,5 +29,6 @@ Poniższa lista opisuje dostępne aliasy w rozszerzeniu:
 - **/z** - atakuje cel oznaczony jako cel ataku.
 - **/za** - zasłania cel oznaczony jako cel obrony.
 - **/zap** - wykonuje polecenie `zapal lampe`.
+- **/zap _numer_** - zaprasza do drużyny obiekt o podanym numerze.
 - **/zg** - wykonuje polecenie `zgas lampe`.
 - **/binds** - wyświetla aktualnie ustawione skróty klawiaturowe.


### PR DESCRIPTION
## Summary
- allow inviting by numeric shortcuts with `/zap <numer>`
- document the new `/zap <numer>` alias
- test the new alias

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6874170f8368832ab8314a3633378af9