### PR TITLE
Add alias management popup

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -218,6 +218,7 @@ import registerGagTriggers from './scripts/gags'
 import initLeaderAttackWarning from './scripts/leaderAttackWarning'
 import initBreakItem from './scripts/breakItem'
 import initExternalScripts from './scripts/externalScripts'
+import initUserAliases from './scripts/userAliases'
 
 initLvlCalc(client, aliases)
 initItemCondition(client)
@@ -228,4 +229,5 @@ initMagics(client)
 initLeaderAttackWarning(client)
 initBreakItem(client)
 initExternalScripts(client)
+initUserAliases(client, aliases)
 

--- a/client/src/scripts/userAliases.ts
+++ b/client/src/scripts/userAliases.ts
@@ -1,0 +1,38 @@
+import Client from "../Client";
+
+export interface UserAlias {
+    pattern: string;
+    command: string;
+}
+
+const STORAGE_KEY = "aliases";
+
+function escapeRegex(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export default function initUserAliases(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
+    const list = aliases || client.aliases;
+    let mapped: { pattern: RegExp; callback: () => void }[] = [];
+
+    const apply = (arr: UserAlias[] = []) => {
+        mapped.forEach(a => {
+            const idx = list.indexOf(a);
+            if (idx !== -1) list.splice(idx, 1);
+        });
+        mapped = arr.map(item => ({
+            pattern: new RegExp('^' + escapeRegex(item.pattern) + '$'),
+            callback: () => client.sendCommand(item.command)
+        }));
+        mapped.forEach(a => list.push(a));
+    };
+
+    client.addEventListener('storage', (ev: CustomEvent) => {
+        if (ev.detail.key === STORAGE_KEY) {
+            const value = Array.isArray(ev.detail.value) ? ev.detail.value : [];
+            apply(value);
+        }
+    });
+
+    client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
+}

--- a/options/src/Aliases.tsx
+++ b/options/src/Aliases.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState, ChangeEvent } from "react";
+import { Button, Form } from "react-bootstrap";
+import { TiDelete, TiEdit } from "react-icons/ti";
+import storage from "./storage";
+
+interface Alias {
+    pattern: string;
+    command: string;
+}
+
+function Aliases() {
+    const [aliases, setAliases] = useState<Alias[]>([]);
+    const [pattern, setPattern] = useState("");
+    const [command, setCommand] = useState("");
+    const [editIndex, setEditIndex] = useState<number | null>(null);
+
+    useEffect(() => {
+        storage.getItem("aliases").then(res => {
+            if (res && Array.isArray(res.aliases)) {
+                setAliases(res.aliases);
+            }
+        });
+    }, []);
+
+    function saveList(list: Alias[]) {
+        setAliases(list);
+        storage.setItem("aliases", list);
+    }
+
+    function resetForm() {
+        setPattern("");
+        setCommand("");
+        setEditIndex(null);
+    }
+
+    function save() {
+        const p = pattern.trim();
+        const c = command.trim();
+        if (!p || !c) return;
+        if (aliases.some((a, i) => i !== editIndex && a.pattern === p)) {
+            alert("Alias already exists");
+            return;
+        }
+        const updated = [...aliases];
+        const entry = { pattern: p, command: c };
+        if (editIndex === null) {
+            updated.push(entry);
+        } else {
+            updated[editIndex] = entry;
+        }
+        saveList(updated);
+        resetForm();
+    }
+
+    function edit(idx: number) {
+        const a = aliases[idx];
+        setPattern(a.pattern);
+        setCommand(a.command);
+        setEditIndex(idx);
+    }
+
+    function remove(idx: number) {
+        if (!confirm("Are you sure you want to delete this alias?")) return;
+        const updated = aliases.filter((_, i) => i !== idx);
+        saveList(updated);
+    }
+
+    return (
+        <div className="m-2 d-flex flex-column gap-2">
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Control
+                    type="text"
+                    size="sm"
+                    placeholder="Pattern"
+                    value={pattern}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setPattern(e.target.value)}
+                    style={{width: '100%', maxWidth: '8rem'}}
+                />
+                <Form.Control
+                    type="text"
+                    size="sm"
+                    placeholder="Command"
+                    value={command}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setCommand(e.target.value)}
+                    style={{width: '100%', maxWidth: '12rem'}}
+                />
+                <Button size="sm" onClick={save}>{editIndex === null ? 'Dodaj' : 'Zapisz'}</Button>
+                {editIndex !== null && (
+                    <Button size="sm" variant="secondary" onClick={resetForm}>Anuluj</Button>
+                )}
+            </Form.Group>
+            <ul className="list-unstyled ms-3">
+                {aliases.map((a, i) => (
+                    <li key={i} className="d-flex align-items-center gap-2">
+                        <span>{a.pattern}</span>
+                        <span className="text-secondary">→</span>
+                        <span>{a.command}</span>
+                        <Button size="sm" variant="secondary" onClick={() => edit(i)}><TiEdit /></Button>
+                        <Button size="sm" variant="danger" onClick={() => remove(i)}><TiDelete /></Button>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+export default Aliases;

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -87,6 +87,19 @@
             </div>
         </div>
     </div>
+    <div id="aliases-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Aliasy</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="aliases-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
     <div id="input-area">
         <input type="search" id="message-input" autocomplete="false" autocapitalize="off" spellcheck="false"/>
         <button id="send-button">➢</button>
@@ -107,6 +120,9 @@
                 </li>
                 <li>
                     <button class="w-100 p-1" id="scripts-button">Skrypty</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="aliases-button">Aliasy</button>
                 </li>
                 <li>
                     <button class="w-100 p-1" id="docs-button">Docs</button>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -24,6 +24,7 @@ import { createRoot} from 'react-dom/client'
 import Binds from "@options/src/Binds.tsx"
 import Npc from "@options/src/Npc.tsx"
 import Scripts from "@options/src/Scripts.tsx"
+import Aliases from "@options/src/Aliases.tsx"
 
 // Prevent tab sleep on mobile when switching tabs
 let noSleepInstance: NoSleep | null = null;
@@ -322,6 +323,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const bindsButton = document.getElementById('binds-button') as HTMLButtonElement | null;
     const npcButton = document.getElementById('npc-button') as HTMLButtonElement | null;
     const scriptsButton = document.getElementById('scripts-button') as HTMLButtonElement | null;
+    const aliasesButton = document.getElementById('aliases-button') as HTMLButtonElement | null;
     wakeLockButton = document.getElementById('wake-lock-button') as HTMLButtonElement | null;
     updateWakeLockButton();
 
@@ -334,6 +336,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const npcModal = npcModalElement ? new Modal(npcModalElement) : null;
     const scriptsModalElement = document.getElementById('scripts-modal');
     const scriptsModal = scriptsModalElement ? new Modal(scriptsModalElement) : null;
+    const aliasesModalElement = document.getElementById('aliases-modal');
+    const aliasesModal = aliasesModalElement ? new Modal(aliasesModalElement) : null;
     const loginCharacter = document.getElementById('login-character') as HTMLInputElement | null;
     const loginPassword = document.getElementById('login-password') as HTMLInputElement | null;
     const loginForm = document.getElementById('login-form') as HTMLFormElement | null;
@@ -354,6 +358,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (scriptsModal) {
             scriptsModal.hide();
+        }
+        if (aliasesModal) {
+            aliasesModal.hide();
         }
     });
 
@@ -379,6 +386,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (scriptsButton && scriptsModal) {
         scriptsButton.addEventListener('click', () => {
             scriptsModal.show();
+        });
+    }
+
+    if (aliasesButton && aliasesModal) {
+        aliasesButton.addEventListener('click', () => {
+            aliasesModal.show();
         });
     }
 
@@ -557,6 +570,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const scriptsRoot = document.getElementById('scripts-options');
     if (scriptsRoot) {
         createRoot(scriptsRoot).render(createElement(Scripts));
+    }
+
+    const aliasesRoot = document.getElementById('aliases-options');
+    if (aliasesRoot) {
+        createRoot(aliasesRoot).render(createElement(Aliases));
     }
 });
 


### PR DESCRIPTION
## Summary
- create React component for editing aliases
- load user aliases from storage into the client
- connect user alias feature on client startup
- expose alias management popup in the web client UI

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6874e85282e0832a9946916987151ea7