### PR TITLE
Add configurable numpad binds

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -12,7 +12,20 @@ const defaultSettings = {
         main: { key: 'BracketRight' },
         lamp: { key: 'Digit4', ctrl: true },
         gates: { key: 'Digit2', ctrl: true },
-        collector: { key: 'Digit3', ctrl: true }
+        collector: { key: 'Digit3', ctrl: true },
+        directions: {
+            n: { key: 'Numpad8' },
+            s: { key: 'Numpad2' },
+            w: { key: 'Numpad4' },
+            e: { key: 'Numpad6' },
+            nw: { key: 'Numpad7' },
+            ne: { key: 'Numpad9' },
+            sw: { key: 'Numpad1' },
+            se: { key: 'Numpad3' },
+            u: { key: 'NumpadMultiply' },
+            d: { key: 'NumpadSubtract' },
+            special: { key: 'Numpad0' },
+        }
     }
 }
 
@@ -90,7 +103,20 @@ function loadIframe(tabId) {
                     main: { key: 'BracketRight' },
                     lamp: { key: 'Digit4', ctrl: true },
                     gates: { key: 'Digit2', ctrl: true },
-                    collector: { key: 'Digit3', ctrl: true }
+                    collector: { key: 'Digit3', ctrl: true },
+                    directions: {
+                        n: { key: 'Numpad8' },
+                        s: { key: 'Numpad2' },
+                        w: { key: 'Numpad4' },
+                        e: { key: 'Numpad6' },
+                        nw: { key: 'Numpad7' },
+                        ne: { key: 'Numpad9' },
+                        sw: { key: 'Numpad1' },
+                        se: { key: 'Numpad3' },
+                        u: { key: 'NumpadMultiply' },
+                        d: { key: 'NumpadSubtract' },
+                        special: { key: 'Numpad0' },
+                    }
                 }
             }
 

--- a/options/src/Binds.tsx
+++ b/options/src/Binds.tsx
@@ -9,14 +9,42 @@ interface Bind {
     shift?: boolean;
 }
 
+interface DirectionBinds {
+    n: Bind;
+    s: Bind;
+    w: Bind;
+    e: Bind;
+    nw: Bind;
+    ne: Bind;
+    sw: Bind;
+    se: Bind;
+    u: Bind;
+    d: Bind;
+    special: Bind;
+}
+
 interface BindSettings {
     main: Bind;
     lamp: Bind;
+    directions: DirectionBinds;
 }
 
 const defaultBinds: BindSettings = {
     main: { key: 'BracketRight' },
     lamp: { key: 'Digit4', ctrl: true },
+    directions: {
+        n: { key: 'Numpad8' },
+        s: { key: 'Numpad2' },
+        w: { key: 'Numpad4' },
+        e: { key: 'Numpad6' },
+        nw: { key: 'Numpad7' },
+        ne: { key: 'Numpad9' },
+        sw: { key: 'Numpad1' },
+        se: { key: 'Numpad3' },
+        u: { key: 'NumpadMultiply' },
+        d: { key: 'NumpadSubtract' },
+        special: { key: 'Numpad0' },
+    },
 };
 
 function label(bind: Bind) {
@@ -42,6 +70,10 @@ function Binds() {
                 ...defaultBinds,
                 main: res.settings?.binds?.main || defaultBinds.main,
                 lamp: res.settings?.binds?.lamp || defaultBinds.lamp,
+                directions: {
+                    ...defaultBinds.directions,
+                    ...res.settings?.binds?.directions,
+                },
             });
         });
     }, []);
@@ -52,9 +84,18 @@ function Binds() {
         setBinds(prev => ({ ...prev, [name]: { key: code, ctrl: ctrlKey, alt: altKey, shift: shiftKey } }));
     }
 
