### PR TITLE
Use token triggers for magics, keys and people

### DIFF
--- a/client/src/People.ts
+++ b/client/src/People.ts
@@ -23,7 +23,7 @@ export default class People {
                 return
             }
             count++
-            this.client.Triggers.registerTrigger(replacement.description, (rawLine, _line, matches) => {
+            this.client.Triggers.registerTokenTrigger(replacement.description, (rawLine, _line, matches) => {
                 const index = matches.index
                 return rawLine.substring(0, index + replacement.description.length) + ` \x1B[22;38;5;228m(${replacement.name} \x1B[22;38;5;210m${replacement.guild}\x1B[22;38;5;228m)` + rawLine.substring(index + replacement.description.length)
             }, this.tag)

--- a/client/src/scripts/magicKeys.ts
+++ b/client/src/scripts/magicKeys.ts
@@ -8,7 +8,7 @@ export default async function initMagicKeys(client: Client) {
     try {
         const keys = await loadMagicKeys();
         keys.forEach((pattern: string) => {
-            client.Triggers.registerTrigger(pattern, (raw) => {
+            client.Triggers.registerTokenTrigger(pattern, (raw) => {
                 return colorStringInLine(raw, pattern, KEYS_COLOR);
             }, tag);
         });

--- a/client/src/scripts/magics.ts
+++ b/client/src/scripts/magics.ts
@@ -8,7 +8,7 @@ export default async function initMagics(client: Client) {
     try {
         const magics = await loadMagics();
         magics.forEach((pattern: string) => {
-            client.Triggers.registerTrigger(pattern, (raw) => {
+            client.Triggers.registerTokenTrigger(pattern, (raw) => {
                 return colorStringInLine(raw, pattern, MAGICS_COLOR);
             }, tag);
         });

--- a/client/test/magicKeys.test.ts
+++ b/client/test/magicKeys.test.ts
@@ -11,12 +11,12 @@ describe('magic keys', () => {
     });
 
     test('registers triggers from remote list', async () => {
-        const client = { Triggers: { registerTrigger: jest.fn() } } as any;
+        const client = { Triggers: { registerTokenTrigger: jest.fn() } } as any;
         await initMagicKeys(client);
         expect(fetch).toHaveBeenCalled();
         expect(localStorage.getItem('magic_keys')).not.toBeNull();
-        expect(client.Triggers.registerTrigger).toHaveBeenCalledTimes(2);
-        const call = client.Triggers.registerTrigger.mock.calls[0];
+        expect(client.Triggers.registerTokenTrigger).toHaveBeenCalledTimes(2);
+        const call = client.Triggers.registerTokenTrigger.mock.calls[0];
         const pattern = call[0];
         const callback = call[1];
         const colored = colorStringInLine('alpha test', pattern, findClosestColor('#00ff7f'));

--- a/client/test/magics.test.ts
+++ b/client/test/magics.test.ts
@@ -11,12 +11,12 @@ describe('magics', () => {
     });
 
     test('registers triggers from remote list', async () => {
-        const client = { Triggers: { registerTrigger: jest.fn() } } as any;
+        const client = { Triggers: { registerTokenTrigger: jest.fn() } } as any;
         await initMagics(client);
         expect(fetch).toHaveBeenCalled();
         expect(localStorage.getItem('magics')).not.toBeNull();
-        expect(client.Triggers.registerTrigger).toHaveBeenCalledTimes(2);
-        const call = client.Triggers.registerTrigger.mock.calls[0];
+        expect(client.Triggers.registerTokenTrigger).toHaveBeenCalledTimes(2);
+        const call = client.Triggers.registerTokenTrigger.mock.calls[0];
         const pattern = call[0];
         const callback = call[1];
         const colored = colorStringInLine('alpha test', pattern, MAGICS_COLOR);


### PR DESCRIPTION
## Summary
- switch magics, magic keys and people highlights to token triggers
- update tests

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68763c2a6e4c832ab92294e04e757aa3