### PR TITLE
Add xterm palette UI switch

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -226,6 +226,12 @@
                         <input id="ui-emoji-labels" type="checkbox" class="form-check-input me-2" />
                         Etykiety emoji w stanie postaci
                     </label>
+                    <label class="form-label">Paleta kolorów xterm
+                        <select id="ui-xterm-palette" class="form-select">
+                            <option value="xtermArkadia">xtermArkadia</option>
+                            <option value="xtermProper">xtermProper</option>
+                        </select>
+                    </label>
                     <label class="form-label">Powiększenie mapy
                         <input id="ui-map-scale" type="number" step="0.05" min="0.05" class="form-control" />
                     </label>

--- a/web-client/src/ansiParser.ts
+++ b/web-client/src/ansiParser.ts
@@ -1,10 +1,43 @@
 // ANSI color table for terminal color rendering
+
+function generateXtermProper(): string[] {
+    const result: string[] = [];
+    const base = [
+        '#000000', '#800000', '#008000', '#808000', '#000080', '#800080', '#008080', '#c0c0c0',
+        '#808080', '#ff0000', '#00ff00', '#ffff00', '#0000ff', '#ff00ff', '#00ffff', '#ffffff',
+    ];
+    result.push(...base);
+    const steps = [0, 95, 135, 175, 215, 255];
+    for (const r of steps) {
+        for (const g of steps) {
+            for (const b of steps) {
+                const hex = (v: number) => v.toString(16).padStart(2, '0');
+                result.push(`#${hex(r)}${hex(g)}${hex(b)}`);
+            }
+        }
+    }
+    for (let i = 0; i < 24; i++) {
+        const c = 8 + i * 10;
+        const hex = c.toString(16).padStart(2, '0');
+        result.push(`#${hex}${hex}${hex}`);
+    }
+    return result;
+}
+
+const XTERM_PROPER = generateXtermProper();
+
 const COLOR_TABLE = {
     xterm: ["#000000", "#800000", "#008000", "#808000", "#000080", "#800080", "#008080", "#c0c0c0", "#808080", "#ff0000", "#00ff00", "#ffff00", "#0000ff", "#ff00ff", "#00ffff", "#ffffff", "#000000", "#00005f", "#000087", "#0000af", "#0000df", "#0000ff", "#005f00", "#005f5f", "#005f87", "#005faf", "#005fdf", "#005fff", "#008700", "#00875f", "#008787", "#0087af", "#0087df", "#0087ff", "#00af00", "#00af5f", "#00af87", "#00afaf", "#00afdf", "#00afff", "#00df00", "#00df5f", "#00df87", "#00dfaf", "#00dfdf", "#00dfff", "#00ff00", "#00ff5f", "#00ff87", "#00ffaf", "#00ffdf", "#00ffff", "#5f0000", "#5f005f", "#5f0087", "#5f00af", "#5f00df", "#5f00ff", "#5f5f00", "#5f5f5f", "#5f5f87", "#5f5faf", "#5f5fdf", "#5f5fff", "#5f8700", "#5f875f", "#5f8787", "#5f87af", "#5f87df", "#5f87ff", "#5faf00", "#5faf5f", "#5faf87", "#5fafaf", "#5fafdf", "#5fafff", "#5fdf00", "#5fdf5f", "#5fdf87", "#5fdfaf", "#5fdfdf", "#5fdfff", "#5fff00", "#5fff5f", "#5fff87", "#5fffaf", "#5fffdf", "#5fffff", "#870000", "#87005f", "#870087", "#8700af", "#8700df", "#8700ff", "#875f00", "#875f5f", "#875f87", "#875faf", "#875fdf", "#875fff", "#878700", "#87875f", "#878787", "#8787af", "#8787df", "#8787ff", "#87af00", "#87af5f", "#87af87", "#87afaf", "#87afdf", "#87afff", "#87df00", "#87df5f", "#87df87", "#87dfaf", "#87dfdf", "#87dfff", "#87ff00", "#87ff5f", "#87ff87", "#87ffaf", "#87ffdf", "#87ffff", "#af0000", "#af005f", "#af0087", "#af00af", "#af00df", "#af00ff", "#af5f00", "#af5f5f", "#af5f87", "#af5faf", "#af5fdf", "#af5fff", "#af8700", "#af875f", "#af8787", "#af87af", "#af87df", "#af87ff", "#afaf00", "#afaf5f", "#afaf87", "#afafaf", "#afafdf", "#afafff", "#afdf00", "#afdf5f", "#afdf87", "#afdfaf", "#afdfdf", "#afdfff", "#afff00", "#afff5f", "#afff87", "#afffaf", "#afffdf", "#afffff", "#df0000", "#df005f", "#df0087", "#df00af", "#df00df", "#df00ff", "#df5f00", "#df5f5f", "#df5f87", "#df5faf", "#df5fdf", "#df5fff", "#df8700", "#df875f", "#df8787", "#df87af", "#df87df", "#df87ff", "#dfaf00", "#dfaf5f", "#dfaf87", "#dfafaf", "#dfafdf", "#dfafff", "#dfdf00", "#dfdf5f", "#dfdf87", "#dfdfaf", "#dfdfdf", "#dfdfff", "#dfff00", "#dfff5f", "#dfff87", "#dfffaf", "#dfffdf", "#dfffff", "#ff0000", "#ff005f", "#ff0087", "#ff00af", "#ff00df", "#ff00ff", "#ff5f00", "#ff5f5f", "#ff5f87", "#ff5faf", "#ff5fdf", "#ff5fff", "#ff8700", "#ff875f", "#ff8787", "#ff87af", "#ff87df", "#ff87ff", "#ffaf00", "#ffaf5f", "#ffaf87", "#ffafaf", "#ffafdf", "#ffafff", "#ffdf00", "#ffdf5f", "#ffdf87", "#ffdfaf", "#ffdfdf", "#ffdfff", "#ffff00", "#ffff5f", "#ffff87", "#ffffaf", "#ffffdf", "#ffffff", "#080808", "#121212", "#1c1c1c", "#262626", "#303030", "#3a3a3a", "#444444", "#4e4e4e", "#585858", "#606060", "#666666", "#767676", "#808080", "#8a8a8a", "#949494", "#9e9e9e", "#a8a8a8", "#b2b2b2", "#bcbcbc", "#c6c6c6", "#d0d0d0", "#dadada", "#e4e4e4", "#eeeeee"],
     ansi: {
         bright: ["#555555", "#ff5555", "#55ff55", "#ffff55", "#5555ff", "#ff55ff", "#55ffff", "#ffffff"],
         dark: ["#000000", "#bb0000", "#00bb00", "#bbbb00", "#0000bb", "#bb00bb", "#00bbbb", "#bbbbbb"]
     }
+}
+
+let currentPalette: string[] = COLOR_TABLE.xterm;
+
+export function setXtermPalette(mode: 'xtermProper' | 'xtermArkadia') {
+    currentPalette = mode === 'xtermProper' ? XTERM_PROPER : COLOR_TABLE.xterm;
 }
 
 /**
@@ -92,7 +125,7 @@ export function parseAnsiPatterns(input: string): string {
         } else if (ansiSequence.startsWith("22;38;5;")) {
             // 256-color mode
             const colorIndex = parseInt(ansiSequence.slice(8), 10);
-            handleColorChange(COLOR_TABLE.xterm, activeColors, spanStartIndices, spanEndIndices, currentSpanCount, matchPos, colorIndex - 1);
+            handleColorChange(currentPalette, activeColors, spanStartIndices, spanEndIndices, currentSpanCount, matchPos, colorIndex - 1);
         } else if (ansiSequence.startsWith("22;")) {
             // Standard color mode
             const colorIndex = parseInt(ansiSequence.slice(3), 10) - 30;

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -1,4 +1,5 @@
 import Modal from "bootstrap/js/dist/modal";
+import { setXtermPalette } from './ansiParser';
 
 interface UiSettings {
     contentFontSize: number;
@@ -8,6 +9,7 @@ interface UiSettings {
     showButtons: boolean;
     mapHeight: number;
     emojiLabels: boolean;
+    xtermProper: boolean;
 }
 
 const defaultSettings: UiSettings = {
@@ -18,6 +20,7 @@ const defaultSettings: UiSettings = {
     showButtons: true,
     mapHeight: typeof window !== 'undefined' && window.innerWidth < 768 ? 25 : 30,
     emojiLabels: false,
+    xtermProper: false,
 };
 
 function apply(settings: UiSettings) {
@@ -56,6 +59,7 @@ function apply(settings: UiSettings) {
         (window as any).embedded.setZoom?.(settings.mapScale);
         (window as any).embedded.refresh();
     }
+    setXtermPalette(settings.xtermProper ? 'xtermProper' : 'xtermArkadia');
     if ((window as any).clientExtension?.eventTarget) {
         (window as any).clientExtension.eventTarget.dispatchEvent(
             new CustomEvent('uiSettings', { detail: { mobileDirectionButtons: settings.showButtons, emojiLabels: settings.emojiLabels } })
@@ -72,7 +76,7 @@ function load(): UiSettings {
                 const value = Math.abs(parseFloat(parsed.mapScale));
                 return value > 0 ? value : defaultSettings.mapScale;
             })();
-            return { ...defaultSettings, ...parsed, mapScale, emojiLabels: !!parsed.emojiLabels };
+            return { ...defaultSettings, ...parsed, mapScale, emojiLabels: !!parsed.emojiLabels, xtermProper: !!parsed.xtermProper };
         }
     } catch {
         // ignore malformed data
@@ -97,6 +101,7 @@ export default function initUiSettings() {
     const mapHeightInput = modalEl.querySelector('#ui-map-height') as HTMLInputElement;
     const showButtonsInput = modalEl.querySelector('#ui-show-buttons') as HTMLInputElement;
     const emojiLabelsInput = modalEl.querySelector('#ui-emoji-labels') as HTMLInputElement;
+    const xtermPaletteInput = modalEl.querySelector('#ui-xterm-palette') as HTMLSelectElement;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
 
     let current = load();
@@ -107,6 +112,7 @@ export default function initUiSettings() {
     mapHeightInput.value = String(current.mapHeight);
     showButtonsInput.checked = current.showButtons;
     emojiLabelsInput.checked = current.emojiLabels;
+    xtermPaletteInput.value = current.xtermProper ? 'xtermProper' : 'xtermArkadia';
     apply(current);
 
     function read(): UiSettings {
@@ -125,6 +131,7 @@ export default function initUiSettings() {
             mapHeight: parseFloat(mapHeightInput.value) || defaultSettings.mapHeight,
             showButtons: showButtonsInput.checked,
             emojiLabels: emojiLabelsInput.checked,
+            xtermProper: xtermPaletteInput.value === 'xtermProper',
         };
     }
 


### PR DESCRIPTION
## Summary
- allow choosing xterm color palette
- expose setting in UI settings dialog
- store preference in localStorage

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687985ae2de4832a819f94a3fc58339e