### PR TITLE
Add /go alias for lead path

### DIFF
--- a/client/src/scripts/mapAliases.ts
+++ b/client/src/scripts/mapAliases.ts
@@ -1,4 +1,5 @@
 import Client from "../Client";
+import { longToShort } from "../MapHelper";
 
 export default function initMapAliases(client: Client, aliases: { pattern: RegExp; callback: Function }[]) {
     aliases.push(
@@ -30,6 +31,23 @@ export default function initMapAliases(client: Client, aliases: { pattern: RegEx
             pattern: /\/prowadz-$/,
             callback: () => {
                 client.sendEvent('leadTo');
+            }
+        },
+        {
+            pattern: /\/go$/,
+            callback: () => {
+                const embedded: any = (window as any).embedded;
+                const room: any = client.Map.currentRoom;
+                if (!embedded?.destinations?.length || !room) return;
+                const target = parseInt(embedded.destinations[0]);
+                const path = embedded.renderer?.controls?.pathFinder?.path(room.id, target);
+                if (!path || path.length < 2) return;
+                const next = parseInt(path[1]);
+                const allExits = Object.assign({}, room.exits ?? {}, room.specialExits ?? {});
+                const entry = Object.entries(allExits).find(([_, id]) => id === next);
+                if (!entry) return;
+                const dir = entry[0];
+                client.sendCommand(longToShort[dir] ?? dir);
             }
         },
         {

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -8,6 +8,7 @@ Poniższa lista opisuje dostępne aliasy w rozszerzeniu:
 - **/ustaw _id_** - ustawia bieżącą pozycję na mapie na podany identyfikator.
 - **/prowadz _id_** - rozpoczyna prowadzenie innej osoby do wskazanego pokoju.
 - **/prowadz-** - kończy prowadzenie rozpoczęte komendą `/prowadz`.
+- **/go** - gdy aktywne jest prowadzenie, wybiera wyjście zgodnie z wyznaczoną trasą.
 - **/zlok** - wymusza odświeżenie bieżącej pozycji na mapie.
 - **/zabici** - pokazuje tabelę z liczbą twoich zabitych istot w bieżącej sesji.
 - **/zabici2** - wyświetla podsumowanie liczby zabitych istot.

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -237,6 +237,7 @@
         <div class="mobile-attack-buttons">
             <button class="mobile-button mobile-button-text top-button" id="z-list-toggle">/z</button>
             <button class="mobile-button mobile-button-text top-button" id="zas-list-toggle">/zas</button>
+            <button class="mobile-button mobile-button-text top-button" id="go-button">/go</button>
             <button class="mobile-button mobile-button-text top-button" id="buttons-toggle">⇩</button>
         </div>
         <div class="mobile-top-buttons">

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -156,6 +156,13 @@ export default class MobileDirectionButtons {
             });
         }
 
+        const goButton = document.getElementById('go-button');
+        if (goButton) {
+            goButton.addEventListener('click', () => {
+                this.client.sendCommand('/go');
+            });
+        }
+
         if (this.zToggle) {
             this.zToggle.addEventListener('click', () => {
                 if (this.zList && this.zList.style.display === 'grid') {


### PR DESCRIPTION
## Summary
- support choosing next exit when leading via new `/go` alias
- document `/go` alias
- mobile button for `/go`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6878b400d188832a9830500a9e1164f8