### PR TITLE
Add durability indicator

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -20,6 +20,7 @@ import initArmorShop from './scripts/armorShop'
 import initHerbCounter from './scripts/herbCounter'
 import initLvlCalc from './scripts/lvlCalc'
 import initItemCondition from './scripts/itemCondition'
+import initDurability from './scripts/durability'
 import initInvite from './scripts/invite'
 import initObjectAliases from './scripts/objectAliases'
 import initMagicKeys from './scripts/magicKeys'
@@ -111,6 +112,7 @@ export function registerScripts(client: Client) {
     initHerbCounter(client, aliases)
     initLvlCalc(client, aliases)
     initItemCondition(client)
+    initDurability(client)
     initInvite(client)
     initObjectAliases(client, aliases)
     initMagicKeys(client)

--- a/client/src/scripts/durability.ts
+++ b/client/src/scripts/durability.ts
@@ -1,0 +1,54 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+export type DurabilityEntry = {
+    patterns: string[];
+    short: string;
+    color: string;
+};
+
+const COLORS: Record<string, number> = {
+    green: findClosestColor("#00ff00"),
+    yellow: findClosestColor("#ffff00"),
+    orange: findClosestColor("#ffa500"),
+    red: findClosestColor("#ff0000"),
+};
+
+export const durabilityEntries: DurabilityEntry[] = [
+    { patterns: ["naprawde dlugo"], short: "8d", color: "green" },
+    { patterns: ["bardzo dlugo"], short: "5d-8d", color: "green" },
+    { patterns: ["dlugo"], short: "3d-5d", color: "green" },
+    { patterns: ["raczej dlugo"], short: "2d-3d", color: "green" },
+    { patterns: ["troche"], short: "1d-2d", color: "yellow" },
+    { patterns: ["raczej krotko"], short: "6h-1d", color: "orange" },
+    { patterns: ["krotko"], short: "1h-6h", color: "orange" },
+    { patterns: ["bardzo krotko"], short: "1h", color: "red" },
+];
+
+export function processDurability(rawLine: string, phrase: string): string {
+    for (const entry of durabilityEntries) {
+        const found = entry.patterns.every((p) => new RegExp(p).test(phrase));
+        if (found) {
+            const colorCode = COLORS[entry.color] ?? COLORS.red;
+            const colored = colorString(phrase, colorCode);
+            const coloredValue = colorString(`[${entry.short}]`, colorCode);
+            const replaced = `${colored} ${coloredValue}`;
+            return rawLine.replace(phrase, replaced);
+        }
+    }
+    return rawLine;
+}
+
+export default function initDurability(client: Client) {
+    const patterns = [
+        /^Wyglada na to, ze mogl(?:a|o|y|)by ci jeszcze ([\w\s]*) sluzyc\.$/,
+        /\(posluzy ([\w\s]*)(?:, .*)?\)/,
+    ];
+    const tag = "durability";
+    patterns.forEach((pattern) => {
+        client.Triggers.registerTrigger(pattern, (raw, _line, m) => {
+            const phrase = m[1];
+            return processDurability(raw, phrase);
+        }, tag);
+    });
+}

--- a/client/test/durability.test.ts
+++ b/client/test/durability.test.ts
@@ -1,0 +1,37 @@
+import initDurability from '../src/scripts/durability';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+}
+
+describe('durability trigger', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initDurability((client as unknown) as any);
+    parse = (line: string) =>
+      Triggers.prototype.parseLine.call(client.Triggers, line, '');
+  });
+
+  test('handles wyglada na to line', () => {
+    const result = parse('Wyglada na to, ze moglby ci jeszcze naprawde dlugo sluzyc.');
+    expect(stripAnsiCodes(result)).toBe(
+      'Wyglada na to, ze moglby ci jeszcze naprawde dlugo [8d] sluzyc.'
+    );
+  });
+
+  test('handles posluzy line', () => {
+    const result = parse('sztylet (posluzy krotko)');
+    expect(stripAnsiCodes(result)).toBe('sztylet (posluzy krotko [1h-6h])');
+  });
+
+  test('handles posluz z dodatkiem', () => {
+    const result = parse('miecz (posluzy raczej krotko, jest w zlym stanie)');
+    expect(stripAnsiCodes(result)).toBe(
+      'miecz (posluzy raczej krotko [6h-1d], jest w zlym stanie)'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- show item durability
- add tests for durability parser

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687a7b4fe248832a9a8bd3f738756d34