### PR TITLE
Add herb wezz alias

### DIFF
--- a/client/src/scripts/herbCounter.ts
+++ b/client/src/scripts/herbCounter.ts
@@ -1,251 +1,359 @@
 import Client from "../Client";
-import {parseItems} from "./prettyContainers";
-import loadHerbs, {HerbsData} from "./herbsLoader";
-import {stripAnsiCodes} from "../Triggers";
+import { parseItems } from "./prettyContainers";
+import loadHerbs, { HerbsData } from "./herbsLoader";
+import { stripAnsiCodes } from "../Triggers";
 
 const STORAGE_KEY = "herb_summary";
-
+const BAGS_KEY = "herb_bags";
 
 const polishNumbers: Record<string, number> = {
-    'jeden': 1, 'jedna': 1, 'jedno': 1,
-    'jednego': 1,
-    'dwa': 2, 'dwie': 2,
-    'dwoch': 2,
-    'trzy': 3,
-    'trzech': 3,
-    'cztery': 4,
-    'czterech': 4,
-    'piec': 5,
-    'pieciu': 5,
-    'szesc': 6,
-    'szesciu': 6,
-    'siedem': 7,
-    'siedmiu': 7,
-    'osiem': 8,
-    'osmiu': 8,
-    'dziewiec': 9,
-    'dziewieciu': 9,
-    'dziesiec': 10,
-    'dziesieciu': 10,
-    'jedenascie': 11,
-    'jedenastu': 11,
-    'dwanascie': 12,
-    'dwunastu': 12,
-    'trzynascie': 13,
-    'trzynastu': 13,
-    'czternascie': 14,
-    'czternastu': 14,
-    'pietnascie': 15,
-    'pietnastu': 15,
-    'szesnascie': 16,
-    'szesnastu': 16,
-    'siedemnascie': 17,
-    'siedemnastu': 17,
-    'osiemnascie': 18,
-    'osiemnastu': 18,
-    'dziewietnascie': 19,
-    'dziewietnastu': 19,
-    'dwadziescia': 20,
-    'dwudziestu': 20,
-    'dwadziescia jeden': 21, 'dwadziescia jedna': 21,
-    'dwadziescia dwa': 22, 'dwadziescia dwie': 22,
-    'dwudziestu dwoch': 22,
-    'dwadziescia trzy': 23,
-    'dwudziestu trzech': 23,
-    'dwadziescia cztery': 24,
-    'dwudziestu czterech': 24,
-    'dwadziescia piec': 25,
-    'dwudziestu pieciu': 25,
-    'dwadziescia szesc': 26,
-    'dwudziestu szesciu': 26,
-    'dwadziescia siedem': 27,
-    'dwudziestu siedmiu': 27,
-    'dwadziescia osiem': 28,
-    'dwudziestu osmiu': 28,
-    'dwadziescia dziewiec': 29,
-    'dwudziestu dziewieciu': 29,
-    'trzydziesci': 30
+  jeden: 1,
+  jedna: 1,
+  jedno: 1,
+  jednego: 1,
+  dwa: 2,
+  dwie: 2,
+  dwoch: 2,
+  trzy: 3,
+  trzech: 3,
+  cztery: 4,
+  czterech: 4,
+  piec: 5,
+  pieciu: 5,
+  szesc: 6,
+  szesciu: 6,
+  siedem: 7,
+  siedmiu: 7,
+  osiem: 8,
+  osmiu: 8,
+  dziewiec: 9,
+  dziewieciu: 9,
+  dziesiec: 10,
+  dziesieciu: 10,
+  jedenascie: 11,
+  jedenastu: 11,
+  dwanascie: 12,
+  dwunastu: 12,
+  trzynascie: 13,
+  trzynastu: 13,
+  czternascie: 14,
+  czternastu: 14,
+  pietnascie: 15,
+  pietnastu: 15,
+  szesnascie: 16,
+  szesnastu: 16,
+  siedemnascie: 17,
+  siedemnastu: 17,
+  osiemnascie: 18,
+  osiemnastu: 18,
+  dziewietnascie: 19,
+  dziewietnastu: 19,
+  dwadziescia: 20,
+  dwudziestu: 20,
+  "dwadziescia jeden": 21,
+  "dwadziescia jedna": 21,
+  "dwadziescia dwa": 22,
+  "dwadziescia dwie": 22,
+  "dwudziestu dwoch": 22,
+  "dwadziescia trzy": 23,
+  "dwudziestu trzech": 23,
+  "dwadziescia cztery": 24,
+  "dwudziestu czterech": 24,
+  "dwadziescia piec": 25,
+  "dwudziestu pieciu": 25,
+  "dwadziescia szesc": 26,
+  "dwudziestu szesciu": 26,
+  "dwadziescia siedem": 27,
+  "dwudziestu siedmiu": 27,
+  "dwadziescia osiem": 28,
+  "dwudziestu osmiu": 28,
+  "dwadziescia dziewiec": 29,
+  "dwudziestu dziewieciu": 29,
+  trzydziesci: 30,
 };
 
 function parseNumber(str: string): number {
-    str = str.trim().toLowerCase();
-    if (/^\d+$/.test(str)) return parseInt(str, 10);
-    str = str.replace(/\s+/g, ' ');
-    return polishNumbers[str] || 0;
+  str = str.trim().toLowerCase();
+  if (/^\d+$/.test(str)) return parseInt(str, 10);
+  str = str.replace(/\s+/g, " ");
+  return polishNumbers[str] || 0;
 }
 
