### PR TITLE
Fix viewport issue on iOS Chrome

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content">
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=overlays-content">
     <meta name="apple-mobile-web-app-capable" content="yes"/>
     <meta name="mobile-web-app-capable" content="yes"/>
     <meta name="theme-color" content="#000000" />


### PR DESCRIPTION
## Summary
- tweak viewport meta to avoid Chrome iOS hiding the top of the viewport when the keyboard toggles

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6877824e86f0832aa7a221f4375f602f