### PR TITLE
Add configurable mobile buttons

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -156,6 +156,9 @@
                     <button class="w-100 p-1" id="ui-settings-button">Interfejs</button>
                 </li>
                 <li>
+                    <button class="w-100 p-1" id="mobile-buttons-button">Przyciski</button>
+                </li>
+                <li>
                     <button class="w-100 p-1" id="binds-button">Bindowanie</button>
                 </li>
                 <li>
@@ -245,6 +248,102 @@
         </div>
     </div>
 
+    <div id="mobile-buttons-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Przyciski mobilne</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body d-flex flex-column gap-2">
+                    <div class="mobile-button-config" data-button-id="bracket-right-button">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config" data-button-id="button-1">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config" data-button-id="button-2">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config" data-button-id="button-3">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" id="mobile-buttons-save">Zapisz</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div id="debug-modal" class="modal fade" tabindex="-1">
         <div class="modal-dialog modal-xl modal-dialog-scrollable">
             <div class="modal-content">
@@ -296,6 +395,7 @@
 </div>
 <script type="module" src="/src/plugin.ts"></script>
 <script type="module" src="/src/main.ts"></script>
+<script type="module" src="/src/mobileButtonSettings.ts"></script>
 <script type="module" src="/src/docs.ts"></script>
 <script type="module" src="/src/debug.ts"></script>
 </body>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -268,8 +268,8 @@
                         <label class="form-label">Etykieta
                             <input type="text" class="form-control form-control-sm mobile-button-label" />
                         </label>
-                        <label class="form-label">Kolor
-                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
                         </label>
                         <label class="form-label mobile-button-command-label">
@@ -289,8 +289,8 @@
                         <label class="form-label">Etykieta
                             <input type="text" class="form-control form-control-sm mobile-button-label" />
                         </label>
-                        <label class="form-label">Kolor
-                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
                         </label>
                         <label class="form-label mobile-button-command-label">
@@ -310,8 +310,8 @@
                         <label class="form-label">Etykieta
                             <input type="text" class="form-control form-control-sm mobile-button-label" />
                         </label>
-                        <label class="form-label">Kolor
-                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
                         </label>
                         <label class="form-label mobile-button-command-label">
@@ -331,8 +331,8 @@
                         <label class="form-label">Etykieta
                             <input type="text" class="form-control form-control-sm mobile-button-label" />
                         </label>
-                        <label class="form-label">Kolor
-                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
                         </label>
                         <label class="form-label mobile-button-command-label">
@@ -352,8 +352,8 @@
                         <label class="form-label">Etykieta
                             <input type="text" class="form-control form-control-sm mobile-button-label" />
                         </label>
-                        <label class="form-label">Kolor
-                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
                         </label>
                         <label class="form-label mobile-button-command-label">
@@ -373,8 +373,8 @@
                         <label class="form-label">Etykieta
                             <input type="text" class="form-control form-control-sm mobile-button-label" />
                         </label>
-                        <label class="form-label">Kolor
-                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
                         </label>
                         <label class="form-label mobile-button-command-label">
@@ -394,8 +394,8 @@
                         <label class="form-label">Etykieta
                             <input type="text" class="form-control form-control-sm mobile-button-label" />
                         </label>
-                        <label class="form-label">Kolor
-                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
                         </label>
                         <label class="form-label mobile-button-command-label">

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -256,6 +256,69 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body d-flex flex-column gap-2">
+                    <div class="mobile-button-config" data-button-id="z-list-toggle">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config" data-button-id="zas-list-toggle">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config" data-button-id="go-button">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
                     <div class="mobile-button-config" data-button-id="bracket-right-button">
                         <label class="form-label">Makro
                             <select class="form-select form-select-sm mobile-button-macro">
