### PR TITLE
Add currency conversion display

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -251,6 +251,7 @@ import initMagics from './scripts/magics'
 import registerGagTriggers from './scripts/gags'
 import initLeaderAttackWarning from './scripts/leaderAttackWarning'
 import initBreakItem from './scripts/breakItem'
+import initPriceEvaluation from './scripts/priceEvaluation'
 import initExternalScripts from './scripts/externalScripts'
 import initUserAliases from './scripts/userAliases'
 
@@ -260,6 +261,7 @@ initInvite(client)
 initObjectAliases(client, aliases)
 initMagicKeys(client)
 initMagics(client)
+initPriceEvaluation(client)
 initLeaderAttackWarning(client)
 initBreakItem(client)
 initExternalScripts(client)

--- a/client/src/scripts/priceEvaluation.ts
+++ b/client/src/scripts/priceEvaluation.ts
@@ -1,0 +1,34 @@
+import Client from "../Client";
+import { colorString } from "../Colors";
+import { MITHRIL_COLOR, GOLD_COLOR, SILVER_COLOR, COPPER_COLOR } from "./shop";
+
+export function convertCurrency(amount: number): string {
+    const parts: string[] = [];
+    let rest = amount;
+    const mth = Math.floor(rest / 2400);
+    rest %= 2400;
+    const zl = Math.floor(rest / 240);
+    rest %= 240;
+    const sr = Math.floor(rest / 12);
+    const mdz = rest % 12;
+    if (mth > 0) parts.push(colorString(`${mth} mth`, MITHRIL_COLOR));
+    if (zl > 0) parts.push(colorString(`${zl} zl`, GOLD_COLOR));
+    if (sr > 0) parts.push(colorString(`${sr} sr`, SILVER_COLOR));
+    if (mdz > 0) parts.push(colorString(`${mdz} mdz`, COPPER_COLOR));
+    return parts.join(', ');
+}
+
+export function processItemValue(rawLine: string, value: number): string {
+    const converted = convertCurrency(value);
+    if (!converted) return rawLine;
+    const base = rawLine.replace(/\.$/, '');
+    return `${base}, czyli ${converted}.`;
+}
+
+export default function initPriceEvaluation(client: Client) {
+    const pattern = /^Wydaje ci sie, ze (jest|sa) wart[aye]? okolo (([0-9]+) mied[a-z]+\.)$/;
+    client.Triggers.registerTrigger(pattern, (raw, _line, m) => {
+        const amount = parseInt(m[3], 10);
+        return processItemValue(raw, amount);
+    });
+}

--- a/client/test/priceEvaluation.test.ts
+++ b/client/test/priceEvaluation.test.ts
@@ -1,0 +1,34 @@
+import initPriceEvaluation from '../src/scripts/priceEvaluation';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+  addEventListener = jest.fn();
+  removeEventListener = jest.fn();
+}
+
+describe('price evaluation trigger', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initPriceEvaluation((client as unknown) as any);
+    parse = (line: string) =>
+      Triggers.prototype.parseLine.call(client.Triggers, line, '');
+  });
+
+  test('converts and colors currency', () => {
+    const result = parse('Wydaje ci sie, ze jest wart okolo 570 miedziakow.');
+    expect(stripAnsiCodes(result)).toBe(
+      'Wydaje ci sie, ze jest wart okolo 570 miedziakow, czyli 2 zl, 7 sr, 6 mdz.'
+    );
+  });
+
+  test('handles mithryl coins', () => {
+    const result = parse('Wydaje ci sie, ze jest wart okolo 4800 miedziakow.');
+    expect(stripAnsiCodes(result)).toBe(
+      'Wydaje ci sie, ze jest wart okolo 4800 miedziakow, czyli 2 mth.'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- convert miedziaki values to higher denominations
- colorize converted currency
- register price evaluation trigger
- test price evaluation logic

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6877685f7c90832ab342cc6b4975ff38