### PR TITLE
Fix mobile buttons reposition after keyboard close

### DIFF
--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -626,7 +626,7 @@ export default class MobileDirectionButtons {
         }
 
         if (rect.bottom > window.innerHeight) {
-            newTop = window.innerHeight - this.container.offsetHeight - margin - 100;
+            newTop = window.innerHeight - this.container.offsetHeight - margin;
         } else if (rect.top < 0) {
             newTop = margin;
         }


### PR DESCRIPTION
## Summary
- fix clamping logic for mobile direction buttons so they return to bottom after closing the keyboard

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687818c09f0c832ab65ebd71c8f35675