### PR TITLE
Add user triggers with macro popup

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -35,6 +35,7 @@ import initPriceEvaluation from './scripts/priceEvaluation'
 import initCoinColors from './scripts/coinColors'
 import initExternalScripts from './scripts/externalScripts'
 import initUserAliases from './scripts/userAliases'
+import initUserTriggers from './scripts/userTriggers'
 import initWeaponEvaluation from './scripts/weaponEvaluation'
 import initArmorEvaluation from './scripts/armorEvaluation'
 import initGps from './scripts/gps'
@@ -135,6 +136,7 @@ export function registerScripts(client: Client) {
     initBreakItem(client)
     initExternalScripts(client)
     initUserAliases(client, aliases)
+    initUserTriggers(client)
     initWeaponEvaluation(client)
     initArmorEvaluation(client)
 

--- a/client/src/scripts/userTriggers.ts
+++ b/client/src/scripts/userTriggers.ts
@@ -1,0 +1,74 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+export interface UserMacro {
+    type: 'uppercase' | 'color' | 'replace';
+    color?: string;
+    from?: string;
+    to?: string;
+}
+
+export interface UserTrigger {
+    pattern: string;
+    macros: UserMacro[];
+}
+
+const STORAGE_KEY = 'triggers';
+
+export default function initUserTriggers(client: Client) {
+    let registered: import("../Triggers").Trigger[] = [];
+
+    const apply = (list: UserTrigger[] = []) => {
+        registered.forEach(t => client.Triggers.removeTrigger(t));
+        registered = [];
+        list.forEach(item => {
+            let regexp: RegExp;
+            try {
+                regexp = new RegExp(item.pattern);
+            } catch (e) {
+                console.error('Invalid trigger pattern', item.pattern, e);
+                return;
+            }
+            const trigger = client.Triggers.registerTrigger(regexp, (raw) => {
+                let line = raw;
+                item.macros?.forEach(m => {
+                    switch (m.type) {
+                        case 'uppercase':
+                            line = line.toUpperCase();
+                            break;
+                        case 'color':
+                            if (m.color) {
+                                const code = findClosestColor(m.color);
+                                line = colorString(line, code);
+                            }
+                            break;
+                        case 'replace':
+                            if (m.from) {
+                                try {
+                                    const r = new RegExp(m.from, 'g');
+                                    line = line.replace(r, m.to || '');
+                                } catch {
+                                    line = line.split(m.from).join(m.to || '');
+                                }
+                            }
+                            break;
+                    }
+                });
+                return line;
+            }, STORAGE_KEY);
+            registered.push(trigger);
+        });
+    };
+
+    client.addEventListener('storage', (ev: CustomEvent) => {
+        if (ev.detail.key === STORAGE_KEY) {
+            apply(Array.isArray(ev.detail.value) ? ev.detail.value : []);
+        }
+    });
+
+    client.addEventListener('port-connected', () => {
+        client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
+    });
+
+    client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
+}

--- a/client/test/userTriggers.test.ts
+++ b/client/test/userTriggers.test.ts
@@ -1,0 +1,22 @@
+import initUserTriggers, { UserTrigger } from '../src/scripts/userTriggers';
+import Triggers from '../src/Triggers';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+  addEventListener = jest.fn();
+  removeEventListener = jest.fn();
+  port = { postMessage: jest.fn() } as any;
+}
+
+describe('userTriggers', () => {
+  test('macros modify line', () => {
+    const client = new FakeClient();
+    initUserTriggers((client as unknown) as any);
+    const apply = client.addEventListener.mock.calls.find(c => c[0] === 'storage')[1];
+    const list: UserTrigger[] = [{ pattern: 'foo', macros: [{ type: 'uppercase' }] }];
+    apply({ detail: { key: 'triggers', value: list } } as any);
+    const result = client.Triggers.parseLine('foo', '');
+    expect(result).toBe('FOO');
+  });
+});
+

