### PR TITLE
Add Jest setup for fetch and IndexedDB

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   roots: [
     '<rootDir>/test',
   ],
+  setupFiles: ['<rootDir>/jest.setup.ts'],
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',

--- a/client/jest.setup.ts
+++ b/client/jest.setup.ts
@@ -1,0 +1,34 @@
+import 'fake-indexeddb/auto';
+
+class LocalStorageMock {
+  private store: Record<string, string> = {};
+  clear() { this.store = {}; }
+  getItem(key: string) { return this.store[key] ?? null; }
+  setItem(key: string, value: string) { this.store[key] = String(value); }
+  removeItem(key: string) { delete this.store[key]; }
+}
+
+if (typeof globalThis.localStorage === 'undefined') {
+  (globalThis as any).localStorage = new LocalStorageMock();
+}
+
+if (typeof globalThis.structuredClone !== 'function') {
+  (globalThis as any).structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
+}
+
+if (typeof globalThis.fetch !== 'function') {
+  if (typeof global.fetch === 'function') {
+    (globalThis as any).fetch = global.fetch.bind(global);
+  } else {
+    (globalThis as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        magics: {},
+        magic_keys: [],
+        herb_id_to_odmiana: {},
+        version: 1,
+        herb_id_to_use: {}
+      }),
+    });
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "@types/jest": "^29.5.5",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.2",
+    "fake-indexeddb": "^6.0.1",
     "mkdirp": "^3.0.1",
     "ts-jest": "^29.1.1",
     "ts-loader": "^9.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4775,6 +4775,11 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
+fake-indexeddb@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-6.0.1.tgz#03937a9065c2ea09733e2147a473c904411b6f2c"
+  integrity sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"


### PR DESCRIPTION
## Summary
- polyfill IndexedDB and fetch during Jest runs
- add fake-indexeddb for tests

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68763ccba580832aaadde9cf3290dfbb