### PR TITLE
Fix options build

### DIFF
--- a/options/src/UserTriggers.tsx
+++ b/options/src/UserTriggers.tsx
@@ -75,9 +75,6 @@ function UserTriggers() {
         setEditIndex(null);
     }
 
-    function openNew() {
-        resetForm();
-    }
 
     function edit(idx: number) {
         const t = triggers[idx];


### PR DESCRIPTION
## Summary
- remove unused `openNew` function from options build to satisfy TypeScript strict rules

## Testing
- `yarn --cwd options build`
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_687d494cdb2c832abec5934856b47e90