### PR TITLE
Improve history navigation

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -612,6 +612,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (historyIndex === -1) {
             currentInput = messageInput.value;
+            // Skip the just sent command if the input wasn't modified
+            if (
+                direction === 'up' &&
+                commandHistory.length > 1 &&
+                messageInput.value === commandHistory[commandHistory.length - 1]
+            ) {
+                historyIndex = 1;
+                messageInput.value = commandHistory[commandHistory.length - 1 - historyIndex];
+                messageInput.select();
+                return;
+            }
         }
 
         if (direction === 'up') {


### PR DESCRIPTION
## Summary
- skip the just-sent command when navigating command history so that one press recalls the prior entry

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687994965f08832a9f444758e0295968