### PR TITLE
Improve alias popup for mobile

### DIFF
--- a/options/src/Aliases.tsx
+++ b/options/src/Aliases.tsx
@@ -67,7 +67,7 @@ function Aliases() {
 
     return (
         <div className="m-2 d-flex flex-column gap-2">
-            <Form.Group className="d-flex align-items-center gap-2">
+            <Form.Group className="d-flex flex-column flex-sm-row align-items-center gap-2 alias-form-group">
                 <Form.Control
                     type="text"
                     size="sm"
@@ -91,7 +91,7 @@ function Aliases() {
             </Form.Group>
             <ul className="list-unstyled ms-3">
                 {aliases.map((a, i) => (
-                    <li key={i} className="d-flex align-items-center gap-2">
+                    <li key={i} className="d-flex align-items-center gap-2 alias-list-item">
                         <span>{a.pattern}</span>
                         <span className="text-secondary">→</span>
                         <span>{a.command}</span>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -88,7 +88,7 @@
         </div>
     </div>
     <div id="aliases-modal" class="modal fade" tabindex="-1">
-        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable modal-fullscreen-sm-down">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Aliasy</h5>

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -473,9 +473,22 @@ button:focus-visible {
   overflow-y: auto;
 }
 
+.alias-form-group {
+  flex-wrap: wrap;
+}
+
+.alias-list-item {
+  flex-wrap: wrap;
+}
+
+.alias-list-item span {
+  word-break: break-word;
+}
+
 #options-modal .modal-dialog,
 #docs-modal .modal-dialog,
-#debug-modal .modal-dialog {
+#debug-modal .modal-dialog,
+#aliases-modal .modal-dialog {
   margin-top: 5vh;
   margin-bottom: 5vh;
 }


### PR DESCRIPTION
## Summary
- tweak alias modal HTML to use Bootstrap fullscreen class on small screens
- adjust alias form to wrap on narrow widths and improve list styling
- ensure alias modal gets the same margin as other modals

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6874f7904404832a98c8d82f4a065ce6