### PR TITLE
Remove accessibility labels

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -53,7 +53,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Opcje</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
                     <div id="options"></div>
@@ -66,7 +66,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Bindowanie</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
                     <div id="binds-options"></div>
@@ -79,7 +79,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Odbiorcy paczek</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
                     <div id="npc-options"></div>
@@ -92,7 +92,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Skrypty</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
                     <div id="scripts-options"></div>
@@ -105,7 +105,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Aliasy</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
                     <div id="aliases-options"></div>
@@ -118,7 +118,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Triggery</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
                     <div id="triggers-options"></div>
@@ -131,7 +131,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Nagrania</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
                     <div id="recordings-options"></div>
@@ -144,7 +144,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Gildie</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
                     <div id="guilds-options"></div>
@@ -154,8 +154,8 @@
     </div>
     <div id="input-area">
         <div id="history-buttons">
-            <button id="history-up-button" aria-label="Previous command">▲</button>
-            <button id="history-down-button" aria-label="Next command">▼</button>
+            <button id="history-up-button">▲</button>
+            <button id="history-down-button">▼</button>
         </div>
         <input type="search" id="message-input" autocomplete="false" autocapitalize="off" spellcheck="false"/>
         <button id="send-button">➢</button>
@@ -206,10 +206,10 @@
     </div>
 
     <div id="auth-overlay">
-        <button id="auth-close" class="overlay-close" aria-label="Close">✖</button>
+        <button id="auth-close" class="overlay-close">✖</button>
         <div id="auth-panel">
-            <img src="logo.png" class="logo mb-3" alt="Logo" />
-            <div id="connecting-spinner" class="spinner-border text-light" role="status"></div>
+            <img src="logo.png" class="logo mb-3" />
+            <div id="connecting-spinner" class="spinner-border text-light"></div>
             <button id="connect-button">Connect</button>
             <div class="auth-or">- LUB -</div>
             <form id="login-form" class="d-flex flex-column gap-2">
@@ -227,7 +227,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Ustawienia UI</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body d-flex flex-column gap-2">
                     <label class="form-label">Rozmiar czcionki treści (rem)
@@ -269,7 +269,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Przyciski mobilne</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body position-relative d-flex flex-column align-items-center gap-2">
                     <div id="mobile-buttons-preview" class="mobile-direction-buttons">
@@ -1036,7 +1036,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Debug Log</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div id="debug-content" class="debug-content modal-body overflow-auto"></div>
             </div>

--- a/web-client/src/docs.ts
+++ b/web-client/src/docs.ts
@@ -27,14 +27,14 @@ function createModal() {
   <div class="modal-content">
     <div class="modal-header">
       <h5 class="modal-title">Dokumentacja</h5>
-      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
     </div>
     <div class="modal-body d-flex flex-column gap-3">
       <div class="dropdown docs-nav align-self-start">
-        <button class="btn btn-secondary dropdown-toggle" type="button" id="docs-menu" data-bs-toggle="dropdown" aria-expanded="false">
+        <button class="btn btn-secondary dropdown-toggle" type="button" id="docs-menu" data-bs-toggle="dropdown">
           Wybierz dokument
         </button>
-        <ul class="dropdown-menu" aria-labelledby="docs-menu">
+        <ul class="dropdown-menu">
           ${docs
             .map(
               (d) =>


### PR DESCRIPTION
## Summary
- strip aria attributes from docs modal template
- remove aria-related attributes and alt text from index.html

## Testing
- `yarn --cwd client test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687e6fa41b10832a874f52d8ae41c5e3