### PR TITLE
Fix text re-selection on input focus

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -483,7 +483,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // Scroll to bottom and select text when input field is focused
     messageInput.addEventListener('focus', () => {
         outputWrapper.scrollTop = outputWrapper.scrollHeight;
-        messageInput.select();
+        // Delay selection to avoid mouse click clearing it on some browsers
+        setTimeout(() => messageInput.select());
     });
 
     // Handle connect/disconnect button click

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -257,7 +257,8 @@ export default class MobileDirectionButtons {
         // Scroll to bottom and select text when input is focused (keyboard appears)
         this.messageInput.addEventListener('focusin', () => {
             this.scrollToBottom();
-            this.messageInput!.select();
+            // Delay selection to avoid mouse click clearing it on some browsers
+            setTimeout(() => this.messageInput!.select());
 
             // Add a small delay to ensure scrolling happens after keyboard appears
             setTimeout(() => this.scrollToBottom(), 300);


### PR DESCRIPTION
## Summary
- ensure text is re-selected after focusing back on the message input
- handle selection in mobile handler with a small delay

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6874344b94ec832a92fe66322c7fe55e