### PR TITLE
Fix Client tests by avoiding circular import

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -1,4 +1,5 @@
-import Triggers, {stripAnsiCodes} from "./Triggers";
+import Triggers from "./Triggers";
+import { stripAnsiCodes } from "./stripAnsiCodes";
 import PackageHelper from "./PackageHelper";
 import MapHelper from "./MapHelper";
 import InlineCompassRose from "./scripts/inlineCompassRose";

--- a/client/src/Triggers.ts
+++ b/client/src/Triggers.ts
@@ -1,7 +1,6 @@
 import Client from "./Client";
-
-export const stripAnsiCodes = (str: string) =>
-    str.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, "");
+import { stripAnsiCodes } from "./stripAnsiCodes";
+export { stripAnsiCodes };
 
 type TriggerCallback = (
     rawLine: string,

--- a/client/src/stripAnsiCodes.ts
+++ b/client/src/stripAnsiCodes.ts
@@ -1,0 +1,2 @@
+export const stripAnsiCodes = (str: string): string =>
+    str.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, "");


### PR DESCRIPTION
## Summary
- move `stripAnsiCodes` to its own file
- import the new helper from both `Client.ts` and `Triggers.ts`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687ae5cc21b4832a951552c09b4fc4b4