### PR TITLE
Add stone value calculator alias

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -32,6 +32,7 @@ import registerGagTriggers from './scripts/gags'
 import initLeaderAttackWarning from './scripts/leaderAttackWarning'
 import initBreakItem from './scripts/breakItem'
 import initPriceEvaluation from './scripts/priceEvaluation'
+import initStoneValue from './scripts/stoneValue'
 import initCoinColors from './scripts/coinColors'
 import initExternalScripts from './scripts/externalScripts'
 import initUserAliases from './scripts/userAliases'
@@ -132,6 +133,7 @@ export function registerScripts(client: Client) {
     initMagicKeys(client)
     initMagics(client)
     initPriceEvaluation(client)
+    initStoneValue(client, aliases)
     initCoinColors(client)
     initLeaderAttackWarning(client)
     initBreakItem(client)

--- a/client/src/scripts/stoneValue.ts
+++ b/client/src/scripts/stoneValue.ts
@@ -1,0 +1,33 @@
+import Client from "../Client";
+import { convertCurrency, processItemValue } from "./priceEvaluation";
+
+export default function initStoneValue(
+    client: Client,
+    aliases?: { pattern: RegExp; callback: Function }[]
+) {
+    const tag = "stone-value";
+    const pattern = /^Wydaje ci sie, ze (jest|sa) wart[aye]? okolo (([0-9]+) mied[a-z]+\.)$/;
+
+    let sum = 0;
+
+    function run() {
+        sum = 0;
+        client.Triggers.registerTrigger(pattern, (raw, _line, m) => {
+            const amount = parseInt(m[3], 10);
+            sum += amount;
+            return processItemValue(raw, amount);
+        }, tag);
+        client.sendCommand("ocen kamienie");
+        setTimeout(() => {
+            client.Triggers.removeByTag(tag);
+            if (sum > 0) {
+                client.print(`Laczna wartosc kamieni: ${convertCurrency(sum)}`);
+            }
+        }, 700);
+    }
+
+    if (aliases) {
+        aliases.push({ pattern: /^\/ocenkamienie$/, callback: run });
+    }
+}
+


### PR DESCRIPTION
## Summary
- add stone value calculator script
- call new alias in `main.ts`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687e020a8b80832aa699a575062d3f46