### PR TITLE
Add special exit macro and editable directional buttons

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -296,6 +296,7 @@
                                     <option value="zList">Create /z dropdown list</option>
                                     <option value="zaList">Create /za dropdown list</option>
                                     <option value="command">Send command</option>
+                                    <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
                         <label class="form-label">Etykieta
@@ -317,6 +318,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
                         <label class="form-label">Etykieta
@@ -422,6 +424,271 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="specialExit">Use special exit</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config d-none" data-button-id="c-button">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                                <option value="specialExit">Use special exit</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config d-none" data-button-id="u-button">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                                <option value="specialExit">Use special exit</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config d-none" data-button-id="d-button">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                                <option value="specialExit">Use special exit</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config d-none" data-button-id="special-exit-button">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                                <option value="specialExit">Use special exit</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config d-none" data-button-id="nw-button">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                                <option value="specialExit">Use special exit</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config d-none" data-button-id="n-button">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                                <option value="specialExit">Use special exit</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config d-none" data-button-id="ne-button">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                                <option value="specialExit">Use special exit</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config d-none" data-button-id="w-button">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                                <option value="specialExit">Use special exit</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config d-none" data-button-id="e-button">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                                <option value="specialExit">Use special exit</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config d-none" data-button-id="sw-button">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                                <option value="specialExit">Use special exit</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config d-none" data-button-id="s-button">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                                <option value="specialExit">Use special exit</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config d-none" data-button-id="se-button">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="command">Send command</option>
+                                <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
                         <label class="form-label">Etykieta

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -1,6 +1,6 @@
 import Modal from "bootstrap/js/dist/modal";
 
-export type MacroType = 'functional' | 'zList' | 'zaList' | 'command';
+export type MacroType = 'functional' | 'zList' | 'zaList' | 'command' | 'specialExit';
 
 export interface ButtonSetting {
     macro: MacroType;
@@ -17,6 +17,18 @@ const defaultSettings: Record<string, ButtonSetting> = {
     'button-1': { macro: 'command', label: 'wesprzyj', color: '#87CEEB', command: 'wesprzyj' },
     'button-2': { macro: 'command', label: '/z cel', color: '#87CEEB', command: '/z' },
     'button-3': { macro: 'command', label: '/za cel', color: '#87CEEB', command: '/za' },
+    'c-button': { macro: 'command', label: 'zerknij', color: '#6CA6CD', command: 'zerknij' },
+    'u-button': { macro: 'command', label: 'u', color: '#6CA6CD', command: 'u' },
+    'd-button': { macro: 'command', label: 'd', color: '#6CA6CD', command: 'd' },
+    'special-exit-button': { macro: 'specialExit', label: 'sp ex', color: '#6CA6CD' },
+    'nw-button': { macro: 'command', label: '↖', color: '#6CA6CD', command: 'nw' },
+    'n-button': { macro: 'command', label: '↑', color: '#6CA6CD', command: 'n' },
+    'ne-button': { macro: 'command', label: '↗', color: '#6CA6CD', command: 'ne' },
+    'w-button': { macro: 'command', label: '←', color: '#6CA6CD', command: 'w' },
+    'e-button': { macro: 'command', label: '→', color: '#6CA6CD', command: 'e' },
+    'sw-button': { macro: 'command', label: '↙', color: '#6CA6CD', command: 'sw' },
+    's-button': { macro: 'command', label: '↓', color: '#6CA6CD', command: 's' },
+    'se-button': { macro: 'command', label: '↘', color: '#6CA6CD', command: 'se' },
 };
 
 export function loadSettings(): Record<string, ButtonSetting> {


### PR DESCRIPTION
## Summary
- allow selecting macro `specialExit`
- make every mobile button configurable
- fix duplicated macro option

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687b5f28acf4832a84ee3766aa4ad2c6