### PR TITLE
Fix TeamManager test

### DIFF
--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -1,5 +1,4 @@
 import Client from "./Client";
-import {client} from "./main";
 
 interface ObjectData {
     attack_num: boolean | number
@@ -122,8 +121,8 @@ export default class TeamManager {
             }
         }, tag);
         triggers.registerTrigger(/^Dolaczasz do druzyny/, (): undefined => {
-            client.sendGMCP("objects.nums")
-            client.sendGMCP("objects.data")
+            this.client.sendGMCP("objects.nums")
+            this.client.sendGMCP("objects.data")
         })
     }
 


### PR DESCRIPTION
## Summary
- avoid importing main when using TeamManager so tests don't pull in map renderer
- use passed client instance for GMCP calls

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68769976f0c0832a90984d78a9826bba