### PR TITLE
Fix history buttons visibility

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -378,7 +378,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const sendButton = document.getElementById('send-button') as HTMLButtonElement;
     const historyUpButton = document.getElementById('history-up-button') as HTMLButtonElement | null;
     const historyDownButton = document.getElementById('history-down-button') as HTMLButtonElement | null;
-    const historyButtons = document.getElementById('history-buttons') as HTMLDivElement | null;
     const connectButton = document.getElementById('connect-button') as HTMLButtonElement;
     const connectButtonFloat = document.getElementById('connect-button-float') as HTMLButtonElement;
     const menuButton = document.getElementById('menu-button') as HTMLButtonElement | null;
@@ -690,11 +689,6 @@ document.addEventListener('DOMContentLoaded', () => {
         outputWrapper.scrollTop = outputWrapper.scrollHeight;
         // Delay selection to avoid mouse click clearing it on some browsers
         setTimeout(() => messageInput.select());
-        if (historyButtons) historyButtons.style.display = 'none';
-    });
-
-    messageInput.addEventListener('blur', () => {
-        if (historyButtons) historyButtons.style.display = '';
     });
 
     // Handle connect/disconnect button click


### PR DESCRIPTION
## Summary
- keep history buttons visible when focusing the input

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6879928e6324832ab4176f9f6d2a86d0