### PR TITLE
Implement stayOpenLines trigger option

### DIFF
--- a/client/test/Triggers.test.ts
+++ b/client/test/Triggers.test.ts
@@ -45,4 +45,18 @@ describe('Triggers', () => {
     expect(cb).toHaveBeenCalledTimes(1);
     expect(result).toBe('changed');
   });
+
+  test('trigger stays open for specified lines enabling children', () => {
+    const triggers = new Triggers({} as any);
+    const parent = triggers.registerTrigger(/start/, undefined, undefined, { stayOpenLines: 2 });
+    const childCb = jest.fn();
+    parent.registerChild(/child/, childCb);
+
+    triggers.parseLine('start', '');
+    triggers.parseLine('child', '');
+    triggers.parseLine('child', '');
+    triggers.parseLine('child', '');
+
+    expect(childCb).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary
- add `TriggerOptions` with `stayOpenLines`
- keep triggers open for several lines after match
- support options in trigger registration
- test staying-open behaviour

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687430836bf4832a9973ea907c79c0ce