### PR TITLE
Fix color picker accessibility

### DIFF
--- a/options/src/GuildRow.tsx
+++ b/options/src/GuildRow.tsx
@@ -69,6 +69,7 @@ export default function GuildRow({guild, selected, enemySelected, color, default
                     value={color ?? defaultColor}
                     onChange={handleColorChange}
                     disabled={enemySelected || color === undefined}
+                    className="form-control-color"
                     style={{width: '3rem'}}
                 />
             </div>


### PR DESCRIPTION
## Summary
- ensure the guild color input uses Bootstrap's `form-control-color`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6878c29cbba4832aaf691b85978ef747