### PR TITLE
Move item collector aliases

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -11,7 +11,7 @@ import initBinds from './scripts/binds'
 import initIdz from './scripts/idz'
 import initKillTrigger from './scripts/kill'
 import initEscape from './scripts/escape'
-import ItemCollector from './scripts/itemCollector'
+import { initItemCollector } from './scripts/itemCollector'
 import initContainers from './scripts/prettyContainers'
 import initBagManager from './scripts/bagManager'
 import initDeposits from './scripts/deposits'
@@ -133,28 +133,8 @@ export function registerScripts(client: Client) {
     initEscape(client)
 
 
-    const itemCollector = new ItemCollector(client);
+    const itemCollector = initItemCollector(client, aliases);
     (client as any).ItemCollector = itemCollector;
-
-    aliases.push({
-        pattern: /\/zbieraj_extra(.*)/,
-        callback: (matches: RegExpMatchArray) => {
-            const strTrim = (matches[1] || '').trim()
-            itemCollector.addExtra(strTrim)
-        }
-    })
-
-    aliases.push({
-        pattern: /\/nie_zbieraj_extra(.*)/,
-        callback: (matches: RegExpMatchArray) => {
-            const strTrim = (matches[1] || '').trim()
-            if (strTrim !== '') {
-                itemCollector.removeExtra(strTrim, false)
-            } else {
-                itemCollector.removeExtra('', true)
-            }
-        }
-    })
 
 
     initContainers(client)

--- a/client/src/scripts/itemCollector.ts
+++ b/client/src/scripts/itemCollector.ts
@@ -104,3 +104,34 @@ export default class ItemCollector {
         }
     }
 }
+
+export function initItemCollector(
+    client: Client,
+    aliases?: { pattern: RegExp; callback: Function }[]
+): ItemCollector {
+    const collector = new ItemCollector(client);
+
+    if (aliases) {
+        aliases.push({
+            pattern: /\/zbieraj_extra(.*)/,
+            callback: (matches: RegExpMatchArray) => {
+                const strTrim = (matches[1] || '').trim();
+                collector.addExtra(strTrim);
+            },
+        });
+
+        aliases.push({
+            pattern: /\/nie_zbieraj_extra(.*)/,
+            callback: (matches: RegExpMatchArray) => {
+                const strTrim = (matches[1] || '').trim();
+                if (strTrim !== '') {
+                    collector.removeExtra(strTrim, false);
+                } else {
+                    collector.removeExtra('', true);
+                }
+            },
+        });
+    }
+
+    return collector;
+}


### PR DESCRIPTION
## Summary
- expose `initItemCollector` helper
- register aliases via `initItemCollector` instead of in `main.ts`

## Testing
- `yarn --cwd client test` *(fails: herbCounter.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68783f54d7c8832aa40924dc026d5ea7