### PR TITLE
Process partial alias commands

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -155,6 +155,13 @@ export default class Client {
             command = stripPolishCharacters(command)
         }
         this.eventTarget.dispatchEvent(new CustomEvent('command', { detail: command }))
+        const split = command.split(/[#;]/)
+        if (split.length > 1) {
+            split.forEach(part => this.sendCommand(part))
+            return
+        }
+
+        command = this.Map.parseCommand(command)
         const isAlias = this.aliases.find(alias => {
             const matches = command.match(alias.pattern)
             if (matches) {
@@ -164,15 +171,7 @@ export default class Client {
             return false
         })
         if (!isAlias) {
-            command = this.Map.parseCommand(command)
-            const split = command.split(/[#;]/)
-            if (split.length > 1) {
-                split.forEach(part => {
-                    this.sendCommand(part)
-                })
-            } else {
-                this.clientAdapter.send(this.Map.move(command).direction)
-            }
+            this.clientAdapter.send(this.Map.move(command).direction)
         }
     }
 

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -107,9 +107,10 @@ test('createButton creates button attached to panel', () => {
 test('sendCommand dispatches event and splits commands', () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   client.sendCommand('foo#bar');
-  expect(parseCommand).toHaveBeenCalledWith('foo#bar');
+  expect(parseCommand).toHaveBeenCalledWith('foo');
+  expect(parseCommand).toHaveBeenCalledWith('bar');
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(1, 'parsed:foo');
-  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'bar');
+  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'parsed:bar');
 });
 
 test('sendCommand allows empty command', () => {


### PR DESCRIPTION
## Summary
- process command splits before alias detection
- parse each command segment separately and handle aliases
- update tests for new recursive command processing

## Testing
- `yarn --cwd client test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a88b0c850832a811dd4787889daa5