### PR TITLE
Add escape direction trigger

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -164,7 +164,9 @@ initBinds(client, aliases)
 initIdz(client, aliases)
 
 import initKillTrigger from './scripts/kill'
+import initEscape from './scripts/escape'
 initKillTrigger(client, aliases)
+initEscape(client)
 
 import ItemCollector from './scripts/itemCollector'
 

--- a/client/src/scripts/escape.ts
+++ b/client/src/scripts/escape.ts
@@ -1,0 +1,40 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+const COLOR = findClosestColor('#6a5acd');
+const PANIC_COLOR = findClosestColor('#ff8c00');
+
+const ARROWS: Record<string, string> = {
+    'wschod': '→',
+    'zachod': '←',
+    'polnoc': '↑',
+    'poludnie': '↓',
+    'polnocny-wschod': '↗',
+    'polnocny-zachod': '↖',
+    'poludniowy-wschod': '↘',
+    'poludniowy-zachod': '↙',
+    'gora': '↑',
+    'dol': '↓',
+};
+
+export default function initEscape(client: Client) {
+    const tag = 'escape';
+    const parent = client.Triggers.registerTrigger(
+        /(.*) uciekl.* ci\.$/,
+        (raw) => colorString(raw, COLOR),
+        tag,
+        { stayOpenLines: 1 }
+    );
+
+    parent.registerChild(/(.*) podaza(?:ja)? na ([a-z-]+)\.$/, (raw, _line, m) => {
+        const dir = m[2];
+        const arrow = ARROWS[dir] ? ` ${ARROWS[dir]}` : '';
+        return colorString(raw + arrow, COLOR);
+    });
+
+    parent.registerChild(/(.*) w panice .* na ([a-z-]+)\.$/, (raw, _line, m) => {
+        const dir = m[2];
+        const arrow = ARROWS[dir] ? ` ${ARROWS[dir]}` : '';
+        return colorString(raw + arrow, PANIC_COLOR);
+    });
+}

--- a/client/test/escape.test.ts
+++ b/client/test/escape.test.ts
@@ -1,0 +1,44 @@
+import initEscape from '../src/scripts/escape';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
+import { findClosestColor } from '../src/Colors';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+}
+
+describe('escape triggers', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+  const color = findClosestColor('#6a5acd');
+  const prefix = `\x1B[22;38;5;${color}m`;
+  const panicColor = findClosestColor('#ff8c00');
+  const panicPrefix = `\x1B[22;38;5;${panicColor}m`;
+  const suffix = '\x1B[0m';
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initEscape((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+  });
+
+  test('highlights escape line', () => {
+    const result = parse('Baz uciekl ci.');
+    expect(result).toBe(prefix + 'Baz uciekl ci.' + suffix);
+  });
+
+  test('highlights follow line with arrow', () => {
+    parse('Baz uciekl ci.');
+    const result = parse('Baz podaza na wschod.');
+    expect(stripAnsiCodes(result)).toBe('Baz podaza na wschod. →');
+    expect(result.startsWith(prefix)).toBe(true);
+    expect(result.endsWith(suffix)).toBe(true);
+  });
+
+  test('highlights panic line with arrow', () => {
+    parse('Baz uciekl ci.');
+    const result = parse('Baz w panice ucieka na polnoc.');
+    expect(stripAnsiCodes(result)).toBe('Baz w panice ucieka na polnoc. ↑');
+    expect(result.startsWith(panicPrefix)).toBe(true);
+    expect(result.endsWith(suffix)).toBe(true);
+  });
+});

--- a/sandbox/src/Controls.tsx
+++ b/sandbox/src/Controls.tsx
@@ -19,6 +19,7 @@ import depositDemo from "./scenario/deposit-demo.ts";
 import stunDemo from "./scenario/stun-demo.ts";
 import inviteDemo from "./scenario/invite-demo.ts";
 import breakItemDemo from "./scenario/break-item-demo.ts";
+import escapeDemo from "./scenario/escape-demo.ts";
 
 // Demo mapping for localStorage persistence
 export const demoMap = {
@@ -38,7 +39,8 @@ export const demoMap = {
     'depositDemo': depositDemo,
     'stunDemo': stunDemo,
     'inviteDemo': inviteDemo,
-    'breakItemDemo': breakItemDemo
+    'breakItemDemo': breakItemDemo,
+    'escapeDemo': escapeDemo
 };
 
 function runDemo(demoName: string) {
@@ -154,6 +156,13 @@ export function Controls() {
                         onClick={() => runDemo('busesDemo')}
                     >
                         Buses Demo
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => runDemo('escapeDemo')}
+                    >
+                        Escape Demo
                     </Button>
                     <Button
                         size="sm"

--- a/sandbox/src/scenario/escape-demo.ts
+++ b/sandbox/src/scenario/escape-demo.ts
@@ -1,0 +1,9 @@
+import ClientScript from "../ClientScript.ts";
+import { fakeClient } from "../fakeClient.ts";
+
+export default new ClientScript(fakeClient)
+    .reset()
+    .fake("Baz uciekl ci.")
+    .fake("Baz podaza na wschod.")
+    .fake("Foo uciekl ci.")
+    .fake("Foo w panice ucieka na polnoc.");


### PR DESCRIPTION
## Summary
- detect when enemies escape and follow direction line
- highlight escape lines in slate blue color
- highlight panic escape lines in dark orange
- append small arrow for escape direction
- test the new escape triggers
- add sandbox demo for escape lines

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6874354bf46c832ab9d9ab65939433f5