### PR TITLE
Fix draggable overlays shifting left on resize

### DIFF
--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -84,21 +84,24 @@ export default class ObjectList {
     private clampToViewport = () => {
         if (!this.container) return;
         const rect = this.container.getBoundingClientRect();
-        let newRight = window.innerWidth - rect.right;
-        let newTop = rect.top;
+        const styles = window.getComputedStyle(this.container);
+        let newRight = parseFloat(styles.right || "0");
+        let newTop = parseFloat(styles.top || "0");
+
+        const maxRight = window.innerWidth - this.container.offsetWidth;
+
         if (rect.right > window.innerWidth) {
             newRight = 0;
+        } else if (rect.left < 0) {
+            newRight = maxRight;
         }
-        if (rect.left < 0) {
-            newRight = window.innerWidth - this.container.offsetWidth;
-        }
+
         if (rect.bottom > window.innerHeight) {
             newTop = window.innerHeight - this.container.offsetHeight;
-        }
-        if (rect.top < 0) {
+        } else if (rect.top < 0) {
             newTop = 0;
         }
-        const maxRight = window.innerWidth - this.container.offsetWidth;
+
         newRight = Math.min(maxRight, Math.max(0, newRight));
         newTop = Math.max(0, newTop);
         this.container.style.right = `${newRight}px`;

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -612,21 +612,28 @@ export default class MobileDirectionButtons {
     private clampToViewport = () => {
         if (!this.container) return;
         const rect = this.container.getBoundingClientRect();
-        let newRight = window.innerWidth - rect.right;
-        let newTop = rect.top;
+        const styles = window.getComputedStyle(this.container);
+        let newRight = parseFloat(styles.right || "5");
+        let newTop = parseFloat(styles.top || "5");
+
+        const margin = 5;
+        const maxRight = window.innerWidth - this.container.offsetWidth - margin;
+
         if (rect.right > window.innerWidth) {
-            newRight = 5;
+            newRight = margin;
+        } else if (rect.left < 0) {
+            newRight = maxRight;
         }
-        if (rect.left < 0) {
-            newRight = window.innerWidth - this.container.offsetWidth - 5;
-        }
+
         if (rect.bottom > window.innerHeight) {
-            newTop = window.innerHeight - this.container.offsetHeight - 5;
+            newTop = window.innerHeight - this.container.offsetHeight - margin;
+        } else if (rect.top < 0) {
+            newTop = margin;
         }
-        if (rect.top < 0) {
-            newTop = 5;
-        }
-        this.container.style.right = `${Math.max(5, newRight)}px`;
-        this.container.style.top = `${Math.max(5, newTop)}px`;
+
+        newRight = Math.min(maxRight, Math.max(margin, newRight));
+        newTop = Math.max(margin, newTop);
+        this.container.style.right = `${newRight}px`;
+        this.container.style.top = `${newTop}px`;
     };
 }


### PR DESCRIPTION
## Summary
- keep original position when clamping ObjectList to the viewport
- keep original position when clamping mobile buttons to the viewport

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68767a593854832a8c9aa45440012e0d