### PR TITLE
Fix tests for updated client API

### DIFF
--- a/client/test/herbCounter.test.ts
+++ b/client/test/herbCounter.test.ts
@@ -106,7 +106,7 @@ describe('herb counter', () => {
     initHerbCounter((client as unknown) as any, aliases);
     const show = aliases[1].callback as any;
     show();
-    client.dispatch('storage', { key: 'herb_counts', value: { 1: { deliona: 2 } } });
+    client.dispatch('storage', { key: 'herb_summary', value: { 1: { deliona: 2 } } });
     const printed = client.println.mock.calls[0][0];
     expect(printed).toMatch(/2/);
     expect(printed).toMatch(/deliona/);


### PR DESCRIPTION
## Summary
- update client tests to use client adapter mock
- align herb counter storage key in tests

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687833c4062c832a8b6d89fb653df720