### PR TITLE
Fix lua script loading

### DIFF
--- a/client/src/scripts/luaGags.ts
+++ b/client/src/scripts/luaGags.ts
@@ -351,12 +351,14 @@ function createLuaEnv() {
 let {global, luaEnv} = createLuaEnv();
 
 let luaFiles: Record<string, { default: string }> = {};
-// Attempt to use import.meta.glob (works in Vite). If unavailable, fall back to require.context
-try {
+// Use import.meta.glob when available (Vite). Otherwise fall back to webpack's require.context
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - import.meta may not have `glob` property in webpack builds
+if (typeof (import.meta as any).glob === "function") {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    luaFiles = import.meta.glob("../lua/**/*.lua", { query: "?raw", eager: true });
-} catch (e) {
+    // @ts-ignore - import.meta.glob is vite-only
+    luaFiles = (import.meta as any).glob("../lua/**/*.lua", { query: "?raw", eager: true });
+} else {
     // require.context is a webpack specific API
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const context = (require as any).context("../lua", true, /\.lua$/);

--- a/client/src/scripts/luaGags.ts
+++ b/client/src/scripts/luaGags.ts
@@ -351,15 +351,14 @@ function createLuaEnv() {
 let {global, luaEnv} = createLuaEnv();
 
 let luaFiles: Record<string, { default: string }> = {};
-// Vite provides import.meta.glob. Webpack does not, so fall back to require.context
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-if (typeof import.meta !== 'undefined' && import.meta.glob) {
+// Attempt to use import.meta.glob (works in Vite). If unavailable, fall back to require.context
+try {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     luaFiles = import.meta.glob("../lua/**/*.lua", { query: "?raw", eager: true });
-} else {
+} catch (e) {
     // require.context is a webpack specific API
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const context = (require as any).context("../lua", true, /\.lua$/);
     luaFiles = context.keys().reduce((acc: Record<string, { default: string }>, key: string) => {
         acc[key] = { default: context(key) as string };

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -18,6 +18,10 @@ module.exports = {
             {
                 test: /\.tsx?$/,
                 loader: "ts-loader"
+            },
+            {
+                test: /\.lua$/,
+                type: 'asset/source'
             }
         ]
     }


### PR DESCRIPTION
## Summary
- handle missing `import.meta.glob` by falling back to `require.context`
- allow webpack to import `.lua` files as strings

## Testing
- `yarn --cwd client test`
- `yarn --cwd client build`


------
https://chatgpt.com/codex/tasks/task_e_68765e122b0c832abb72c925cc11f74e