### PR TITLE
Fix web-client build

### DIFF
--- a/options/src/Binds.tsx
+++ b/options/src/Binds.tsx
@@ -78,13 +78,13 @@ function Binds() {
         });
     }, []);
 
-    function handleCapture(name: keyof BindSettings, ev: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) {
+    function handleCapture(name: keyof BindSettings, ev: React.KeyboardEvent) {
         ev.preventDefault();
         const { code, ctrlKey, altKey, shiftKey } = ev;
         setBinds(prev => ({ ...prev, [name]: { key: code, ctrl: ctrlKey, alt: altKey, shift: shiftKey } }));
     }
 
-    function handleCaptureDir(dir: keyof DirectionBinds, ev: React.KeyboardEvent<HTMLInputElement>) {
+    function handleCaptureDir(dir: keyof DirectionBinds, ev: React.KeyboardEvent) {
         ev.preventDefault();
         const { code, ctrlKey, altKey, shiftKey } = ev;
         setBinds(prev => ({

--- a/options/src/Recordings.tsx
+++ b/options/src/Recordings.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Button, Table, Form } from 'react-bootstrap';
 import { getRecordingNames, deleteRecording, getRecording } from './recordingStorage';
+/// <reference path="./types.d.ts" />
 
 function Recordings() {
     const [names, setNames] = useState<string[]>([]);

--- a/options/src/types.d.ts
+++ b/options/src/types.d.ts
@@ -1,0 +1,6 @@
+declare global {
+    interface Window {
+        client?: any;
+    }
+}
+export {};

--- a/options/tsconfig.app.json
+++ b/options/tsconfig.app.json
@@ -14,6 +14,9 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": [
+      "./src/types.d.ts"
+    ],
 
     /* Linting */
     "strict": true,

--- a/options/tsconfig.node.json
+++ b/options/tsconfig.node.json
@@ -12,6 +12,9 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "types": [
+      "./src/types.d.ts"
+    ],
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary
- allow all elements in keyboard capture handlers
- expose `window.client` via types
- link global types in tsconfig

## Testing
- `yarn --cwd web-client build`
- `yarn --cwd client test` *(fails: Canvas [object HTMLCanvasElement] is unable to provide a 2D context)*

------
https://chatgpt.com/codex/tasks/task_e_687699824ed4832a9874b4cd6b7b97fc