### PR TITLE
Add map render distance setting

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -230,6 +230,9 @@
                     <label class="form-label">Powiększenie mapy
                         <input id="ui-map-scale" type="number" step="0.05" min="0.05" class="form-control" />
                     </label>
+                    <label class="form-label">Zasięg renderowania mapy
+                        <input id="ui-map-limit" type="number" step="1" min="1" class="form-control" />
+                    </label>
                     <label class="form-label">Wysokość mapy (vh)
                         <input id="ui-map-height" type="number" step="1" class="form-control" />
                     </label>

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -5,6 +5,7 @@ interface UiSettings {
     objectsFontSize: number;
     buttonSize: number;
     mapScale: number;
+    mapRenderLimit: number;
     showButtons: boolean;
     mapHeight: number;
     emojiLabels: boolean;
@@ -15,6 +16,7 @@ const defaultSettings: UiSettings = {
     objectsFontSize: 0.6,
     buttonSize: 1,
     mapScale: 0.30,
+    mapRenderLimit: 25,
     showButtons: true,
     mapHeight: typeof window !== 'undefined' && window.innerWidth < 768 ? 25 : 30,
     emojiLabels: false,
@@ -58,6 +60,7 @@ function apply(settings: UiSettings) {
     });
     if ((window as any).embedded?.renderer?.controls) {
         (window as any).embedded.setZoom?.(settings.mapScale);
+        (window as any).embedded.setLimit?.(settings.mapRenderLimit);
         (window as any).embedded.refresh();
     }
     if ((window as any).clientExtension?.eventTarget) {
@@ -76,7 +79,11 @@ function load(): UiSettings {
                 const value = Math.abs(parseFloat(parsed.mapScale));
                 return value > 0 ? value : defaultSettings.mapScale;
             })();
-            return { ...defaultSettings, ...parsed, mapScale, emojiLabels: !!parsed.emojiLabels };
+            const mapRenderLimit = (() => {
+                const value = parseInt(parsed.mapRenderLimit);
+                return value > 0 ? value : defaultSettings.mapRenderLimit;
+            })();
+            return { ...defaultSettings, ...parsed, mapScale, mapRenderLimit, emojiLabels: !!parsed.emojiLabels };
         }
     } catch {
         // ignore malformed data
@@ -99,6 +106,7 @@ export default function initUiSettings() {
     const buttonInput = modalEl.querySelector('#ui-button-size') as HTMLInputElement;
     const mapInput = modalEl.querySelector('#ui-map-scale') as HTMLInputElement;
     const mapHeightInput = modalEl.querySelector('#ui-map-height') as HTMLInputElement;
+    const mapLimitInput = modalEl.querySelector('#ui-map-limit') as HTMLInputElement;
     const showButtonsInput = modalEl.querySelector('#ui-show-buttons') as HTMLInputElement;
     const emojiLabelsInput = modalEl.querySelector('#ui-emoji-labels') as HTMLInputElement;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
@@ -108,6 +116,7 @@ export default function initUiSettings() {
     objectsInput.value = String(current.objectsFontSize);
     buttonInput.value = String(current.buttonSize);
     mapInput.value = String(current.mapScale);
+    mapLimitInput.value = String(current.mapRenderLimit);
     mapHeightInput.value = String(current.mapHeight);
     showButtonsInput.checked = current.showButtons;
     emojiLabelsInput.checked = current.emojiLabels;
@@ -120,12 +129,19 @@ export default function initUiSettings() {
             mapInput.value = String(scale);
             return scale;
         })();
+        const mapRenderLimit = (() => {
+            const value = parseInt(mapLimitInput.value);
+            const limit = value > 0 ? value : defaultSettings.mapRenderLimit;
+            mapLimitInput.value = String(limit);
+            return limit;
+        })();
 
         return {
             contentFontSize: parseFloat(contentInput.value) || defaultSettings.contentFontSize,
             objectsFontSize: parseFloat(objectsInput.value) || defaultSettings.objectsFontSize,
             buttonSize: parseFloat(buttonInput.value) || defaultSettings.buttonSize,
             mapScale,
+            mapRenderLimit,
             mapHeight: parseFloat(mapHeightInput.value) || defaultSettings.mapHeight,
             showButtons: showButtonsInput.checked,
             emojiLabels: emojiLabelsInput.checked,


### PR DESCRIPTION
## Summary
- add configurable map render limit
- expose limit setting to the UI
- persist render limit in local storage

## Testing
- `yarn --cwd map build`
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687a072c9664832aa59a636c5ae03109