### PR TITLE
Fix pretty containers width calculation

### DIFF
--- a/client/src/scripts/prettyContainers.ts
+++ b/client/src/scripts/prettyContainers.ts
@@ -205,7 +205,10 @@ export function formatTable(title: string, groups: Record<string, ContainerItem[
         return [groupName, ...itemTexts];
     });
 
-    let colWidth = Math.max(title.length + padding * 2, ...allLines.map(l => l.length + padding * 2));
+    let colWidth = Math.max(
+        stripAnsiCodes(title).length + padding * 2,
+        ...allLines.map(l => stripAnsiCodes(l).length + padding * 2),
+    );
 
     const calcWidth = (cw: number) => columns * cw + (columns - 1) * 3 + 2;
 


### PR DESCRIPTION
## Summary
- fix width calculation to ignore ANSI color codes when printing pretty containers

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6878ee9de86c832a90504b7bb626341b