### PR TITLE
Add GPS trigger registration on map load

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -37,6 +37,7 @@ import initExternalScripts from './scripts/externalScripts'
 import initUserAliases from './scripts/userAliases'
 import initWeaponEvaluation from './scripts/weaponEvaluation'
 import initArmorEvaluation from './scripts/armorEvaluation'
+import initGps from './scripts/gps'
 import initMapAliases from './scripts/mapAliases'
 import initCompareAll from './scripts/compareAll'
 import initFollowSpecialExits from './scripts/followSpecialExits'
@@ -104,6 +105,7 @@ export function registerScripts(client: Client) {
     initIdz(client, aliases)
     initKillCounter(client, aliases)
     initEscape(client)
+    initGps(client)
     initFollowSpecialExits(client)
 
 

--- a/client/src/scripts/gps.ts
+++ b/client/src/scripts/gps.ts
@@ -1,0 +1,90 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+interface GpsEntry {
+    gps_string_lines: string[];
+    line_delta?: number;
+    area_name?: string;
+    room_id: number;
+    within_room_ids?: number[];
+}
+
+export default function initGps(client: Client) {
+    const COLOR = findClosestColor("#ffa500");
+
+    function register(mapData: MapData.Map) {
+        mapData.forEach(area => {
+            area.rooms.forEach(room => {
+                const raw = room.userData?.gps;
+                if (!raw) {
+                    return;
+                }
+                let entries: GpsEntry[];
+                try {
+                    entries = JSON.parse(raw);
+                } catch {
+                    return;
+                }
+                entries.forEach((entry, idx) => {
+                    const lines = entry.gps_string_lines;
+                    if (!lines || lines.length === 0) {
+                        return;
+                    }
+                    const delta = entry.line_delta ? Number(entry.line_delta) - 1 : lines.length - 1;
+                    const gpsId = `${room.id}_${idx}`;
+                    let current = 1;
+                    const checkContext = () => {
+                        if (entry.area_name && client.Map.currentRoom?.areaId !== entry.area_name) {
+                            return false;
+                        }
+                        if (entry.within_room_ids && entry.within_room_ids.length > 0) {
+                            const id = client.Map.currentRoom?.id;
+                            if (!id || !entry.within_room_ids.includes(id)) {
+                                return false;
+                            }
+                        }
+                        return true;
+                    };
+                    const parent = client.Triggers.registerTrigger(
+                        lines[0],
+                        () => {
+                            if (!checkContext()) {
+                                return;
+                            }
+                            if (lines.length === 1) {
+                                client.Map.setMapRoomById(room.id);
+                                client.println(colorString(` Map Sync: gps ${gpsId}`, COLOR));
+                            } else {
+                                current = 1;
+                            }
+                            return undefined;
+                        },
+                        "gps",
+                        { stayOpenLines: delta }
+                    );
+                    if (lines.length > 1) {
+                        parent.registerChild((_, line) => {
+                            if (!checkContext()) {
+                                return undefined;
+                            }
+                            if (line === lines[current]) {
+                                current++;
+                                if (current === lines.length) {
+                                    client.Map.setMapRoomById(room.id);
+                                    client.println(colorString(` Map Sync: gps ${gpsId}`, COLOR));
+                                    current = 1;
+                                }
+                                return [line];
+                            }
+                            return undefined;
+                        });
+                    }
+                });
+            });
+        });
+    }
+
+    window.addEventListener('map-ready', (ev: CustomEvent) => {
+        register(ev.detail.mapData);
+    });
+}

--- a/client/test/gps.test.ts
+++ b/client/test/gps.test.ts
@@ -1,0 +1,53 @@
+import initGps from '../src/scripts/gps';
+import Triggers from '../src/Triggers';
+
+class FakeClient {
+  Triggers = new Triggers({} as unknown as any);
+  Map = { setMapRoomById: jest.fn(), currentRoom: { id: 10, areaId: 'Area' } } as any;
+  println = jest.fn();
+}
+
+describe('gps triggers', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initGps(client as unknown as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    const mapData = [
+      {
+        areaName: 'Area',
+        areaId: 'Area',
+        rooms: [
+          {
+            id: 10,
+            area: 1,
+            x: 0,
+            y: 0,
+            z: 0,
+            weight: 1,
+            symbol: '',
+            userData: { gps: JSON.stringify([{ gps_string_lines: ['l1', 'l2'], room_id: 10 }]) },
+            customLines: {},
+            stubs: [],
+            doors: {},
+            env: 0,
+            exits: {},
+            specialExits: {},
+            hash: ''
+          }
+        ],
+        labels: []
+      }
+    ];
+    window.dispatchEvent(new CustomEvent('map-ready', { detail: { mapData, colors: [] } }));
+  });
+
+  test('gps lines set map location', () => {
+    parse('l1');
+    parse('l2');
+    expect(client.Map.setMapRoomById).toHaveBeenCalledWith(10);
+    expect(client.println).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- register gps triggers when the map data is loaded
- expose new `initGps` script and hook into client initialization
- test gps trigger behaviour

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687ad6b5f908832a8a25d43d076dacf2