### PR TITLE
Add close button for auth overlay

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -185,6 +185,8 @@
         <button id="auth-close" class="btn-close btn-close-white" aria-label="Close"></button>
         <div id="auth-panel">
             <div id="connecting-spinner" class="spinner-border text-light" role="status"></div>
+            <button id="connect-button">Connect</button>
+            <div class="auth-or">- LUB -</div>
             <form id="login-form" class="d-flex flex-column gap-2">
                 <input id="login-character" class="form-control" placeholder="Postać">
                 <input id="login-password" type="password" class="form-control" placeholder="Hasło">
@@ -193,7 +195,7 @@
         </div>
     </div>
 
-    <button id="connect-button">🔌 Connect</button>
+    <button id="connect-button-float">🔌</button>
 
     <div id="ui-settings-modal" class="modal fade" tabindex="-1">
         <div class="modal-dialog">

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -182,10 +182,9 @@
     </div>
 
     <div id="auth-overlay">
+        <button id="auth-close" class="btn-close btn-close-white" aria-label="Close"></button>
         <div id="auth-panel">
             <div id="connecting-spinner" class="spinner-border text-light" role="status"></div>
-            <button id="connect-button">Połącz</button>
-            <div class="auth-or">- LUB -</div>
             <form id="login-form" class="d-flex flex-column gap-2">
                 <input id="login-character" class="form-control" placeholder="Postać">
                 <input id="login-password" type="password" class="form-control" placeholder="Hasło">
@@ -193,6 +192,8 @@
             </form>
         </div>
     </div>
+
+    <button id="connect-button">🔌 Connect</button>
 
     <div id="ui-settings-modal" class="modal fade" tabindex="-1">
         <div class="modal-dialog">

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -182,7 +182,7 @@
     </div>
 
     <div id="auth-overlay">
