### PR TITLE
Avoid coloring description before 'chaosu'

### DIFF
--- a/client/src/People.ts
+++ b/client/src/People.ts
@@ -1,6 +1,7 @@
 import people from './people.json'
 import Client from "./Client";
 import { color, RESET, findClosestColor } from './Colors';
+import { stripAnsiCodes } from './Triggers';
 
 export default class People {
 
@@ -38,6 +39,12 @@ export default class People {
                 const token = matches[0]
                 const prefix = rawLine.substring(0, index)
                 const suffix = rawLine.substring(index + token.length)
+                const nextWord = stripAnsiCodes(suffix)
+                    .toLowerCase()
+                    .replace(/^\s+/, '')
+                if (nextWord.startsWith('chaosu')) {
+                    return rawLine
+                }
                 let highlighted = token
                 if (isEnemy) {
                     highlighted = color(RED) + token + RESET

--- a/client/test/people.test.ts
+++ b/client/test/people.test.ts
@@ -5,6 +5,7 @@ import { color, RESET, findClosestColor } from '../src/Colors';
 jest.mock('../src/people.json', () => [
   { name: 'Eamon', description: 'wysoki mezczyzna', guild: 'CKN' },
   { name: 'Eamon', description: 'wysoki mezczyzna w kapturze', guild: 'CKN' },
+  { name: 'Krasn', description: 'krepy lysy krasnolud', guild: 'CKN' },
   { name: 'Mara', description: 'niska kobieta', guild: 'NPC' },
   { name: 'w', description: 'koscisty mezczyzna', guild: 'GP' }
 ], { virtual: true });
@@ -56,6 +57,13 @@ describe('people triggers enemy highlight', () => {
     const result = parse('spotykasz w drodze przyjaciela.');
     const red = findClosestColor('#ff0000');
     expect(result).not.toContain(color(red));
+  });
+
+  test("doesn't color description when followed by chaosu", () => {
+    const result = parse('Widzisz krepy lysy krasnolud chaosu tutaj.');
+    const red = findClosestColor('#ff0000');
+    expect(result).not.toContain(color(red));
+    expect(stripAnsiCodes(result)).not.toContain('(Krasn CKN)');
   });
 });
 


### PR DESCRIPTION
## Summary
- avoid coloring person descriptions when they are immediately followed by `chaosu`
- test that descriptions followed by `chaosu` are ignored
- simplify logic for detecting `chaosu` after a description

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_687a77116e08832a89486dd0a9a622f3