### PR TITLE
Fix disembark bind when not aboard ship

### DIFF
--- a/client/src/scripts/ships.ts
+++ b/client/src/scripts/ships.ts
@@ -39,7 +39,9 @@ export default function initShips(client: Client) {
         return undefined;
     };
     const disembark = () => {
-        bindShip(client, ["zejdz ze statku"], "zejdz ze statku", true);
+        if (onShip) {
+            bindShip(client, ["zejdz ze statku"], "zejdz ze statku", true);
+        }
         return undefined;
     };
 

--- a/client/test/ships.test.ts
+++ b/client/test/ships.test.ts
@@ -56,7 +56,13 @@ describe('ships triggers', () => {
     expect(client.sendCommand).toHaveBeenNthCalledWith(4, 'wlm');
   });
 
-  test('disembark trigger sends command and event', () => {
+  test('disembark trigger sends command and event when on ship', () => {
+    parse('Tratwa przybija do brzegu.');
+    const [, boardCallback] = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
+    boardCallback();
+    client.FunctionalBind.set.mockClear();
+    client.sendCommand.mockClear();
+    client.sendEvent.mockClear();
     parse('Marynarze sprawnie cumuja');
     const [label, callback] = client.FunctionalBind.set.mock.calls.pop()!;
     expect(label).toBe('zejdz ze statku');
@@ -66,7 +72,13 @@ describe('ships triggers', () => {
     expect(client.sendEvent).toHaveBeenCalledWith('refreshPositionWhenAble');
   });
 
-  test('disembark message starting with Jakis also binds', () => {
+  test('disembark message starting with Jakis binds only when on ship', () => {
+    parse('Tratwa przybija do brzegu.');
+    const [, boardCallback] = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
+    boardCallback();
+    client.FunctionalBind.set.mockClear();
+    client.sendCommand.mockClear();
+    client.sendEvent.mockClear();
     parse('Jakis mezczyzna krzyczy na galeonie: Doplynelismy do przystani w Urbimo! Mozna wysiadac!');
     expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
     const [label] = client.FunctionalBind.set.mock.calls[0];


### PR DESCRIPTION
## Summary
- ignore disembark messages unless player is on board
- update ship tests for new behaviour

## Testing
- `npx -y yarn@1 --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687e56843440832aa16a1a0234e214e0