### PR TITLE
Implement width limits for pretty containers

### DIFF
--- a/client/src/scripts/deposits.ts
+++ b/client/src/scripts/deposits.ts
@@ -34,8 +34,12 @@ export default function initDeposits(client: Client, aliases?: { pattern: RegExp
     };
 
     let columns = 1;
+    let width = client.contentWidth;
     client.addEventListener('settings', (ev: CustomEvent) => {
         columns = ev.detail.containerColumns ?? columns;
+    });
+    client.addEventListener('contentWidth', (ev: CustomEvent) => {
+        width = ev.detail;
     });
 
     function update(items: ContainerItem[] | null) {
@@ -68,7 +72,7 @@ export default function initDeposits(client: Client, aliases?: { pattern: RegExp
         const text = (m.groups?.content || m[1]).replace(/\.$/, "");
         const items = parseItems(text);
         update(items);
-        client.print(prettyPrintContainer(m as RegExpMatchArray, columns, 'DEPOZYT', 5));
+        client.print(prettyPrintContainer(m as RegExpMatchArray, columns, 'DEPOZYT', 5, width));
         return undefined;
     });
     client.Triggers.registerTrigger(matchEmpty, () => { update([] as ContainerItem[]); return undefined; });

--- a/client/test/deposit.test.ts
+++ b/client/test/deposit.test.ts
@@ -16,6 +16,7 @@ class FakeClient {
   print = jest.fn();
   port = { postMessage: jest.fn() } as any;
   sendCommand = jest.fn();
+  contentWidth = 80;
 
   addEventListener(event: string, cb: any) {
     this.emitter.on(event, cb);
@@ -127,6 +128,6 @@ describe('deposits', () => {
   test('uses column setting for pretty print', () => {
     client.dispatch('settings', { containerColumns: 3 });
     parse('Twoj depozyt zawiera miecz.');
-    expect(prettyPrintContainer).toHaveBeenCalledWith(expect.anything(), 3, 'DEPOZYT', 5);
+    expect(prettyPrintContainer).toHaveBeenCalledWith(expect.anything(), 3, 'DEPOZYT', 5, client.contentWidth);
   });
 });

--- a/client/test/prettyContainers.test.ts
+++ b/client/test/prettyContainers.test.ts
@@ -141,4 +141,12 @@ describe('prettyContainers', () => {
     expect(parsed!.items[0]).toEqual({count: 25, name: 'monet'});
     expect(parsed!.items[1]).toEqual({count: 100, name: 'klejnotow'});
   });
+
+  test('formatTable obeys maxWidth', () => {
+    const parsed = parseContainer(input)!;
+    const cat = categorizeItems(parsed.items, groups);
+    const table = formatTable('POJEMNIK', cat, { columns: 2, maxWidth: 40 });
+    const lines = table.split('\n').map(l => l.replace(/\x1b\[[0-9;]*m/g, ''));
+    lines.forEach(l => expect(l.length).toBeLessThanOrEqual(40));
+  });
 });


### PR DESCRIPTION
## Summary
- support maxWidth option in pretty containers
- enforce width and column adjustments in `formatTable`
- forward client width to pretty container printing
- update deposit printing and tests
- verify maximum width in pretty container tests

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687660855074832aa717c82e2388b08e