### PR TITLE
Fix disembark trigger for new messages

### DIFF
--- a/client/src/scripts/ships.ts
+++ b/client/src/scripts/ships.ts
@@ -43,7 +43,14 @@ export default function initShips(client: Client) {
         return undefined;
     };
 
-    client.Triggers.registerTrigger(/.*przybija wielki trojmasztowy galeon\.$/, board(true), "ships");
+    client.Triggers.registerTrigger(
+        [
+            /.*przybija wielki trojmasztowy galeon\.$/,
+            /^Wielki trojmasztowy galeon przybija do brzegu\.$/,
+        ],
+        board(true),
+        "ships"
+    );
 
     client.Triggers.registerTrigger(
         [
@@ -55,7 +62,11 @@ export default function initShips(client: Client) {
         "ships"
     );
 
-    client.Triggers.registerTrigger(/^(?!Ktos|Jakis|Jakas).*(Doplynelismy.*(Mozna|w calej swej)|Marynarze sprawnie cumuja)/, disembark, "ships");
+    client.Triggers.registerTrigger(
+        /^(?!Ktos|Jakas).*(Doplynelismy.*(Mozna|w calej swej)|Marynarze sprawnie cumuja)/,
+        disembark,
+        "ships"
+    );
 
     client.Triggers.registerTrigger(
         [

--- a/client/test/ships.test.ts
+++ b/client/test/ships.test.ts
@@ -34,6 +34,14 @@ describe('ships triggers', () => {
     expect(client.sendCommand).toHaveBeenNthCalledWith(4, 'wlm');
   });
 
+  test('galeon boarding trigger binds command and beeps', () => {
+    parse('Wielki trojmasztowy galeon przybija do brzegu.');
+    expect(client.playSound).toHaveBeenCalledTimes(1);
+    expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
+    const [label] = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
+    expect(label).toBe('wem;kup bilet;wsiadz na statek;wlm');
+  });
+
   test('statki trigger binds without beep', () => {
     client.playSound.mockClear();
     parse('Tajemniczy okret');
@@ -56,6 +64,18 @@ describe('ships triggers', () => {
     expect(client.sendCommand).toHaveBeenCalledTimes(1);
     expect(client.sendCommand).toHaveBeenCalledWith('zejdz ze statku');
     expect(client.sendEvent).toHaveBeenCalledWith('refreshPositionWhenAble');
+  });
+
+  test('disembark message starting with Jakis also binds', () => {
+    parse('Jakis mezczyzna krzyczy na galeonie: Doplynelismy do przystani w Urbimo! Mozna wysiadac!');
+    expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
+    const [label] = client.FunctionalBind.set.mock.calls[0];
+    expect(label).toBe('zejdz ze statku');
+  });
+
+  test('schodzi z galeonu line does not bind', () => {
+    parse('Wysoki kruczowlosy mezczyzna schodzi z galeonu na brzeg.');
+    expect(client.FunctionalBind.set).not.toHaveBeenCalled();
   });
 
   test('does not bind boarding command when already on ship', () => {


### PR DESCRIPTION
## Summary
- broaden ships disembark regex so lines beginning with "Jakis" are matched
- add tests for new disembark messages and to ensure no extra bind

## Testing
- `yarn --cwd client test` *(fails: Internal Error: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687e4f678cbc832aa3d434b95cb7cfe1