### PR TITLE
Add weapon evaluation parser

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -15,6 +15,7 @@ import ObjectManager from "./ObjectManager";
 import { beepSound } from "./sounds";
 import { attachGmcpListener } from "./gmcp";
 import {color} from "./Colors";
+import {SKIP_LINE} from "./ControlConstants";
 
 export default class Client {
     port: chrome.runtime.Port;
@@ -170,7 +171,7 @@ export default class Client {
         const ansiRegex =/\x1b\[[0-9;]*m/g
 
         line = this.Triggers.parseMultiline(line, type)
-        let result = line.split('\n').map(partial => this.Triggers.parseLine(partial, type)).join('\n')
+        let result = line.split('\n').map(partial => this.Triggers.parseLine(partial, type)).filter(line => line !== SKIP_LINE).join('\n')
         if (!result.startsWith("\x1b")) {
             result = color(255) + result
         }

--- a/client/src/ControlConstants.ts
+++ b/client/src/ControlConstants.ts
@@ -1,0 +1,1 @@
+export const SKIP_LINE = "~SKIP~"

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -253,6 +253,7 @@ import initLeaderAttackWarning from './scripts/leaderAttackWarning'
 import initBreakItem from './scripts/breakItem'
 import initExternalScripts from './scripts/externalScripts'
 import initUserAliases from './scripts/userAliases'
+import initWeaponEvaluation from './scripts/weaponEvaluation'
 
 initLvlCalc(client, aliases)
 initItemCondition(client)
@@ -264,4 +265,5 @@ initLeaderAttackWarning(client)
 initBreakItem(client)
 initExternalScripts(client)
 initUserAliases(client, aliases)
+initWeaponEvaluation(client)
 

--- a/client/src/scripts/weaponEvaluation.ts
+++ b/client/src/scripts/weaponEvaluation.ts
@@ -1,4 +1,8 @@
 import Client from "../Client";
+import {colorString, findClosestColor} from "../Colors";
+import {SKIP_LINE} from "../ControlConstants";
+
+const LABEL_COLOR = findClosestColor("#446fb1");
 
 export default function initWeaponEvaluation(client: Client) {
     const tag = 'weapon-evaluation';
@@ -8,37 +12,37 @@ export default function initWeaponEvaluation(client: Client) {
     const statsRegex = /^Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na (.+?) (jest|sa) (on|one|ono|ona) (.*) (wywazony|wywazona|wywazone) i (.*)\.$/;
 
     const EFFECTIVENESS: Record<string, { value: number; label: string }> = {
-        "kompletnie nieskuteczn": { value: 1, label: "kompletnie nieskuteczne [1/14]" },
-        "strasznie nieskuteczn": { value: 2, label: "strasznie nieskuteczne [2/14]" },
-        "bardzo nieskuteczn": { value: 3, label: "bardzo nieskuteczne [3/14]" },
-        "raczej nieskuteczn": { value: 4, label: "raczej nieskuteczne [4/14]" },
-        "malo skuteczn": { value: 5, label: "malo skuteczne [5/14]" },
-        "niezbyt skuteczn": { value: 6, label: "niezbyt skuteczne [6/14]" },
-        "raczej skuteczn": { value: 7, label: "raczej skuteczne [7/14]" },
-        "dosyc skuteczn": { value: 8, label: "dosyc skuteczne [8/14]" },
-        "calkiem skuteczn": { value: 9, label: "calkiem skuteczne [9/14]" },
-        "bardzo skuteczn": { value: 10, label: "bardzo skuteczne [10/14]" },
-        "niezwykle skuteczn": { value: 11, label: "niezwykle skuteczne [11/14]" },
-        "wyjatkowo skuteczn": { value: 12, label: "wyjatkowo skuteczne [12/14]" },
-        "zabojczo skuteczn": { value: 13, label: "zabojczo skuteczne [13/14]" },
-        "fantastycznie skuteczn": { value: 14, label: "fantastycznie skuteczne [14/14]" },
+        "kompletnie nieskuteczn": { value: 1, label: "[1/14]" },
+        "strasznie nieskuteczn": { value: 2, label: "[2/14]" },
+        "bardzo nieskuteczn": { value: 3, label: "[3/14]" },
+        "raczej nieskuteczn": { value: 4, label: "[4/14]" },
+        "malo skuteczn": { value: 5, label: "[5/14]" },
+        "niezbyt skuteczn": { value: 6, label: "[6/14]" },
+        "raczej skuteczn": { value: 7, label: "[7/14]" },
+        "dosyc skuteczn": { value: 8, label: "[8/14]" },
+        "calkiem skuteczn": { value: 9, label: "[9/14]" },
+        "bardzo skuteczn": { value: 10, label: "[10/14]" },
+        "niezwykle skuteczn": { value: 11, label: "[11/14]" },
+        "wyjatkowo skuteczn": { value: 12, label: "[12/14]" },
+        "zabojczo skuteczn": { value: 13, label: "[13/14]" },
+        "fantastycznie skuteczn": { value: 14, label: "[14/14]" },
     };
 
     const BALANCE: Record<string, { value: number; label: string }> = {
-        "wyjatkowo zle": { value: 1, label: "wyjatkowo zle [1/14]" },
-        "bardzo zle": { value: 2, label: "bardzo zle [2/14]" },
-        "zle": { value: 3, label: "zle [3/14]" },
-        "bardzo kiepsko": { value: 4, label: "bardzo kiepsko [4/14]" },
-        "kiepsko": { value: 5, label: "kiepsko [5/14]" },
-        "przyzwoicie": { value: 6, label: "przyzwoicie [6/14]" },
-        "srednio": { value: 7, label: "srednio [7/14]" },
-        "niezle": { value: 8, label: "niezle [8/14]" },
-        "dosc dobrze": { value: 9, label: "dosc dobrze [9/14]" },
-        "dobrze": { value: 10, label: "dobrze [10/14]" },
-        "bardzo dobrze": { value: 11, label: "bardzo dobrze [11/14]" },
-        "doskonale": { value: 12, label: "doskonale [12/14]" },
-        "perfekcyjnie": { value: 13, label: "perfekcyjnie [13/14]" },
-        "genialnie": { value: 14, label: "genialnie [14/14]" },
+        "wyjatkowo zle": { value: 1, label: "[1/14]" },
+        "bardzo zle": { value: 2, label: "[2/14]" },
+        "zle": { value: 3, label: "[3/14]" },
+        "bardzo kiepsko": { value: 4, label: "[4/14]" },
+        "kiepsko": { value: 5, label: "[5/14]" },
+        "przyzwoicie": { value: 6, label: "[6/14]" },
+        "srednio": { value: 7, label: "[7/14]" },
+        "niezle": { value: 8, label: "[8/14]" },
+        "dosc dobrze": { value: 9, label: "[9/14]" },
+        "dobrze": { value: 10, label: "[10/14]" },
+        "bardzo dobrze": { value: 11, label: "[11/14]" },
+        "doskonale": { value: 12, label: "[12/14]" },
+        "perfekcyjnie": { value: 13, label: "[13/14]" },
+        "genialnie": { value: 14, label: "[14/14]" },
     };
 
     client.Triggers.registerTrigger(gripRegex, (_r, _l, m) => {
@@ -50,7 +54,7 @@ export default function initWeaponEvaluation(client: Client) {
 
         client.Triggers.registerOneTimeTrigger(dmgRegex, (_r2, _l2, m2) => {
             wound = m2[2];
-            return '';
+            return SKIP_LINE;
         }, tag);
 
         client.Triggers.registerOneTimeTrigger(statsRegex, (_r3, _l3, m3) => {
@@ -66,18 +70,19 @@ export default function initWeaponEvaluation(client: Client) {
             if (balEntry && effEntry) {
                 const sum = balEntry.value + effEntry.value;
                 const avg = sum / 2;
+                const pad = 15;
                 const lines = [
-                    `Typ broni: ${weaponType}                            Chwyt: ${grip}`,
-                    `Obrazenia: ${wound}`,
-                    `Wywazenie: ${balEntry.label}                Skutecznosc: ${effEntry.label}`,
+                    `${colorString("Typ broni", LABEL_COLOR)}: ${weaponType.padEnd(pad, " ")} ${colorString("Chwyt", LABEL_COLOR)}: ${grip}`,
+                    `${colorString("Obrazenia", LABEL_COLOR)}: ${wound}`,
+                    `${colorString("Wywazenie", LABEL_COLOR)}: ${balEntry.label.padEnd(pad, ' ')} ${colorString("Skutecznosc", LABEL_COLOR)}: ${effEntry.label}`,
                     '',
-                    `Suma: ${sum}                                    Srednia: ${avg}`,
+                    `${colorString("Suma", LABEL_COLOR)}: ${String(sum).padEnd(pad + 5)} ${colorString("Srednia", LABEL_COLOR)}: ${avg}`,
                 ];
-                client.println(lines.join('\n'));
+                client.print(lines.join('\n'));
             }
-            return '';
+            return SKIP_LINE;
         }, tag);
 
-        return '';
+        return SKIP_LINE;
     }, tag);
 }

--- a/client/src/scripts/weaponEvaluation.ts
+++ b/client/src/scripts/weaponEvaluation.ts
@@ -1,0 +1,83 @@
+import Client from "../Client";
+
+export default function initWeaponEvaluation(client: Client) {
+    const tag = 'weapon-evaluation';
+
+    const gripRegex = /^Zauwazasz, iz (.+?) (?:jest|sa) przystosowan[yae] do chwytania (w dowolnej rece lub oburacz|w lewej rece lub oburacz|w prawej rece lub oburacz|w dowolnej rece|oburacz|w lewej rece|w prawej rece)(, jednak ty .*)?\.$/;
+    const dmgRegex = /^Za (jego|jej|ich) pomoca mozna zadawac rany (.*)\.$/;
+    const statsRegex = /^Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na (.+?) (jest|sa) (on|one|ono|ona) (.*) (wywazony|wywazona|wywazone) i (.*)\.$/;
+
+    const EFFECTIVENESS: Record<string, { value: number; label: string }> = {
+        "kompletnie nieskuteczn": { value: 1, label: "kompletnie nieskuteczne [1/14]" },
+        "strasznie nieskuteczn": { value: 2, label: "strasznie nieskuteczne [2/14]" },
+        "bardzo nieskuteczn": { value: 3, label: "bardzo nieskuteczne [3/14]" },
+        "raczej nieskuteczn": { value: 4, label: "raczej nieskuteczne [4/14]" },
+        "malo skuteczn": { value: 5, label: "malo skuteczne [5/14]" },
+        "niezbyt skuteczn": { value: 6, label: "niezbyt skuteczne [6/14]" },
+        "raczej skuteczn": { value: 7, label: "raczej skuteczne [7/14]" },
+        "dosyc skuteczn": { value: 8, label: "dosyc skuteczne [8/14]" },
+        "calkiem skuteczn": { value: 9, label: "calkiem skuteczne [9/14]" },
+        "bardzo skuteczn": { value: 10, label: "bardzo skuteczne [10/14]" },
+        "niezwykle skuteczn": { value: 11, label: "niezwykle skuteczne [11/14]" },
+        "wyjatkowo skuteczn": { value: 12, label: "wyjatkowo skuteczne [12/14]" },
+        "zabojczo skuteczn": { value: 13, label: "zabojczo skuteczne [13/14]" },
+        "fantastycznie skuteczn": { value: 14, label: "fantastycznie skuteczne [14/14]" },
+    };
+
+    const BALANCE: Record<string, { value: number; label: string }> = {
+        "wyjatkowo zle": { value: 1, label: "wyjatkowo zle [1/14]" },
+        "bardzo zle": { value: 2, label: "bardzo zle [2/14]" },
+        "zle": { value: 3, label: "zle [3/14]" },
+        "bardzo kiepsko": { value: 4, label: "bardzo kiepsko [4/14]" },
+        "kiepsko": { value: 5, label: "kiepsko [5/14]" },
+        "przyzwoicie": { value: 6, label: "przyzwoicie [6/14]" },
+        "srednio": { value: 7, label: "srednio [7/14]" },
+        "niezle": { value: 8, label: "niezle [8/14]" },
+        "dosc dobrze": { value: 9, label: "dosc dobrze [9/14]" },
+        "dobrze": { value: 10, label: "dobrze [10/14]" },
+        "bardzo dobrze": { value: 11, label: "bardzo dobrze [11/14]" },
+        "doskonale": { value: 12, label: "doskonale [12/14]" },
+        "perfekcyjnie": { value: 13, label: "perfekcyjnie [13/14]" },
+        "genialnie": { value: 14, label: "genialnie [14/14]" },
+    };
+
+    client.Triggers.registerTrigger(gripRegex, (_r, _l, m) => {
+        const grip = m[2];
+        let wound = '';
+        let weaponType = '';
+        let balanceRaw = '';
+        let effectRaw = '';
+
+        client.Triggers.registerOneTimeTrigger(dmgRegex, (_r2, _l2, m2) => {
+            wound = m2[2];
+            return '';
+        }, tag);
+
+        client.Triggers.registerOneTimeTrigger(statsRegex, (_r3, _l3, m3) => {
+            weaponType = m3[1];
+            balanceRaw = m3[4].trim();
+            effectRaw = m3[6].trim();
+
+            const balEntry = BALANCE[balanceRaw.toLowerCase()];
+            const effEntry = EFFECTIVENESS[
+                Object.keys(EFFECTIVENESS).find(k => effectRaw.toLowerCase().startsWith(k)) || ''
+            ];
+
+            if (balEntry && effEntry) {
+                const sum = balEntry.value + effEntry.value;
+                const avg = sum / 2;
+                const lines = [
+                    `Typ broni: ${weaponType}                            Chwyt: ${grip}`,
+                    `Obrazenia: ${wound}`,
+                    `Wywazenie: ${balEntry.label}                Skutecznosc: ${effEntry.label}`,
+                    '',
+                    `Suma: ${sum}                                    Srednia: ${avg}`,
+                ];
+                client.println(lines.join('\n'));
+            }
+            return '';
+        }, tag);
+
+        return '';
+    }, tag);
+}

--- a/client/test/weaponEvaluation.test.ts
+++ b/client/test/weaponEvaluation.test.ts
@@ -1,0 +1,33 @@
+import initWeaponEvaluation from '../src/scripts/weaponEvaluation';
+import Triggers from '../src/Triggers';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+  println = jest.fn();
+}
+
+describe('weapon evaluation trigger', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initWeaponEvaluation((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+  });
+
+  test('parses evaluation lines', () => {
+    parse('Zauwazasz, iz obosieczny topor bojowy jest przystosowany do chwytania w dowolnej rece.');
+    parse('Za jego pomoca mozna zadawac rany ciete.');
+    parse('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na topor jest on doskonale wywazony i fantastycznie skuteczne.');
+
+    const output = client.println.mock.calls[0][0];
+    expect(output).toContain('Typ broni: topor');
+    expect(output).toContain('Chwyt: w dowolnej rece');
+    expect(output).toContain('Obrazenia: ciete');
+    expect(output).toContain('Wywazenie: doskonale [12/14]');
+    expect(output).toContain('Skutecznosc: fantastycznie skuteczne [14/14]');
+    expect(output).toContain('Suma: 26');
+    expect(output).toContain('Srednia: 13');
+  });
+});

--- a/client/test/weaponEvaluation.test.ts
+++ b/client/test/weaponEvaluation.test.ts
@@ -1,9 +1,9 @@
 import initWeaponEvaluation from '../src/scripts/weaponEvaluation';
-import Triggers from '../src/Triggers';
+import Triggers, {stripAnsiCodes} from '../src/Triggers';
 
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
-  println = jest.fn();
+  print = jest.fn();
 }
 
 describe('weapon evaluation trigger', () => {
@@ -21,12 +21,12 @@ describe('weapon evaluation trigger', () => {
     parse('Za jego pomoca mozna zadawac rany ciete.');
     parse('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na topor jest on doskonale wywazony i fantastycznie skuteczne.');
 
-    const output = client.println.mock.calls[0][0];
+    const output = stripAnsiCodes(client.print.mock.calls[0][0]);
     expect(output).toContain('Typ broni: topor');
     expect(output).toContain('Chwyt: w dowolnej rece');
     expect(output).toContain('Obrazenia: ciete');
-    expect(output).toContain('Wywazenie: doskonale [12/14]');
-    expect(output).toContain('Skutecznosc: fantastycznie skuteczne [14/14]');
+    expect(output).toContain('Wywazenie: [12/14]');
+    expect(output).toContain('Skutecznosc: [14/14]');
     expect(output).toContain('Suma: 26');
     expect(output).toContain('Srednia: 13');
   });

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -1,5 +1,6 @@
 import { parseAnsiPatterns } from './ansiParser';
 import { saveRecording, getRecording, getRecordingNames, deleteRecording, RecordedEvent } from './recordingStorage';
+import {SKIP_LINE} from "@client/src/ControlConstants.ts";
 
 // Event emitter types
 type EventListener = (...args: any[]) => void;


### PR DESCRIPTION
## Summary
- add weaponEvaluation script parsing three-line weapon evaluation
- wire the script into main initialization
- test weapon evaluation parsing

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68776629b8ec832a97223965045c88ee