### PR TITLE
Add shortExits support

### DIFF
--- a/client/src/scripts/shortExits.ts
+++ b/client/src/scripts/shortExits.ts
@@ -1,0 +1,64 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+export const ORANGE = findClosestColor('#ffa500');
+
+const shortToLong: Record<string, string> = {
+    n: "north",
+    s: "south",
+    e: "east",
+    w: "west",
+    ne: "northeast",
+    nw: "northwest",
+    se: "southeast",
+    sw: "southwest",
+    u: "up",
+    d: "down",
+};
+
+const polishToShort: Record<string, string> = {
+    polnoc: "n",
+    poludnie: "s",
+    wschod: "e",
+    zachod: "w",
+    "polnocny-wschod": "ne",
+    "polnocny-zachod": "nw",
+    "poludniowy-wschod": "se",
+    "poludniowy-zachod": "sw",
+    dol: "d",
+    gora: "u",
+    gore: "u",
+};
+
+export function toShort(exit: string): string {
+    if (polishToShort[exit]) return polishToShort[exit];
+    if (shortToLong[exit]) return exit;
+    const long = exit.toLowerCase();
+    const short = Object.entries(shortToLong).find(([_, l]) => l === long);
+    if (short) return short[0];
+    return exit;
+}
+
+function parseExits(detail: any): string[] {
+    let list: string[] = [];
+    if (!detail) return list;
+    if (Array.isArray(detail)) {
+        list = detail;
+    } else if (Array.isArray(detail.exits)) {
+        list = detail.exits;
+    } else if (detail.exits && typeof detail.exits === "object") {
+        list = Object.keys(detail.exits);
+    } else if (detail.room && detail.room.exits) {
+        const e = detail.room.exits;
+        list = Array.isArray(e) ? e : Object.keys(e);
+    }
+    return list.map(toShort);
+}
+
+export default function initShortExits(client: Client) {
+    client.addEventListener("gmcp_msg.room.exits", (event: CustomEvent) => {
+        const exits = parseExits(event.detail).join(" ");
+        const str = colorString(exits, ORANGE);
+        client.println(str);
+    });
+}

--- a/client/test/shortExits.test.ts
+++ b/client/test/shortExits.test.ts
@@ -1,0 +1,28 @@
+import initShortExits, { toShort, ORANGE } from '../src/scripts/shortExits';
+
+class FakeClient {
+  eventTarget = new EventTarget();
+  println = jest.fn();
+  addEventListener(event: string, cb: any) {
+    this.eventTarget.addEventListener(event, cb);
+    return () => this.eventTarget.removeEventListener(event, cb);
+  }
+}
+
+describe('short exits', () => {
+  test('toShort returns input for unknown direction', () => {
+    expect(toShort('unknown')).toBe('unknown');
+  });
+
+  test('prints exits with unknown direction', () => {
+    const client = new FakeClient();
+    initShortExits(client as unknown as any);
+    const detail = { exits: ['north', 'mystery'] };
+    client.eventTarget.dispatchEvent(new CustomEvent('gmcp_msg.room.exits', { detail }));
+    expect(client.println).toHaveBeenCalledTimes(1);
+    const printed = (client.println as jest.Mock).mock.calls[0][0];
+    const prefix = `\x1B[22;38;5;${ORANGE}m`;
+    const suffix = '\x1B[0m';
+    expect(printed).toBe(prefix + 'n mystery' + suffix);
+  });
+});


### PR DESCRIPTION
## Summary
- add new `shortExits` script printing room exits in orange
- handle unknown directions without filtering
- test shortExits helper and callback output

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687d578b0de4832a989c41c62312bb8b