-export default async function initHerbCounter(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
-    let herbs: HerbsData | null = null;
-    let loading: Promise<void> | null = null;
-    const herbMap: Record<string, string> = {};
-    let width = client.contentWidth;
-    client.addEventListener('contentWidth', (ev: CustomEvent) => {
-        width = ev.detail;
-    });
-    let lastSummary: string[] = [];
-    client.addEventListener('storage', (ev: CustomEvent) => {
-        if (ev.detail.key === STORAGE_KEY) {
-            lastSummary = Array.isArray(ev.detail.value) ? ev.detail.value : [];
-        }
-    });
-    client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
-
-    async function ensureData() {
-        if (!herbs) {
-            if (!loading) {
-                loading = loadHerbs().then(data => {
-                    herbs = data;
-                    if (herbs) {
-                        Object.entries(herbs.herb_id_to_odmiana).forEach(([id, forms]) => {
-                            Object.values(forms).forEach(f => {
-                                herbMap[f.toLowerCase()] = id;
-                            });
-                        });
-                    }
-                }).finally(() => { loading = null; });
-            }
-            if (loading) {
-                await loading;
-            }
-        }
-    }
-
-    const countRegex = /^Doliczyl(?:es|as) sie (?<num>[0-9a-z ]+) sztuk\.$/;
-    const contentRegex = /^Rozwiazujesz na chwile rzemyk, sprawdzajac zawartosc swojego.*woreczka.* W srodku dostrzegasz (?<content>.*)\.$/;
-    const emptyRegex = /^Rozwiazujesz na chwile rzemyk, sprawdzajac zawartosc swojego.*woreczka.* W jego srodku nic jednak nie ma\.$/;
-
-    let awaiting = false;
-    let left = 0;
-    const totals: Record<string, number> = {};
-    const bagTotals: Record<number, Record<string, number>> = {};
-    let currentBag = 0;
-
-    function finish() {
-        const entries = Object.entries(totals);
-        if (entries.length === 0) {
-            lastSummary = ['Brak ziol.'];
-            client.println(lastSummary.join('\n'));
-        } else {
-            const lines: string[] = [];
-            const normal = width >= 63;
-            if (normal) {
-                lines.push('------+--------------------+-----------------------------------');
-                lines.push('  ile |        nazwa       |              dzialanie            ');
-                lines.push('------+--------------------+-----------------------------------');
-            }
-
-            const prefixWidth = normal ? 28 : 0;
-
-            entries.sort((a, b) => a[0].localeCompare(b[0])).forEach(([id, c]) => {
-                const uses = herbs?.herb_id_to_use[id]?.map(u => `${u.action}: ${u.effect}`).join(' | ') || '--';
-
-                if (normal) {
-                    const base = `${String(c).padStart(5, ' ')} | ${id.padEnd(18, ' ')} | `;
-                    const available = width - stripAnsiCodes(base).length;
-                    if (available >= stripAnsiCodes(uses).length) {
-                        lines.push(base + uses);
-                    } else if (available > 0) {
-                        lines.push(base + uses.slice(0, available));
-                        lines.push(' '.repeat(stripAnsiCodes(base).length) + uses.slice(available));
-                    } else {
-                        lines.push(`${String(c).padStart(5, ' ')} | ${id}`);
-                        lines.push(' '.repeat(prefixWidth) + uses);
-                    }
-                } else {
-                    const base = `${String(c).padStart(3, ' ')} ${id}`;
-                    lines.push(base);
-                    lines.push(' '.repeat(4) + uses);
-                }
-            });
-            if (normal) {
-                lines.push('---------------------------------------------------------------');
-            }
-            if (Object.keys(bagTotals).length > 0) {
-                lines.push('');
-                Object.entries(bagTotals).forEach(([num, contents]) => {
-                    const parts = Object.entries(contents)
-                        .sort((a, b) => a[0].localeCompare(b[0]))
-                        .map(([id, c]) => `${c} ${id}`)
-                        .join(', ');
-                    lines.push(`${num}. ${parts || '(pusty)'}`);
-                });
-            }
-            lastSummary = lines;
-            client.println(lastSummary.join('\n'));
-        }
-        client.port?.postMessage({ type: 'SET_STORAGE', key: STORAGE_KEY, value: lastSummary });
-        awaiting = false;
-        left = 0;
-        Object.keys(totals).forEach(k => delete totals[k]);
-        currentBag = 0;
-        Object.keys(bagTotals).forEach(k => delete bagTotals[parseInt(k)]);
-    }
-
-    client.Triggers.registerTrigger(countRegex, (_r, _l, m) => {
-        if (!awaiting) return undefined;
-        left = parseNumber(m.groups?.num || m[1]);
-        for (let i = 1; i <= left; i++) {
-            client.sendCommand(`zajrzyj do ${i}. swojego woreczka`);
-        }
-        return undefined;
-    });
-
-    client.Triggers.registerTrigger(contentRegex, (_r, _l, m) => {
-        if (!awaiting) return undefined;
-        currentBag += 1;
-        const items = parseItems(m.groups?.content || '');
-        const bag: Record<string, number> = {};
-        items.forEach(it => {
-            const key = herbMap[it.name.toLowerCase()] || it.name.toLowerCase();
-            const count = typeof it.count === 'number' ? it.count : parseNumber(String(it.count));
-            totals[key] = (totals[key] || 0) + count;
-            bag[key] = (bag[key] || 0) + count;
+export default async function initHerbCounter(
+  client: Client,
+  aliases?: { pattern: RegExp; callback: Function }[],
+) {
+  let herbs: HerbsData | null = null;
+  let loading: Promise<void> | null = null;
+  const herbMap: Record<string, string> = {};
+  let width = client.contentWidth;
+  client.addEventListener("contentWidth", (ev: CustomEvent) => {
+    width = ev.detail;
+  });
+  let lastSummary: string[] = [];
+  const bagContents: Record<number, Record<string, number>> = {};
+  client.addEventListener("storage", (ev: CustomEvent) => {
+    if (ev.detail.key === STORAGE_KEY) {
+      lastSummary = Array.isArray(ev.detail.value) ? ev.detail.value : [];
+    } else if (ev.detail.key === BAGS_KEY) {
+      const val = ev.detail.value || {};
+      Object.keys(bagContents).forEach((k) => delete bagContents[parseInt(k)]);
+      if (val && typeof val === "object") {
+        Object.entries(val).forEach(([k, v]) => {
+          bagContents[parseInt(k)] = { ...(v as Record<string, number>) };
         });
-        bagTotals[currentBag] = bag;
-        left -= 1;
-        if (left <= 0) finish();
-        return undefined;
-    });
-
-    client.Triggers.registerTrigger(emptyRegex, () => {
-        if (!awaiting) return undefined;
-        currentBag += 1;
-        bagTotals[currentBag] = {};
-        left -= 1;
-        if (left <= 0) finish();
-        return undefined;
-    });
-
-    async function start() {
-        await ensureData();
-        awaiting = true;
-        lastSummary = [];
-        currentBag = 0;
-        Object.keys(bagTotals).forEach(k => delete bagTotals[parseInt(k)]);
-        client.sendCommand('policz swoje woreczki');
+      }
     }
+  });
+  client.port?.postMessage({ type: "GET_STORAGE", key: STORAGE_KEY });
+  client.port?.postMessage({ type: "GET_STORAGE", key: BAGS_KEY });
 
-    if (aliases) {
-        aliases.push({pattern: /\/ziola_buduj$/, callback: start});
-        aliases.push({
-            pattern: /\/ziola_pokaz$/, callback: () => {
-                const listener = (ev: CustomEvent) => {
-                    if (ev.detail.key === STORAGE_KEY) {
-                        const summary = Array.isArray(ev.detail.value) ? ev.detail.value : [];
-                        if (summary.length > 0) {
-                            client.println(summary.join('\n'));
-                        } else {
-                            client.println('Brak podsumowania.');
-                        }
-                        client.removeEventListener('storage', listener);
-                    }
-                };
-                client.addEventListener('storage', listener);
-                client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
+  async function ensureData() {
+    if (!herbs) {
+      if (!loading) {
+        loading = loadHerbs()
+          .then((data) => {
+            herbs = data;
+            if (herbs) {
+              Object.entries(herbs.herb_id_to_odmiana).forEach(
+                ([id, forms]) => {
+                  Object.values(forms).forEach((f) => {
+                    herbMap[f.toLowerCase()] = id;
+                  });
+                },
+              );
             }
-        });
+          })
+          .finally(() => {
+            loading = null;
+          });
+      }
+      if (loading) {
+        await loading;
+      }
     }
+  }
 
-    // load herb data in background so it's ready after refresh
-    ensureData().catch(() => {});
+  const countRegex = /^Doliczyl(?:es|as) sie (?<num>[0-9a-z ]+) sztuk\.$/;
+  const contentRegex =
+    /^Rozwiazujesz na chwile rzemyk, sprawdzajac zawartosc swojego.*woreczka.* W srodku dostrzegasz (?<content>.*)\.$/;
+  const emptyRegex =
+    /^Rozwiazujesz na chwile rzemyk, sprawdzajac zawartosc swojego.*woreczka.* W jego srodku nic jednak nie ma\.$/;
+
+  let awaiting = false;
+  let left = 0;
+  const totals: Record<string, number> = {};
+  const bagTotals: Record<number, Record<string, number>> = {};
+  let currentBag = 0;
+
+  function finish() {
+    const entries = Object.entries(totals);
+    if (entries.length === 0) {
+      lastSummary = ["Brak ziol."];
+      client.println(lastSummary.join("\n"));
+    } else {
+      const lines: string[] = [];
+      const normal = width >= 63;
+      if (normal) {
+        lines.push(
+          "------+--------------------+-----------------------------------",
+        );
+        lines.push(
+          "  ile |        nazwa       |              dzialanie            ",
+        );
+        lines.push(
+          "------+--------------------+-----------------------------------",
+        );
+      }
+
+      const prefixWidth = normal ? 28 : 0;
+
+      entries
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .forEach(([id, c]) => {
+          const uses =
+            herbs?.herb_id_to_use[id]
+              ?.map((u) => `${u.action}: ${u.effect}`)
+              .join(" | ") || "--";
+
+          if (normal) {
+            const base = `${String(c).padStart(5, " ")} | ${id.padEnd(18, " ")} | `;
+            const available = width - stripAnsiCodes(base).length;
+            if (available >= stripAnsiCodes(uses).length) {
+              lines.push(base + uses);
+            } else if (available > 0) {
+              lines.push(base + uses.slice(0, available));
+              lines.push(
+                " ".repeat(stripAnsiCodes(base).length) + uses.slice(available),
+              );
+            } else {
+              lines.push(`${String(c).padStart(5, " ")} | ${id}`);
+              lines.push(" ".repeat(prefixWidth) + uses);
+            }
+          } else {
+            const base = `${String(c).padStart(3, " ")} ${id}`;
+            lines.push(base);
+            lines.push(" ".repeat(4) + uses);
+          }
+        });
+      if (normal) {
+        lines.push(
+          "---------------------------------------------------------------",
+        );
+      }
+      if (Object.keys(bagTotals).length > 0) {
+        lines.push("");
+        Object.entries(bagTotals).forEach(([num, contents]) => {
+          const parts = Object.entries(contents)
+            .sort((a, b) => a[0].localeCompare(b[0]))
+            .map(([id, c]) => `${c} ${id}`)
+            .join(", ");
+          lines.push(`${num}. ${parts || "(pusty)"}`);
+        });
+      }
+      lastSummary = lines;
+      client.println(lastSummary.join("\n"));
+    }
+    client.port?.postMessage({
+      type: "SET_STORAGE",
+      key: STORAGE_KEY,
+      value: lastSummary,
+    });
+    Object.keys(bagContents).forEach((k) => delete bagContents[parseInt(k)]);
+    Object.entries(bagTotals).forEach(([num, bag]) => {
+      bagContents[parseInt(num)] = { ...bag };
+    });
+    client.port?.postMessage({
+      type: "SET_STORAGE",
+      key: BAGS_KEY,
+      value: bagContents,
+    });
+    awaiting = false;
+    left = 0;
+    Object.keys(totals).forEach((k) => delete totals[k]);
+    currentBag = 0;
+    Object.keys(bagTotals).forEach((k) => delete bagTotals[parseInt(k)]);
+  }
+
+  client.Triggers.registerTrigger(countRegex, (_r, _l, m) => {
+    if (!awaiting) return undefined;
+    left = parseNumber(m.groups?.num || m[1]);
+    for (let i = 1; i <= left; i++) {
+      client.sendCommand(`zajrzyj do ${i}. swojego woreczka`);
+    }
+    return undefined;
+  });
+
+  client.Triggers.registerTrigger(contentRegex, (_r, _l, m) => {
+    if (!awaiting) return undefined;
+    currentBag += 1;
+    const items = parseItems(m.groups?.content || "");
+    const bag: Record<string, number> = {};
+    items.forEach((it) => {
+      const key = herbMap[it.name.toLowerCase()] || it.name.toLowerCase();
+      const count =
+        typeof it.count === "number" ? it.count : parseNumber(String(it.count));
+      totals[key] = (totals[key] || 0) + count;
+      bag[key] = (bag[key] || 0) + count;
+    });
+    bagTotals[currentBag] = bag;
+    left -= 1;
+    if (left <= 0) finish();
+    return undefined;
+  });
+
+  client.Triggers.registerTrigger(emptyRegex, () => {
+    if (!awaiting) return undefined;
+    currentBag += 1;
+    bagTotals[currentBag] = {};
+    left -= 1;
+    if (left <= 0) finish();
+    return undefined;
+  });
+
+  async function takeHerb(name: string, amount: number) {
+    await ensureData();
+    const id = herbMap[name.toLowerCase()] || name.toLowerCase();
+    let remaining = amount;
+    const forms = herbs?.herb_id_to_odmiana[id];
+    const bags = Object.keys(bagContents)
+      .map((n) => parseInt(n))
+      .sort((a, b) => a - b);
+    for (const num of bags) {
+      if (remaining <= 0) break;
+      const bag = bagContents[num];
+      const available = bag?.[id] || 0;
+      if (available <= 0) continue;
+      const take = Math.min(available, remaining);
+      const herbDesc = forms
+        ? take === 1
+          ? forms.biernik
+          : `${take} ${forms.mnoga_biernik}`
+        : take === 1
+          ? id
+          : `${take} ${id}`;
+      client.sendCommand(`otworz ${num}. woreczek`);
+      client.sendCommand(`wez ${herbDesc} z ${num}. woreczka`);
+      client.sendCommand(`zamknij ${num}. woreczek`);
+      bag[id] = available - take;
+      if (bag[id] <= 0) delete bag[id];
+      remaining -= take;
+    }
+    client.port?.postMessage({
+      type: "SET_STORAGE",
+      key: BAGS_KEY,
+      value: bagContents,
+    });
+  }
+
+  async function start() {
+    await ensureData();
+    awaiting = true;
+    lastSummary = [];
+    currentBag = 0;
+    Object.keys(bagTotals).forEach((k) => delete bagTotals[parseInt(k)]);
+    client.sendCommand("policz swoje woreczki");
+  }
+
+  if (aliases) {
+    aliases.push({ pattern: /\/ziola_buduj$/, callback: start });
+    aliases.push({
+      pattern: /\/ziola_pokaz$/,
+      callback: () => {
+        const listener = (ev: CustomEvent) => {
+          if (ev.detail.key === STORAGE_KEY) {
+            const summary = Array.isArray(ev.detail.value)
+              ? ev.detail.value
+              : [];
+            if (summary.length > 0) {
+              client.println(summary.join("\n"));
+            } else {
+              client.println("Brak podsumowania.");
+            }
+            client.removeEventListener("storage", listener);
+          }
+        };
+        client.addEventListener("storage", listener);
+        client.port?.postMessage({ type: "GET_STORAGE", key: STORAGE_KEY });
+      },
+    });
+    aliases.push({
+      pattern: /\/wezz ([a-z_]+) ([0-9]+)/,
+      callback: (m: RegExpMatchArray) => {
+        const name = m[1].toLowerCase();
+        const cnt = parseInt(m[2], 10);
+        takeHerb(name, cnt);
+      },
+    });
+    aliases.push({
+      pattern: /\/wezz ([a-zA-Z_]+)/,
+      callback: (m: RegExpMatchArray) => {
+        const name = m[1].toLowerCase();
+        takeHerb(name, 1);
+      },
+    });
+  }
+
+  // load herb data in background so it's ready after refresh
+  ensureData().catch(() => {});
 }

--- a/client/src/scripts/herbCounter.ts
+++ b/client/src/scripts/herbCounter.ts
@@ -72,8 +72,12 @@ const polishNumbers: Record<string, number> = {
   trzydziesci: 30,
 };
 
+function stripDiacritics(str: string): string {
+  return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
 function parseNumber(str: string): number {
-  str = str.trim().toLowerCase();
+  str = stripDiacritics(str.trim().toLowerCase());
   if (/^\d+$/.test(str)) return parseInt(str, 10);
   str = str.replace(/\s+/g, " ");
   return polishNumbers[str] || 0;
@@ -134,7 +138,7 @@ export default async function initHerbCounter(
     }
   }
 
-  const countRegex = /^Doliczyl(?:es|as) sie (?<num>[0-9a-z ]+) sztuk\.$/;
+  const countRegex = /^Doliczyl(?:es|as) sie (?<num>[0-9a-z ]+) sztuk[ia]?\.$/;
   const contentRegex =
     /^Rozwiazujesz na chwile rzemyk, sprawdzajac zawartosc swojego.*woreczka.* W srodku dostrzegasz (?<content>.*)\.$/;
   const emptyRegex =


### PR DESCRIPTION
## Summary
- keep track of herb bag contents in storage
- expose `/wezz` aliases to take herbs from bags

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68779642fde4832a923e405ddb7819f5