### PR TITLE
Add map shortcuts

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -77,6 +77,10 @@ export default class Client {
         Object.values(this.sounds).forEach((sound) => sound.load())
 
         window.addEventListener('keydown', (ev) => {
+            const target = ev.target as HTMLElement | null
+            if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+                return
+            }
             if (
                 (ev.code === this.lampBind.key || ev.key === this.lampBind.key) &&
                 !!this.lampBind.ctrl === ev.ctrlKey &&

--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -48,6 +48,7 @@ export default class Client {
         }),
     };
     aliases: { pattern: RegExp; callback: Function }[] = [];
+    shortcuts: Record<string, number> = {};
     lampBind = {key: "Digit4", ctrl: true} as {
         key: string;
         ctrl?: boolean;
@@ -124,6 +125,16 @@ export default class Client {
                 this.eventTarget.dispatchEvent(new CustomEvent(key, {detail: value}))
             })
         })
+        if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
+            chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+                if (msg?.type === 'LEAD_TO') {
+                    this.sendEvent('leadTo', msg.loc)
+                }
+                if (msg?.type === 'GET_LOCATION') {
+                    sendResponse({ loc: this.Map.currentRoom?.id })
+                }
+            })
+        }
     }
 
     connect(port: any, initial: boolean) {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -42,6 +42,7 @@ import initArmorEvaluation from './scripts/armorEvaluation'
 import initShortExits from './scripts/shortExits'
 import initGps from './scripts/gps'
 import initMapAliases from './scripts/mapAliases'
+import initShortcuts from './scripts/shortcuts'
 import initCompareAll from './scripts/compareAll'
 import initFollowSpecialExits from './scripts/followSpecialExits'
 import Client from "./Client";
@@ -58,6 +59,7 @@ export function registerScripts(client: Client) {
             return Output.send(Text.parse_patterns(client.onLine(matches[1])))
         }
     })
