### PR TITLE
Fix team follow regex

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -129,13 +129,13 @@ registerLuaGagTriggers(client)
 
 const follows = [
     /^.*[pP]odazasz (|skradajac sie )za (.* na (.*?))(?:,.*)?\.$/,
-    /^Wraz z ([a-zA-Z ,]*) podazasz za (.* na (.*?))(?:,.*)?\.$/
+    /^Wraz z ([A-Za-z ,'-]*) podazasz za (.* na (.*?))(?:,.*)?\.$/
 ]
 
 follows.forEach(follow => {
     client.Triggers.registerTrigger(follow, (_rawLine, line): undefined => {
         const matches = line.match(follow)
-        client.sendEvent('move', matches[3])
+        client.Map.move(matches[3])
     }, 'follow')
 })
 


### PR DESCRIPTION
## Summary
- allow hyphens and apostrophes in names when parsing team follow messages
- send movement info directly to `MapHelper` instead of emitting a `move` event

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6874f86ca008832a96cd4d70cc4e09be