### PR TITLE
Add kierunek macro for mobile directions

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -296,6 +296,7 @@
                                     <option value="zList">Create /z dropdown list</option>
                                     <option value="zaList">Create /za dropdown list</option>
                                     <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                     <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -305,6 +306,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -318,6 +334,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -327,6 +344,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -340,6 +372,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                             </select>
                         </label>
                         <label class="form-label">Etykieta
@@ -348,6 +381,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -361,6 +409,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                             </select>
                         </label>
                         <label class="form-label">Etykieta
@@ -369,6 +418,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -382,6 +446,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                             </select>
                         </label>
                         <label class="form-label">Etykieta
@@ -390,6 +455,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -403,6 +483,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                             </select>
                         </label>
                         <label class="form-label">Etykieta
@@ -411,6 +492,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -424,6 +520,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -433,6 +530,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -446,6 +558,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -455,6 +568,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -468,6 +596,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -477,6 +606,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -490,6 +634,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -499,6 +644,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -512,6 +672,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -521,6 +682,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -534,6 +710,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -543,6 +720,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -556,6 +748,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -565,6 +758,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -578,6 +786,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -587,6 +796,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -600,6 +824,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -609,6 +834,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -622,6 +862,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -631,6 +872,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -644,6 +900,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -653,6 +910,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -666,6 +938,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -675,6 +948,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda
@@ -688,6 +976,7 @@
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
                                 <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
                             </select>
                         </label>
@@ -697,6 +986,21 @@
                         <label class="form-label d-flex align-items-center gap-1">Kolor
                             <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
                             <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
                         </label>
                         <label class="form-label mobile-button-command-label">
                             Komenda

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -1,12 +1,13 @@
 import Modal from "bootstrap/js/dist/modal";
 
