### PR TITLE
Add idz list button macro

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -276,7 +276,6 @@
                         <div class="mobile-attack-buttons">
                             <button class="mobile-button mobile-button-text top-button" data-button-id="z-list-toggle">/z</button>
                             <button class="mobile-button mobile-button-text top-button" data-button-id="zas-list-toggle">/zas</button>
-                            <button class="mobile-button mobile-button-text top-button" data-button-id="idz-list-toggle">/idz</button>
                             <button class="mobile-button mobile-button-text top-button" data-button-id="go-button">/go</button>
                             <button class="mobile-button mobile-button-text top-button" data-button-id="buttons-toggle">⇩</button>
                         </div>
@@ -346,45 +345,6 @@
                         </label>
                     </div>
                     <div class="mobile-button-config d-none" data-button-id="zas-list-toggle">
-                        <label class="form-label">Makro
-                            <select class="form-select form-select-sm mobile-button-macro">
-                                <option value="functional">Send functional</option>
-                                <option value="zList">Create /z dropdown list</option>
-                                <option value="zaList">Create /za dropdown list</option>
-                                <option value="idzList">Create /idz dropdown list</option>
-                                <option value="command">Send command</option>
-                                <option value="kierunek">Direction button</option>
-                                <option value="specialExit">Use special exit</option>
-                            </select>
-                        </label>
-                        <label class="form-label">Etykieta
-                            <input type="text" class="form-control form-control-sm mobile-button-label" />
-                        </label>
-                        <label class="form-label d-flex align-items-center gap-1">Kolor
-                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
-                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
-                        </label>
-                        <label class="form-label mobile-button-direction-label">
-                            Kierunek
-                            <select class="form-select form-select-sm mobile-button-direction">
-                                <option value="nw">↖ nw</option>
-                                <option value="n">↑ n</option>
-                                <option value="ne">↗ ne</option>
-                                <option value="w">← w</option>
-                                <option value="e">→ e</option>
-                                <option value="sw">↙ sw</option>
-                                <option value="s">↓ s</option>
-                                <option value="se">↘ se</option>
-                                <option value="u">u</option>
-                                <option value="d">d</option>
-                            </select>
-                        </label>
-                        <label class="form-label mobile-button-command-label">
-                            Komenda
-                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
-                        </label>
-                    </div>
-                    <div class="mobile-button-config d-none" data-button-id="idz-list-toggle">
                         <label class="form-label">Makro
                             <select class="form-select form-select-sm mobile-button-macro">
                                 <option value="functional">Send functional</option>
@@ -1106,7 +1066,6 @@
         <div class="mobile-attack-buttons">
             <button class="mobile-button mobile-button-text top-button" id="z-list-toggle">/z</button>
             <button class="mobile-button mobile-button-text top-button" id="zas-list-toggle">/zas</button>
-            <button class="mobile-button mobile-button-text top-button" id="idz-list-toggle">/idz</button>
             <button class="mobile-button mobile-button-text top-button" id="go-button">/go</button>
             <button class="mobile-button mobile-button-text top-button" id="buttons-toggle">⇩</button>
         </div>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -276,6 +276,7 @@
                         <div class="mobile-attack-buttons">
                             <button class="mobile-button mobile-button-text top-button" data-button-id="z-list-toggle">/z</button>
                             <button class="mobile-button mobile-button-text top-button" data-button-id="zas-list-toggle">/zas</button>
+                            <button class="mobile-button mobile-button-text top-button" data-button-id="idz-list-toggle">/idz</button>
                             <button class="mobile-button mobile-button-text top-button" data-button-id="go-button">/go</button>
                             <button class="mobile-button mobile-button-text top-button" data-button-id="buttons-toggle">⇩</button>
                         </div>
@@ -311,6 +312,7 @@
                                     <option value="functional">Send functional</option>
                                     <option value="zList">Create /z dropdown list</option>
                                     <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                     <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                     <option value="specialExit">Use special exit</option>
