### PR TITLE
Add custom external scripts support

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -216,6 +216,7 @@ import initMagics from './scripts/magics'
 import registerGagTriggers from './scripts/gags'
 import initLeaderAttackWarning from './scripts/leaderAttackWarning'
 import initBreakItem from './scripts/breakItem'
+import initExternalScripts from './scripts/externalScripts'
 
 initLvlCalc(client, aliases)
 initItemCondition(client)
@@ -225,5 +226,6 @@ initMagicKeys(client)
 initMagics(client)
 initLeaderAttackWarning(client)
 initBreakItem(client)
+initExternalScripts(client)
 
 window['clientExtension'] = client

--- a/client/src/scripts/externalScripts.ts
+++ b/client/src/scripts/externalScripts.ts
@@ -1,0 +1,32 @@
+import Client from "../Client";
+
+const STORAGE_KEY = "scripts";
+
+export default function initExternalScripts(client: Client) {
+    const loaded: Record<string, HTMLScriptElement> = {};
+
+    const apply = (list: string[] = []) => {
+        Object.keys(loaded).forEach(url => {
+            if (!list.includes(url)) {
+                loaded[url].remove();
+                delete loaded[url];
+            }
+        });
+        list.forEach(url => {
+            if (!loaded[url]) {
+                const script = document.createElement("script");
+                script.src = url;
+                document.head.appendChild(script);
+                loaded[url] = script;
+            }
+        });
+    };
+
+    client.addEventListener("storage", (ev: CustomEvent) => {
+        if (ev.detail.key === STORAGE_KEY) {
+            apply(ev.detail.value || []);
+        }
+    });
+
+    client.port?.postMessage({ type: "GET_STORAGE", key: STORAGE_KEY });
+}

--- a/options/src/App.tsx
+++ b/options/src/App.tsx
@@ -5,10 +5,11 @@ import SettingsForm from "./Settings.tsx";
 import Npc from "./Npc.tsx";
 import SettingsFile from "./SettingsFile";
 import Binds from "./Binds";
+import Scripts from "./Scripts";
 
 
 function App() {
-    const [tab, setTab] = useState<'settings' | 'npc' | 'file' | 'binds'>('settings')
+    const [tab, setTab] = useState<'settings' | 'npc' | 'file' | 'binds' | 'scripts'>('settings')
 
     return (
         <div className="p-2 d-flex flex-column h-100">
@@ -24,6 +25,9 @@ function App() {
                 </Tab>
                 <Tab eventKey="binds" title="Bindowanie">
                     <Binds />
+                </Tab>
+                <Tab eventKey="scripts" title="Skrypty">
+                    <Scripts />
                 </Tab>
             </Tabs>
         </div>

--- a/options/src/Scripts.tsx
+++ b/options/src/Scripts.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState, ChangeEvent } from "react";
+import { Button, Form } from "react-bootstrap";
+import { TiDelete } from "react-icons/ti";
+import storage from "./storage";
+
+function Scripts() {
+    const [scripts, setScripts] = useState<string[]>([]);
+    const [input, setInput] = useState("");
+
+    useEffect(() => {
+        storage.getItem("scripts").then(res => {
+            if (res && Array.isArray(res.scripts)) {
+                setScripts(res.scripts);
+            }
+        });
+    }, []);
+
+    function save(list: string[]) {
+        setScripts(list);
+        storage.setItem("scripts", list);
+    }
+
+    function add() {
+        const url = input.trim();
+        if (!url) return;
+        if (!scripts.includes(url)) {
+            const updated = [...scripts, url];
+            save(updated);
+        }
+        setInput("");
+    }
+
+    function remove(url: string) {
+        const updated = scripts.filter(u => u !== url);
+        save(updated);
+    }
+
+    return (
+        <div className="m-2 d-flex flex-column gap-2">
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Control
+                    type="text"
+                    size="sm"
+                    value={input}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setInput(e.target.value)}
+                    onKeyDown={e => {
+                        if (e.key === "Enter") {
+                            e.preventDefault();
+                            add();
+                        }
+                    }}
+                    placeholder="URL skryptu"
+                    style={{width: '100%', maxWidth: '16rem'}}
+                />
+                <Button size="sm" onClick={add}>Dodaj</Button>
+            </Form.Group>
+            <ul className="list-unstyled ms-3">
+                {scripts.map(url => (
+                    <li key={url} className="d-flex align-items-center gap-2">
+                        <span>{url}</span>
+                        <Button size="sm" variant="secondary" onClick={() => remove(url)}>
+                            <TiDelete />
+                        </Button>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+export default Scripts;


### PR DESCRIPTION
## Summary
- add tab in popup to manage external script URLs
- load user scripts after client initialization

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_68744f517320832a86c8a6ec6b5fd516