### PR TITLE
Refactor ArkadiaClient send API

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -587,8 +587,10 @@ document.addEventListener('DOMContentLoaded', () => {
             arkadiaClient.setStoredCharacter(character || null);
 
             const sendCreds = () => {
+                arkadiaClient.setCredentialsPossible(true);
                 if (character) client.send(character);
                 if (password) client.send(password);
+                arkadiaClient.setCredentialsPossible(false);
                 arkadiaClient.off('client.connect', sendCreds);
             };
 


### PR DESCRIPTION
## Summary
- remove recordCredentials argument from `send`
- track potential credential output via `credentialsPossible` flag
- emit `send` event on message transmit
- update login flow to toggle credential flag
- avoid echoing credential messages

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_687929340ae4832ab1492eb97ec31c0b