@@ -349,6 +351,46 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
+                                <option value="command">Send command</option>
+                                <option value="kierunek">Direction button</option>
+                                <option value="specialExit">Use special exit</option>
+                            </select>
+                        </label>
+                        <label class="form-label">Etykieta
+                            <input type="text" class="form-control form-control-sm mobile-button-label" />
+                        </label>
+                        <label class="form-label d-flex align-items-center gap-1">Kolor
+                            <input type="color" class="form-control form-control-color form-control-sm mobile-button-color flex-grow-1" />
+                            <button type="button" class="btn btn-sm btn-secondary mobile-button-color-reset">↺</button>
+                        </label>
+                        <label class="form-label mobile-button-direction-label">
+                            Kierunek
+                            <select class="form-select form-select-sm mobile-button-direction">
+                                <option value="nw">↖ nw</option>
+                                <option value="n">↑ n</option>
+                                <option value="ne">↗ ne</option>
+                                <option value="w">← w</option>
+                                <option value="e">→ e</option>
+                                <option value="sw">↙ sw</option>
+                                <option value="s">↓ s</option>
+                                <option value="se">↘ se</option>
+                                <option value="u">u</option>
+                                <option value="d">d</option>
+                            </select>
+                        </label>
+                        <label class="form-label mobile-button-command-label">
+                            Komenda
+                            <textarea class="form-control form-control-sm mobile-button-command"></textarea>
+                        </label>
+                    </div>
+                    <div class="mobile-button-config d-none" data-button-id="idz-list-toggle">
+                        <label class="form-label">Makro
+                            <select class="form-select form-select-sm mobile-button-macro">
+                                <option value="functional">Send functional</option>
+                                <option value="zList">Create /z dropdown list</option>
+                                <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
@@ -387,6 +429,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                             </select>
@@ -424,6 +467,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                             </select>
@@ -461,6 +505,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                             </select>
@@ -498,6 +543,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                             </select>
@@ -535,6 +581,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
@@ -573,6 +620,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
@@ -611,6 +659,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
@@ -649,6 +698,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
@@ -687,6 +737,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
@@ -725,6 +776,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
@@ -763,6 +815,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
@@ -801,6 +854,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
@@ -839,6 +893,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
@@ -877,6 +932,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
@@ -915,6 +971,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
@@ -953,6 +1010,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
@@ -991,6 +1049,7 @@
                                 <option value="functional">Send functional</option>
                                 <option value="zList">Create /z dropdown list</option>
                                 <option value="zaList">Create /za dropdown list</option>
+                                <option value="idzList">Create /idz dropdown list</option>
                                 <option value="command">Send command</option>
                                 <option value="kierunek">Direction button</option>
                                 <option value="specialExit">Use special exit</option>
@@ -1047,6 +1106,7 @@
         <div class="mobile-attack-buttons">
             <button class="mobile-button mobile-button-text top-button" id="z-list-toggle">/z</button>
             <button class="mobile-button mobile-button-text top-button" id="zas-list-toggle">/zas</button>
+            <button class="mobile-button mobile-button-text top-button" id="idz-list-toggle">/idz</button>
             <button class="mobile-button mobile-button-text top-button" id="go-button">/go</button>
             <button class="mobile-button mobile-button-text top-button" id="buttons-toggle">⇩</button>
         </div>
@@ -1076,6 +1136,7 @@
         </div>
         <div id="z-buttons-list" class="mobile-z-buttons"></div>
         <div id="zas-buttons-list" class="mobile-z-buttons"></div>
