### PR TITLE
Add step back button for playback

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -43,6 +43,7 @@
         <button id="playback-stop" class="btn btn-secondary">Stop</button>
         <span id="playback-info" class="px-1 text-light"></span>
         <button id="playback-replay" class="btn btn-secondary">Replay</button>
+        <button id="playback-step-back" class="btn btn-secondary">Back</button>
         <button id="playback-step" class="btn btn-secondary">Step</button>
     </div>
     <span id="content-width-measure" style="visibility:hidden;position:absolute;white-space:pre">M</span>

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -377,6 +377,21 @@ class ArkadiaClient {
         this.executeCurrent();
     }
 
+    stepBack() {
+        if (!this.isPlaying || this.playbackIndex === 0) return;
+        if (this.playbackTimeout !== null) {
+            clearTimeout(this.playbackTimeout);
+            this.playbackTimeout = null;
+        }
+        this.paused = true;
+        if (this.playbackIndex >= 2) {
+            this.playbackIndex -= 2;
+        } else {
+            this.playbackIndex = 0;
+        }
+        this.executeCurrent();
+    }
+
     replayLast() {
         if (!this.isPlaying || this.playbackIndex === 0) return;
         const ev = this.recordedMessages[this.playbackIndex - 1];

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -377,6 +377,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const playbackStop = document.getElementById('playback-stop') as HTMLButtonElement | null;
     const playbackInfo = document.getElementById('playback-info') as HTMLElement | null;
     const playbackReplay = document.getElementById('playback-replay') as HTMLButtonElement | null;
+    const playbackStepBack = document.getElementById('playback-step-back') as HTMLButtonElement | null;
     const playbackStep = document.getElementById('playback-step') as HTMLButtonElement | null;
     wakeLockButton = document.getElementById('wake-lock-button') as HTMLButtonElement | null;
     updateWakeLockButton();
@@ -485,6 +486,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (playbackReplay) {
         playbackReplay.addEventListener('click', () => {
             client.replayLast();
+        });
+    }
+
+    if (playbackStepBack) {
+        playbackStepBack.addEventListener('click', () => {
+            client.stepBack();
         });
     }
 


### PR DESCRIPTION
## Summary
- add Step Back button to recording playback controls
- implement stepBack handling in client
- wire up new button in initialization logic

## Testing
- `yarn --cwd client test` *(fails: Canvas [object HTMLCanvasElement] is unable to provide a 2D context)*

------
https://chatgpt.com/codex/tasks/task_e_6876984bfe5c832ab276996607430b98