--- a/options/src/UserTriggers.tsx
+++ b/options/src/UserTriggers.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState, ChangeEvent } from "react";
+import { Button, Form, Modal } from "react-bootstrap";
+import { TiDelete, TiEdit } from "react-icons/ti";
+import storage from "./storage";
+
+export interface UserMacro {
+    type: 'uppercase' | 'color' | 'replace';
+    color?: string;
+    from?: string;
+    to?: string;
+}
+
+export interface UserTrigger {
+    pattern: string;
+    macros: UserMacro[];
+}
+
+function MacroEditor({ macro, onChange, onRemove }: { macro: UserMacro; onChange: (m: UserMacro) => void; onRemove: () => void }) {
+    return (
+        <div className="d-flex align-items-center gap-2 mb-1">
+            <Form.Select
+                size="sm"
+                className="w-auto"
+                value={macro.type}
+                onChange={e => onChange({ ...macro, type: e.target.value as any })}
+            >
+                <option value="uppercase">Uppercase</option>
+                <option value="color">Color</option>
+                <option value="replace">Replace</option>
+            </Form.Select>
+            {macro.type === 'color' && (
+                <Form.Control
+                    type="color"
+                    size="sm"
+                    className="w-auto"
+                    value={macro.color || '#ffffff'}
+                    onChange={e => onChange({ ...macro, color: e.target.value })}
+                />
+            )}
+            {macro.type === 'replace' && (
+                <>
+                    <Form.Control
+                        type="text"
+                        size="sm"
+                        placeholder="From"
+                        value={macro.from || ''}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) => onChange({ ...macro, from: e.target.value })}
+                        style={{ width: '100%', maxWidth: '6rem' }}
+                    />
+                    <Form.Control
+                        type="text"
+                        size="sm"
+                        placeholder="To"
+                        value={macro.to || ''}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) => onChange({ ...macro, to: e.target.value })}
+                        style={{ width: '100%', maxWidth: '6rem' }}
+                    />
+                </>
+            )}
+            <Button size="sm" variant="secondary" onClick={onRemove}><TiDelete /></Button>
+        </div>
+    );
+}
+
+function TriggerPopup({ show, onClose, onSave, initial }: { show: boolean; onClose: () => void; onSave: (t: UserTrigger) => void; initial?: UserTrigger }) {
+    const [pattern, setPattern] = useState('');
+    const [macros, setMacros] = useState<UserMacro[]>([]);
+
+    useEffect(() => {
+        if (initial) {
+            setPattern(initial.pattern);
+            setMacros(initial.macros ? [...initial.macros] : []);
+        } else {
+            setPattern('');
+            setMacros([]);
+        }
+    }, [initial]);
+
+    function addMacro() {
+        setMacros(prev => [...prev, { type: 'uppercase' }]);
+    }
+
+    function updateMacro(idx: number, macro: UserMacro) {
+        setMacros(prev => prev.map((m, i) => i === idx ? macro : m));
+    }
+
+    function removeMacro(idx: number) {
+        setMacros(prev => prev.filter((_, i) => i !== idx));
+    }
+
+    function save() {
+        if (!pattern.trim()) return;
+        onSave({ pattern: pattern.trim(), macros });
+    }
+
+    return (
+        <Modal show={show} onHide={onClose} centered>
+            <Modal.Header closeButton>
+                <Modal.Title>Trigger</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <Form.Group className="mb-2">
+                    <Form.Label>Pattern</Form.Label>
+                    <Form.Control
+                        type="text"
+                        size="sm"
+                        value={pattern}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) => setPattern(e.target.value)}
+                    />
+                </Form.Group>
+                {macros.map((m, i) => (
+                    <MacroEditor
+                        key={i}
+                        macro={m}
+                        onChange={macro => updateMacro(i, macro)}
+                        onRemove={() => removeMacro(i)}
+                    />
+                ))}
+                <Button size="sm" onClick={addMacro}>Add macro</Button>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button size="sm" variant="secondary" onClick={onClose}>Cancel</Button>
+                <Button size="sm" onClick={save}>Save</Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}
+
+function UserTriggers() {
+    const [triggers, setTriggers] = useState<UserTrigger[]>([]);
+    const [showPopup, setShowPopup] = useState(false);
+    const [editIndex, setEditIndex] = useState<number | null>(null);
+
+    useEffect(() => {
+        storage.getItem('triggers').then(res => {
+            if (res && Array.isArray(res.triggers)) {
+                setTriggers(res.triggers);
+            }
+        });
+    }, []);
+
+    function saveList(list: UserTrigger[]) {
+        setTriggers(list);
+        storage.setItem('triggers', list);
+    }
+
+    function openNew() {
+        setEditIndex(null);
+        setShowPopup(true);
+    }
+
+    function edit(idx: number) {
+        setEditIndex(idx);
+        setShowPopup(true);
+    }
+
+    function remove(idx: number) {
+        if (!confirm('Delete trigger?')) return;
+        const updated = triggers.filter((_, i) => i !== idx);
+        saveList(updated);
+    }
+
+    function saveTrigger(t: UserTrigger) {
+        const list = [...triggers];
+        if (editIndex === null) {
+            list.push(t);
+        } else {
+            list[editIndex] = t;
+        }
+        saveList(list);
+        setShowPopup(false);
+    }
+
+    const current = editIndex !== null ? triggers[editIndex] : undefined;
+
+    return (
+        <div className="m-2 d-flex flex-column gap-2">
+            <Button size="sm" onClick={openNew}>Add trigger</Button>
+            <ul className="list-unstyled ms-3">
+                {triggers.map((t, i) => (
+                    <li key={i} className="d-flex align-items-center gap-2">
+                        <span>{t.pattern}</span>
+                        <Button size="sm" variant="secondary" onClick={() => edit(i)}><TiEdit /></Button>
+                        <Button size="sm" variant="danger" onClick={() => remove(i)}><TiDelete /></Button>
+                    </li>
+                ))}
+            </ul>
+            <TriggerPopup
+                show={showPopup}
+                onClose={() => setShowPopup(false)}
+                onSave={saveTrigger}
+                initial={current}
+            />
+        </div>
+    );
+}
+
+export default UserTriggers;

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -113,6 +113,19 @@
             </div>
         </div>
     </div>
