### PR TITLE
Add short exits display

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -38,6 +38,7 @@ import initUserAliases from './scripts/userAliases'
 import initUserTriggers from './scripts/userTriggers'
 import initWeaponEvaluation from './scripts/weaponEvaluation'
 import initArmorEvaluation from './scripts/armorEvaluation'
+import initShortExits from './scripts/shortExits'
 import initGps from './scripts/gps'
 import initMapAliases from './scripts/mapAliases'
 import initCompareAll from './scripts/compareAll'
@@ -134,6 +135,7 @@ export function registerScripts(client: Client) {
     initCoinColors(client)
     initLeaderAttackWarning(client)
     initBreakItem(client)
+    initShortExits(client)
     initExternalScripts(client)
     initUserAliases(client, aliases)
     initUserTriggers(client)

--- a/client/src/scripts/shortExits.ts
+++ b/client/src/scripts/shortExits.ts
@@ -1,0 +1,93 @@
+import Client from "../Client";
+import { SKIP_LINE } from "../ControlConstants";
+
+const polishToEnglish: Record<string, string> = {
+    polnoc: "north",
+    poludnie: "south",
+    wschod: "east",
+    zachod: "west",
+    "polnocny-wschod": "northeast",
+    "polnocny-zachod": "northwest",
+    "poludniowy-wschod": "southeast",
+    "poludniowy-zachod": "southwest",
+    dol: "down",
+    gora: "up",
+    gore: "up",
+};
+
+const longToShort: Record<string, string> = {
+    north: "n",
+    south: "s",
+    east: "e",
+    west: "w",
+    northeast: "ne",
+    northwest: "nw",
+    southeast: "se",
+    southwest: "sw",
+    up: "u",
+    down: "d",
+};
+
+export function toShort(dir: string): string {
+    const long = polishToEnglish[dir] ?? dir.toLowerCase();
+    return longToShort[long] ?? "";
+}
+
+export function parseExitString(str: string): string[] {
+    return str
+        .replace(/(?: i | oraz | albo | lub )/g, ",")
+        .split(/,\s*/)
+        .map(s => s.trim())
+        .filter(Boolean);
+}
+
+const EXIT_PATTERNS: RegExp[] = [
+    /^(?:Jest|Sa) tutaj .* widoczn(?:e|ych) wyjsc(?:|ia|ie): (.*)\.$/,
+    /^W gestych ciemnosciach dostrzegasz .* (?:wiodacy|rozwidlajacy sie) na (.*)\.$/,
+    /^Korytarze jaskini ciagna sie na (.*)\.$/,
+    /^Trakt wiedzie na ([^.]+)\.$/,
+    /[tT]rakt rozgalezia sie na (.*)\.$/,
+    /^(?:Szlak|Sciezka) prowadzi tutaj w .* kieru.*: (.*)\.$/,
+    /^Linia brzegowa ciagnie sie na (.*)\.$/,
+    /^Wedrowke (?:skrajem lasu|po karczowisku|po lesie|przez rozlegle laki) mozesz kontynuowac udajac sie na (.*)\.$/,
+    /^Wijaca sie miedzy skalami, gorska sciezka prowadzi na (.*)\.$/,
+    /^Wydeptane w kukurydzy sciezki prowadza na (.*)\.$/,
+    /^Wyjscia prowadza tutaj w .* kierunkach: (.*)\.$/,
+    /^Wykopany w ziemi tunel rozgalezia sie tutaj, zas jego odnogi wioda na (.*)\.$/,
+    /^Wykopany w ziemi tunel wiedzie w dwoch kierunkach: (.*)\.$/,
+    /^Mozesz sie stad udac na (.*)\.$/,
+    /^Mozesz skierowac lodz na (.*)\.$/,
+    /^Trakt jest zasypany glazami i mozna podazac nim tylko w jednym kierunku, na (.*)\.$/,
+    /^Mozesz podazac traktem na (.*), w strone fortu\.$/,
+    /^Mozesz stad poplynac na (.*)\.$/,
+    /^W mroku nocy dostrzegasz .* widoczne wyjsci.: (.*)\.$/,
+    /^Tunel ciagnie sie na (.*)\.$/,
+    /^Jaskinie ciagna sie na (.*)\.$/,
+    /^Tunele ciagna sie na (.*)\.$/,
+    /^Rozpadlina ciagnie sie na (.*)\.$/,
+    /^W gestych ciemnosciach dostrzegasz sciezke wiodaca na (.*)\.$/,
+    /^Ulice krzyzuja sie tutaj, prowadzac w trzech kierunkach: (.*)\.$/,
+    /^Ulica prowadzi na (.*)\.$/,
+    /^Wykop konczy sie tutaj, zas jedyne widoczne przejscie prowadzi na (.*)\.$/,
+    /^Wykopany w ziemi tunel rozgalezia sie tutaj, zas jego odnogi wioda na (.*)\.$/,
+];
+
+export default function initShortExits(client: Client) {
+    let enabled = false;
+
+    client.addEventListener('settings', (event: CustomEvent) => {
+        const settings = event.detail || {};
+        enabled = !!settings.shortenExits;
+    });
+
+    const callback = (_r: string, _l: string, m: RegExpMatchArray) => {
+        if (!enabled) return undefined;
+        const dirs = parseExitString(m[1]).map(toShort).filter(Boolean);
+        if (dirs.length === 0) return undefined;
+        const str = "\n-----:" + dirs.map(d => " " + d.toUpperCase()).join("") + "\n";
+        client.println(str);
+        return SKIP_LINE;
+    };
+
+    client.Triggers.registerTrigger(EXIT_PATTERNS, callback, 'shortExits');
+}

--- a/client/src/scripts/shortExits.ts
+++ b/client/src/scripts/shortExits.ts
@@ -1,5 +1,8 @@
 import Client from "../Client";
 import { SKIP_LINE } from "../ControlConstants";
+import { colorString, findClosestColor } from "../Colors";
+
+const ORANGE = findClosestColor('#ffa500');
 
 const polishToEnglish: Record<string, string> = {
     polnoc: "north",
@@ -30,7 +33,7 @@ const longToShort: Record<string, string> = {
 
 export function toShort(dir: string): string {
     const long = polishToEnglish[dir] ?? dir.toLowerCase();
-    return longToShort[long] ?? "";
+    return longToShort[long] ?? dir;
 }
 
 export function parseExitString(str: string): string[] {
@@ -82,10 +85,10 @@ export default function initShortExits(client: Client) {
 
     const callback = (_r: string, _l: string, m: RegExpMatchArray) => {
         if (!enabled) return undefined;
-        const dirs = parseExitString(m[1]).map(toShort).filter(Boolean);
+        const dirs = parseExitString(m[1]).map(toShort);
         if (dirs.length === 0) return undefined;
         const str = "\n-----:" + dirs.map(d => " " + d.toUpperCase()).join("") + "\n";
-        client.println(str);
+        client.println(colorString(str, ORANGE));
         return SKIP_LINE;
     };
 

--- a/client/src/scripts/shortExits.ts
+++ b/client/src/scripts/shortExits.ts
@@ -1,5 +1,4 @@
 import Client from "../Client";
-import { SKIP_LINE } from "../ControlConstants";
 import { colorString, findClosestColor } from "../Colors";
 
 const ORANGE = findClosestColor('#ffa500');
@@ -87,9 +86,8 @@ export default function initShortExits(client: Client) {
         if (!enabled) return undefined;
         const dirs = parseExitString(m[1]).map(toShort);
         if (dirs.length === 0) return undefined;
-        const str = "\n-----:" + dirs.map(d => " " + d.toUpperCase()).join("") + "\n";
-        client.println(colorString(str, ORANGE));
-        return SKIP_LINE;
+        const str = "-----:" + dirs.map(d => " " + d.toUpperCase()).join("");
+        return colorString(str, ORANGE);
     };
 
     client.Triggers.registerTrigger(EXIT_PATTERNS, callback, 'shortExits');

--- a/client/test/shortExits.test.ts
+++ b/client/test/shortExits.test.ts
@@ -1,5 +1,8 @@
 import initShortExits, { parseExitString, toShort } from '../src/scripts/shortExits';
 import Triggers from '../src/Triggers';
+import { colorString, findClosestColor } from '../src/Colors';
+
+const ORANGE = findClosestColor('#ffa500');
 
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
@@ -30,12 +33,20 @@ describe('short exits trigger', () => {
     expect(toShort('polnoc')).toBe('n');
     expect(toShort('south')).toBe('s');
     expect(toShort('north')).toBe('n');
-    expect(toShort('unknown')).toBe('');
+    expect(toShort('unknown')).toBe('unknown');
   });
 
   test('replaces exit line', () => {
     const result = parse('Sa tutaj dwa widoczne wyjscia: polnoc i wschod.');
     expect(result).toBe('~SKIP~');
-    expect(client.println).toHaveBeenCalledWith('\n-----: N E\n');
+    expect(client.println).toHaveBeenCalledWith(colorString('\n-----: N E\n', ORANGE));
+    expect(client.println.mock.calls[0][0]).toContain(`\x1B[22;38;5;${ORANGE}m`);
+  });
+
+  test('includes unknown directions in output', () => {
+    const result = parse('Sa tutaj dwa widoczne wyjscia: polnoc i foo.');
+    expect(result).toBe('~SKIP~');
+    expect(client.println).toHaveBeenCalledWith(colorString('\n-----: N FOO\n', ORANGE));
+    expect(client.println.mock.calls[0][0]).toContain(`\x1B[22;38;5;${ORANGE}m`);
   });
 });

--- a/client/test/shortExits.test.ts
+++ b/client/test/shortExits.test.ts
@@ -1,0 +1,41 @@
+import initShortExits, { parseExitString, toShort } from '../src/scripts/shortExits';
+import Triggers from '../src/Triggers';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+  println = jest.fn();
+  addEventListener = jest.fn();
+}
+
+describe('short exits trigger', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initShortExits(client as unknown as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    const handler = client.addEventListener.mock.calls[0]?.[1];
+    if (handler) {
+      handler({ detail: { shortenExits: true } } as any);
+    }
+    jest.clearAllMocks();
+  });
+
+  test('parseExitString splits directions', () => {
+    expect(parseExitString('polnoc, poludnie i wschod')).toEqual(['polnoc', 'poludnie', 'wschod']);
+  });
+
+  test('toShort converts directions', () => {
+    expect(toShort('polnoc')).toBe('n');
+    expect(toShort('south')).toBe('s');
+    expect(toShort('north')).toBe('n');
+    expect(toShort('unknown')).toBe('');
+  });
+
+  test('replaces exit line', () => {
+    const result = parse('Sa tutaj dwa widoczne wyjscia: polnoc i wschod.');
+    expect(result).toBe('~SKIP~');
+    expect(client.println).toHaveBeenCalledWith('\n-----: N E\n');
+  });
+});

