### PR TITLE
Fix leader attack mismatch notification

### DIFF
--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -67,7 +67,7 @@ export default class TeamManager {
                 this.avatarAttackTargetId = typeof obj.attack_num == "boolean" ? undefined : String(obj.attack_num)
             }
         });
-        if (this.avatarAttackTargetId && this.leaderAttackTargetId && this.avatarAttackTargetId !== this.leaderAttackTargetId) {
+        if (this.leaderAttackTargetId && this.avatarAttackTargetId !== this.leaderAttackTargetId) {
             this.client.sendEvent('teamLeaderTargetNoAvatar', this.leaderAttackTargetId);
         } else  {
             this.client.sendEvent('teamLeaderTargetAvatar');

--- a/client/test/TeamManager.test.ts
+++ b/client/test/TeamManager.test.ts
@@ -74,6 +74,22 @@ describe('TeamManager', () => {
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
+  test('emits event when leader attacks and avatar does not', () => {
+    const callback = jest.fn();
+    client.addEventListener('teamLeaderTargetNoAvatar', callback);
+    client.sendEvent('gmcp.objects.data', {
+      '1': {
+        desc: 'Eamon',
+        living: true,
+        team: true,
+        team_leader: true,
+        attack_num: '3',
+      },
+      '99': { desc: 'You', living: true, team: true, attack_num: false },
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
   test('does not emit event when targets match', () => {
     const noAvatar = jest.fn();
     const avatar = jest.fn();


### PR DESCRIPTION
## Summary
- trigger warning when leader attacks but avatar does not
- cover new scenario in team manager tests

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6879984891b4832aa61e847abdc79a06