+    function handleCaptureDir(dir: keyof DirectionBinds, ev: React.KeyboardEvent<HTMLInputElement>) {
+        ev.preventDefault();
+        const { code, ctrlKey, altKey, shiftKey } = ev;
+        setBinds(prev => ({
+            ...prev,
+            directions: { ...prev.directions, [dir]: { key: code, ctrl: ctrlKey, alt: altKey, shift: shiftKey } },
+        }));
+    }
+
     function save() {
             storage.getItem('settings').then(res => {
-                const settings = { ...(res.settings || {}), binds: { main: binds.main, lamp: binds.lamp } };
+                const settings = { ...(res.settings || {}), binds: { main: binds.main, lamp: binds.lamp, directions: binds.directions } };
                 storage.setItem('settings', settings).then(() => {
                     if (chrome.runtime) {
                         window.close();
@@ -87,6 +128,127 @@ function Binds() {
                     className="w-40"
                     value={label(binds.lamp)}
                     onKeyDown={ev => handleCapture('lamp', ev)}
+                />
+            </Form.Group>
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Label className="w-32 mb-0">N</Form.Label>
+                <Form.Control
+                    type="text"
+                    readOnly
+                    size="sm"
+                    className="w-40"
+                    value={label(binds.directions.n)}
+                    onKeyDown={ev => handleCaptureDir('n', ev)}
+                />
+            </Form.Group>
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Label className="w-32 mb-0">S</Form.Label>
+                <Form.Control
+                    type="text"
+                    readOnly
+                    size="sm"
+                    className="w-40"
+                    value={label(binds.directions.s)}
+                    onKeyDown={ev => handleCaptureDir('s', ev)}
+                />
+            </Form.Group>
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Label className="w-32 mb-0">W</Form.Label>
+                <Form.Control
+                    type="text"
+                    readOnly
+                    size="sm"
+                    className="w-40"
+                    value={label(binds.directions.w)}
+                    onKeyDown={ev => handleCaptureDir('w', ev)}
+                />
+            </Form.Group>
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Label className="w-32 mb-0">E</Form.Label>
+                <Form.Control
+                    type="text"
+                    readOnly
+                    size="sm"
+                    className="w-40"
+                    value={label(binds.directions.e)}
+                    onKeyDown={ev => handleCaptureDir('e', ev)}
+                />
+            </Form.Group>
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Label className="w-32 mb-0">NW</Form.Label>
+                <Form.Control
+                    type="text"
+                    readOnly
+                    size="sm"
+                    className="w-40"
+                    value={label(binds.directions.nw)}
+                    onKeyDown={ev => handleCaptureDir('nw', ev)}
+                />
+            </Form.Group>
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Label className="w-32 mb-0">NE</Form.Label>
+                <Form.Control
+                    type="text"
+                    readOnly
+                    size="sm"
+                    className="w-40"
+                    value={label(binds.directions.ne)}
+                    onKeyDown={ev => handleCaptureDir('ne', ev)}
+                />
+            </Form.Group>
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Label className="w-32 mb-0">SW</Form.Label>
+                <Form.Control
+                    type="text"
+                    readOnly
+                    size="sm"
+                    className="w-40"
+                    value={label(binds.directions.sw)}
+                    onKeyDown={ev => handleCaptureDir('sw', ev)}
+                />
+            </Form.Group>
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Label className="w-32 mb-0">SE</Form.Label>
+                <Form.Control
+                    type="text"
+                    readOnly
+                    size="sm"
+                    className="w-40"
+                    value={label(binds.directions.se)}
+                    onKeyDown={ev => handleCaptureDir('se', ev)}
+                />
+            </Form.Group>
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Label className="w-32 mb-0">U</Form.Label>
+                <Form.Control
+                    type="text"
+                    readOnly
+                    size="sm"
+                    className="w-40"
+                    value={label(binds.directions.u)}
+                    onKeyDown={ev => handleCaptureDir('u', ev)}
+                />
+            </Form.Group>
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Label className="w-32 mb-0">D</Form.Label>
+                <Form.Control
+                    type="text"
+                    readOnly
+                    size="sm"
+                    className="w-40"
+                    value={label(binds.directions.d)}
+                    onKeyDown={ev => handleCaptureDir('d', ev)}
+                />
+            </Form.Group>
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Label className="w-32 mb-0">Specjalne</Form.Label>
+                <Form.Control
+                    type="text"
+                    readOnly
+                    size="sm"
+                    className="w-40"
+                    value={label(binds.directions.special)}
+                    onKeyDown={ev => handleCaptureDir('special', ev)}
                 />
             </Form.Group>
             <Button className="mt-2 w-auto" onClick={save}>Zapisz</Button>


### PR DESCRIPTION
## Summary
- add direction and special exit binds to settings page
- expose default numpad binds in extension background
- handle special exit via numpad0 in client

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687653d7d7ac832abeaddaba8bd7b652