-export type MacroType = 'functional' | 'zList' | 'zaList' | 'command' | 'specialExit';
+export type MacroType = 'functional' | 'zList' | 'zaList' | 'command' | 'specialExit' | 'kierunek';
 
 export interface ButtonSetting {
     macro: MacroType;
     label: string;
     color: string;
     command?: string;
+    direction?: string;
 }
 
 const defaultSettings: Record<string, ButtonSetting> = {
@@ -18,17 +19,17 @@ const defaultSettings: Record<string, ButtonSetting> = {
     'button-2': { macro: 'command', label: '/z cel', color: '#87CEEB', command: '/z' },
     'button-3': { macro: 'command', label: '/za cel', color: '#87CEEB', command: '/za' },
     'c-button': { macro: 'command', label: 'zerknij', color: '#6CA6CD', command: 'zerknij' },
-    'u-button': { macro: 'command', label: 'u', color: '#6CA6CD', command: 'u' },
-    'd-button': { macro: 'command', label: 'd', color: '#6CA6CD', command: 'd' },
+    'u-button': { macro: 'kierunek', label: 'u', color: '#6CA6CD', command: 'u', direction: 'u' },
+    'd-button': { macro: 'kierunek', label: 'd', color: '#6CA6CD', command: 'd', direction: 'd' },
     'special-exit-button': { macro: 'specialExit', label: 'sp ex', color: '#6CA6CD' },
-    'nw-button': { macro: 'command', label: '↖', color: '#6CA6CD', command: 'nw' },
-    'n-button': { macro: 'command', label: '↑', color: '#6CA6CD', command: 'n' },
-    'ne-button': { macro: 'command', label: '↗', color: '#6CA6CD', command: 'ne' },
-    'w-button': { macro: 'command', label: '←', color: '#6CA6CD', command: 'w' },
-    'e-button': { macro: 'command', label: '→', color: '#6CA6CD', command: 'e' },
-    'sw-button': { macro: 'command', label: '↙', color: '#6CA6CD', command: 'sw' },
-    's-button': { macro: 'command', label: '↓', color: '#6CA6CD', command: 's' },
-    'se-button': { macro: 'command', label: '↘', color: '#6CA6CD', command: 'se' },
+    'nw-button': { macro: 'kierunek', label: '↖', color: '#6CA6CD', command: 'nw', direction: 'nw' },
+    'n-button': { macro: 'kierunek', label: '↑', color: '#6CA6CD', command: 'n', direction: 'n' },
+    'ne-button': { macro: 'kierunek', label: '↗', color: '#6CA6CD', command: 'ne', direction: 'ne' },
+    'w-button': { macro: 'kierunek', label: '←', color: '#6CA6CD', command: 'w', direction: 'w' },
+    'e-button': { macro: 'kierunek', label: '→', color: '#6CA6CD', command: 'e', direction: 'e' },
+    'sw-button': { macro: 'kierunek', label: '↙', color: '#6CA6CD', command: 'sw', direction: 'sw' },
+    's-button': { macro: 'kierunek', label: '↓', color: '#6CA6CD', command: 's', direction: 's' },
+    'se-button': { macro: 'kierunek', label: '↘', color: '#6CA6CD', command: 'se', direction: 'se' },
 };
 
 export function loadSettings(): Record<string, ButtonSetting> {
@@ -51,6 +52,11 @@ export function applySettings(settings: Record<string, ButtonSetting>) {
         if (!el) return;
         el.textContent = cfg.label;
         el.style.backgroundColor = cfg.color;
+        if (cfg.direction) {
+            el.dataset.direction = cfg.direction;
+        } else {
+            el.removeAttribute('data-direction');
+        }
     });
     if ((window as any).clientExtension?.eventTarget) {
         (window as any).clientExtension.eventTarget.dispatchEvent(
@@ -106,12 +112,15 @@ export default function initMobileButtonSettings() {
         const color = section.querySelector('.mobile-button-color') as HTMLInputElement;
         const command = section.querySelector('.mobile-button-command') as HTMLTextAreaElement;
         const cmdLabel = section.querySelector('.mobile-button-command-label') as HTMLElement;
+        const direction = section.querySelector('.mobile-button-direction') as HTMLSelectElement;
+        const dirLabel = section.querySelector('.mobile-button-direction-label') as HTMLElement;
         const reset = section.querySelector('.mobile-button-color-reset') as HTMLButtonElement | null;
 
         macro.value = cfg.macro;
         label.value = cfg.label;
         color.value = cfg.color;
         if (command) command.value = cfg.command || '';
+        if (direction) direction.value = cfg.direction || '';
         if (preview) {
             preview.textContent = label.value;
             preview.style.backgroundColor = color.value;
@@ -122,6 +131,11 @@ export default function initMobileButtonSettings() {
                 cmdLabel.style.display = '';
             } else {
                 cmdLabel.style.display = 'none';
+            }
+            if (macro.value === 'kierunek') {
+                dirLabel.style.display = '';
+            } else {
+                dirLabel.style.display = 'none';
             }
         };
         macro.addEventListener('change', update);
@@ -180,7 +194,8 @@ export default function initMobileButtonSettings() {
             const label = (section.querySelector('.mobile-button-label') as HTMLInputElement).value;
             const color = (section.querySelector('.mobile-button-color') as HTMLInputElement).value;
             const command = (section.querySelector('.mobile-button-command') as HTMLTextAreaElement).value;
-            result[id] = { macro, label, color, command };
+            const direction = (section.querySelector('.mobile-button-direction') as HTMLSelectElement).value;
+            result[id] = { macro, label, color, command, direction };
         });
         return result;
     };

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -96,6 +96,9 @@ export default class MobileDirectionButtons {
             u: document.getElementById('u-button') as HTMLButtonElement | null,
             d: document.getElementById('d-button') as HTMLButtonElement | null,
         };
+        Object.entries(this.directionButtons).forEach(([dir, btn]) => {
+            if (btn) btn.dataset.direction = dir;
+        });
 
         this.setupEventHandlers();
         this.updateBracketRightButton();
@@ -430,8 +433,11 @@ export default class MobileDirectionButtons {
 
     private highlightExits(exits: string[]) {
         const available = new Set(exits.map((e) => this.getShortDir(e)));
-        Object.entries(this.directionButtons).forEach(([dir, btn]) => {
-            if (!btn) return;
+        const buttons = this.container.querySelectorAll<HTMLButtonElement>(
+            'button[data-direction]'
+        );
+        buttons.forEach(btn => {
+            const dir = btn.dataset.direction || '';
             if (available.has(dir)) {
                 btn.classList.add('exit-available');
             } else {
@@ -482,7 +488,13 @@ export default class MobileDirectionButtons {
             const dirKey = id.replace('-button', '');
             if (Object.prototype.hasOwnProperty.call(this.directionButtons, dirKey)) {
                 this.directionButtons[dirKey] = newBtn;
+                newBtn.dataset.direction = dirKey;
             }
+        }
+        if (cfg.macro === 'kierunek' && cfg.direction) {
+            newBtn.dataset.direction = this.getShortDir(cfg.direction);
+        } else if (!newBtn.dataset.direction) {
+            newBtn.removeAttribute('data-direction');
         }
 
         const handler = () => {
@@ -519,6 +531,13 @@ export default class MobileDirectionButtons {
                     break;
                 case 'command':
                     if (cfg.command) this.client.sendCommand(cfg.command);
+                    break;
+                case 'kierunek':
+                    if (cfg.command) {
+                        this.client.sendCommand(cfg.command);
+                    } else if (cfg.direction) {
+                        this.client.sendCommand(cfg.direction);
+                    }
                     break;
                 case 'specialExit':
                     const specialExits = this.client.Map.currentRoom?.specialExits ?? {};


### PR DESCRIPTION
## Summary
- introduce `kierunek` macro type
- allow buttons to have assigned direction
- highlight exits using button data-direction
- expose new macro and direction dropdown in UI

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687b658bb0dc832ab23e0f7b293809bc