### PR TITLE
Fix dir_bind commands split after parse

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -165,6 +165,11 @@ export default class Client {
         }
 
         command = this.Map.parseCommand(command)
+        const postParseSplit = command.split(/[#;]/)
+        if (postParseSplit.length > 1) {
+            postParseSplit.forEach(part => this.sendCommand(part, echo))
+            return
+        }
         const isAlias = this.aliases.find(alias => {
             const matches = command.match(alias.pattern)
             if (matches) {

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -120,6 +120,15 @@ test('sendCommand allows empty command', () => {
   expect((global as any).clientAdapterMock.send).toHaveBeenCalledWith('parsed:', true);
 });
 
+test('sendCommand splits commands returned by parseCommand', () => {
+  parseCommand.mockImplementationOnce(() => 'foo;bar');
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  client.sendCommand('e');
+  expect(parseCommand).toHaveBeenCalledWith('e');
+  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(1, 'parsed:foo', true);
+  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'parsed:bar', true);
+});
+
 test('onLine sends printed messages after line and restores Output.send', () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   const originalOutputSend = (window as any).Output.send;


### PR DESCRIPTION
## Summary
- split commands returned from MapHelper.parseCommand
- cover new split logic with a test

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687d847ab7c4832abce595483d62ef6a