-        <button id="auth-close" class="btn-close btn-close-white" aria-label="Close"></button>
+        <button id="auth-close" class="overlay-close" aria-label="Close">✖</button>
         <div id="auth-panel">
             <div id="connecting-spinner" class="spinner-border text-light" role="status"></div>
             <button id="connect-button">Connect</button>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -276,7 +276,7 @@ function updateConnectButtons() {
 
     if (connectButtonFloat) {
         if (!isConnected && !isConnecting && authClosed) {
-            connectButtonFloat.style.display = '';
+            connectButtonFloat.style.display = 'block';
         } else {
             connectButtonFloat.style.display = 'none';
         }

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -253,6 +253,7 @@ arkadiaClient.on('message', (message: string, type?: string) => {
 let isConnected = false;
 let isConnecting = false;
 let playbackMode = false;
+let authClosed = false;
 
 // Function to update the connect button state
 function updateConnectButtons() {
@@ -262,11 +263,11 @@ function updateConnectButtons() {
     const spinner = document.getElementById('connecting-spinner') as HTMLElement | null;
 
     if (connectButton) {
-        if (isConnected || isConnecting) {
+        if (isConnected || isConnecting || !authClosed) {
             connectButton.style.display = 'none';
         } else {
             connectButton.style.display = '';
-            connectButton.textContent = 'Connect';
+            connectButton.textContent = '🔌 Connect';
             connectButton.classList.add('disconnected');
             connectButton.classList.remove('connected');
         }
@@ -282,7 +283,7 @@ function updateConnectButtons() {
     }
 
     if (authOverlay) {
-        authOverlay.style.display = (isConnected || playbackMode) ? 'none' : 'flex';
+        authOverlay.style.display = (!isConnected && !playbackMode && !authClosed) ? 'flex' : 'none';
     }
 }
 
@@ -407,6 +408,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const loginCharacter = document.getElementById('login-character') as HTMLInputElement | null;
     const loginPassword = document.getElementById('login-password') as HTMLInputElement | null;
     const loginForm = document.getElementById('login-form') as HTMLFormElement | null;
+    const authClose = document.getElementById('auth-close') as HTMLButtonElement | null;
 
     if (menuButton) {
         new Dropdown(menuButton);
@@ -682,6 +684,13 @@ document.addEventListener('DOMContentLoaded', () => {
             arkadiaClient.connect();
         }
     });
+
+    if (authClose) {
+        authClose.addEventListener('click', () => {
+            authClosed = true;
+            updateConnectButtons();
+        });
+    }
 
 
     // Initialize button state

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -257,19 +257,28 @@ let authClosed = false;
 
 // Function to update the connect button state
 function updateConnectButtons() {
-    const connectButton = document.getElementById('connect-button') as HTMLButtonElement;
+    const connectButton = document.getElementById('connect-button') as HTMLButtonElement | null;
+    const connectButtonFloat = document.getElementById('connect-button-float') as HTMLButtonElement | null;
     const loginForm = document.getElementById('login-form') as HTMLFormElement | null;
     const authOverlay = document.getElementById('auth-overlay') as HTMLElement | null;
     const spinner = document.getElementById('connecting-spinner') as HTMLElement | null;
 
     if (connectButton) {
-        if (isConnected || isConnecting || !authClosed) {
+        if (isConnected || isConnecting || authClosed) {
             connectButton.style.display = 'none';
         } else {
             connectButton.style.display = '';
-            connectButton.textContent = '🔌 Connect';
+            connectButton.textContent = 'Connect';
             connectButton.classList.add('disconnected');
             connectButton.classList.remove('connected');
+        }
+    }
+
+    if (connectButtonFloat) {
+        if (!isConnected && !isConnecting && authClosed) {
+            connectButtonFloat.style.display = '';
+        } else {
+            connectButtonFloat.style.display = 'none';
         }
     }
 
@@ -371,6 +380,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const messageInput = document.getElementById('message-input') as HTMLInputElement;
     const sendButton = document.getElementById('send-button') as HTMLButtonElement;
     const connectButton = document.getElementById('connect-button') as HTMLButtonElement;
+    const connectButtonFloat = document.getElementById('connect-button-float') as HTMLButtonElement;
     const menuButton = document.getElementById('menu-button') as HTMLButtonElement | null;
     const optionsButton = document.getElementById('options-button') as HTMLButtonElement;
     const bindsButton = document.getElementById('binds-button') as HTMLButtonElement | null;
@@ -675,7 +685,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // Handle connect/disconnect button click
-    connectButton.addEventListener('click', () => {
+    const handleConnect = () => {
         if (isConnected) {
             arkadiaClient.disconnect();
         } else {
@@ -683,7 +693,9 @@ document.addEventListener('DOMContentLoaded', () => {
             updateConnectButtons();
             arkadiaClient.connect();
         }
-    });
+    };
+    connectButton.addEventListener('click', handleConnect);
+    connectButtonFloat.addEventListener('click', handleConnect);
 
     if (authClose) {
         authClose.addEventListener('click', () => {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -239,7 +239,7 @@ h1 {
   position: fixed;
   top: 0.5rem;
   right: 0.5rem;
-  z-index: 1012;
+  z-index: 1103;
   display: none;
   white-space: nowrap;
 }
@@ -559,11 +559,17 @@ button:focus-visible {
   justify-content: center;
 }
 
-#auth-close {
+#auth-close,
+.overlay-close {
   position: absolute;
   top: 0.5rem;
   right: 0.5rem;
-  filter: invert(1);
+  background: transparent;
+  border: 0;
+  color: white;
+  font-size: 1.25rem;
+  line-height: 1;
+  opacity: 1;
 }
 
 #login-form {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -244,6 +244,8 @@ h1 {
   white-space: nowrap;
   padding: 0.25rem 0.5rem;
   font-size: 1.25rem;
+  background-color: #f44336;
+  color: white;
 }
 
 #connect-button.connected {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -232,7 +232,11 @@ h1 {
 
 #connect-button {
   white-space: nowrap;
-  width: 100%;
+  position: fixed;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 1012;
+  display: none;
 }
 
 #connect-button.connected {
@@ -548,6 +552,12 @@ button:focus-visible {
   display: none;
   align-items: center;
   justify-content: center;
+}
+
+#auth-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
 }
 
 #login-form {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -232,11 +232,16 @@ h1 {
 
 #connect-button {
   white-space: nowrap;
+  width: 100%;
+}
+
+#connect-button-float {
   position: fixed;
   top: 0.5rem;
   right: 0.5rem;
   z-index: 1012;
   display: none;
+  white-space: nowrap;
 }
 
 #connect-button.connected {
@@ -558,6 +563,7 @@ button:focus-visible {
   position: absolute;
   top: 0.5rem;
   right: 0.5rem;
+  filter: invert(1);
 }
 
 #login-form {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -242,6 +242,8 @@ h1 {
   z-index: 1103;
   display: none;
   white-space: nowrap;
+  padding: 0.25rem 0.5rem;
+  font-size: 1.25rem;
 }
 
 #connect-button.connected {


### PR DESCRIPTION
## Summary
- add close button to authentication overlay
- move connect button outside overlay and hide until overlay is closed
- style floating connect button
- hide overlay when closed via new button

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6878d5392e90832aa64ce821d457abca