+    <div id="triggers-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Triggery</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="triggers-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
     <div id="recordings-modal" class="modal fade" tabindex="-1">
         <div class="modal-dialog modal-lg modal-dialog-scrollable">
             <div class="modal-content">
@@ -172,6 +185,9 @@
                 </li>
                 <li>
                     <button class="w-100 p-1" id="aliases-button">Aliasy</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="triggers-button">Triggery</button>
                 </li>
                 <li>
                     <button class="w-100 p-1" id="recordings-button">Nagrania</button>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -24,6 +24,7 @@ import Scripts from "@options/src/Scripts.tsx"
 import Aliases from "@options/src/Aliases.tsx"
 import Recordings from "@options/src/Recordings.tsx"
 import Guilds from "@options/src/Guilds.tsx"
+import UserTriggers from "@options/src/UserTriggers.tsx"
 
 const client = new Client(arkadiaClient, new MockPort())
 window.clientExtension = client;
@@ -387,6 +388,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const guildsButton = document.getElementById('guilds-button') as HTMLButtonElement | null;
     const scriptsButton = document.getElementById('scripts-button') as HTMLButtonElement | null;
     const aliasesButton = document.getElementById('aliases-button') as HTMLButtonElement | null;
+    const triggersButton = document.getElementById('triggers-button') as HTMLButtonElement | null;
     const recordingsButton = document.getElementById('recordings-button') as HTMLButtonElement | null;
     const recordingButton = document.getElementById('recording-button') as HTMLButtonElement | null;
     const playbackControls = document.getElementById('playback-controls') as HTMLElement | null;
@@ -412,6 +414,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const scriptsModal = scriptsModalElement ? new Modal(scriptsModalElement) : null;
     const aliasesModalElement = document.getElementById('aliases-modal');
     const aliasesModal = aliasesModalElement ? new Modal(aliasesModalElement) : null;
+    const triggersModalElement = document.getElementById('triggers-modal');
+    const triggersModal = triggersModalElement ? new Modal(triggersModalElement) : null;
     const recordingsModalElement = document.getElementById('recordings-modal');
     const recordingsModal = recordingsModalElement ? new Modal(recordingsModalElement) : null;
     const loginCharacter = document.getElementById('login-character') as HTMLInputElement | null;
@@ -441,6 +445,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (aliasesModal) {
             aliasesModal.hide();
+        }
+        if (triggersModal) {
+            triggersModal.hide();
         }
         if (recordingsModal) {
             recordingsModal.hide();
@@ -481,6 +488,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (aliasesButton && aliasesModal) {
         aliasesButton.addEventListener('click', () => {
             aliasesModal.show();
+        });
+    }
+
+    if (triggersButton && triggersModal) {
+        triggersButton.addEventListener('click', () => {
+            triggersModal.show();
         });
     }
 
@@ -776,6 +789,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const aliasesRoot = document.getElementById('aliases-options');
     if (aliasesRoot) {
         createRoot(aliasesRoot).render(createElement(Aliases));
+    }
+
+    const triggersRoot = document.getElementById('triggers-options');
+    if (triggersRoot) {
+        createRoot(triggersRoot).render(createElement(UserTriggers));
     }
 
     const recordingsRoot = document.getElementById('recordings-options');


### PR DESCRIPTION
## Summary
- add `userTriggers` script for custom triggers
- implement popup UI to add triggers and macros
- hook new modal in client index and script
- test macros

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687bc264d7f0832aa7c94d2d95d55577