### PR TITLE
Add escape direction trigger

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -164,7 +164,9 @@ initBinds(client, aliases)
 initIdz(client, aliases)
 
 import initKillTrigger from './scripts/kill'
+import initEscape from './scripts/escape'
 initKillTrigger(client, aliases)
+initEscape(client)
 
 import ItemCollector from './scripts/itemCollector'
 

--- a/client/src/scripts/escape.ts
+++ b/client/src/scripts/escape.ts
@@ -2,6 +2,7 @@ import Client from "../Client";
 import { colorString, findClosestColor } from "../Colors";
 
 const COLOR = findClosestColor('#6a5acd');
+const PANIC_COLOR = findClosestColor('#ff8c00');
 
 const ARROWS: Record<string, string> = {
     'wschod': '→',
@@ -34,6 +35,6 @@ export default function initEscape(client: Client) {
     parent.registerChild(/(.*) w panice .* na ([a-z-]+)\.$/, (raw, _line, m) => {
         const dir = m[2];
         const arrow = ARROWS[dir] ? ` ${ARROWS[dir]}` : '';
-        return colorString(raw + arrow, COLOR);
+        return colorString(raw + arrow, PANIC_COLOR);
     });
 }

--- a/client/src/scripts/escape.ts
+++ b/client/src/scripts/escape.ts
@@ -1,0 +1,39 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+const COLOR = findClosestColor('#6a5acd');
+
+const ARROWS: Record<string, string> = {
+    'wschod': '→',
+    'zachod': '←',
+    'polnoc': '↑',
+    'poludnie': '↓',
+    'polnocny-wschod': '↗',
+    'polnocny-zachod': '↖',
+    'poludniowy-wschod': '↘',
+    'poludniowy-zachod': '↙',
+    'gora': '↑',
+    'dol': '↓',
+};
+
+export default function initEscape(client: Client) {
+    const tag = 'escape';
+    const parent = client.Triggers.registerTrigger(
+        /(.*) uciekl.* ci\.$/,
+        (raw) => colorString(raw, COLOR),
+        tag,
+        { stayOpenLines: 1 }
+    );
+
+    parent.registerChild(/(.*) podaza(?:ja)? na ([a-z-]+)\.$/, (raw, _line, m) => {
+        const dir = m[2];
+        const arrow = ARROWS[dir] ? ` ${ARROWS[dir]}` : '';
+        return colorString(raw + arrow, COLOR);
+    });
+
+    parent.registerChild(/(.*) w panice .* na ([a-z-]+)\.$/, (raw, _line, m) => {
+        const dir = m[2];
+        const arrow = ARROWS[dir] ? ` ${ARROWS[dir]}` : '';
+        return colorString(raw + arrow, COLOR);
+    });
+}

--- a/client/test/escape.test.ts
+++ b/client/test/escape.test.ts
@@ -11,6 +11,8 @@ describe('escape triggers', () => {
   let parse: (line: string) => string;
   const color = findClosestColor('#6a5acd');
   const prefix = `\x1B[22;38;5;${color}m`;
+  const panicColor = findClosestColor('#ff8c00');
+  const panicPrefix = `\x1B[22;38;5;${panicColor}m`;
   const suffix = '\x1B[0m';
 
   beforeEach(() => {
@@ -36,7 +38,7 @@ describe('escape triggers', () => {
     parse('Baz uciekl ci.');
     const result = parse('Baz w panice ucieka na polnoc.');
     expect(stripAnsiCodes(result)).toBe('Baz w panice ucieka na polnoc. ↑');
-    expect(result.startsWith(prefix)).toBe(true);
+    expect(result.startsWith(panicPrefix)).toBe(true);
     expect(result.endsWith(suffix)).toBe(true);
   });
 });

--- a/client/test/escape.test.ts
+++ b/client/test/escape.test.ts
@@ -1,0 +1,42 @@
+import initEscape from '../src/scripts/escape';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
+import { findClosestColor } from '../src/Colors';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+}
+
+describe('escape triggers', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+  const color = findClosestColor('#6a5acd');
+  const prefix = `\x1B[22;38;5;${color}m`;
+  const suffix = '\x1B[0m';
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initEscape((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+  });
+
+  test('highlights escape line', () => {
+    const result = parse('Baz uciekl ci.');
+    expect(result).toBe(prefix + 'Baz uciekl ci.' + suffix);
+  });
+
+  test('highlights follow line with arrow', () => {
+    parse('Baz uciekl ci.');
+    const result = parse('Baz podaza na wschod.');
+    expect(stripAnsiCodes(result)).toBe('Baz podaza na wschod. →');
+    expect(result.startsWith(prefix)).toBe(true);
+    expect(result.endsWith(suffix)).toBe(true);
+  });
+
+  test('highlights panic line with arrow', () => {
+    parse('Baz uciekl ci.');
+    const result = parse('Baz w panice ucieka na polnoc.');
+    expect(stripAnsiCodes(result)).toBe('Baz w panice ucieka na polnoc. ↑');
+    expect(result.startsWith(prefix)).toBe(true);
+    expect(result.endsWith(suffix)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- detect when enemies escape and follow direction line
- highlight escape lines in slate blue color
- append small arrow for escape direction
- test the new escape triggers

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6874354bf46c832ab9d9ab65939433f5