### PR TITLE
Add /puszczaj toggle for releasing guard

### DIFF
--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -1,4 +1,5 @@
 import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
 
 export default function initObjectAliases(
     client: Client,
@@ -22,12 +23,19 @@ export default function initObjectAliases(
     function shield(short: string) {
         const obj = findByShortcut(short);
         if (obj) {
+            if (releaseGuard) {
+                client.sendCommand("przestan zaslaniac");
+            }
             const data = client.TeamManager.getAccumulatedObjectsData?.();
             const isTeam = data && data[obj.num]?.team;
             const cmd = isTeam ? `zaslon ob_${obj.num}` : `zaslon przed ob_${obj.num}`;
             client.sendCommand(cmd);
         }
     }
+    let releaseGuard = false;
+    const ON_COLOR = findClosestColor("#7cfc00");
+    const OFF_COLOR = findClosestColor("#ff6347");
+
 
     if (aliases) {
         aliases.push({
@@ -52,6 +60,9 @@ export default function initObjectAliases(
             callback: () => {
                 const id = client.TeamManager.getDefenseTargetId();
                 if (id) {
+                    if (releaseGuard) {
+                        client.sendCommand("przestan zaslaniac");
+                    }
                     const data = client.TeamManager.getAccumulatedObjectsData?.();
                     const isTeam = data && data[id]?.team;
                     const cmd = isTeam ? `zaslon ob_${id}` : `zaslon przed ob_${id}`;
@@ -62,6 +73,34 @@ export default function initObjectAliases(
         aliases.push({
             pattern: /\/zap ([0-9]+)$/,
             callback: (m: RegExpMatchArray) => exec(m[1], "zapros")
+        });
+        aliases.push({
+            pattern: /\/za ([A-Za-z0-9@]+)$/,
+            callback: (m: RegExpMatchArray) => shield(m[1])
+        });
+        aliases.push({
+            pattern: /^\/za$/,
+            callback: () => {
+                const id = client.TeamManager.getDefenseTargetId();
+                if (id) {
+                    if (releaseGuard) {
+                        client.sendCommand("przestan zaslaniac");
+                    }
+                    const data = client.TeamManager.getAccumulatedObjectsData?.();
+                    const isTeam = data && data[id]?.team;
+                    const cmd = isTeam ? `zaslon ob_${id}` : `zaslon przed ob_${id}`;
+                    client.sendCommand(cmd);
+                }
+            }
+        });
+        aliases.push({
+            pattern: /^\/puszczaj$/,
+            callback: () => {
+                releaseGuard = !releaseGuard;
+                const color = releaseGuard ? ON_COLOR : OFF_COLOR;
+                const state = releaseGuard ? 'ON' : 'OFF';
+                client.print(colorString(`Puszczanie zaslon: ${state}`, color));
+            }
         });
     }
 }

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -10,6 +10,7 @@ class FakeClient {
     getAccumulatedObjectsData: jest.fn(() => ({})),
   };
   sendCommand = jest.fn();
+  print = jest.fn();
 }
 
 describe('object aliases', () => {
@@ -19,6 +20,7 @@ describe('object aliases', () => {
   let killTarget: () => void;
   let shieldTarget: () => void;
   let invite: (m: RegExpMatchArray) => void;
+  let toggle: () => void;
 
   beforeEach(() => {
     client = new FakeClient();
@@ -29,6 +31,7 @@ describe('object aliases', () => {
     killTarget = aliases[2].callback as any;
     shieldTarget = aliases[3].callback as any;
     invite = aliases[4].callback as any;
+    toggle = aliases[7].callback as any;
     (global as any).Input = { send: jest.fn() };
   });
 
@@ -69,5 +72,12 @@ describe('object aliases', () => {
     client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 8, shortcut: '2' }]);
     invite(['', '2'] as unknown as RegExpMatchArray);
     expect(client.sendCommand).toHaveBeenCalledWith('zapros ob_8');
+  });
+
+  test('/puszczaj toggles release flag', () => {
+    toggle();
+    expect(client.print).toHaveBeenCalledWith(expect.stringContaining('ON'));
+    toggle();
+    expect(client.print).toHaveBeenCalledWith(expect.stringContaining('OFF'));
   });
 });

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -29,8 +29,11 @@ Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorze
 - **/cechy** - uruchamia licznik poziomowania i wyświetla postępy.
 - **/z _skrot_** - wykonuje polecenie `zabij` na obiekcie o podanym skrócie.
 - **/zas _skrot_** - zasłania obiekt o podanym skrócie; jeśli nie jest w drużynie używa komendy `zaslon przed`.
+- **/za _skrot_** - to samo co `/zas _skrot_`.
 - **/z** - atakuje cel oznaczony jako cel ataku.
 - **/zas** - zasłania cel oznaczony jako cel obrony lub `zaslon przed`, gdy cel nie jest w drużynie.
+- **/za** - to samo co `/zas`.
+- **/puszczaj** - przełącza automatyczne zwalnianie zasłony przy użyciu `/za` lub `/zas`.
 - **/zap** - wykonuje polecenie `zapal lampe`.
 - **/zap _numer_** - zaprasza do drużyny obiekt o podanym numerze.
 - **/zg** - wykonuje polecenie `zgas lampe`.


### PR DESCRIPTION
## Summary
- add `/puszczaj` alias to toggle releasing shield
- support `/za` alias as synonym for `/zas`
- when releasing guard is active, shielding sends `przestan zaslaniac`
- document new aliases
- test the toggle

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687d48cd11f0832ab801cb6ed9cb9759