### PR TITLE
Fix web-client build

### DIFF
--- a/client/src/scripts/leaderAttackWarning.ts
+++ b/client/src/scripts/leaderAttackWarning.ts
@@ -10,7 +10,7 @@ export default function initLeaderAttackWarning(client: Client) {
     const line = "=".repeat(width);
     const message = colorString(`${line}\n  ${text}  \n${line}`, RED)
     const warningInternval = 5000;
-    let interval: string | number | NodeJS.Timeout;
+    let interval: ReturnType<typeof setInterval> | undefined;
 
     function printWarning() {
         client.println(message);

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -22,6 +22,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@types/chrome": "^0.0.313",
+    "@types/node": "^20.11.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",


### PR DESCRIPTION
## Summary
- add missing Node and Chrome types for web-client
- adjust timeout type to avoid NodeJS namespace

## Testing
- `yarn --cwd web-client build`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687e5c81cf54832aab3b76941510ce17