### PR TITLE
Store herb summary in storage

### DIFF
--- a/client/test/herbCounter.test.ts
+++ b/client/test/herbCounter.test.ts
@@ -98,4 +98,13 @@ describe('herb counter', () => {
       expect(l.length).toBeLessThanOrEqual(client.contentWidth);
     });
   });
+
+  test('prints summary from storage', () => {
+    const aliases: { pattern: RegExp; callback: () => void }[] = [];
+    initHerbCounter((client as unknown) as any, aliases);
+    const show = aliases[1].callback as any;
+    show();
+    client.dispatch('storage', { key: 'herb_summary', value: ['line1', 'line2'] });
+    expect(client.println).toHaveBeenCalledWith('line1\nline2');
+  });
 });


### PR DESCRIPTION
## Summary
- persist herb counter summary via storage
- fetch summary from storage when printing
- test herb summary retrieval from storage

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6876664887f0832aab5b08bd00960d59