### PR TITLE
Adjust /zas alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,7 @@ Use `yarn --cwd client test` to run tests.
 
 In Regexps don't add ever polish letters.
 Prefer creation of HTML elements in HTML files, when possible.
+
+## Data directory
+
+Never modify files inside the `data` directory.

--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -19,14 +19,24 @@ export default function initObjectAliases(
         }
     }
 
+    function shield(short: string) {
+        const obj = findByShortcut(short);
+        if (obj) {
+            const data = client.TeamManager.getAccumulatedObjectsData?.();
+            const isTeam = data && data[obj.num]?.team;
+            const cmd = isTeam ? `zaslon ob_${obj.num}` : `zaslon przed ob_${obj.num}`;
+            client.sendCommand(cmd);
+        }
+    }
+
     if (aliases) {
         aliases.push({
             pattern: /\/z ([A-Za-z0-9@]+)$/,
             callback: (m: RegExpMatchArray) => exec(m[1], "zabij")
         });
         aliases.push({
-            pattern: /\/za ([A-Za-z0-9@]+)$/,
-            callback: (m: RegExpMatchArray) => exec(m[1], "zaslon")
+            pattern: /\/zas ([A-Za-z0-9@]+)$/,
+            callback: (m: RegExpMatchArray) => shield(m[1])
         });
         aliases.push({
             pattern: /^\/z$/,
@@ -38,11 +48,14 @@ export default function initObjectAliases(
             }
         });
         aliases.push({
-            pattern: /^\/za$/,
+            pattern: /^\/zas$/,
             callback: () => {
                 const id = client.TeamManager.getDefenseTargetId();
                 if (id) {
-                    client.sendCommand(`zaslon ob_${id}`);
+                    const data = client.TeamManager.getAccumulatedObjectsData?.();
+                    const isTeam = data && data[id]?.team;
+                    const cmd = isTeam ? `zaslon ob_${id}` : `zaslon przed ob_${id}`;
+                    client.sendCommand(cmd);
                 }
             }
         });

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -7,6 +7,7 @@ class FakeClient {
   TeamManager = {
     getAttackTargetId: jest.fn(() => undefined),
     getDefenseTargetId: jest.fn(() => undefined),
+    getAccumulatedObjectsData: jest.fn(() => ({})),
   };
   sendCommand = jest.fn();
 }
@@ -37,10 +38,18 @@ describe('object aliases', () => {
     expect(client.sendCommand).toHaveBeenCalledWith('zabij ob_5');
   });
 
-  test('zaslon alias sends zaslon with object number', () => {
+  test('zaslon alias sends zaslon with object number when target is in team', () => {
     client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 7, shortcut: 'A' }]);
+    client.TeamManager.getAccumulatedObjectsData.mockReturnValue({ 7: { team: true } });
     shield(['', 'A'] as unknown as RegExpMatchArray);
     expect(client.sendCommand).toHaveBeenCalledWith('zaslon ob_7');
+  });
+
+  test('zaslon alias uses "zaslon przed" when target is not in team', () => {
+    client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 9, shortcut: 'B' }]);
+    client.TeamManager.getAccumulatedObjectsData.mockReturnValue({ 9: { team: false } });
+    shield(['', 'B'] as unknown as RegExpMatchArray);
+    expect(client.sendCommand).toHaveBeenCalledWith('zaslon przed ob_9');
   });
 
   test('/z alias attacks attack target', () => {
@@ -49,8 +58,9 @@ describe('object aliases', () => {
     expect(client.sendCommand).toHaveBeenCalledWith('zabij ob_10');
   });
 
-  test('/za alias covers defense target', () => {
+  test('/zas alias covers defense target', () => {
     client.TeamManager.getDefenseTargetId.mockReturnValue('15');
+    client.TeamManager.getAccumulatedObjectsData.mockReturnValue({ 15: { team: true } });
     shieldTarget();
     expect(client.sendCommand).toHaveBeenCalledWith('zaslon ob_15');
   });

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -25,9 +25,9 @@ Poniższa lista opisuje dostępne aliasy w rozszerzeniu:
 - **/nie_zbieraj_extra [_przedmiot_]** - usuwa wskazany przedmiot z listy ekstra lub bez parametru czyści całą listę.
 - **/cechy** - uruchamia licznik poziomowania i wyświetla postępy.
 - **/z _skrot_** - wykonuje polecenie `zabij` na obiekcie o podanym skrócie.
-- **/za _skrot_** - wykonuje polecenie `zaslon` na obiekcie o podanym skrócie.
+- **/zas _skrot_** - zasłania obiekt o podanym skrócie; jeśli nie jest w drużynie używa komendy `zaslon przed`.
 - **/z** - atakuje cel oznaczony jako cel ataku.
-- **/za** - zasłania cel oznaczony jako cel obrony.
+- **/zas** - zasłania cel oznaczony jako cel obrony lub `zaslon przed`, gdy cel nie jest w drużynie.
 - **/zap** - wykonuje polecenie `zapal lampe`.
 - **/zap _numer_** - zaprasza do drużyny obiekt o podanym numerze.
 - **/zg** - wykonuje polecenie `zgas lampe`.


### PR DESCRIPTION
## Summary
- rename `/za` alias to `/zas`
- make `/zas` use `zaslon przed` when target is not in team
- update docs and tests
- revert Arkadia.xml alias changes and document policy for data directory

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6874d63b91e0832aaf86f251f9b6b6b9