### PR TITLE
Implement bag-based herb summary

### DIFF
--- a/client/test/herbCounter.test.ts
+++ b/client/test/herbCounter.test.ts
@@ -106,7 +106,9 @@ describe('herb counter', () => {
     initHerbCounter((client as unknown) as any, aliases);
     const show = aliases[1].callback as any;
     show();
-    client.dispatch('storage', { key: 'herb_summary', value: ['line1', 'line2'] });
-    expect(client.println).toHaveBeenCalledWith('line1\nline2');
+    client.dispatch('storage', { key: 'herb_counts', value: { 1: { deliona: 2 } } });
+    const printed = client.println.mock.calls[0][0];
+    expect(printed).toMatch(/2/);
+    expect(printed).toMatch(/deliona/);
   });
 });


### PR DESCRIPTION
## Summary
- persist herb counts in bags instead of storing the printed summary
- generate printed summary from stored bag counts
- adjust herb counter tests
- update client tests to provide mocks

## Testing
- `yarn --cwd client test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68782fad0698832a82cbd7f62a1bc276