### PR TITLE
Add wear condition replacements

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -20,6 +20,7 @@ import initArmorShop from './scripts/armorShop'
 import initHerbCounter from './scripts/herbCounter'
 import initLvlCalc from './scripts/lvlCalc'
 import initItemCondition from './scripts/itemCondition'
+import initWearUsed from './scripts/wearUsed'
 import initInvite from './scripts/invite'
 import initObjectAliases from './scripts/objectAliases'
 import initMagicKeys from './scripts/magicKeys'
@@ -111,6 +112,7 @@ export function registerScripts(client: Client) {
     initHerbCounter(client, aliases)
     initLvlCalc(client, aliases)
     initItemCondition(client)
+    initWearUsed(client)
     initInvite(client)
     initObjectAliases(client, aliases)
     initMagicKeys(client)

--- a/client/src/scripts/wearUsed.ts
+++ b/client/src/scripts/wearUsed.ts
@@ -1,0 +1,53 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+const COLORS: Record<string, number> = {
+    green: findClosestColor("#00ff00"),
+    yellow: findClosestColor("#ffff00"),
+    red: findClosestColor("#ff0000"),
+};
+
+const WEAR_USED_DESC: Record<string, string> = {
+    "calkiem nowe.": "[5/5]",
+    "calkiem nowa.": "[5/5]",
+    "w miare nowe.": "[4/5]",
+    "w miare nowa.": "[4/5]",
+    "troche znoszone.": "[3/5]",
+    "troche znoszona.": "[3/5]",
+    "prawie calkiem znoszone.": "[2/5]",
+    "prawie calkiem znoszona.": "[2/5]",
+    "gotowe rozpasc sie w kazdej chwili.": "[1/5]",
+    "gotowa rozpasc sie w kazdej chwili.": "[1/5]",
+};
+
+const WEAR_USED_COLOR: Record<string, string> = {
+    "calkiem nowe.": "green",
+    "calkiem nowa.": "green",
+    "w miare nowe.": "green",
+    "w miare nowa.": "green",
+    "troche znoszone.": "yellow",
+    "troche znoszona.": "yellow",
+    "prawie calkiem znoszone.": "red",
+    "prawie calkiem znoszona.": "red",
+    "gotowe rozpasc sie w kazdej chwili.": "red",
+    "gotowa rozpasc sie w kazdej chwili.": "red",
+};
+
+export function processWearUsed(rawLine: string, desc: string): string {
+    const key = desc.toLowerCase();
+    const replacement = WEAR_USED_DESC[key];
+    if (!replacement) return rawLine;
+    const colorName = WEAR_USED_COLOR[key] ?? "red";
+    const colorCode = COLORS[colorName] ?? COLORS.red;
+    const coloredDesc = colorString(desc, colorCode);
+    const coloredValue = colorString(replacement, colorCode);
+    return rawLine.replace(desc, `${coloredDesc} ${coloredValue}`);
+}
+
+export default function initWearUsed(client: Client) {
+    const pattern = /^Ubranie to.* wyglada na (.*)$/;
+    client.Triggers.registerTrigger(pattern, (raw, _line, m) => {
+        const desc = m[1];
+        return processWearUsed(raw, desc);
+    }, "wear-used");
+}

--- a/client/test/wearUsed.test.ts
+++ b/client/test/wearUsed.test.ts
@@ -1,0 +1,29 @@
+import initWearUsed from '../src/scripts/wearUsed';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+}
+
+describe('wear used trigger', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initWearUsed((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+  });
+
+  test('replaces wear description', () => {
+    const line = 'Ubranie to cos wyglada na troche znoszone.';
+    const result = stripAnsiCodes(parse(line));
+    expect(result).toBe('Ubranie to cos wyglada na troche znoszone. [3/5]');
+  });
+
+  test('handles feminine form', () => {
+    const line = 'Ubranie to cos wyglada na prawie calkiem znoszona.';
+    const result = stripAnsiCodes(parse(line));
+    expect(result).toBe('Ubranie to cos wyglada na prawie calkiem znoszona. [2/5]');
+  });
+});


### PR DESCRIPTION
## Summary
- add mapping for clothing wear descriptions
- expose new trigger `wearUsed`
- register `wearUsed` trigger
- test wear used replacements

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687a7b5c19f8832ab4b2873743442bab