### PR TITLE
Fix: remove middle-click history close

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -147,11 +147,6 @@ function closeHistoryScrollback() {
     outputWrapper.scrollTop = outputWrapper.scrollHeight;
 }
 
-outputWrapper.addEventListener('mouseup', (e) => {
-    if (e.button === 1) {
-        closeHistoryScrollback();
-    }
-});
 
 let lastTap = 0;
 outputWrapper.addEventListener('touchend', (e) => {


### PR DESCRIPTION
## Summary
- remove middle-click handler that closed history scrollback

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68796599f314832ab8d59e3a1491003a