### PR TITLE
Add herb docs and alias

### DIFF
--- a/client/test/herbCounter.test.ts
+++ b/client/test/herbCounter.test.ts
@@ -106,7 +106,7 @@ describe('herb counter', () => {
     initHerbCounter((client as unknown) as any, aliases);
     const show = aliases[1].callback as any;
     show();
-    client.dispatch('storage', { key: 'herb_summary', value: { 1: { deliona: 2 } } });
+    client.dispatch('storage', { key: 'herb_counts', value: { 1: { deliona: 2 } } });
     const printed = client.println.mock.calls[0][0];
     expect(printed).toMatch(/2/);
     expect(printed).toMatch(/deliona/);

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -36,3 +36,4 @@ Poniższa lista opisuje dostępne aliasy w rozszerzeniu:
 - **/idz** - wybiera przeciwne wyjście w pomieszczeniu.
 - **/ziola_buduj** - przegląda wszystkie woreczki z ziołami i podsumowuje ich zawartość.
 - **/ziola_pokaz** - wyświetla ostatnie podsumowanie ziół.
+- **/wezz _ziolo_ [_ilosc_]** - wyjmuje wskazaną liczbę zioła z woreczków (domyślnie jedną sztukę).

--- a/docs/HERBS.md
+++ b/docs/HERBS.md
@@ -1,0 +1,11 @@
+# Licznik ziół
+
+Moduł licznika ziół pozwala zliczyć zawartość wszystkich noszonych woreczków z ziołami i zapisać te dane w pamięci przeglądarki. Dzięki temu możesz łatwo sprawdzić posiadane zioła oraz szybko je wyjmować.
+
+## Użycie
+
+1. Użyj aliasu `/ziola_buduj`, aby przeglądnąć woreczki i zapisać ich zawartość.
+2. Alias `/ziola_pokaz` wyświetla ostatnie podsumowanie ziół.
+3. Za pomocą `/wezz nazwa [ilosc]` wyjmiesz wskazane zioło z woreczków. Jeśli ilość nie zostanie podana, domyślnie wyjmowana jest jedna sztuka.
+
+Informacje o zliczonych ziołach są przechowywane w pamięci przeglądarki i wczytywane po ponownym uruchomieniu klienta.

--- a/web-client/src/docs.ts
+++ b/web-client/src/docs.ts
@@ -3,6 +3,7 @@ import Modal from "bootstrap/js/dist/modal";
 import aliasesMd from "../../docs/ALIASES.md?raw";
 import bagManagerMd from "../../docs/BAG_MANAGER.md?raw";
 import bindsMd from "../../docs/BINDS.md?raw";
+import herbsMd from "../../docs/HERBS.md?raw";
 
 interface DocDef {
   key: string;
@@ -12,7 +13,8 @@ interface DocDef {
 const docs: DocDef[] = [
   { key: "aliases", title: "Aliasy", md: aliasesMd },
   { key: "bag", title: "Mened\u017cer pojemnik\u00f3w", md: bagManagerMd },
-  { key: "binds", title: "Bindowanie", md: bindsMd }
+  { key: "binds", title: "Bindowanie", md: bindsMd },
+  { key: "herbs", title: "Licznik z\u00f3\u0142", md: herbsMd }
 ];
 
 function createModal() {


### PR DESCRIPTION
## Summary
- document herb counter usage
- document `/wezz` alias
- include herb docs in docs popup
- fix herb counter test for new storage key

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68783efd0150832abfee5c623532cdd8