### PR TITLE
Fix aliases not loading after refresh

### DIFF
--- a/client/src/scripts/userAliases.ts
+++ b/client/src/scripts/userAliases.ts
@@ -34,5 +34,9 @@ export default function initUserAliases(client: Client, aliases?: { pattern: Reg
         }
     });
 
+    client.addEventListener('port-connected', () => {
+        client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
+    });
+
     client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
 }


### PR DESCRIPTION
## Summary
- ensure alias list is requested whenever the extension port connects

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6876707ae110832a87e68c296e1af2fb