### PR TITLE
Add clickable Lua error message

### DIFF
--- a/client/src/scripts/luaGags.ts
+++ b/client/src/scripts/luaGags.ts
@@ -129,7 +129,14 @@ function registerTrigger(parent: Triggers | Trigger, tr: GagTrigger) {
                 try {
                     luaEnv.parse(tr.script).exec()
                 } catch (e) {
-                    global.line = global.line + "\n" + "Zglos blad w powyzszej lini: " + e.message
+                    const warn = `Zglos blad w powyzszej lini: ${e.message}`
+                    const clickable = client.OutputHandler.makeClickable(
+                        warn,
+                        warn,
+                        () => navigator.clipboard.writeText(rawLine),
+                        'Kopiuj linie'
+                    )
+                    global.line = global.line + "\n" + clickable
 
                 }
                 rawLine = global.line


### PR DESCRIPTION
## Summary
- make Lua gag error messages clickable
- clicking copies the offending line to clipboard

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6876497c4874832aa3ba80d604a06be0