### PR TITLE
Handle echo commands locally

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -161,6 +161,10 @@ export default class Client {
 
         let preparse = command
         command = this.Map.parseCommand(command)
+        if (command.startsWith('echo ')) {
+            this.print(command.substring(5))
+            return
+        }
         const split = command.split(/[#;]/)
         if (split.length > 1) {
             split.forEach(part => {

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -130,6 +130,15 @@ test('sendCommand splits commands returned by parseCommand', () => {
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'parsed:bar', true);
 });
 
+test('sendCommand prints echo commands locally', () => {
+  parseCommand.mockImplementationOnce((cmd: string) => cmd);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const printSpy = jest.spyOn(client, 'print').mockImplementation();
+  client.sendCommand('echo <red> text');
+  expect(printSpy).toHaveBeenCalledWith('<red> text');
+  expect((global as any).clientAdapterMock.send).not.toHaveBeenCalled();
+});
+
 test('onLine sends printed messages after line and restores Output.send', () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   const originalOutputSend = (window as any).Output.send;


### PR DESCRIPTION
## Summary
- intercept commands starting with `echo ` so they're printed locally
- test echo command handling without using global Output helpers

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_687e4c146a08832ab5b8c45e298bf9a2