### PR TITLE
Fix scroll after changing font size

### DIFF
--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -47,6 +47,10 @@ function apply(settings: UiSettings) {
         btn.style.fontSize = baseFont * settings.buttonSize + 'px';
     });
 
+    if (content) {
+        content.scrollTop = content.scrollHeight;
+    }
+
     // Adjust grid row size for dynamically created Z buttons
     document.querySelectorAll<HTMLDivElement>('.mobile-z-buttons').forEach(div => {
         const baseRow = 36; // default row height in px


### PR DESCRIPTION
## Summary
- ensure output stays scrolled to bottom when applying new UI settings

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_68799775af84832ab1b63ac6daedce1c