### PR TITLE
Add coin color triggers

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -28,6 +28,7 @@ import registerGagTriggers from './scripts/gags'
 import initLeaderAttackWarning from './scripts/leaderAttackWarning'
 import initBreakItem from './scripts/breakItem'
 import initPriceEvaluation from './scripts/priceEvaluation'
+import initCoinColors from './scripts/coinColors'
 import initExternalScripts from './scripts/externalScripts'
 import initUserAliases from './scripts/userAliases'
 import initWeaponEvaluation from './scripts/weaponEvaluation'
@@ -115,6 +116,7 @@ export function registerScripts(client: Client) {
     initMagicKeys(client)
     initMagics(client)
     initPriceEvaluation(client)
+    initCoinColors(client)
     initLeaderAttackWarning(client)
     initBreakItem(client)
     initExternalScripts(client)

--- a/client/src/scripts/coinColors.ts
+++ b/client/src/scripts/coinColors.ts
@@ -1,0 +1,22 @@
+import Client from "../Client";
+import { colorStringInLine } from "../Colors";
+import { MITHRIL_COLOR, GOLD_COLOR, SILVER_COLOR, COPPER_COLOR } from "./shop";
+
+export default function initCoinColors(client: Client) {
+    const tag = "coinColors";
+    const patterns: { regex: RegExp; color: number }[] = [
+        { regex: /(\w+\s+)?zlot(a|e|ych) monet(y|e|a|)/i, color: GOLD_COLOR },
+        { regex: /[Zz]lot(a|e|ych) monet(y|e|a|)/, color: GOLD_COLOR },
+        { regex: /(\w+\s+)?mithrylow(a|e|ych) monet(y|e|a|)/i, color: MITHRIL_COLOR },
+        { regex: /[Mm]ithrylow(a|e|ych) monet(y|e|a|)/, color: MITHRIL_COLOR },
+        { regex: /srebrn(a|e|ych) monet(y|e|a|)/i, color: SILVER_COLOR },
+        { regex: /(\w+\s+)?srebrn(a|e|ych) monet(y|e|a|)/i, color: SILVER_COLOR },
+        { regex: /(\w+\s+)?miedzian(a|e|ych) monet(y|e|a|)/i, color: COPPER_COLOR },
+        { regex: /miedzian(a|e|ych) monet(y|e|a|)/i, color: COPPER_COLOR }
+    ];
+    patterns.forEach(({ regex, color }) => {
+        client.Triggers.registerTrigger(regex, (raw, _line, m) => {
+            return colorStringInLine(raw, m[0], color);
+        }, tag);
+    });
+}


### PR DESCRIPTION
## Summary
- highlight money phrases such as mithryl, gold, silver, and copper coins
- activate the triggers through `initCoinColors`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6879954c8d58832a86619409102eebf1