### PR TITLE
Enable links in pretty containers after /przejrzyj

### DIFF
--- a/client/src/scripts/prettyContainers.ts
+++ b/client/src/scripts/prettyContainers.ts
@@ -311,7 +311,9 @@ export function prettyPrintContainer(
     const categorized = categorizeItems(parsed.items, defs);
     const tableTitle = title || parsed.container;
     filter = defaultFilter
-    return formatTable(tableTitle, categorized, {columns, padding, maxWidth});
+    const result = formatTable(tableTitle, categorized, {columns, padding, maxWidth});
+    plugLinks = false;
+    return result;
 }
 
 
@@ -392,6 +394,8 @@ const defaultTransforms: TransformDefinition[] = [
     { check: (item: string) => item.match("miedzian\\w+ monet") != null, transform: (item) => colorString(item, COPPER_COLOR)}
 ]
 
+let plugLinks = false;
+
 
 async function loadMagicAndKeysFilter(client: Client) {
     try {
@@ -400,12 +404,20 @@ async function loadMagicAndKeysFilter(client: Client) {
         defs.push({ name: "klucze", filter: keyRegexp });
         defaultTransforms.push({
             check: keyRegexp,
-            transform: (item) => colorString(client.OutputHandler.makeStringClickable(item, () => client.sendCommand(`wybierz ${item}`)), KEYS_COLOR),
+            transform: (item) => colorString(
+                plugLinks ?
+                    client.OutputHandler.makeStringClickable(item, () => client.sendCommand(`wybierz ${item}`)) :
+                    item,
+                KEYS_COLOR),
         });
         const magicRegexp = createRegexpFilter(magics);
         defaultTransforms.push({
             check: magicRegexp,
-            transform: (item) => colorString(client.OutputHandler.makeStringClickable(item, () => client.sendCommand(`wybierz ${item}`)), MAGICS_COLOR),
+            transform: (item) => colorString(
+                plugLinks ?
+                    client.OutputHandler.makeStringClickable(item, () => client.sendCommand(`wybierz ${item}`)) :
+                    item,
+                MAGICS_COLOR),
         });
         magicAndKeysFilter = (item: ContainerItem) =>
             keyRegexp(item.name) || magicRegexp(item.name);
@@ -450,6 +462,7 @@ export default function initContainers(client: Client) {
     client.aliases.push({
         pattern: /\/przejrzyj/, callback: () => {
             filter = magicAndKeysFilter
+            plugLinks = true
             client.send("ob skrzynie");
         }
     })


### PR DESCRIPTION
## Summary
- gate clickable link insertion in containers behind a flag
- turn the flag on when running `/przejrzyj`
- reset the flag after printing the container

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687a9d7c23f0832a883e30b9e4e3afdd