### PR TITLE
Add missing alias documentation

### DIFF
--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -41,4 +41,5 @@ Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorze
 - **/ziola_pokaz** - wyświetla ostatnie podsumowanie ziół.
 - **/wezz _ziolo_ [_ilosc_]** - wyjmuje wskazaną liczbę zioła z woreczków (domyślnie jedną sztukę).
 - **/napraw** - Naprawianie sprzetu u kowala.
+- **/naprawa** - Alias do `/napraw`.
 - **/napraw_ubrania** - Naprawianie ubrania u krawca.


### PR DESCRIPTION
## Summary
- document the `/naprawa` alias in `docs/ALIASES.md`

## Testing
- `yarn --cwd client test` *(fails: sendCommand dispatches event and splits commands)*

------
https://chatgpt.com/codex/tasks/task_e_687a84d6d9a0832ab3a216e6c347f2d0