### PR TITLE
Fix attack beep for enemy guild members only

### DIFF
--- a/client/src/scripts/attackBeep.ts
+++ b/client/src/scripts/attackBeep.ts
@@ -33,7 +33,8 @@ export default function initAttackBeep(client: Client) {
             return false; // If no enemy guilds selected no beep needed
         }
         const guild = findPersonGuild(attackerName);
-        return guild ? enemyGuilds.includes(guild) : true; // If guild not found, beep anyway
+        // Beep only when we know the attacker belongs to an enemy guild
+        return !!guild && enemyGuilds.includes(guild);
     }
 
     const beep = (raw: string, _line: string, matches: RegExpMatchArray): string => {

--- a/client/test/attackBeep.test.ts
+++ b/client/test/attackBeep.test.ts
@@ -16,20 +16,20 @@ describe('attack beep triggers', () => {
     client = new FakeClient();
     initAttackBeep((client as unknown) as any);
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
-    // initialize with some enemy guilds so beeping is enabled
+    // initialize with enemy guilds so beeping is enabled only for configured guilds
     const handler = client.addEventListener.mock.calls[0]?.[1];
     if (handler) {
-      handler({ detail: { enemyGuilds: ['foo'] } } as any);
+      handler({ detail: { enemyGuilds: ['CKN'] } } as any);
     }
     jest.clearAllMocks();
   });
 
   test('beeps and highlights on attack', () => {
-    const result = parse('Wojownik atakuje cie!');
+    const result = parse('Intia atakuje cie!');
     expect(client.playSound).toHaveBeenCalledTimes(1);
     const prefix = `\x1B[22;38;5;${findClosestColor('#ff0000')}m`;
     expect(result.startsWith(prefix)).toBe(true);
-    expect(result).toContain('Wojownik ATAKUJE CIE!');
+    expect(result).toContain('Intia ATAKUJE CIE!');
     expect(result.endsWith('\x1B[0m')).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- beep when attacked only by configured enemy guild members
- adjust tests to use a named enemy

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687991e86038832a8f36511e9ed75502