+        <div id="idz-buttons-list" class="mobile-z-buttons"></div>
     </div>
 </div>
 <script type="module" src="/src/plugin.ts"></script>

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -13,7 +13,6 @@ export interface ButtonSetting {
 const defaultSettings: Record<string, ButtonSetting> = {
     'z-list-toggle': { macro: 'zList', label: '/z', color: '#87CEEB' },
     'zas-list-toggle': { macro: 'zaList', label: '/zas', color: '#87CEEB' },
-    'idz-list-toggle': { macro: 'idzList', label: '/idz', color: '#87CEEB' },
     'go-button': { macro: 'command', label: '/go', color: '#87CEEB', command: '/go' },
     'bracket-right-button': { macro: 'functional', label: ']', color: '#87CEEB' },
     'button-1': { macro: 'command', label: 'wesprzyj', color: '#87CEEB', command: 'wesprzyj' },

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -1,6 +1,6 @@
 import Modal from "bootstrap/js/dist/modal";
 
-export type MacroType = 'functional' | 'zList' | 'zaList' | 'command' | 'specialExit' | 'kierunek';
+export type MacroType = 'functional' | 'zList' | 'zaList' | 'idzList' | 'command' | 'specialExit' | 'kierunek';
 
 export interface ButtonSetting {
     macro: MacroType;
@@ -13,6 +13,7 @@ export interface ButtonSetting {
 const defaultSettings: Record<string, ButtonSetting> = {
     'z-list-toggle': { macro: 'zList', label: '/z', color: '#87CEEB' },
     'zas-list-toggle': { macro: 'zaList', label: '/zas', color: '#87CEEB' },
+    'idz-list-toggle': { macro: 'idzList', label: '/idz', color: '#87CEEB' },
     'go-button': { macro: 'command', label: '/go', color: '#87CEEB', command: '/go' },
     'bracket-right-button': { macro: 'functional', label: ']', color: '#87CEEB' },
     'button-1': { macro: 'command', label: 'wesprzyj', color: '#87CEEB', command: 'wesprzyj' },

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -9,8 +9,10 @@ export default class MobileDirectionButtons {
     private readonly contentArea: HTMLElement | null = null;
     private readonly zList: HTMLDivElement | null = null;
     private readonly zasList: HTMLDivElement | null = null;
+    private readonly idzList: HTMLDivElement | null = null;
     private readonly zToggle: HTMLButtonElement | null = null;
     private readonly zasToggle: HTMLButtonElement | null = null;
+    private readonly idzToggle: HTMLButtonElement | null = null;
     private bracketRightButton: HTMLButtonElement | null = null;
     private readonly toggleButton: HTMLButtonElement | null = null;
     private boundKey = 'BracketRight';
@@ -74,8 +76,10 @@ export default class MobileDirectionButtons {
         this.contentArea = document.getElementById('main_text_output_msg_wrapper');
         this.zList = document.getElementById('z-buttons-list') as HTMLDivElement;
         this.zasList = document.getElementById('zas-buttons-list') as HTMLDivElement;
+        this.idzList = document.getElementById('idz-buttons-list') as HTMLDivElement;
         this.zToggle = document.getElementById('z-list-toggle') as HTMLButtonElement;
         this.zasToggle = document.getElementById('zas-list-toggle') as HTMLButtonElement;
+        this.idzToggle = document.getElementById('idz-list-toggle') as HTMLButtonElement;
         this.bracketRightButton = document.getElementById('bracket-right-button') as HTMLButtonElement;
         this.toggleButton = document.getElementById('buttons-toggle') as HTMLButtonElement;
 
@@ -393,6 +397,7 @@ export default class MobileDirectionButtons {
     private hideLists() {
         if (this.zList) this.zList.style.display = 'none';
         if (this.zasList) this.zasList.style.display = 'none';
+        if (this.idzList) this.idzList.style.display = 'none';
     }
 
     private applyButtonSize(btn: HTMLButtonElement) {
@@ -474,6 +479,29 @@ export default class MobileDirectionButtons {
         this.renderList(this.zasList, /^[A-Z]$/, 'zas');
     }
 
+    private renderIdzList() {
+        if (!this.idzList) return;
+        this.idzList.innerHTML = '';
+        const commands = [
+            'idz niespiesznie',
+            'idz marszem',
+            'idz truchtem',
+            'idz biegiem',
+            'idz szybkim biegiem',
+        ];
+        commands.forEach(cmd => {
+            const b = document.createElement('button');
+            b.className = 'mobile-button';
+            this.applyButtonSize(b);
+            b.textContent = cmd.replace('idz ', '');
+            b.addEventListener('click', () => {
+                this.client.sendCommand(cmd);
+                this.hideLists();
+            });
+            this.idzList!.appendChild(b);
+        });
+    }
+
     private applyConfigToButton(id: string, btn: HTMLButtonElement) {
         const cfg = this.buttonSettings[id];
         if (!cfg) return;
@@ -527,6 +555,15 @@ export default class MobileDirectionButtons {
                         this.hideLists();
                         this.renderZasList();
                         if (this.zasList) this.zasList.style.display = 'grid';
+                    }
+                    break;
+                case 'idzList':
+                    if (this.idzList && this.idzList.style.display === 'grid') {
+                        this.hideLists();
+                    } else {
+                        this.hideLists();
+                        this.renderIdzList();
+                        if (this.idzList) this.idzList.style.display = 'grid';
                     }
                     break;
                 case 'command':

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -12,7 +12,6 @@ export default class MobileDirectionButtons {
     private readonly idzList: HTMLDivElement | null = null;
     private readonly zToggle: HTMLButtonElement | null = null;
     private readonly zasToggle: HTMLButtonElement | null = null;
-    private readonly idzToggle: HTMLButtonElement | null = null;
     private bracketRightButton: HTMLButtonElement | null = null;
     private readonly toggleButton: HTMLButtonElement | null = null;
     private boundKey = 'BracketRight';
@@ -79,7 +78,6 @@ export default class MobileDirectionButtons {
         this.idzList = document.getElementById('idz-buttons-list') as HTMLDivElement;
         this.zToggle = document.getElementById('z-list-toggle') as HTMLButtonElement;
         this.zasToggle = document.getElementById('zas-list-toggle') as HTMLButtonElement;
-        this.idzToggle = document.getElementById('idz-list-toggle') as HTMLButtonElement;
         this.bracketRightButton = document.getElementById('bracket-right-button') as HTMLButtonElement;
         this.toggleButton = document.getElementById('buttons-toggle') as HTMLButtonElement;
 

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -472,7 +472,8 @@ button:focus-visible {
 .mobile-direction-buttons.collapsed .mobile-top-buttons,
 .mobile-direction-buttons.collapsed .mobile-direction-main,
 .mobile-direction-buttons.collapsed #z-buttons-list,
-.mobile-direction-buttons.collapsed #zas-buttons-list {
+.mobile-direction-buttons.collapsed #zas-buttons-list,
+.mobile-direction-buttons.collapsed #idz-buttons-list {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- extend mobile button settings with new `idzList` macro
- add `/idz` button in the mobile UI and configuration dialog
- generate list of "idz" movement speed commands
- show/hide the new list with other dropdown lists

## Testing
- `yarn --cwd client test` *(fails: shortExits.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_687d6709b0dc832a8ccd97d3fcf5a0a3