### PR TITLE
Use common caching for data loaders

### DIFF
--- a/client/src/scripts/herbsLoader.ts
+++ b/client/src/scripts/herbsLoader.ts
@@ -1,3 +1,5 @@
+import { loadCachedJSON } from "../utils/dataCache";
+
 export const HERBS_URL = "https://raw.githubusercontent.com/tjurczyk/arkadia-data/refs/heads/master/herbs_data.json";
 
 export interface HerbForms {
@@ -20,106 +22,19 @@ export interface HerbsData {
     herb_id_to_use: Record<string, HerbUse[]>;
 }
 
-function isIndexedDBSupported() {
-    return typeof indexedDB !== 'undefined';
-}
-
-async function storeInIndexedDB(data: HerbsData) {
-    return new Promise<void>((resolve, reject) => {
-        if (!isIndexedDBSupported()) {
-            reject(new Error('IndexedDB is not supported'));
-            return;
-        }
-
-        const request = indexedDB.open('ArkadiaHerbsDB', 1);
-        request.onupgradeneeded = () => {
-            const db = request.result;
-            if (!db.objectStoreNames.contains('herbs')) {
-                db.createObjectStore('herbs', { keyPath: 'id' });
-            }
-        };
-
-        request.onsuccess = () => {
-            const db = request.result;
-            const transaction = db.transaction(['herbs'], 'readwrite');
-            const store = transaction.objectStore('herbs');
-
-            const storeRequest = store.put({ id: 'herbs', data });
-            storeRequest.onsuccess = () => resolve();
-            storeRequest.onerror = () => reject(new Error('Failed to store data in IndexedDB'));
-        };
-
-        request.onerror = () => {
-            reject(new Error('Failed to open IndexedDB'));
-        };
-    });
-}
-
-async function getFromIndexedDB(): Promise<HerbsData | null> {
-    return new Promise<HerbsData | null>((resolve, reject) => {
-        if (!isIndexedDBSupported()) {
-            resolve(null);
-            return;
-        }
-
-        const request = indexedDB.open('ArkadiaHerbsDB', 1);
-        request.onupgradeneeded = () => {
-            const db = request.result;
-            if (!db.objectStoreNames.contains('herbs')) {
-                db.createObjectStore('herbs', { keyPath: 'id' });
-            }
-        };
-
-        request.onsuccess = () => {
-            const db = request.result;
-            const transaction = db.transaction(['herbs'], 'readonly');
-            const store = transaction.objectStore('herbs');
-
-            const getRequest = store.get('herbs');
-            getRequest.onsuccess = () => {
-                if (getRequest.result) {
-                    resolve(getRequest.result.data as HerbsData);
-                } else {
-                    resolve(null);
-                }
-            };
-            getRequest.onerror = () => reject(new Error('Failed to get data from IndexedDB'));
-        };
-
-        request.onerror = () => {
-            reject(new Error('Failed to open IndexedDB'));
-        };
-    });
-}
+const TTL = 24 * 60 * 60 * 1000; // 24h
 
 export default async function loadHerbs(): Promise<HerbsData | null> {
     try {
-        const indexed = await getFromIndexedDB();
-        if (indexed) {
-            return indexed;
-        }
+        return await loadCachedJSON<HerbsData>({
+            url: HERBS_URL,
+            localStorageKey: "herbs_data",
+            indexedDB: { dbName: "ArkadiaHerbsDB", storeName: "herbs", key: "herbs" },
+            ttl: TTL,
+            cacheInLocalStorage: false,
+        });
     } catch (e) {
-        console.warn('Failed to load herbs from IndexedDB:', e);
-    }
-
-    try {
-        const response = await fetch(HERBS_URL);
-        if (!response.ok) {
-            throw new Error(`HTTP ${response.status}`);
-        }
-        const data = await response.json();
-        if (!data || typeof data !== 'object') {
-            throw new Error('Invalid data format');
-        }
-        try {
-            await storeInIndexedDB(data);
-            console.log('Successfully stored herbs in IndexedDB');
-        } catch (e) {
-            console.warn('Failed to store herbs in IndexedDB:', e);
-        }
-        return data as HerbsData;
-    } catch (e) {
-        console.error('Failed to load herbs:', e);
+        console.error("Failed to load herbs:", e);
         return null;
     }
 }

--- a/client/src/scripts/magicKeyLoader.ts
+++ b/client/src/scripts/magicKeyLoader.ts
@@ -1,106 +1,28 @@
+import { loadCachedJSON } from "../utils/dataCache";
+
 export const MAGIC_KEYS_URL = "https://raw.githubusercontent.com/tjurczyk/arkadia-data/refs/heads/master/magic_keys.json";
 
-function isIndexedDBSupported() {
-    return typeof indexedDB !== 'undefined';
+interface MagicKeysData {
+    magic_keys: string[];
 }
 
-async function storeInIndexedDB(data: string[]) {
-    return new Promise<void>((resolve, reject) => {
-        if (!isIndexedDBSupported()) {
-            reject(new Error('IndexedDB is not supported'));
-            return;
-        }
-
-        const request = indexedDB.open('ArkadiaMagicKeysDB', 1);
-        request.onupgradeneeded = () => {
-            const db = request.result;
-            if (!db.objectStoreNames.contains('magicKeys')) {
-                db.createObjectStore('magicKeys', { keyPath: 'id' });
-            }
-        };
-
-        request.onsuccess = () => {
-            const db = request.result;
-            const transaction = db.transaction(['magicKeys'], 'readwrite');
-            const store = transaction.objectStore('magicKeys');
-
-            const storeRequest = store.put({ id: 'keys', data });
-            storeRequest.onsuccess = () => resolve();
-            storeRequest.onerror = () => reject(new Error('Failed to store data in IndexedDB'));
-        };
-
-        request.onerror = () => {
-            reject(new Error('Failed to open IndexedDB'));
-        };
-    });
-}
-
-async function getFromIndexedDB() {
-    return new Promise<string[] | null>((resolve, reject) => {
-        if (!isIndexedDBSupported()) {
-            resolve(null);
-            return;
-        }
-
-        const request = indexedDB.open('ArkadiaMagicKeysDB', 1);
-        request.onupgradeneeded = () => {
-            const db = request.result;
-            if (!db.objectStoreNames.contains('magicKeys')) {
-                db.createObjectStore('magicKeys', { keyPath: 'id' });
-            }
-        };
-
-        request.onsuccess = () => {
-            const db = request.result;
-            const transaction = db.transaction(['magicKeys'], 'readonly');
-            const store = transaction.objectStore('magicKeys');
-
-            const getRequest = store.get('keys');
-            getRequest.onsuccess = () => {
-                if (getRequest.result) {
-                    resolve(getRequest.result.data as string[]);
-                } else {
-                    resolve(null);
-                }
-            };
-            getRequest.onerror = () => reject(new Error('Failed to get data from IndexedDB'));
-        };
-
-        request.onerror = () => {
-            reject(new Error('Failed to open IndexedDB'));
-        };
-    });
-}
+const TTL = 24 * 60 * 60 * 1000; // 24h
 
 export default async function loadMagicKeys(): Promise<string[]> {
     try {
-        const indexed = await getFromIndexedDB();
-        if (indexed) {
-            return indexed;
+        const data = await loadCachedJSON<MagicKeysData>({
+            url: MAGIC_KEYS_URL,
+            localStorageKey: "magic_keys",
+            indexedDB: { dbName: "ArkadiaMagicKeysDB", storeName: "magicKeys", key: "keys" },
+            ttl: TTL,
+            cacheInLocalStorage: false,
+        });
+        if (!Array.isArray(data.magic_keys)) {
+            throw new Error("Invalid data format");
         }
+        return data.magic_keys;
     } catch (e) {
-        console.warn('Failed to load magic keys from IndexedDB:', e);
-    }
-
-    try {
-        const response = await fetch(MAGIC_KEYS_URL);
-        if (!response.ok) {
-            throw new Error(`HTTP ${response.status}`);
-        }
-        const data = await response.json();
-        if (!Array.isArray(data?.magic_keys)) {
-            throw new Error('Invalid data format');
-        }
-        const keys: string[] = data.magic_keys;
-        try {
-            await storeInIndexedDB(keys);
-            console.log('Successfully stored magic keys in IndexedDB');
-        } catch (e) {
-            console.warn('Failed to store magic keys in IndexedDB:', e);
-        }
-        return keys;
-    } catch (e) {
-        console.error('Failed to load magic keys:', e);
+        console.error("Failed to load magic keys:", e);
         return [];
     }
 }

--- a/client/src/scripts/magicsLoader.ts
+++ b/client/src/scripts/magicsLoader.ts
@@ -1,112 +1,31 @@
+import { loadCachedJSON } from "../utils/dataCache";
+
 export const MAGICS_URL = "https://raw.githubusercontent.com/tjurczyk/arkadia-data/refs/heads/master/magics_data.json";
 
-function isIndexedDBSupported() {
-    return typeof indexedDB !== 'undefined';
+interface MagicsFile {
+    magics: Record<string, { regexps?: string[] }>;
 }
 
-async function storeInIndexedDB(data: string[]) {
-    return new Promise<void>((resolve, reject) => {
-        if (!isIndexedDBSupported()) {
-            reject(new Error('IndexedDB is not supported'));
-            return;
-        }
-
-        const request = indexedDB.open('ArkadiaMagicsDB', 1);
-        request.onupgradeneeded = () => {
-            const db = request.result;
-            if (!db.objectStoreNames.contains('magics')) {
-                db.createObjectStore('magics', { keyPath: 'id' });
-            }
-        };
-
-        request.onsuccess = () => {
-            const db = request.result;
-            const transaction = db.transaction(['magics'], 'readwrite');
-            const store = transaction.objectStore('magics');
-
-            const storeRequest = store.put({ id: 'magics', data });
-            storeRequest.onsuccess = () => resolve();
-            storeRequest.onerror = () => reject(new Error('Failed to store data in IndexedDB'));
-        };
-
-        request.onerror = () => {
-            reject(new Error('Failed to open IndexedDB'));
-        };
-    });
-}
-
-async function getFromIndexedDB() {
-    return new Promise<string[] | null>((resolve, reject) => {
-        if (!isIndexedDBSupported()) {
-            resolve(null);
-            return;
-        }
-
-        const request = indexedDB.open('ArkadiaMagicsDB', 1);
-        request.onupgradeneeded = () => {
-            const db = request.result;
-            if (!db.objectStoreNames.contains('magics')) {
-                db.createObjectStore('magics', { keyPath: 'id' });
-            }
-        };
-
-        request.onsuccess = () => {
-            const db = request.result;
-            const transaction = db.transaction(['magics'], 'readonly');
-            const store = transaction.objectStore('magics');
-
-            const getRequest = store.get('magics');
-            getRequest.onsuccess = () => {
-                if (getRequest.result) {
-                    resolve(getRequest.result.data as string[]);
-                } else {
-                    resolve(null);
-                }
-            };
-            getRequest.onerror = () => reject(new Error('Failed to get data from IndexedDB'));
-        };
-
-        request.onerror = () => {
-            reject(new Error('Failed to open IndexedDB'));
-        };
-    });
-}
+const TTL = 24 * 60 * 60 * 1000; // 24h
 
 export default async function loadMagics(): Promise<string[]> {
     try {
-        const indexed = await getFromIndexedDB();
-        if (indexed) {
-            return indexed;
-        }
-    } catch (e) {
-        console.warn('Failed to load magics from IndexedDB:', e);
-    }
-
-    try {
-        const response = await fetch(MAGICS_URL);
-        if (!response.ok) {
-            throw new Error(`HTTP ${response.status}`);
-        }
-        const data = await response.json();
-        const magicsObj = data?.magics;
-        if (!magicsObj || typeof magicsObj !== 'object') {
-            throw new Error('Invalid data format');
-        }
+        const data = await loadCachedJSON<MagicsFile>({
+            url: MAGICS_URL,
+            localStorageKey: "magics",
+            indexedDB: { dbName: "ArkadiaMagicsDB", storeName: "magics", key: "magics" },
+            ttl: TTL,
+            cacheInLocalStorage: false,
+        });
         const magics: string[] = [];
-        for (const value of Object.values(magicsObj)) {
-            if (value && Array.isArray((value as any).regexps)) {
-                magics.push(...(value as any).regexps);
+        for (const value of Object.values(data.magics)) {
+            if (value && Array.isArray(value.regexps)) {
+                magics.push(...value.regexps);
             }
-        }
-        try {
-            await storeInIndexedDB(magics);
-            console.log('Successfully stored magics in IndexedDB');
-        } catch (e) {
-            console.warn('Failed to store magics in IndexedDB:', e);
         }
         return magics;
     } catch (e) {
-        console.error('Failed to load magics:', e);
+        console.error("Failed to load magics:", e);
         return [];
     }
 }

--- a/client/src/utils/dataCache.ts
+++ b/client/src/utils/dataCache.ts
@@ -119,7 +119,8 @@ export async function loadCachedJSON<T>(options: LoadOptions): Promise<T> {
 
     const response = await fetch(options.url);
     let data: T;
-    const total = parseInt(response.headers.get('Content-Length') || '0', 10);
+    const totalHeader = (response as any).headers?.get?.('Content-Length');
+    const total = parseInt(totalHeader || '0', 10);
     if (response.body && total) {
         const reader = response.body.getReader();
         const chunks: Uint8Array[] = [];


### PR DESCRIPTION
## Summary
- update herbs, magics and magic key loaders to use `loadCachedJSON`
- use 24h TTL for downloaded data
- make `loadCachedJSON` handle missing `Content-Length`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687b59462f8c832ab4ffc500a397a680