### PR TITLE
Implement bag assignment in herb counter

### DIFF
--- a/client/test/herbCounter.test.ts
+++ b/client/test/herbCounter.test.ts
@@ -54,6 +54,8 @@ describe('herb counter', () => {
     const printed = client.println.mock.calls[0][0];
     expect(printed).toMatch(/3/);
     expect(printed).toMatch(/deliona/);
+    expect(printed).toMatch(/1\.\s+2 deliona/);
+    expect(printed).toMatch(/2\.\s+1 deliona/);
   });
 
   test('splits summary when width is limited', async () => {


### PR DESCRIPTION
## Summary
- track herbs per bag in herb counter
- update herb counter tests for bag info

## Testing
- `yarn --cwd client test herbCounter.test.ts`
- `yarn --cwd client test` *(fails: TeamManager.test due to Canvas 2D context)*

------
https://chatgpt.com/codex/tasks/task_e_687698eda110832ab99ee9242d97c0c8