### PR TITLE
Add comparison alias

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -19,7 +19,7 @@ import {SKIP_LINE} from "./ControlConstants";
 import {stripPolishCharacters} from "./stripPolishCharacters";
 
 export interface ClientAdapter {
-    send(text: string): void;
+    send(text: string, echo?: boolean): void;
     output(text?: string, type?: string): void
     sendGmcp(type: string, payload?: any): void
 }
@@ -146,18 +146,18 @@ export default class Client {
         this.eventTarget.removeEventListener(event, listener)
     }
 
-    send(command: string) {
-        this.clientAdapter.send(command)
+    send(command: string, echo: boolean = true) {
+        this.clientAdapter.send(command, echo)
     }
 
-    sendCommand(command: string) {
+    sendCommand(command: string, echo: boolean = true) {
         if (command) {
             command = stripPolishCharacters(command)
         }
         this.eventTarget.dispatchEvent(new CustomEvent('command', { detail: command }))
         const split = command.split(/[#;]/)
         if (split.length > 1) {
-            split.forEach(part => this.sendCommand(part))
+            split.forEach(part => this.sendCommand(part, echo))
             return
         }
 
@@ -171,7 +171,7 @@ export default class Client {
             return false
         })
         if (!isAlias) {
-            this.clientAdapter.send(this.Map.move(command).direction)
+            this.clientAdapter.send(this.Map.move(command).direction, echo)
         }
     }
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -37,6 +37,7 @@ import initUserAliases from './scripts/userAliases'
 import initWeaponEvaluation from './scripts/weaponEvaluation'
 import initArmorEvaluation from './scripts/armorEvaluation'
 import initMapAliases from './scripts/mapAliases'
+import initCompareAll from './scripts/compareAll'
 import Client from "./Client";
 
 
@@ -114,6 +115,7 @@ export function registerScripts(client: Client) {
     initSmith(client, aliases)
     initHerbCounter(client, aliases)
     initLvlCalc(client, aliases)
+    initCompareAll(client, aliases)
     initItemCondition(client)
     initDurability(client)
     initWearUsed(client)

--- a/client/src/scripts/compareAll.ts
+++ b/client/src/scripts/compareAll.ts
@@ -1,0 +1,121 @@
+import Client from "../Client";
+
+export interface ComparisonStats {
+    sil?: number;
+    zre?: number;
+    wyt?: number;
+}
+
+const level: Record<string, number> = {
+    "rownie dobrze zbudowan": 0,
+    "niewiele lepiej zbudowan": 1,
+    "troche lepiej zbudowan": 2,
+    "lepiej zbudowan": 3,
+    "znacznie lepiej zbudowan": 4,
+    "duzo lepiej zbudowan": 5,
+    "rownie siln": 0,
+    "niewiele silniejsz": 1,
+    "troche silniejsz": 2,
+    "silniejsz": 3,
+    "znacznie silniejsz": 4,
+    "duzo silniejsz": 5,
+    "rownie zreczn": 0,
+    "niewiele zreczniejsz": 1,
+    "troche zreczniejsz": 2,
+    "zreczniejsz": 3,
+    "znacznie zreczniejsz": 4,
+    "duzo zreczniejsz": 5,
+};
+
+let comparisonResults: Record<string, ComparisonStats> = {};
+let queue: { target: string; stat: keyof ComparisonStats }[] = [];
+let pending = 0;
+
+function getTargets(client: Client): string[] {
+    return client
+        .ObjectManager
+        .getObjectsOnLocation()
+        .filter(o => o.shortcut !== "@")
+        .map(o => String(o.num));
+}
+
+export function formatComparisonTable(results: Record<string, ComparisonStats>): string {
+    const lines: string[] = [];
+    const header = `#   OSOBA                   SIL  ZRE  WYT  SUMA`;
+    const line = `--  ---------------------- ---- ---- ---- -----`;
+    lines.push(header);
+    lines.push(line);
+    let i = 1;
+    const pad = (str: string, len: number) => str + " ".repeat(Math.max(0, len - str.length));
+    const formatVal = (n: number | undefined) => {
+        if (n === undefined) return "0";
+        return n > 0 ? `+${n}` : String(n);
+    };
+    Object.entries(results).forEach(([name, stats]) => {
+        const total = (stats.sil || 0) + (stats.zre || 0) + (stats.wyt || 0);
+        lines.push(
+            `${pad(String(i),3)} ${pad(name,22)} ${pad(formatVal(stats.sil),4)} ${pad(formatVal(stats.zre),4)} ${pad(formatVal(stats.wyt),4)} ${pad(formatVal(total),5)}`
+        );
+        i++;
+    });
+    return lines.join("\n");
+}
+
+export function displayComparisonResults(client: Client) {
+    if (pending > 0) {
+        client.print("Not all comparison data has been received. Please wait or try again.");
+        return;
+    }
+    client.println(formatComparisonTable(comparisonResults));
+}
+
+export default function initCompareAll(
+    client: Client,
+    aliases?: { pattern: RegExp; callback: Function }[]
+) {
+    const triggerPattern = /^(?:Wydaje ci sie|Masz wrazenie), ze jest(?<mod>es)? (?<desc>.*?)(?:a|e|y) (?:jak|niz) (?<osoba>.*)\.$/;
+
+    client.Triggers.registerTrigger(triggerPattern, (_raw, _line, m) => {
+        if (!queue.length) return undefined;
+        const item = queue.shift()!;
+        const osoba = m.groups?.osoba?.trim() || item.target;
+        const desc = m.groups?.desc?.trim() || "";
+        let val = level[desc] ?? 0;
+        if (m.groups?.mod) {
+            val = -val;
+        }
+        if (!comparisonResults[osoba]) {
+            comparisonResults[osoba] = {};
+        }
+        comparisonResults[osoba][item.stat] = val;
+        pending--;
+        return undefined;
+    }, "compare-all");
+
+    function send(statWord: string, stat: keyof ComparisonStats, id: string) {
+        queue.push({ target: id, stat });
+        client.sendCommand(`porownaj ${statWord} z ob_${id}`, false);
+    }
+
+    function run() {
+        comparisonResults = {};
+        queue = [];
+        const targets = getTargets(client);
+        pending = targets.length * 3;
+        if (pending === 0) {
+            client.print("No one else is here to compare with.");
+            return;
+        }
+        targets.forEach(id => {
+            send("sile", "sil", id);
+            send("zrecznosc", "zre", id);
+            send("wytrzymalosc", "wyt", id);
+        });
+        setTimeout(() => displayComparisonResults(client), 500);
+    }
+
+    if (aliases) {
+        aliases.push({ pattern: /^\/porownaj_ze_wszystkimi$/, callback: run });
+    }
+}
+

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -109,15 +109,15 @@ test('sendCommand dispatches event and splits commands', () => {
   client.sendCommand('foo#bar');
   expect(parseCommand).toHaveBeenCalledWith('foo');
   expect(parseCommand).toHaveBeenCalledWith('bar');
-  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(1, 'parsed:foo');
-  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'parsed:bar');
+  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(1, 'parsed:foo', true);
+  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'parsed:bar', true);
 });
 
 test('sendCommand allows empty command', () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   client.sendCommand('');
   expect(parseCommand).toHaveBeenCalledWith('');
-  expect((global as any).clientAdapterMock.send).toHaveBeenCalledWith('parsed:');
+  expect((global as any).clientAdapterMock.send).toHaveBeenCalledWith('parsed:', true);
 });
 
 test('onLine sends printed messages after line and restores Output.send', () => {

--- a/client/test/comparison.test.ts
+++ b/client/test/comparison.test.ts
@@ -1,0 +1,56 @@
+import initCompareAll from '../src/scripts/compareAll';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
+
+class FakeClient {
+  ObjectManager = {
+    getObjectsOnLocation: jest.fn(() => []),
+  };
+  Triggers = new Triggers(({} as unknown) as any);
+  sendCommand = jest.fn();
+  print = jest.fn();
+  println = jest.fn();
+}
+
+describe('compare all alias', () => {
+  let client: FakeClient;
+  let compareAll: () => void;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    const aliases: { pattern: RegExp; callback: () => void }[] = [];
+    initCompareAll((client as unknown) as any, aliases);
+    compareAll = aliases[0].callback as any;
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('sends comparison commands for each target', () => {
+    client.ObjectManager.getObjectsOnLocation.mockReturnValue([
+      { num: 1, shortcut: '1' },
+      { num: 2, shortcut: '2' },
+    ]);
+    compareAll();
+    expect(client.sendCommand).toHaveBeenCalledWith('porownaj sile z ob_1', false);
+    expect(client.sendCommand).toHaveBeenCalledWith('porownaj zrecznosc z ob_1', false);
+    expect(client.sendCommand).toHaveBeenCalledWith('porownaj wytrzymalosc z ob_1', false);
+    expect(client.sendCommand).toHaveBeenCalledWith('porownaj sile z ob_2', false);
+    jest.runAllTimers();
+  });
+
+  test('prints formatted table with results', () => {
+    client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 3, shortcut: '1' }]);
+    compareAll();
+    parse('Wydaje ci sie, ze jestes silniejszy niz Goblin.');
+    parse('Wydaje ci sie, ze jestes zreczniejszy niz Goblin.');
+    parse('Wydaje ci sie, ze jestes lepiej zbudowany niz Goblin.');
+    jest.runAllTimers();
+    const printed = stripAnsiCodes(client.println.mock.calls[0][0]);
+    expect(printed).toMatch(/Goblin/);
+    expect(printed).toMatch(/-3/);
+  });
+});

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -201,9 +201,9 @@ class ArkadiaClient implements ClientAdapter{
     /**
      * Compatibility wrapper matching old client API
      */
-    sendCommand(command: string): void {
+    sendCommand(command: string, echo: boolean = true): void {
         this.recorder.handleOutgoing(command);
-        this.send(command);
+        this.send(command, echo);
     }
 
     output(text?: string, type?: string) {

--- a/web-client/src/Recorder.ts
+++ b/web-client/src/Recorder.ts
@@ -2,7 +2,7 @@ import { saveRecording, getRecording, getRecordingNames, deleteRecording, Record
 
 export interface RecorderHooks {
     processIncomingData(data: string): void;
-    sendCommand(command: string): void;
+    sendCommand(command: string, echo?: boolean): void;
     emit(event: string, ...args: any[]): void;
 }
 


### PR DESCRIPTION
## Summary
- add new `/porownaj_ze_wszystkimi` alias to compare stats with every object
- print results in a table format
- wire comparison alias into script registration
- test comparison alias
- add echo flag to sendCommand for silent commands

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_687abd250b1c832a9b8f057c7aa5c233