### PR TITLE
Extract map aliases

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -31,6 +31,7 @@ import initPriceEvaluation from './scripts/priceEvaluation'
 import initExternalScripts from './scripts/externalScripts'
 import initUserAliases from './scripts/userAliases'
 import initWeaponEvaluation from './scripts/weaponEvaluation'
+import initMapAliases from './scripts/mapAliases'
 import Client from "./Client";
 
 
@@ -38,51 +39,14 @@ export function registerScripts(client: Client) {
 
 
     const aliases = client.aliases
-    aliases.push(
-        {
-            pattern: /\/fake (.*)/,
-            callback: (matches: RegExpMatchArray) => {
-                // @ts-ignore
-                return Output.send(Text.parse_patterns(client.onLine(matches[1])))
-            }
-        },
-        {
-            pattern: /\/cofnij$/,
-            callback: () => {
-                client.Map.moveBack()
-            }
-        },
-        {
-            pattern: /\/move (.*)$/,
-            callback: (matches: RegExpMatchArray) => {
-                client.Map.move(matches[1])
-            }
-        },
-        {
-            pattern: /\/ustaw (.*)$/,
-            callback: (matches: RegExpMatchArray) => {
-                client.Map.setMapRoomById(parseInt(matches[1]))
-            }
-        },
-        {
-            pattern: /\/prowadz (.*)$/,
-            callback: (matches: RegExpMatchArray) => {
-                client.sendEvent('leadTo', matches[1])
-            }
-        },
-        {
-            pattern: /\/prowadz-$/,
-            callback: () => {
-                client.sendEvent('leadTo')
-            }
-        },
-        {
-            pattern: /\/zlok$/,
-            callback: () => {
-                client.Map.refresh()
-            }
+    aliases.push({
+        pattern: /\/fake (.*)/,
+        callback: (matches: RegExpMatchArray) => {
+            // @ts-ignore
+            return Output.send(Text.parse_patterns(client.onLine(matches[1])))
         }
-    )
+    })
+    initMapAliases(client, aliases)
 
     blockers.forEach(blocker => {
         let blockerPattern = blocker.type === "0" ? blocker.pattern : new RegExp(blocker.pattern)

--- a/client/src/scripts/mapAliases.ts
+++ b/client/src/scripts/mapAliases.ts
@@ -1,0 +1,42 @@
+import Client from "../Client";
+
+export default function initMapAliases(client: Client, aliases: { pattern: RegExp; callback: Function }[]) {
+    aliases.push(
+        {
+            pattern: /\/cofnij$/,
+            callback: () => {
+                client.Map.moveBack();
+            }
+        },
+        {
+            pattern: /\/move (.*)$/,
+            callback: (matches: RegExpMatchArray) => {
+                client.Map.move(matches[1]);
+            }
+        },
+        {
+            pattern: /\/ustaw (.*)$/,
+            callback: (matches: RegExpMatchArray) => {
+                client.Map.setMapRoomById(parseInt(matches[1]));
+            }
+        },
+        {
+            pattern: /\/prowadz (.*)$/,
+            callback: (matches: RegExpMatchArray) => {
+                client.sendEvent('leadTo', matches[1]);
+            }
+        },
+        {
+            pattern: /\/prowadz-$/,
+            callback: () => {
+                client.sendEvent('leadTo');
+            }
+        },
+        {
+            pattern: /\/zlok$/,
+            callback: () => {
+                client.Map.refresh();
+            }
+        }
+    );
+}


### PR DESCRIPTION
## Summary
- move map-related aliases into their own module
- register map alias module in `main.ts`

## Testing
- `yarn --cwd client test` *(fails: herbCounter.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68783f36c2a0832a97bf8222df3ce2f7