### PR TITLE
Fix alias form centering

### DIFF
--- a/options/src/Aliases.tsx
+++ b/options/src/Aliases.tsx
@@ -67,7 +67,7 @@ function Aliases() {
 
     return (
         <div className="m-2 d-flex flex-column gap-2">
-            <Form.Group className="d-flex flex-column flex-sm-row align-items-center gap-2 alias-form-group">
+            <Form.Group className="d-flex flex-column flex-sm-row align-items-start align-items-sm-center gap-2 alias-form-group">
                 <Form.Control
                     type="text"
                     size="sm"

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -88,7 +88,7 @@
         </div>
     </div>
     <div id="aliases-modal" class="modal fade" tabindex="-1">
-        <div class="modal-dialog modal-lg modal-dialog-scrollable modal-fullscreen-sm-down">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Aliasy</h5>


### PR DESCRIPTION
## Summary
- tweak the alias add form so inputs are not centered on small screens
- remove fullscreen mode from alias popup

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6874fa7be7ac832ab465fadd862e6c1a