--- a/extension/background.js
+++ b/extension/background.js
@@ -9,6 +9,7 @@ const defaultSettings = {
     mapWidth: null,
     mapHeight: null,
     xtermPalette: 'arkadia',
+    shortenExits: false,
     binds: {
         main: { key: 'BracketRight' },
         lamp: { key: 'Digit4', ctrl: true },
@@ -101,6 +102,7 @@ function loadIframe(tabId) {
                 mapWidth: null,
                 mapHeight: null,
                 xtermPalette: 'arkadia',
+                shortenExits: false,
                 binds: {
                     main: { key: 'BracketRight' },
                     lamp: { key: 'Digit4', ctrl: true },

--- a/options/src/Settings.tsx
+++ b/options/src/Settings.tsx
@@ -19,6 +19,7 @@ interface Settings {
     packageHelper: boolean;
     replaceMap: boolean;
     inlineCompassRose: boolean;
+    shortenExits: boolean;
     prettyContainers: boolean;
     containerColumns: number;
     collectMode: number;
@@ -33,6 +34,7 @@ function SettingsForm() {
         packageHelper: false,
         replaceMap: false,
         inlineCompassRose: false,
+        shortenExits: false,
         prettyContainers: true,
         containerColumns: 2,
         collectMode: 3,
@@ -90,6 +92,14 @@ function SettingsForm() {
                         label="Róża wiatrów"
                         checked={settings.inlineCompassRose}
                         onChange={e => onChangeSetting(s => s.inlineCompassRose = e.target.checked)}
+                        className="me-2"
+                    />
+                    <Form.Check
+                        type="checkbox"
+                        id="shortenExits"
+                        label="Skrócone wyjścia"
+                        checked={settings.shortenExits}
+                        onChange={e => onChangeSetting(s => s.shortenExits = e.target.checked)}
                         className="me-2"
                     />
                     <Form.Group className="d-flex align-items-center">

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -13,6 +13,7 @@ const defaultSettings = {
     guilds: [],
     packageHelper: true,
     inlineCompassRose: true,
+    shortenExits: false,
     emojiLabels: false,
     prettyContainers: true,
     containerColumns: 2,


### PR DESCRIPTION
## Summary
- display short form exits when enabled
- wire up ShortExits script in client
- test short exit parsing and rendering
- add shorten exits setting

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_687d4d8f7e1c832a8e26a62f9ec1fdbf