### PR TITLE
Fix viewport clamping for draggable UI

### DIFF
--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -14,6 +14,7 @@ export default class ObjectList {
         this.client = client;
         this.container = document.getElementById("objects-list");
         this.setupDraggable();
+        window.addEventListener("resize", this.clampToViewport);
         this.client.addEventListener("gmcp.objects.nums", () => this.render());
         this.client.addEventListener("gmcp.objects.data", () => this.render());
         this.client.addEventListener("gmcp.char.state", () => this.render());
@@ -33,6 +34,7 @@ export default class ObjectList {
                 console.error("Error parsing saved objects list position", e);
             }
         }
+        this.clampToViewport();
 
         this.container.addEventListener("pointerdown", this.onPointerDown);
         window.addEventListener("pointermove", this.onPointerMove);
@@ -73,6 +75,27 @@ export default class ObjectList {
             y: rect.top,
         };
         localStorage.setItem("objectsListPosition", JSON.stringify(position));
+    };
+
+    private clampToViewport = () => {
+        if (!this.container) return;
+        const rect = this.container.getBoundingClientRect();
+        let newRight = window.innerWidth - rect.right;
+        let newTop = rect.top;
+        if (rect.right > window.innerWidth) {
+            newRight = 0;
+        }
+        if (rect.left < 0) {
+            newRight = window.innerWidth - this.container.offsetWidth;
+        }
+        if (rect.bottom > window.innerHeight) {
+            newTop = window.innerHeight - this.container.offsetHeight;
+        }
+        if (rect.top < 0) {
+            newTop = 0;
+        }
+        this.container.style.right = `${Math.max(0, newRight)}px`;
+        this.container.style.top = `${Math.max(0, newTop)}px`;
     };
 
     private render() {

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -55,12 +55,14 @@ export default class MobileDirectionButtons {
         this.updateToggleButton();
         this.setupDraggable();
         this.checkMobile();
+        this.clampToViewport();
         this.setupKeyboardHandlers();
 
         // Listen for window resize to check if mobile view
         window.addEventListener('resize', () => {
             this.checkMobile();
             this.scrollToBottom();
+            this.clampToViewport();
         });
 
         // Listen for UI settings changes
@@ -291,6 +293,7 @@ export default class MobileDirectionButtons {
                 console.error('Error parsing saved position:', e);
             }
         }
+        this.clampToViewport();
 
         // Add touch event listeners for long press and drag
         this.container.addEventListener('touchstart', this.handleTouchStart.bind(this), { passive: false });
@@ -593,4 +596,25 @@ export default class MobileDirectionButtons {
             this.zasList!.appendChild(b);
         });
     }
+
+    private clampToViewport = () => {
+        if (!this.container) return;
+        const rect = this.container.getBoundingClientRect();
+        let newRight = window.innerWidth - rect.right;
+        let newTop = rect.top;
+        if (rect.right > window.innerWidth) {
+            newRight = 5;
+        }
+        if (rect.left < 0) {
+            newRight = window.innerWidth - this.container.offsetWidth - 5;
+        }
+        if (rect.bottom > window.innerHeight) {
+            newTop = window.innerHeight - this.container.offsetHeight - 5;
+        }
+        if (rect.top < 0) {
+            newTop = 5;
+        }
+        this.container.style.right = `${Math.max(5, newRight)}px`;
+        this.container.style.top = `${Math.max(5, newTop)}px`;
+    };
 }


### PR DESCRIPTION
## Summary
- keep objects list within the viewport on resize
- keep mobile direction buttons within the viewport on resize

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68766c1f3bf4832ababd46aee71d884f