### PR TITLE
Improve team follow exit detection

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -140,7 +140,7 @@ export default class Client {
         if (!isAlias) {
             command = this.Map.parseCommand(command)
             command.split(/[#;]/).forEach(part => {
-                rawInputSend(this.Map.move(part))
+                rawInputSend(this.Map.move(part).direction)
             })
         }
     }

--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -4,7 +4,7 @@ import Room = MapData.Room;
 
 const STORAGE_KEY = 'mapperRoomId';
 
-const polishToEnglish = {
+export const polishToEnglish = {
     ["polnoc"]: "north",
     ["poludnie"]: "south",
     ["wschod"]: "east",
@@ -61,7 +61,6 @@ export default class MapHelper {
     hashes = {};
     gmcpPosition: Position;
     savedRoomId: number | null = null;
-    pendingSpecial: string[] = [];
 
     constructor(clientExtension: Client) {
         this.client = clientExtension
@@ -141,17 +140,12 @@ export default class MapHelper {
         return {direction: actualDirection, moved: false}
     }
 
-    followMove(direction: string, line: string) {
-        const prevId = this.currentRoom?.id
-        const result = this.move(direction)
-        if (result.moved) {
-            return result.direction
-        }
+    followMove(direction: string) {
         if (this.currentRoom?.userData?.team_follow_link) {
             const entries = this.currentRoom.userData.team_follow_link.split('#')
             for (const entry of entries) {
                 const [search, exit] = entry.split('*')
-                if (search && exit && line.includes(search)) {
+                if (search && exit && direction.includes(search)) {
                     const res = this.move(exit)
                     if (res.moved) {
                         return res.direction
@@ -162,7 +156,7 @@ export default class MapHelper {
         if (this.currentRoom?.specialExits) {
             const specials = Object.keys(this.currentRoom.specialExits)
             for (const ex of specials) {
-                if (line.includes(ex)) {
+                if (direction.includes(ex)) {
                     const res = this.move(ex)
                     if (res.moved) {
                         return res.direction
@@ -171,7 +165,7 @@ export default class MapHelper {
             }
             for (const ex of specials) {
                 const part = ex.substring(0, Math.ceil(ex.length * 0.7))
-                if (line.includes(part)) {
+                if (direction.includes(part)) {
                     const res = this.move(ex)
                     if (res.moved) {
                         return res.direction
@@ -179,7 +173,8 @@ export default class MapHelper {
                 }
             }
         }
-        return result.direction
+
+        return direction
     }
 
     refresh() {

--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -135,9 +135,51 @@ export default class MapHelper {
             if (locationId) {
                 this.locationHistory.push(locationId)
                 this.renderRoomById(locationId);
+                return {direction: actualDirection, moved: true}
             }
         }
-        return actualDirection;
+        return {direction: actualDirection, moved: false}
+    }
+
+    followMove(direction: string, line: string) {
+        const prevId = this.currentRoom?.id
+        const result = this.move(direction)
+        if (result.moved) {
+            return result.direction
+        }
+        if (this.currentRoom?.userData?.team_follow_link) {
+            const entries = this.currentRoom.userData.team_follow_link.split('#')
+            for (const entry of entries) {
+                const [search, exit] = entry.split('*')
+                if (search && exit && line.includes(search)) {
+                    const res = this.move(exit)
+                    if (res.moved) {
+                        return res.direction
+                    }
+                }
+            }
+        }
+        if (this.currentRoom?.specialExits) {
+            const specials = Object.keys(this.currentRoom.specialExits)
+            for (const ex of specials) {
+                if (line.includes(ex)) {
+                    const res = this.move(ex)
+                    if (res.moved) {
+                        return res.direction
+                    }
+                }
+            }
+            for (const ex of specials) {
+                const part = ex.substring(0, Math.ceil(ex.length * 0.7))
+                if (line.includes(part)) {
+                    const res = this.move(ex)
+                    if (res.moved) {
+                        return res.direction
+                    }
+                }
+            }
+        }
+        return result.direction
     }
 
     refresh() {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -168,7 +168,7 @@ const follows = [
 follows.forEach(follow => {
     client.Triggers.registerTrigger(follow, (_rawLine, line): undefined => {
         const matches = line.match(follow)
-        client.Map.move(matches[3])
+        client.Map.followMove(matches[3], line)
     }, 'follow')
 })
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -160,17 +160,16 @@ registerLuaGagTriggers(client)
     Follows
  */
 
-const follows = [
-    /^.*[pP]odazasz (|skradajac sie )za (.* na (.*?))(?:,.*)?\.$/,
-    /^Wraz z ([A-Za-z ,'-]*) podazasz za (.* na (.*?))(?:,.*)?\.$/
-]
 
-follows.forEach(follow => {
-    client.Triggers.registerTrigger(follow, (_rawLine, line): undefined => {
-        const matches = line.match(follow)
-        client.Map.followMove(matches[3], line)
-    }, 'follow')
-})
+client.Triggers.registerTrigger(/^.*[pP]odazasz (|skradajac sie )za (.*)\.$/, (_, __, matches): undefined => {
+    const tokenized = matches[2].split(' ')
+    const direction = tokenized[tokenized.length - 1]
+    const result = client.Map.move(direction)
+    if (result.moved) {
+        return;
+    }
+    client.Map.followMove(matches[2])
+}, 'follow')
 
 client.Triggers.registerTrigger('Wykonuje komende \'idz ', (): undefined => {
     client.sendEvent('refreshPositionWhenAble')

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -53,7 +53,8 @@ jest.mock('../src/MapHelper', () => {
     __esModule: true,
     default: jest.fn().mockImplementation(() => ({
       parseCommand,
-      move: jest.fn((dir: string) => dir),
+      move: jest.fn((dir: string) => ({ direction: dir, moved: false })),
+      followMove: jest.fn(),
     })),
   };
 });


### PR DESCRIPTION
## Summary
- add followMove method in MapHelper for smarter exit detection when following the team
- adjust sendCommand to use new return format of MapHelper.move
- use followMove in follow triggers
- adapt tests to new MapHelper API

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6876d0bb46f4832aab86cfb31ee01eee