### PR TITLE
Move guild settings to dedicated tab

### DIFF
--- a/options/src/App.tsx
+++ b/options/src/App.tsx
@@ -2,6 +2,7 @@ import './App.css'
 import {useState} from "react";
 import {Tabs, Tab} from 'react-bootstrap';
 import SettingsForm from "./Settings.tsx";
+import Guilds from "./Guilds";
 import Npc from "./Npc.tsx";
 import SettingsFile from "./SettingsFile";
 import Binds from "./Binds";
@@ -10,13 +11,16 @@ import Recordings from "./Recordings";
 
 
 function App() {
-    const [tab, setTab] = useState<'settings' | 'npc' | 'file' | 'binds' | 'scripts' | 'recordings'>('settings')
+    const [tab, setTab] = useState<'settings' | 'guilds' | 'npc' | 'file' | 'binds' | 'scripts' | 'recordings'>('settings')
 
     return (
         <div className="p-2 d-flex flex-column h-100">
             <Tabs activeKey={tab} onSelect={(k) => k && setTab(k as any)} className="mb-2" variant={"pills"}>
                 <Tab eventKey="settings" title="Ustawienia">
                     <SettingsForm />
+                </Tab>
+                <Tab eventKey="guilds" title="Gildie">
+                    <Guilds />
                 </Tab>
                 <Tab eventKey="npc" title="Odbiorcy paczek">
                     <Npc />

--- a/options/src/Settings.tsx
+++ b/options/src/Settings.tsx
@@ -1,9 +1,7 @@
 import './App.css'
-import {useEffect, useState, useMemo} from "react";
+import {useEffect, useState} from "react";
 import {Form, Button} from 'react-bootstrap';
 import storage from "./storage.ts";
-import GuildSection from "./GuildSection";
-import guilds from "./guilds";
 
 const collectModeOptions = [
     "monety",
@@ -18,9 +16,6 @@ const collectModeOptions = [
 const collectMoneyOptions = ["wszystkie", "srebrne", "zlote"]
 
 interface Settings {
-    guilds: string[];
-    enemyGuilds: string[];
-    guildColors: Record<string, string | undefined>;
     packageHelper: boolean;
     replaceMap: boolean;
     inlineCompassRose: boolean;
@@ -32,18 +27,8 @@ interface Settings {
 }
 
 function SettingsForm() {
-    const defaultColors = useMemo(() => {
-        const map: Record<string, string> = {};
-        guilds.forEach(g => {
-            map[g] = '#' + Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0');
-        });
-        return map;
-    }, []);
 
     const [settings, setSettings] = useState<Settings>({
-        guilds: [],
-        enemyGuilds: [],
-        guildColors: {},
         packageHelper: false,
         replaceMap: false,
         inlineCompassRose: false,
@@ -64,49 +49,6 @@ function SettingsForm() {
         })
     }
 
-    function onChange(guild: string, checked: boolean) {
-        setSettings(prev => {
-            const next = checked
-                ? [...prev.guilds, guild]
-                : prev.guilds.filter(g => g !== guild)
-            return {...prev, guilds: next}
-        })
-    }
-
-    function onChangeAll(checked: boolean) {
-        setSettings(prev => ({
-            ...prev,
-            guilds: checked ? [...guilds] : []
-        }))
-    }
-
-    function onChangeEnemy(guild: string, checked: boolean) {
-        setSettings(prev => {
-            const next = checked
-                ? [...prev.enemyGuilds, guild]
-                : prev.enemyGuilds.filter(g => g !== guild)
-            return {...prev, enemyGuilds: next}
-        })
-    }
-
-    function onColorChange(guild: string, color?: string) {
-        setSettings(prev => {
-            const next = { ...prev.guildColors } as Record<string, string | undefined>;
-            if (color) {
-                next[guild] = color;
-            } else {
-                delete next[guild];
-            }
-            return { ...prev, guildColors: next };
-        })
-    }
-
-    function onChangeAllEnemy(checked: boolean) {
-        setSettings(prev => ({
-            ...prev,
-            enemyGuilds: checked ? [...guilds] : []
-        }))
-    }
 
     function handleSubmission() {
         storage.setItem("settings", settings)
@@ -115,23 +57,12 @@ function SettingsForm() {
 
     useEffect(() => {
         storage.getItem("settings").then(res => {
-            setSettings(Object.assign({}, settings, {guildColors: {}}, res.settings));
+            setSettings(Object.assign({}, settings, res.settings));
         })
     }, []);
 
     return (
         <div className="my-4 p-2">
-            <GuildSection
-                selected={settings.guilds}
-                enemySelected={settings.enemyGuilds}
-                colors={settings.guildColors}
-                defaultColors={defaultColors}
-                onChange={onChange}
-                onEnemyChange={onChangeEnemy}
-                onColorChange={onColorChange}
-                onChangeAll={onChangeAll}
-                onChangeAllEnemy={onChangeAllEnemy}
-            />
             <div className="mb-4 border rounded p-3">
                 <h5 className="fw-bold mb-2">Pozostałe opcje</h5>
                 <div className="d-flex flex-wrap gap-3">


### PR DESCRIPTION
## Summary
- remove guild settings handling from main settings page
- add Guilds tab in options

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6878d369ea4c832ab16d517cdfd59bde