### PR TITLE
Add guild color selection

### DIFF
--- a/client/src/People.ts
+++ b/client/src/People.ts
@@ -8,7 +8,7 @@ export default class People {
     client: Client
     guildFilter: string[] = []
     enemyGuilds: string[] = []
-    guildColors: Record<string, string> = {}
+    guildColors: Record<string, string | undefined> = {}
 
     constructor(clientExtension: Client) {
         this.client = clientExtension

--- a/options/src/GuildRow.tsx
+++ b/options/src/GuildRow.tsx
@@ -5,17 +5,23 @@ interface Props {
     guild: string;
     selected: boolean;
     enemySelected: boolean;
+    color: string;
     onChange: (guild: string, checked: boolean) => void;
     onEnemyChange: (guild: string, checked: boolean) => void;
+    onColorChange: (guild: string, color: string) => void;
 }
 
-export default function GuildRow({guild, selected, enemySelected, onChange, onEnemyChange}: Props) {
+export default function GuildRow({guild, selected, enemySelected, color, onChange, onEnemyChange, onColorChange}: Props) {
     function handleSelect(ev: ChangeEvent<HTMLInputElement>) {
         onChange(guild, ev.target.checked);
     }
 
     function handleEnemySelect(ev: ChangeEvent<HTMLInputElement>) {
         onEnemyChange(guild, ev.target.checked);
+    }
+
+    function handleColorChange(ev: ChangeEvent<HTMLInputElement>) {
+        onColorChange(guild, ev.target.value);
     }
 
     return (
@@ -38,6 +44,17 @@ export default function GuildRow({guild, selected, enemySelected, onChange, onEn
                     onChange={handleEnemySelect}
                     className="me-2"
                 />
+                <Form.Group className="d-flex align-items-center me-2">
+                    <Form.Label className="me-1 mb-0">Kolor:</Form.Label>
+                    <Form.Control
+                        type="color"
+                        id={`guild-color-${guild}`}
+                        value={color}
+                        onChange={handleColorChange}
+                        disabled={enemySelected}
+                        style={{width: '3rem'}}
+                    />
+                </Form.Group>
             </div>
         </div>
     );

--- a/options/src/GuildRow.tsx
+++ b/options/src/GuildRow.tsx
@@ -5,13 +5,19 @@ interface Props {
     guild: string;
     selected: boolean;
     enemySelected: boolean;
-    color: string;
+    /** currently active color, undefined when disabled */
+    color?: string;
+    /** default color for the guild */
+    defaultColor: string;
     onChange: (guild: string, checked: boolean) => void;
     onEnemyChange: (guild: string, checked: boolean) => void;
-    onColorChange: (guild: string, color: string) => void;
+    /**
+     * when color is undefined color should be disabled
+     */
+    onColorChange: (guild: string, color?: string) => void;
 }
 
-export default function GuildRow({guild, selected, enemySelected, color, onChange, onEnemyChange, onColorChange}: Props) {
+export default function GuildRow({guild, selected, enemySelected, color, defaultColor, onChange, onEnemyChange, onColorChange}: Props) {
     function handleSelect(ev: ChangeEvent<HTMLInputElement>) {
         onChange(guild, ev.target.checked);
     }
@@ -24,10 +30,14 @@ export default function GuildRow({guild, selected, enemySelected, color, onChang
         onColorChange(guild, ev.target.value);
     }
 
+    function handleColorToggle(ev: ChangeEvent<HTMLInputElement>) {
+        onColorChange(guild, ev.target.checked ? (color ?? defaultColor) : undefined);
+    }
+
     return (
         <div className="mb-2">
             <h6 className="fw-bold mb-1">{guild}</h6>
-            <div className="d-flex flex-wrap gap-2 ms-2">
+            <div className="d-flex align-items-center flex-wrap gap-2 ms-2">
                 <Form.Check
                     type="checkbox"
                     id={`guild-${guild}`}
@@ -44,17 +54,23 @@ export default function GuildRow({guild, selected, enemySelected, color, onChang
                     onChange={handleEnemySelect}
                     className="me-2"
                 />
-                <Form.Group className="d-flex align-items-center me-2">
-                    <Form.Label className="me-1 mb-0">Kolor:</Form.Label>
-                    <Form.Control
-                        type="color"
-                        id={`guild-color-${guild}`}
-                        value={color}
-                        onChange={handleColorChange}
-                        disabled={enemySelected}
-                        style={{width: '3rem'}}
-                    />
-                </Form.Group>
+                <Form.Check
+                    type="checkbox"
+                    id={`guild-color-enabled-${guild}`}
+                    label="Kolor"
+                    checked={color !== undefined}
+                    onChange={handleColorToggle}
+                    className="me-2"
+                    disabled={enemySelected}
+                />
+                <Form.Control
+                    type="color"
+                    id={`guild-color-${guild}`}
+                    value={color ?? defaultColor}
+                    onChange={handleColorChange}
+                    disabled={enemySelected || color === undefined}
+                    style={{width: '3rem'}}
+                />
             </div>
         </div>
     );

--- a/options/src/GuildSection.tsx
+++ b/options/src/GuildSection.tsx
@@ -5,13 +5,15 @@ import {Form} from "react-bootstrap";
 interface Props {
     selected: string[];
     enemySelected: string[];
+    colors: Record<string, string>;
     onChange: (guild: string, checked: boolean) => void;
     onEnemyChange: (guild: string, checked: boolean) => void;
+    onColorChange: (guild: string, color: string) => void;
     onChangeAll: (checked: boolean) => void;
     onChangeAllEnemy: (checked: boolean) => void;
 }
 
-export default function GuildSection({selected, enemySelected, onChange, onEnemyChange, onChangeAll, onChangeAllEnemy}: Props) {
+export default function GuildSection({selected, enemySelected, colors, onChange, onEnemyChange, onColorChange, onChangeAll, onChangeAllEnemy}: Props) {
     const allSelected = selected.length === guilds.length;
     const allEnemySelected = enemySelected.length === guilds.length;
     return (
@@ -42,8 +44,10 @@ export default function GuildSection({selected, enemySelected, onChange, onEnemy
                         guild={g}
                         selected={selected.includes(g)}
                         enemySelected={enemySelected.includes(g)}
+                        color={colors[g] || '#ffffff'}
                         onChange={onChange}
                         onEnemyChange={onEnemyChange}
+                        onColorChange={onColorChange}
                     />
                 ))}
             </div>

--- a/options/src/GuildSection.tsx
+++ b/options/src/GuildSection.tsx
@@ -5,15 +5,18 @@ import {Form} from "react-bootstrap";
 interface Props {
     selected: string[];
     enemySelected: string[];
-    colors: Record<string, string>;
+    /** map of enabled colors */
+    colors?: Record<string, string | undefined>;
+    /** default colors for display */
+    defaultColors: Record<string, string>;
     onChange: (guild: string, checked: boolean) => void;
     onEnemyChange: (guild: string, checked: boolean) => void;
-    onColorChange: (guild: string, color: string) => void;
+    onColorChange: (guild: string, color?: string) => void;
     onChangeAll: (checked: boolean) => void;
     onChangeAllEnemy: (checked: boolean) => void;
 }
 
-export default function GuildSection({selected, enemySelected, colors, onChange, onEnemyChange, onColorChange, onChangeAll, onChangeAllEnemy}: Props) {
+export default function GuildSection({selected, enemySelected, colors = {}, defaultColors, onChange, onEnemyChange, onColorChange, onChangeAll, onChangeAllEnemy}: Props) {
     const allSelected = selected.length === guilds.length;
     const allEnemySelected = enemySelected.length === guilds.length;
     return (
@@ -44,7 +47,8 @@ export default function GuildSection({selected, enemySelected, colors, onChange,
                         guild={g}
                         selected={selected.includes(g)}
                         enemySelected={enemySelected.includes(g)}
-                        color={colors[g] || '#ffffff'}
+                        color={colors[g]}
+                        defaultColor={defaultColors[g]}
                         onChange={onChange}
                         onEnemyChange={onEnemyChange}
                         onColorChange={onColorChange}

--- a/options/src/Guilds.tsx
+++ b/options/src/Guilds.tsx
@@ -7,12 +7,14 @@ import guilds from "./guilds";
 function Guilds() {
     const [selected, setSelected] = useState<string[]>([]);
     const [enemySelected, setEnemySelected] = useState<string[]>([]);
+    const [colors, setColors] = useState<Record<string, string>>({});
 
     useEffect(() => {
         storage.getItem("settings").then(res => {
             if (res && res.settings) {
                 setSelected(res.settings.guilds || []);
                 setEnemySelected(res.settings.enemyGuilds || []);
+                setColors(res.settings.guildColors || {});
             }
         });
     }, []);
@@ -25,6 +27,10 @@ function Guilds() {
         setEnemySelected(prev => checked ? [...prev, guild] : prev.filter(g => g !== guild));
     }
 
+    function onColorChange(guild: string, color: string) {
+        setColors(prev => ({...prev, [guild]: color}));
+    }
+
     function onChangeAll(checked: boolean) {
         setSelected(checked ? [...guilds] : []);
     }
@@ -35,7 +41,7 @@ function Guilds() {
 
     function save() {
         storage.getItem("settings").then(res => {
-            const settings = { ...(res.settings || {}), guilds: selected, enemyGuilds: enemySelected };
+            const settings = { ...(res.settings || {}), guilds: selected, enemyGuilds: enemySelected, guildColors: colors };
             storage.setItem("settings", settings).then(() => {
                 window.dispatchEvent(new Event('close-options'));
             });
@@ -47,8 +53,10 @@ function Guilds() {
             <GuildSection
                 selected={selected}
                 enemySelected={enemySelected}
+                colors={colors}
                 onChange={onChange}
                 onEnemyChange={onEnemyChange}
+                onColorChange={onColorChange}
                 onChangeAll={onChangeAll}
                 onChangeAllEnemy={onChangeAllEnemy}
             />

--- a/options/src/Guilds.tsx
+++ b/options/src/Guilds.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, ChangeEvent } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { Button } from "react-bootstrap";
 import storage from "./storage";
 import GuildSection from "./GuildSection";
@@ -7,7 +7,14 @@ import guilds from "./guilds";
 function Guilds() {
     const [selected, setSelected] = useState<string[]>([]);
     const [enemySelected, setEnemySelected] = useState<string[]>([]);
-    const [colors, setColors] = useState<Record<string, string>>({});
+    const [colors, setColors] = useState<Record<string, string | undefined>>({});
+    const defaultColors = useMemo(() => {
+        const map: Record<string, string> = {};
+        guilds.forEach(g => {
+            map[g] = '#' + Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0');
+        });
+        return map;
+    }, []);
 
     useEffect(() => {
         storage.getItem("settings").then(res => {
@@ -27,8 +34,16 @@ function Guilds() {
         setEnemySelected(prev => checked ? [...prev, guild] : prev.filter(g => g !== guild));
     }
 
-    function onColorChange(guild: string, color: string) {
-        setColors(prev => ({...prev, [guild]: color}));
+    function onColorChange(guild: string, color?: string) {
+        setColors(prev => {
+            const next = {...prev};
+            if (color) {
+                next[guild] = color;
+            } else {
+                delete next[guild];
+            }
+            return next;
+        });
     }
 
     function onChangeAll(checked: boolean) {
@@ -54,6 +69,7 @@ function Guilds() {
                 selected={selected}
                 enemySelected={enemySelected}
                 colors={colors}
+                defaultColors={defaultColors}
                 onChange={onChange}
                 onEnemyChange={onEnemyChange}
                 onColorChange={onColorChange}

--- a/options/src/Settings.tsx
+++ b/options/src/Settings.tsx
@@ -20,6 +20,7 @@ const collectMoneyOptions = ["wszystkie", "srebrne", "zlote"]
 interface Settings {
     guilds: string[];
     enemyGuilds: string[];
+    guildColors: Record<string, string>;
     packageHelper: boolean;
     replaceMap: boolean;
     inlineCompassRose: boolean;
@@ -35,6 +36,7 @@ function SettingsForm() {
     const [settings, setSettings] = useState<Settings>({
         guilds: [],
         enemyGuilds: [],
+        guildColors: {},
         packageHelper: false,
         replaceMap: false,
         inlineCompassRose: false,
@@ -82,6 +84,13 @@ function SettingsForm() {
         })
     }
 
+    function onColorChange(guild: string, color: string) {
+        setSettings(prev => ({
+            ...prev,
+            guildColors: {...prev.guildColors, [guild]: color}
+        }))
+    }
+
     function onChangeAllEnemy(checked: boolean) {
         setSettings(prev => ({
             ...prev,
@@ -96,7 +105,7 @@ function SettingsForm() {
 
     useEffect(() => {
         storage.getItem("settings").then(res => {
-            setSettings(Object.assign({}, settings, res.settings));
+            setSettings(Object.assign({}, settings, {guildColors: {}}, res.settings));
         })
     }, []);
 
@@ -105,8 +114,10 @@ function SettingsForm() {
             <GuildSection
                 selected={settings.guilds}
                 enemySelected={settings.enemyGuilds}
+                colors={settings.guildColors}
                 onChange={onChange}
                 onEnemyChange={onChangeEnemy}
+                onColorChange={onColorChange}
                 onChangeAll={onChangeAll}
                 onChangeAllEnemy={onChangeAllEnemy}
             />

--- a/options/src/Settings.tsx
+++ b/options/src/Settings.tsx
@@ -1,5 +1,5 @@
 import './App.css'
-import {ChangeEvent, useEffect, useState} from "react";
+import {ChangeEvent, useEffect, useState, useMemo} from "react";
 import {Form, Button} from 'react-bootstrap';
 import storage from "./storage.ts";
 import GuildSection from "./GuildSection";
@@ -20,7 +20,7 @@ const collectMoneyOptions = ["wszystkie", "srebrne", "zlote"]
 interface Settings {
     guilds: string[];
     enemyGuilds: string[];
-    guildColors: Record<string, string>;
+    guildColors: Record<string, string | undefined>;
     packageHelper: boolean;
     replaceMap: boolean;
     inlineCompassRose: boolean;
@@ -32,6 +32,13 @@ interface Settings {
 }
 
 function SettingsForm() {
+    const defaultColors = useMemo(() => {
+        const map: Record<string, string> = {};
+        guilds.forEach(g => {
+            map[g] = '#' + Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0');
+        });
+        return map;
+    }, []);
 
     const [settings, setSettings] = useState<Settings>({
         guilds: [],
@@ -84,11 +91,16 @@ function SettingsForm() {
         })
     }
 
-    function onColorChange(guild: string, color: string) {
-        setSettings(prev => ({
-            ...prev,
-            guildColors: {...prev.guildColors, [guild]: color}
-        }))
+    function onColorChange(guild: string, color?: string) {
+        setSettings(prev => {
+            const next = { ...prev.guildColors } as Record<string, string | undefined>;
+            if (color) {
+                next[guild] = color;
+            } else {
+                delete next[guild];
+            }
+            return { ...prev, guildColors: next };
+        })
     }
 
     function onChangeAllEnemy(checked: boolean) {
@@ -115,6 +127,7 @@ function SettingsForm() {
                 selected={settings.guilds}
                 enemySelected={settings.enemyGuilds}
                 colors={settings.guildColors}
+                defaultColors={defaultColors}
                 onChange={onChange}
                 onEnemyChange={onChangeEnemy}
                 onColorChange={onColorChange}


### PR DESCRIPTION
## Summary
- add `guildColors` settings
- allow color selection on guild settings page
- color non-enemy guild names in client

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6878b84dfcac832a853dfaf3e0c7125b