### PR TITLE
Add scripts modal to web client

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -74,6 +74,19 @@
             </div>
         </div>
     </div>
+    <div id="scripts-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Skrypty</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="scripts-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
     <div id="input-area">
         <input type="search" id="message-input" autocomplete="false" autocapitalize="off" spellcheck="false"/>
         <button id="send-button">➢</button>
@@ -91,6 +104,9 @@
                 </li>
                 <li>
                     <button class="w-100 p-1" id="npc-button">Odbiorcy paczek</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="scripts-button">Skrypty</button>
                 </li>
                 <li>
                     <button class="w-100 p-1" id="docs-button">Docs</button>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -21,6 +21,7 @@ import { createElement } from 'react'
 import { createRoot} from 'react-dom/client'
 import Binds from "@options/src/Binds.tsx"
 import Npc from "@options/src/Npc.tsx"
+import Scripts from "@options/src/Scripts.tsx"
 
 // Prevent tab sleep on mobile when switching tabs
 let noSleepInstance: NoSleep | null = null;
@@ -318,6 +319,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const optionsButton = document.getElementById('options-button') as HTMLButtonElement;
     const bindsButton = document.getElementById('binds-button') as HTMLButtonElement | null;
     const npcButton = document.getElementById('npc-button') as HTMLButtonElement | null;
+    const scriptsButton = document.getElementById('scripts-button') as HTMLButtonElement | null;
     wakeLockButton = document.getElementById('wake-lock-button') as HTMLButtonElement | null;
     updateWakeLockButton();
 
@@ -328,6 +330,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const bindsModal = bindsModalElement ? new Modal(bindsModalElement) : null;
     const npcModalElement = document.getElementById('npc-modal');
     const npcModal = npcModalElement ? new Modal(npcModalElement) : null;
+    const scriptsModalElement = document.getElementById('scripts-modal');
+    const scriptsModal = scriptsModalElement ? new Modal(scriptsModalElement) : null;
     const loginCharacter = document.getElementById('login-character') as HTMLInputElement | null;
     const loginPassword = document.getElementById('login-password') as HTMLInputElement | null;
     const loginForm = document.getElementById('login-form') as HTMLFormElement | null;
@@ -345,6 +349,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (npcModal) {
             npcModal.hide();
+        }
+        if (scriptsModal) {
+            scriptsModal.hide();
         }
     });
 
@@ -364,6 +371,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (npcButton && npcModal) {
         npcButton.addEventListener('click', () => {
             npcModal.show();
+        });
+    }
+
+    if (scriptsButton && scriptsModal) {
+        scriptsButton.addEventListener('click', () => {
+            scriptsModal.show();
         });
     }
 
@@ -537,6 +550,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const npcRoot = document.getElementById('npc-options');
     if (npcRoot) {
         createRoot(npcRoot).render(createElement(Npc));
+    }
+
+    const scriptsRoot = document.getElementById('scripts-options');
+    if (scriptsRoot) {
+        createRoot(scriptsRoot).render(createElement(Scripts));
     }
 });
 


### PR DESCRIPTION
## Summary
- add modal dialog for managing scripts
- include "Scripts" entry in menu dropdown
- wire up modal show/hide in TypeScript and render Scripts component

## Testing
- `yarn --cwd client test` *(fails: TypeError: client.print is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_687453158198832a9288b1c7983e5a98