### PR TITLE
Implement transport stop location updates

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -3,6 +3,7 @@ import registerLuaGagTriggers from "./scripts/./luaGags";
 
 import blockers from './blockers.json'
 import initShips from './scripts/ships'
+import initTransportStops from './scripts/transportStops'
 import initBuses from './scripts/buses'
 import initGates from './scripts/gates'
 import initAttackBeep from './scripts/attackBeep'
@@ -93,6 +94,7 @@ export function registerScripts(client: Client) {
     })
 
     initShips(client)
+    initTransportStops(client)
     initBuses(client)
     initGates(client)
     initAttackBeep(client)

--- a/client/src/scripts/transportStops.ts
+++ b/client/src/scripts/transportStops.ts
@@ -1,0 +1,96 @@
+import Client from "../Client";
+
+interface Stop {
+    destination: number;
+    stop_pattern: string;
+}
+
+interface Transport {
+    stops: Stop[];
+}
+
+// Import ship definitions
+import Ancelmus from './ships/Ancelmus.json';
+import Annibale from './ships/Annibale.json';
+import Asa from './ships/Asa.json';
+import Batista from './ships/Batista.json';
+import Bjorn from './ships/Bjorn.json';
+import Cern from './ships/Cern.json';
+import Charonda from './ships/Charonda.json';
+import Creyard from './ships/Creyard.json';
+import Daniel from './ships/Daniel.json';
+import Elich from './ships/Elich.json';
+import Flavius from './ships/Flavius.json';
+import Francois from './ships/Francois.json';
+import Gervais from './ships/Gervais.json';
+import Gmeath from './ships/Gmeath.json';
+import Gvidon from './ships/Gvidon.json';
+import Hallgerda from './ships/Hallgerda.json';
+import Haming from './ships/Haming.json';
+import Jacob from './ships/Jacob.json';
+import Kelim from './ships/Kelim.json';
+import Louis from './ships/Louis.json';
+import Luiggi from './ships/Luiggi.json';
+import Malacius from './ships/Malacius.json';
+import Mallcolm from './ships/Mallcolm.json';
+import Olaf from './ships/Olaf.json';
+import Pluskolec from './ships/Pluskolec.json';
+import Rygwit from './ships/Rygwit.json';
+import Strag from './ships/Strag.json';
+
+import Jouinard from './other/Jouinard - Nuln.json';
+import KrainaZgromadzenia from './other/Kraina Zgromadzenia - Nuln.json';
+import MariborGrabowa from './other/Maribor - Grabowa Buchta.json';
+import Salignac from './other/Salignac - Nuln.json';
+import Varieno from './other/Varieno - Miragliano - Campogrotta.json';
+import WyzimaOxenfurt from './other/Wyzima - Oxenfurt.json';
+
+const transports: Transport[] = [
+    Ancelmus,
+    Annibale,
+    Asa,
+    Batista,
+    Bjorn,
+    Cern,
+    Charonda,
+    Creyard,
+    Daniel,
+    Elich,
+    Flavius,
+    Francois,
+    Gervais,
+    Gmeath,
+    Gvidon,
+    Hallgerda,
+    Haming,
+    Jacob,
+    Kelim,
+    Louis,
+    Luiggi,
+    Malacius,
+    Mallcolm,
+    Olaf,
+    Pluskolec,
+    Rygwit,
+    Strag,
+    Jouinard,
+    KrainaZgromadzenia,
+    MariborGrabowa,
+    Salignac,
+    Varieno,
+    WyzimaOxenfurt,
+];
+
+export default function initTransportStops(client: Client) {
+    transports.forEach(t => {
+        t.stops.forEach(stop => {
+            if (stop.stop_pattern) {
+                const regex = new RegExp(stop.stop_pattern);
+                client.Triggers.registerTrigger(regex, () => {
+                    client.Map.setMapRoomById(stop.destination);
+                    return undefined;
+                }, 'transport-stop');
+            }
+        });
+    });
+}

--- a/client/test/transportStops.test.ts
+++ b/client/test/transportStops.test.ts
@@ -1,0 +1,27 @@
+import initTransportStops from '../src/scripts/transportStops';
+import Triggers from '../src/Triggers';
+import Bjorn from '../src/scripts/ships/Bjorn.json';
+
+class FakeClient {
+  Triggers = new Triggers({} as unknown as any);
+  Map = { setMapRoomById: jest.fn() } as any;
+}
+
+describe('transport stop triggers', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initTransportStops(client as unknown as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    jest.clearAllMocks();
+  });
+
+  test('stop pattern sets map location', () => {
+    const stop = Bjorn.stops[0];
+    const line = 'Bjorn krzyczy: Doplynelismy do przystani na wyspie Mekan! Mozna wysiadac!';
+    parse(line);
+    expect(client.Map.setMapRoomById).toHaveBeenCalledWith(stop.destination);
+  });
+});


### PR DESCRIPTION
## Summary
- add new `transportStops` script
- integrate transport stop triggers in main
- test that stop patterns update map location

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687aca7a2e88832a94635f80e891a61b

closes issue #410 