### PR TITLE
Highlight exits on mobile buttons

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -506,7 +506,7 @@ button:focus-visible {
 }
 
 .direction-button.exit-available {
-  color: #ffc107;
+  background-color: #2fa7c5;
 }
 
 .mobile-button-text {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -505,6 +505,10 @@ button:focus-visible {
   background-color: #6CA6CD; /* Match 'zerknij' button color */
 }
 
+.direction-button.exit-available {
+  color: #ffc107;
+}
+
 .mobile-button-text {
   font-size: 9px; /* Smaller font for 'zerknij' text */
   padding: 1px; /* Minimal padding */


### PR DESCRIPTION
## Summary
- show available exits on mobile buttons

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687acf23a6a8832ab8e893abe61e1130

closes #409 