@@ -270,6 +333,7 @@
                         </label>
                         <label class="form-label">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -290,6 +354,7 @@
                         </label>
                         <label class="form-label">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -310,6 +375,7 @@
                         </label>
                         <label class="form-label">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -330,6 +396,7 @@
                         </label>
                         <label class="form-label">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -10,6 +10,9 @@ export interface ButtonSetting {
 }
 
 const defaultSettings: Record<string, ButtonSetting> = {
+    'z-list-toggle': { macro: 'zList', label: '/z', color: '#87CEEB' },
+    'zas-list-toggle': { macro: 'zaList', label: '/zas', color: '#87CEEB' },
+    'go-button': { macro: 'command', label: '/go', color: '#87CEEB', command: '/go' },
     'bracket-right-button': { macro: 'functional', label: ']', color: '#87CEEB' },
     'button-1': { macro: 'command', label: 'wesprzyj', color: '#87CEEB', command: 'wesprzyj' },
     'button-2': { macro: 'command', label: '/z cel', color: '#87CEEB', command: '/z cel' },
@@ -63,6 +66,7 @@ export default function initMobileButtonSettings() {
         const color = section.querySelector('.mobile-button-color') as HTMLInputElement;
         const command = section.querySelector('.mobile-button-command') as HTMLTextAreaElement;
         const cmdLabel = section.querySelector('.mobile-button-command-label') as HTMLElement;
+        const reset = section.querySelector('.mobile-button-color-reset') as HTMLButtonElement | null;
 
         macro.value = cfg.macro;
         label.value = cfg.label;
@@ -76,6 +80,11 @@ export default function initMobileButtonSettings() {
             }
         };
         macro.addEventListener('change', update);
+        if (reset) {
+            reset.addEventListener('click', () => {
+                color.value = defaultSettings[id].color;
+            });
+        }
         update();
     });
 

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -106,3 +106,5 @@ export default function initMobileButtonSettings() {
     applySettings(current);
 }
 
