### PR TITLE
Fix trigger modal input on mobile

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -602,6 +602,13 @@ button:focus-visible {
   max-height: 85%;
 }
 
+.modal input,
+.modal textarea,
+.modal select {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
 #auth-panel {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- allow text selection inside modals so inputs work on mobile

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687d86377f68832a81d3a6f9b6f94f61