### PR TITLE
Ensure data cached only in indexeddb

### DIFF
--- a/client/src/scripts/herbsLoader.ts
+++ b/client/src/scripts/herbsLoader.ts
@@ -96,20 +96,10 @@ export default async function loadHerbs(): Promise<HerbsData | null> {
     try {
         const indexed = await getFromIndexedDB();
         if (indexed) {
-            localStorage.setItem('herbs_data', JSON.stringify(indexed));
             return indexed;
         }
     } catch (e) {
-        console.warn('Failed to load herbs from IndexedDB, falling back to localStorage:', e);
-    }
-
-    const cached = localStorage.getItem('herbs_data');
-    if (cached) {
-        try {
-            return JSON.parse(cached) as HerbsData;
-        } catch {
-            console.error('Failed to parse cached herbs');
-        }
+        console.warn('Failed to load herbs from IndexedDB:', e);
     }
 
     try {
@@ -125,12 +115,7 @@ export default async function loadHerbs(): Promise<HerbsData | null> {
             await storeInIndexedDB(data);
             console.log('Successfully stored herbs in IndexedDB');
         } catch (e) {
-            console.warn('Failed to store herbs in IndexedDB, falling back to localStorage:', e);
-        }
-        try {
-            localStorage.setItem('herbs_data', JSON.stringify(data));
-        } catch (lsErr) {
-            console.error('Failed to cache herbs in localStorage:', lsErr);
+            console.warn('Failed to store herbs in IndexedDB:', e);
         }
         return data as HerbsData;
     } catch (e) {

--- a/client/src/scripts/magicKeyLoader.ts
+++ b/client/src/scripts/magicKeyLoader.ts
@@ -76,20 +76,10 @@ export default async function loadMagicKeys(): Promise<string[]> {
     try {
         const indexed = await getFromIndexedDB();
         if (indexed) {
-            localStorage.setItem('magic_keys', JSON.stringify(indexed));
             return indexed;
         }
     } catch (e) {
-        console.warn('Failed to load magic keys from IndexedDB, falling back to localStorage:', e);
-    }
-
-    const cached = localStorage.getItem('magic_keys');
-    if (cached) {
-        try {
-            return JSON.parse(cached);
-        } catch {
-            console.error('Failed to parse cached magic keys');
-        }
+        console.warn('Failed to load magic keys from IndexedDB:', e);
     }
 
     try {
@@ -106,12 +96,7 @@ export default async function loadMagicKeys(): Promise<string[]> {
             await storeInIndexedDB(keys);
             console.log('Successfully stored magic keys in IndexedDB');
         } catch (e) {
-            console.warn('Failed to store magic keys in IndexedDB, falling back to localStorage:', e);
-        }
-        try {
-            localStorage.setItem('magic_keys', JSON.stringify(keys));
-        } catch (lsErr) {
-            console.error('Failed to cache magic keys in localStorage:', lsErr);
+            console.warn('Failed to store magic keys in IndexedDB:', e);
         }
         return keys;
     } catch (e) {

--- a/client/src/scripts/magicsLoader.ts
+++ b/client/src/scripts/magicsLoader.ts
@@ -76,20 +76,10 @@ export default async function loadMagics(): Promise<string[]> {
     try {
         const indexed = await getFromIndexedDB();
         if (indexed) {
-            localStorage.setItem('magics', JSON.stringify(indexed));
             return indexed;
         }
     } catch (e) {
-        console.warn('Failed to load magics from IndexedDB, falling back to localStorage:', e);
-    }
-
-    const cached = localStorage.getItem('magics');
-    if (cached) {
-        try {
-            return JSON.parse(cached);
-        } catch {
-            console.error('Failed to parse cached magics');
-        }
+        console.warn('Failed to load magics from IndexedDB:', e);
     }
 
     try {
@@ -112,12 +102,7 @@ export default async function loadMagics(): Promise<string[]> {
             await storeInIndexedDB(magics);
             console.log('Successfully stored magics in IndexedDB');
         } catch (e) {
-            console.warn('Failed to store magics in IndexedDB, falling back to localStorage:', e);
-        }
-        try {
-            localStorage.setItem('magics', JSON.stringify(magics));
-        } catch (lsErr) {
-            console.error('Failed to cache magics in localStorage:', lsErr);
+            console.warn('Failed to store magics in IndexedDB:', e);
         }
         return magics;
     } catch (e) {

--- a/client/test/herbsLoader.test.ts
+++ b/client/test/herbsLoader.test.ts
@@ -22,10 +22,10 @@ describe('herbs loader', () => {
         });
     });
 
-    test('loads herbs and caches', async () => {
+    test('loads herbs without using localStorage', async () => {
         const data = await loadHerbs();
         expect(fetch).toHaveBeenCalled();
         expect(data?.version).toBe(1);
-        expect(localStorage.getItem('herbs_data')).not.toBeNull();
+        expect(localStorage.getItem('herbs_data')).toBeNull();
     });
 });

--- a/client/test/magicKeys.test.ts
+++ b/client/test/magicKeys.test.ts
@@ -10,11 +10,11 @@ describe('magic keys', () => {
         });
     });
 
-    test('registers triggers from remote list', async () => {
+    test('registers triggers from remote list without localStorage', async () => {
         const client = { Triggers: { registerTokenTrigger: jest.fn() } } as any;
         await initMagicKeys(client);
         expect(fetch).toHaveBeenCalled();
-        expect(localStorage.getItem('magic_keys')).not.toBeNull();
+        expect(localStorage.getItem('magic_keys')).toBeNull();
         expect(client.Triggers.registerTokenTrigger).toHaveBeenCalledTimes(2);
         const call = client.Triggers.registerTokenTrigger.mock.calls[0];
         const pattern = call[0];

--- a/client/test/magics.test.ts
+++ b/client/test/magics.test.ts
@@ -10,11 +10,11 @@ describe('magics', () => {
         });
     });
 
-    test('registers triggers from remote list', async () => {
+    test('registers triggers from remote list without localStorage', async () => {
         const client = { Triggers: { registerTokenTrigger: jest.fn() } } as any;
         await initMagics(client);
         expect(fetch).toHaveBeenCalled();
-        expect(localStorage.getItem('magics')).not.toBeNull();
+        expect(localStorage.getItem('magics')).toBeNull();
         expect(client.Triggers.registerTokenTrigger).toHaveBeenCalledTimes(2);
         const call = client.Triggers.registerTokenTrigger.mock.calls[0];
         const pattern = call[0];

--- a/sandbox/src/mapDataLoader.ts
+++ b/sandbox/src/mapDataLoader.ts
@@ -7,6 +7,7 @@ export function loadMapData(onProgress?: (progress: number, loaded?: number, tot
         localStorageKey: 'cachedMapData',
         indexedDB: { dbName: 'ArkadiaMapDB', storeName: 'mapData', key: 'mapExport' },
         onProgress,
+        cacheInLocalStorage: false,
     });
 }
 

--- a/sandbox/src/npcDataLoader.ts
+++ b/sandbox/src/npcDataLoader.ts
@@ -6,5 +6,6 @@ export function loadNpcData() {
         url: './data/npc.json',
         localStorageKey: 'npc',
         indexedDB: { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' },
+        cacheInLocalStorage: false,
     });
 }

--- a/web-client/src/mapDataLoader.ts
+++ b/web-client/src/mapDataLoader.ts
@@ -10,6 +10,7 @@ export function loadMapData(onProgress?: (progress: number, loaded?: number, tot
         indexedDB: { dbName: 'ArkadiaMapDB', storeName: 'mapData', key: 'mapExport' },
         ttl: TTL,
         onProgress,
+        cacheInLocalStorage: false,
     });
 }
 

--- a/web-client/src/npcDataLoader.ts
+++ b/web-client/src/npcDataLoader.ts
@@ -9,5 +9,6 @@ export function loadNpcData() {
         localStorageKey: 'npc',
         indexedDB: { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' },
         ttl: TTL,
+        cacheInLocalStorage: false,
     });
 }


### PR DESCRIPTION
## Summary
- avoid using localStorage for herbs, magics, magic keys and map data
- add flag to `loadCachedJSON` to disable localStorage
- update loaders to opt out of localStorage
- adjust unit tests to reflect new behavior

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687b56610868832aa6ff301ac1524689