### PR TITLE
Fix input area layering over popups

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -174,7 +174,7 @@ h1 {
   border-top: 0.1vh solid rgba(255, 255, 255, 0.1);
   gap: 1vw;
   position: relative;
-  z-index: 1102;
+  z-index: 1001;
 }
 
 #message-input {
@@ -355,7 +355,7 @@ button:focus-visible {
   padding: 5px 5px;
   position: sticky;
   bottom: 0;
-  z-index: 1102;
+  z-index: 1001;
   }
 
   #message-input {


### PR DESCRIPTION
## Summary
- lower z-index for `#input-area` so Bootstrap modals and overlays sit above it

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687926790f50832ab0b79f2b27a127fd