+document.addEventListener('DOMContentLoaded', initMobileButtonSettings);
+

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -1,0 +1,108 @@
+import Modal from "bootstrap/js/dist/modal";
+
+export type MacroType = 'functional' | 'zList' | 'zaList' | 'command';
+
+export interface ButtonSetting {
+    macro: MacroType;
+    label: string;
+    color: string;
+    command?: string;
+}
+
+const defaultSettings: Record<string, ButtonSetting> = {
+    'bracket-right-button': { macro: 'functional', label: ']', color: '#87CEEB' },
+    'button-1': { macro: 'command', label: 'wesprzyj', color: '#87CEEB', command: 'wesprzyj' },
+    'button-2': { macro: 'command', label: '/z cel', color: '#87CEEB', command: '/z cel' },
+    'button-3': { macro: 'command', label: '/zas cel', color: '#87CEEB', command: '/zas cel' },
+};
+
+export function loadSettings(): Record<string, ButtonSetting> {
+    try {
+        const raw = localStorage.getItem('mobileButtonSettings');
+        if (raw) {
+            return { ...defaultSettings, ...JSON.parse(raw) };
+        }
+    } catch {}
+    return { ...defaultSettings };
+}
+
+export function saveSettings(settings: Record<string, ButtonSetting>) {
+    localStorage.setItem('mobileButtonSettings', JSON.stringify(settings));
+}
+
+export function applySettings(settings: Record<string, ButtonSetting>) {
+    Object.entries(settings).forEach(([id, cfg]) => {
+        const el = document.getElementById(id) as HTMLButtonElement | null;
+        if (!el) return;
+        el.textContent = cfg.label;
+        el.style.backgroundColor = cfg.color;
+    });
+    if ((window as any).clientExtension?.eventTarget) {
+        (window as any).clientExtension.eventTarget.dispatchEvent(
+            new CustomEvent('mobileButtonsSettings', { detail: settings })
+        );
+    }
+}
+
+export default function initMobileButtonSettings() {
+    const button = document.getElementById('mobile-buttons-button') as HTMLButtonElement | null;
+    const modalEl = document.getElementById('mobile-buttons-modal');
+    if (!button || !modalEl) return;
+
+    const modal = new Modal(modalEl);
+    const saveBtn = modalEl.querySelector('#mobile-buttons-save') as HTMLButtonElement;
+
+    const sections = Array.from(modalEl.querySelectorAll<HTMLElement>('.mobile-button-config'));
+
+    let current = loadSettings();
+    sections.forEach(section => {
+        const id = section.dataset.buttonId!;
+        const cfg = current[id] || defaultSettings[id];
+        const macro = section.querySelector('.mobile-button-macro') as HTMLSelectElement;
+        const label = section.querySelector('.mobile-button-label') as HTMLInputElement;
+        const color = section.querySelector('.mobile-button-color') as HTMLInputElement;
+        const command = section.querySelector('.mobile-button-command') as HTMLTextAreaElement;
+        const cmdLabel = section.querySelector('.mobile-button-command-label') as HTMLElement;
+
+        macro.value = cfg.macro;
+        label.value = cfg.label;
+        color.value = cfg.color;
+        if (command) command.value = cfg.command || '';
+        const update = () => {
+            if (macro.value === 'command') {
+                cmdLabel.style.display = '';
+            } else {
+                cmdLabel.style.display = 'none';
+            }
+        };
+        macro.addEventListener('change', update);
+        update();
+    });
+
+    const read = (): Record<string, ButtonSetting> => {
+        const result: Record<string, ButtonSetting> = {};
+        sections.forEach(section => {
+            const id = section.dataset.buttonId!;
+            const macro = (section.querySelector('.mobile-button-macro') as HTMLSelectElement).value as MacroType;
+            const label = (section.querySelector('.mobile-button-label') as HTMLInputElement).value;
+            const color = (section.querySelector('.mobile-button-color') as HTMLInputElement).value;
+            const command = (section.querySelector('.mobile-button-command') as HTMLTextAreaElement).value;
+            result[id] = { macro, label, color, command };
+        });
+        return result;
+    };
+
+    saveBtn.addEventListener('click', () => {
+        current = read();
+        saveSettings(current);
+        applySettings(current);
+        modal.hide();
+    });
+
+    button.addEventListener('click', () => {
+        modal.show();
+    });
+
+    applySettings(current);
+}
+

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -134,7 +134,7 @@ export default class MobileDirectionButtons {
 
         this.client.addEventListener('mobileButtonsSettings', (ev: CustomEvent) => {
             this.buttonSettings = ev.detail || this.buttonSettings;
-            ['bracket-right-button', 'button-1', 'button-2', 'button-3'].forEach(id => {
+            ['z-list-toggle', 'zas-list-toggle', 'go-button', 'bracket-right-button', 'button-1', 'button-2', 'button-3'].forEach(id => {
                 const b = document.getElementById(id) as HTMLButtonElement | null;
                 if (b) this.applyConfigToButton(id, b);
             });
@@ -177,42 +177,11 @@ export default class MobileDirectionButtons {
             });
         }
 
-        ['bracket-right-button', 'button-1', 'button-2', 'button-3'].forEach(id => {
+        ['z-list-toggle', 'zas-list-toggle', 'go-button', 'bracket-right-button', 'button-1', 'button-2', 'button-3'].forEach(id => {
             const btn = document.getElementById(id) as HTMLButtonElement | null;
             if (!btn) return;
             this.applyConfigToButton(id, btn);
         });
-
-        const goButton = document.getElementById('go-button');
-        if (goButton) {
-            goButton.addEventListener('click', () => {
-                this.client.sendCommand('/go');
-            });
-        }
-
-        if (this.zToggle) {
-            this.zToggle.addEventListener('click', () => {
-                if (this.zList && this.zList.style.display === 'grid') {
-                    this.hideLists();
-                } else {
-                    this.hideLists();
-                    this.renderZList();
-                    if (this.zList) this.zList.style.display = 'grid';
-                }
-            });
-        }
-
-        if (this.zasToggle) {
-            this.zasToggle.addEventListener('click', () => {
-                if (this.zasList && this.zasList.style.display === 'grid') {
-                    this.hideLists();
-                } else {
-                    this.hideLists();
-                    this.renderZasList();
-                    if (this.zasList) this.zasList.style.display = 'grid';
-                }
-            });
-        }
 
         // Setup direction buttons
         const directionButtons = [

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -581,14 +581,22 @@ export default class MobileDirectionButtons {
                     document.dispatchEvent(event);
                     break;
                 case 'zList':
-                    this.hideLists();
-                    this.renderZList();
-                    if (this.zList) this.zList.style.display = 'grid';
+                    if (this.zList && this.zList.style.display === 'grid') {
+                        this.hideLists();
+                    } else {
+                        this.hideLists();
+                        this.renderZList();
+                        if (this.zList) this.zList.style.display = 'grid';
+                    }
                     break;
                 case 'zaList':
-                    this.hideLists();
-                    this.renderZasList();
-                    if (this.zasList) this.zasList.style.display = 'grid';
+                    if (this.zasList && this.zasList.style.display === 'grid') {
+                        this.hideLists();
+                    } else {
+                        this.hideLists();
+                        this.renderZasList();
+                        if (this.zasList) this.zasList.style.display = 'grid';
+                    }
                     break;
                 case 'command':
                     if (cfg.command) this.client.sendCommand(cfg.command);


### PR DESCRIPTION
## Summary
- add mobile buttons options button & modal
- add settings loader & saver for mobile buttons
- update MobileDirectionButtons to apply configured actions

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687ad8d817b4832a970cb2e8b503c033