+    initShortcuts(client, aliases)
     initMapAliases(client, aliases)
 
     blockers.forEach(blocker => {

--- a/client/src/scripts/functionalBind.ts
+++ b/client/src/scripts/functionalBind.ts
@@ -52,6 +52,10 @@ export class FunctionalBind {
         this.alt = !!options.alt;
         this.shift = !!options.shift;
         window.addEventListener('keydown', (ev) => {
+            const target = ev.target as HTMLElement | null;
+            if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+                return;
+            }
             if (
                 (ev.code === this.key || ev.key === this.key) &&
                 (!!this.ctrl === ev.ctrlKey) &&

--- a/client/src/scripts/shortcuts.ts
+++ b/client/src/scripts/shortcuts.ts
@@ -1,0 +1,50 @@
+import Client from "../Client";
+
+export interface Shortcut {
+    name: string;
+    loc: number;
+}
+
+const STORAGE_KEY = "shortcuts";
+
+export default function initShortcuts(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
+    const list = aliases || client.aliases;
+    let shortcuts: Record<string, number> = {};
+
+    const apply = (arr: Shortcut[] = []) => {
+        shortcuts = {};
+        arr.forEach(s => {
+            if (s && s.name && typeof s.loc === 'number') {
+                shortcuts[s.name.toLowerCase()] = s.loc;
+            }
+        });
+    };
+
+    client.addEventListener('storage', (ev: CustomEvent) => {
+        if (ev.detail.key === STORAGE_KEY) {
+            apply(Array.isArray(ev.detail.value) ? ev.detail.value : []);
+        }
+    });
+
+    client.addEventListener('port-connected', () => {
+        client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
+    });
+
+    client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
+
+    list.push({
+        pattern: /\/prowadz (.+)$/,
+        callback: (m: RegExpMatchArray) => {
+            const arg = m[1].trim();
+            const loc = shortcuts[arg.toLowerCase()];
+            const num = parseInt(arg);
+            if (loc) {
+                client.sendEvent('leadTo', loc);
+            } else if (!isNaN(num)) {
+                client.sendEvent('leadTo', num);
+            } else {
+                client.sendEvent('leadTo', arg);
+            }
+        }
+    });
+}

--- a/options/src/App.tsx
+++ b/options/src/App.tsx
@@ -8,10 +8,11 @@ import SettingsFile from "./SettingsFile";
 import Binds from "./Binds";
 import Scripts from "./Scripts";
 import Recordings from "./Recordings";
+import Shortcuts from "./Shortcuts";
 
 
 function App() {
-    const [tab, setTab] = useState<'settings' | 'guilds' | 'npc' | 'file' | 'binds' | 'scripts' | 'recordings'>('settings')
+    const [tab, setTab] = useState<'settings' | 'guilds' | 'npc' | 'file' | 'binds' | 'scripts' | 'recordings' | 'shortcuts'>('settings')
 
     return (
         <div className="p-2 d-flex flex-column h-100">
@@ -36,6 +37,9 @@ function App() {
                 </Tab>
                 <Tab eventKey="recordings" title="Nagrania">
                     <Recordings />
+                </Tab>
+                <Tab eventKey="shortcuts" title="Skróty">
+                    <Shortcuts />
                 </Tab>
             </Tabs>
         </div>

--- a/options/src/Shortcuts.tsx
+++ b/options/src/Shortcuts.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState, ChangeEvent } from 'react';
+import { Button, Form, Modal, Table } from 'react-bootstrap';
+import { TiDelete } from 'react-icons/ti';
+import storage from './storage';
+
+interface Shortcut {
+    name: string;
+    loc: number;
+}
+
+function Shortcuts() {
+    const [shortcuts, setShortcuts] = useState<Shortcut[]>([]);
+    const [name, setName] = useState('');
+    const [loc, setLoc] = useState('');
+    const [show, setShow] = useState(false);
+
+    useEffect(() => {
+        storage.getItem('shortcuts').then(res => {
+            const list = Array.isArray(res.shortcuts) ? res.shortcuts : [];
+            setShortcuts(list);
+        });
+    }, []);
+
+    function save(list: Shortcut[]) {
+        setShortcuts(list);
+        storage.setItem('shortcuts', list);
+    }
+
+    function add() {
+        const n = name.trim();
+        const id = parseInt(loc);
+        if (!n || isNaN(id)) return;
+        const updated = shortcuts.filter(s => s.name !== n);
+        updated.push({ name: n, loc: id });
+        save(updated);
+        setShow(false);
+    }
+
+    function remove(s: Shortcut) {
+        const updated = shortcuts.filter(x => !(x.name === s.name && x.loc === s.loc));
+        save(updated);
+    }
+
+    function leadTo(s: Shortcut) {
+        if (window.client) {
+            window.client.sendEvent('leadTo', s.loc);
+        } else {
+            chrome.tabs?.query({ active: true, currentWindow: true }, tabs => {
+                if (tabs[0]?.id) {
+                    chrome.tabs.sendMessage(tabs[0].id!, { type: 'LEAD_TO', loc: s.loc });
+                }
+            });
+        }
+    }
+
+    function fillCurrent() {
+        if (window.client) {
+            const id = window.client.Map.currentRoom?.id;
+            if (id) setLoc(String(id));
+        } else {
+            chrome.tabs?.query({ active: true, currentWindow: true }, tabs => {
+                if (tabs[0]?.id) {
+                    chrome.tabs.sendMessage(tabs[0].id!, { type: 'GET_LOCATION' }, res => {
+                        if (res?.loc) setLoc(String(res.loc));
+                    });
+                }
+            });
+        }
+    }
+
+    return (
+        <div className="m-2">
+            <div className="mb-2">
+                <Button size="sm" onClick={() => { setName(''); setLoc(''); setShow(true); }}>Dodaj skrót</Button>
+            </div>
+            <Table bordered size="sm" className="table-zebra">
+                <tbody>
+                {shortcuts.map(s => (
+                    <tr key={s.name}>
+                        <td>{s.name}</td>
+                        <td>{s.loc}</td>
+                        <td className="d-flex gap-2">
+                            <Button size="sm" onClick={() => leadTo(s)}>Prowadź</Button>
+                            <Button size="sm" variant="danger" onClick={() => remove(s)}><TiDelete /></Button>
+                        </td>
+                    </tr>
+                ))}
+                </tbody>
+            </Table>
+            <Modal show={show} onHide={() => setShow(false)}>
+                <Modal.Header closeButton>
+                    <Modal.Title>Dodaj skrót</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <Form.Group className="d-flex flex-column gap-2">
+                        <Form.Control
+                            type="text"
+                            size="sm"
+                            placeholder="Nazwa"
+                            value={name}
+                            onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+                        />
+                        <div className="d-flex gap-2">
+                            <Form.Control
+                                type="number"
+                                size="sm"
+                                placeholder="Lokacja"
+                                value={loc}
+                                onChange={(e: ChangeEvent<HTMLInputElement>) => setLoc(e.target.value)}
+                            />
+                            <Button size="sm" variant="secondary" onClick={fillCurrent}>Bieżąca</Button>
+                        </div>
+                    </Form.Group>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button size="sm" variant="secondary" onClick={() => setShow(false)}>Anuluj</Button>
+                    <Button size="sm" onClick={add}>Dodaj</Button>
+                </Modal.Footer>
+            </Modal>
+        </div>
+    );
+}
+
+export default Shortcuts;

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -152,6 +152,19 @@
             </div>
         </div>
     </div>
+    <div id="shortcuts-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Skróty</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="shortcuts-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
     <div id="input-area">
         <div id="history-buttons">
             <button id="history-up-button" aria-label="Previous command">▲</button>
@@ -191,6 +204,9 @@
                 </li>
                 <li>
                     <button class="w-100 p-1" id="recordings-button">Nagrania</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="shortcuts-button">Skróty</button>
                 </li>
                 <li>
                     <button class="w-100 p-1" id="docs-button">Dokumentacja</button>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -354,6 +354,10 @@ function applyDirectionBinds(dirs: any) {
 
 // Add global keydown event listener for numpad directions
 document.addEventListener('keydown', (e) => {
+    const target = e.target as HTMLElement | null;
+    if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+        return;
+    }
     const direction = numpadDirections[e.code];
     if (direction) {
         e.preventDefault();

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -25,6 +25,7 @@ import Aliases from "@options/src/Aliases.tsx"
 import Recordings from "@options/src/Recordings.tsx"
 import Guilds from "@options/src/Guilds.tsx"
 import UserTriggers from "@options/src/UserTriggers.tsx"
+import Shortcuts from "@options/src/Shortcuts.tsx"
 
 const client = new Client(arkadiaClient, new MockPort())
 window.clientExtension = client;
@@ -390,6 +391,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const aliasesButton = document.getElementById('aliases-button') as HTMLButtonElement | null;
     const triggersButton = document.getElementById('triggers-button') as HTMLButtonElement | null;
     const recordingsButton = document.getElementById('recordings-button') as HTMLButtonElement | null;
+    const shortcutsButton = document.getElementById('shortcuts-button') as HTMLButtonElement | null;
     const recordingButton = document.getElementById('recording-button') as HTMLButtonElement | null;
     const playbackControls = document.getElementById('playback-controls') as HTMLElement | null;
     const playbackPause = document.getElementById('playback-pause') as HTMLButtonElement | null;
@@ -418,6 +420,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const triggersModal = triggersModalElement ? new Modal(triggersModalElement) : null;
     const recordingsModalElement = document.getElementById('recordings-modal');
     const recordingsModal = recordingsModalElement ? new Modal(recordingsModalElement) : null;
+    const shortcutsModalElement = document.getElementById('shortcuts-modal');
+    const shortcutsModal = shortcutsModalElement ? new Modal(shortcutsModalElement) : null;
     const loginCharacter = document.getElementById('login-character') as HTMLInputElement | null;
     const loginPassword = document.getElementById('login-password') as HTMLInputElement | null;
     const loginForm = document.getElementById('login-form') as HTMLFormElement | null;
@@ -451,6 +455,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (recordingsModal) {
             recordingsModal.hide();
+        }
+        if (shortcutsModal) {
+            shortcutsModal.hide();
         }
     });
 
@@ -500,6 +507,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (recordingsButton && recordingsModal) {
         recordingsButton.addEventListener('click', () => {
             recordingsModal.show();
+        });
+    }
+
+    if (shortcutsButton && shortcutsModal) {
+        shortcutsButton.addEventListener('click', () => {
+            shortcutsModal.show();
         });
     }
 
@@ -799,6 +812,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const recordingsRoot = document.getElementById('recordings-options');
     if (recordingsRoot) {
         createRoot(recordingsRoot).render(createElement(Recordings));
+    }
+
+    const shortcutsRoot = document.getElementById('shortcuts-options');
+    if (shortcutsRoot) {
+        createRoot(shortcutsRoot).render(createElement(Shortcuts));
     }
 });
 

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -39,6 +39,10 @@ body {
     -webkit-user-select: none;
     user-select: none;
   }
+  body.modal-open {
+    -webkit-user-select: text;
+    user-select: text;
+  }
 }
 
 h1 {
@@ -603,9 +607,8 @@ button:focus-visible {
   max-height: 85%;
 }
 
-.modal input,
-.modal textarea,
-.modal select {
+.modal,
+.modal * {
   -webkit-user-select: text;
   user-select: text;
 }


### PR DESCRIPTION
## Summary
- allow storing map shortcuts
- hook them into `/prowadz` alias and client
- add a new "Skróty" tab in options UI
- include a popup for shortcut creation with current location button
- expose shortcuts in the in-game popup menu

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_687e30e882b4832a8075f9ecc81f1b0d