### PR TITLE
Fix drag clamping to keep UI inside viewport

### DIFF
--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -61,8 +61,11 @@ export default class ObjectList {
         const deltaY = e.clientY - this.startY;
         const newRight = this.offsetRight + deltaX;
         const newTop = this.offsetTop + deltaY;
-        this.container.style.right = `${Math.max(0, newRight)}px`;
-        this.container.style.top = `${Math.max(0, newTop)}px`;
+        const maxRight = window.innerWidth - this.container.offsetWidth;
+        const clampedRight = Math.min(maxRight, Math.max(0, newRight));
+        const clampedTop = Math.max(0, newTop);
+        this.container.style.right = `${clampedRight}px`;
+        this.container.style.top = `${clampedTop}px`;
     };
 
     private onPointerUp = (e: PointerEvent) => {
@@ -75,6 +78,7 @@ export default class ObjectList {
             y: rect.top,
         };
         localStorage.setItem("objectsListPosition", JSON.stringify(position));
+        this.clampToViewport();
     };
 
     private clampToViewport = () => {
@@ -94,8 +98,11 @@ export default class ObjectList {
         if (rect.top < 0) {
             newTop = 0;
         }
-        this.container.style.right = `${Math.max(0, newRight)}px`;
-        this.container.style.top = `${Math.max(0, newTop)}px`;
+        const maxRight = window.innerWidth - this.container.offsetWidth;
+        newRight = Math.min(maxRight, Math.max(0, newRight));
+        newTop = Math.max(0, newTop);
+        this.container.style.right = `${newRight}px`;
+        this.container.style.top = `${newTop}px`;
     };
 
     private render() {

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -387,9 +387,13 @@ export default class MobileDirectionButtons {
         const newRight = this.offsetX + deltaX;
         const newTop = this.offsetY + deltaY;
 
+        const maxRight = window.innerWidth - this.container.offsetWidth - 5;
+        const clampedRight = Math.min(maxRight, Math.max(5, newRight));
+        const clampedTop = Math.max(5, newTop);
+
         // Apply new position
-        this.container.style.right = `${Math.max(5, newRight)}px`;
-        this.container.style.top = `${Math.max(5, newTop)}px`;
+        this.container.style.right = `${clampedRight}px`;
+        this.container.style.top = `${clampedTop}px`;
     }
 
     private handleTouchEnd(e: TouchEvent) {
@@ -418,6 +422,8 @@ export default class MobileDirectionButtons {
             buttons.forEach(button => {
                 button.classList.remove('no-click');
             });
+
+            this.clampToViewport();
 
             // Prevent any click events immediately after dragging ends
             e.preventDefault();
@@ -468,9 +474,13 @@ export default class MobileDirectionButtons {
         const newRight = this.offsetX + deltaX;
         const newTop = this.offsetY + deltaY;
 
+        const maxRight = window.innerWidth - this.container.offsetWidth - 5;
+        const clampedRight = Math.min(maxRight, Math.max(5, newRight));
+        const clampedTop = Math.max(5, newTop);
+
         // Apply new position
-        this.container.style.right = `${Math.max(5, newRight)}px`;
-        this.container.style.top = `${Math.max(5, newTop)}px`;
+        this.container.style.right = `${clampedRight}px`;
+        this.container.style.top = `${clampedTop}px`;
     }
 
     private handleMouseUp(e: MouseEvent) {
@@ -499,6 +509,8 @@ export default class MobileDirectionButtons {
             buttons.forEach(button => {
                 button.classList.remove('no-click');
             });
+
+            this.clampToViewport();
 
             // Prevent any click events immediately after dragging ends
             e.preventDefault();


### PR DESCRIPTION
## Summary
- clamp objects list drag movement so it stays within the viewport
- clamp mobile direction buttons drag movement so it can't move out of bounds

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687676046800832a9b62ce660fb5df0e