### PR TITLE
Limit text selection to mobile

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -31,9 +31,14 @@ body {
   height: 100svh;
   overflow: hidden;
   -webkit-tap-highlight-color: transparent;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  user-select: none;
+}
+
+@media (max-width: 768px) {
+  body {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
+  }
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- adjust CSS to disable text selection only on mobile

## Testing
- `yarn --cwd client test` *(fails: Expected 2 arguments, but got 0)*

------
https://chatgpt.com/codex/tasks/task_e_6878323aaec4832aad4cd428b9f1f2c2