### PR TITLE
Add /por alias with optional shortcut

### DIFF
--- a/client/src/scripts/compareAll.ts
+++ b/client/src/scripts/compareAll.ts
@@ -97,10 +97,20 @@ export default function initCompareAll(
         client.sendCommand(`porownaj ${statWord} z ob_${id}`, false);
     }
 
-    function run() {
+    function findByShortcut(short: string): string | undefined {
+        const lower = short.toLowerCase();
+        const obj = client
+            .ObjectManager
+            .getObjectsOnLocation()
+            .find(o => o.shortcut?.toLowerCase() === lower);
+        return obj ? String(obj.num) : undefined;
+    }
+
+    function run(short?: string) {
         comparisonResults = {};
         queue = [];
-        const targets = getTargets(client);
+        const id = short ? findByShortcut(short) : undefined;
+        const targets = short ? (id ? [id] : []) : getTargets(client);
         pending = targets.length * 3;
         if (pending === 0) {
             client.print("No one else is here to compare with.");
@@ -115,7 +125,10 @@ export default function initCompareAll(
     }
 
     if (aliases) {
-        aliases.push({ pattern: /^\/porownaj_ze_wszystkimi$/, callback: run });
+        aliases.push({
+            pattern: /^\/por(?: ([A-Za-z0-9]+))?$/,
+            callback: (m: RegExpMatchArray) => run(m[1])
+        });
     }
 }
 

--- a/client/test/comparison.test.ts
+++ b/client/test/comparison.test.ts
@@ -13,12 +13,12 @@ class FakeClient {
 
 describe('compare all alias', () => {
   let client: FakeClient;
-  let compareAll: () => void;
+  let compareAll: (m: RegExpMatchArray) => void;
   let parse: (line: string) => string;
 
   beforeEach(() => {
     client = new FakeClient();
-    const aliases: { pattern: RegExp; callback: () => void }[] = [];
+    const aliases: { pattern: RegExp; callback: (m: RegExpMatchArray) => void }[] = [];
     initCompareAll((client as unknown) as any, aliases);
     compareAll = aliases[0].callback as any;
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
@@ -34,7 +34,7 @@ describe('compare all alias', () => {
       { num: 1, shortcut: '1' },
       { num: 2, shortcut: '2' },
     ]);
-    compareAll();
+    compareAll([''] as unknown as RegExpMatchArray);
     expect(client.sendCommand).toHaveBeenCalledWith('porownaj sile z ob_1', false);
     expect(client.sendCommand).toHaveBeenCalledWith('porownaj zrecznosc z ob_1', false);
     expect(client.sendCommand).toHaveBeenCalledWith('porownaj wytrzymalosc z ob_1', false);
@@ -44,7 +44,7 @@ describe('compare all alias', () => {
 
   test('prints formatted table with results', () => {
     client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 3, shortcut: '1' }]);
-    compareAll();
+    compareAll([''] as unknown as RegExpMatchArray);
     parse('Wydaje ci sie, ze jestes silniejszy niz Goblin.');
     parse('Wydaje ci sie, ze jestes zreczniejszy niz Goblin.');
     parse('Wydaje ci sie, ze jestes lepiej zbudowany niz Goblin.');
@@ -52,5 +52,16 @@ describe('compare all alias', () => {
     const printed = stripAnsiCodes(client.println.mock.calls[0][0]);
     expect(printed).toMatch(/Goblin/);
     expect(printed).toMatch(/-3/);
+  });
+
+  test('sends comparison commands for shortcut', () => {
+    client.ObjectManager.getObjectsOnLocation.mockReturnValue([
+      { num: 5, shortcut: '1' },
+      { num: 6, shortcut: '2' },
+    ]);
+    compareAll(['', '2'] as unknown as RegExpMatchArray);
+    expect(client.sendCommand).toHaveBeenCalledWith('porownaj sile z ob_6', false);
+    expect(client.sendCommand).toHaveBeenCalledWith('porownaj zrecznosc z ob_6', false);
+    expect(client.sendCommand).toHaveBeenCalledWith('porownaj wytrzymalosc z ob_6', false);
   });
 });


### PR DESCRIPTION
## Summary
- change `/porownaj_ze_wszystkimi` alias to `/por`
- allow optional shortcut to compare one target
- test new alias behaviour

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687ac7c44888832ab8d9a7ee05920a09