### PR TITLE
Add map location shortcuts

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -42,6 +42,7 @@ import initArmorEvaluation from './scripts/armorEvaluation'
 import initShortExits from './scripts/shortExits'
 import initGps from './scripts/gps'
 import initMapAliases from './scripts/mapAliases'
+import initShortcuts from './scripts/shortcuts'
 import initCompareAll from './scripts/compareAll'
 import initFollowSpecialExits from './scripts/followSpecialExits'
 import Client from "./Client";
@@ -137,6 +138,7 @@ export function registerScripts(client: Client) {
     initCoinColors(client)
     initLeaderAttackWarning(client)
     initBreakItem(client)
+    initShortcuts(client, aliases)
     initShortExits(client)
     initExternalScripts(client)
     initUserAliases(client, aliases)

--- a/client/src/scripts/mapAliases.ts
+++ b/client/src/scripts/mapAliases.ts
@@ -1,5 +1,6 @@
 import Client from "../Client";
 import { longToShort } from "../MapHelper";
+import { getShortcut } from "./shortcuts";
 
 export default function initMapAliases(client: Client, aliases: { pattern: RegExp; callback: Function }[]) {
     aliases.push(
@@ -24,7 +25,8 @@ export default function initMapAliases(client: Client, aliases: { pattern: RegEx
         {
             pattern: /\/prowadz (.*)$/,
             callback: (matches: RegExpMatchArray) => {
-                client.sendEvent('leadTo', matches[1]);
+                const dest = getShortcut(matches[1]) ?? matches[1];
+                client.sendEvent('leadTo', dest);
             }
         },
         {

--- a/client/src/scripts/shortcuts.ts
+++ b/client/src/scripts/shortcuts.ts
@@ -56,7 +56,7 @@ export default function initShortcuts(client: Client, aliases?: { pattern: RegEx
         client.println(lines.length ? lines.join("\n") : "Brak skrotow.");
     }
 
-    function add(id: number, key: string, label: string) {
+    function add(id: number, key: string, label: string = '') {
         shortcuts[key] = { key, id, label };
         persist();
     }
@@ -75,7 +75,7 @@ export default function initShortcuts(client: Client, aliases?: { pattern: RegEx
 
     if (aliases) {
         aliases.push({ pattern: /^\/pokaz_skroty$/, callback: printShortcuts });
-        aliases.push({ pattern: /^\/dodaj_skrot ([0-9]+) ([a-zA-Z_0-9]+) (.*)$/, callback: (m: RegExpMatchArray) => add(parseInt(m[1]), m[2], m[3]) });
+        aliases.push({ pattern: /^\/dodaj_skrot ([0-9]+) ([a-zA-Z_0-9]+)(?:\s+(.*))?$/, callback: (m: RegExpMatchArray) => add(parseInt(m[1]), m[2], m[3] ?? '') });
         aliases.push({ pattern: /^\/usun_skrot ([a-zA-Z_]+)$/, callback: (m: RegExpMatchArray) => remove(m[1]) });
         aliases.push({ pattern: /^\/usun_skroty$/, callback: clear });
     }

--- a/client/src/scripts/shortcuts.ts
+++ b/client/src/scripts/shortcuts.ts
@@ -1,0 +1,82 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+export interface ShortcutEntry {
+    key: string;
+    id: number;
+    label: string;
+}
+
+const STORAGE_KEY = "shortcuts";
+
+const shortcuts: Record<string, ShortcutEntry> = {};
+
+export function getShortcut(id: string): number | undefined {
+    return shortcuts[id]?.id;
+}
+
+export default function initShortcuts(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
+    const HEADER_COLOR = findClosestColor("#7cfc00");
+    const NAME_COLOR = findClosestColor("#ffa500");
+
+    function apply(list: ShortcutEntry[] = []) {
+        Object.keys(shortcuts).forEach(k => delete shortcuts[k]);
+        list.forEach(s => {
+            if (s && s.key) {
+                shortcuts[s.key] = { key: s.key, id: s.id, label: s.label };
+            }
+        });
+    }
+
+    function persist() {
+        client.port?.postMessage({ type: "SET_STORAGE", key: STORAGE_KEY, value: Object.values(shortcuts) });
+    }
+
+    client.addEventListener("storage", (ev: CustomEvent) => {
+        if (ev.detail.key === STORAGE_KEY) {
+            const value = Array.isArray(ev.detail.value) ? ev.detail.value : [];
+            apply(value);
+        }
+    });
+
+    client.addEventListener("port-connected", () => {
+        client.port?.postMessage({ type: "GET_STORAGE", key: STORAGE_KEY });
+    });
+
+    client.port?.postMessage({ type: "GET_STORAGE", key: STORAGE_KEY });
+
+    function printShortcuts() {
+        const lines: string[] = [];
+        Object.values(shortcuts).forEach(sc => {
+            const lead = client.OutputHandler.makeClickable("prowadz", "prowadz " + sc.key, () => {
+                client.sendCommand("/prowadz " + sc.key);
+            });
+            lines.push(`${colorString(sc.key, HEADER_COLOR)} -> ${sc.id} ${colorString(sc.label, NAME_COLOR)} [ ${lead} ]`);
+        });
+        client.println(lines.length ? lines.join("\n") : "Brak skrotow.");
+    }
+
+    function add(id: number, key: string, label: string) {
+        shortcuts[key] = { key, id, label };
+        persist();
+    }
+
+    function remove(key: string) {
+        if (shortcuts[key]) {
+            delete shortcuts[key];
+            persist();
+        }
+    }
+
+    function clear() {
+        Object.keys(shortcuts).forEach(k => delete shortcuts[k]);
+        persist();
+    }
+
+    if (aliases) {
+        aliases.push({ pattern: /^\/pokaz_skroty$/, callback: printShortcuts });
+        aliases.push({ pattern: /^\/dodaj_skrot ([0-9]+) ([a-zA-Z_0-9]+) (.*)$/, callback: (m: RegExpMatchArray) => add(parseInt(m[1]), m[2], m[3]) });
+        aliases.push({ pattern: /^\/usun_skrot ([a-zA-Z_]+)$/, callback: (m: RegExpMatchArray) => remove(m[1]) });
+        aliases.push({ pattern: /^\/usun_skroty$/, callback: clear });
+    }
+}

--- a/docs/SHORTCUTS.md
+++ b/docs/SHORTCUTS.md
@@ -1,0 +1,12 @@
+# Skróty
+
+Moduł skrótów pozwala powiązać numery lokacji z mapy z wybraną nazwą.
+
+- **/dodaj_skrot _id nazwa opis_** – zapisuje skrót do lokacji.
+- **/pokaz_skroty** – wyświetla listę zapisanych skrótów.
+- **/usun_skrot _nazwa_** – usuwa wskazany skrót.
+- **/usun_skroty** – usuwa wszystkie skróty.
+
+Do zapisanej lokacji możesz przejść komendą **/prowadz _nazwa_** lub klikając przycisk `Prowadź` na liście skrótów.
+
+Dane przechowywane są w pamięci przeglądarki.

--- a/docs/SHORTCUTS.md
+++ b/docs/SHORTCUTS.md
@@ -2,7 +2,7 @@
 
 Moduł skrótów pozwala powiązać numery lokacji z mapy z wybraną nazwą.
 
-- **/dodaj_skrot _id nazwa opis_** – zapisuje skrót do lokacji.
+- **/dodaj_skrot _id nazwa [opis]_** – zapisuje skrót do lokacji (opis jest opcjonalny).
 - **/pokaz_skroty** – wyświetla listę zapisanych skrótów.
 - **/usun_skrot _nazwa_** – usuwa wskazany skrót.
 - **/usun_skroty** – usuwa wszystkie skróty.

--- a/options/src/App.tsx
+++ b/options/src/App.tsx
@@ -8,10 +8,11 @@ import SettingsFile from "./SettingsFile";
 import Binds from "./Binds";
 import Scripts from "./Scripts";
 import Recordings from "./Recordings";
+import Shortcuts from "./Shortcuts";
 
 
 function App() {
-    const [tab, setTab] = useState<'settings' | 'guilds' | 'npc' | 'file' | 'binds' | 'scripts' | 'recordings'>('settings')
+    const [tab, setTab] = useState<'settings' | 'guilds' | 'npc' | 'file' | 'binds' | 'scripts' | 'recordings' | 'shortcuts'>('settings')
 
     return (
         <div className="p-2 d-flex flex-column h-100">
@@ -36,6 +37,9 @@ function App() {
                 </Tab>
                 <Tab eventKey="recordings" title="Nagrania">
                     <Recordings />
+                </Tab>
+                <Tab eventKey="shortcuts" title="Skr\u00f3ty">
+                    <Shortcuts />
                 </Tab>
             </Tabs>
         </div>

--- a/options/src/Shortcuts.tsx
+++ b/options/src/Shortcuts.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Button, Form, Table, Modal } from 'react-bootstrap';
+import { Button, Form, Table } from 'react-bootstrap';
 import { TiDelete } from 'react-icons/ti';
 import storage from "./storage";
 
@@ -11,7 +11,7 @@ interface ShortcutEntry {
 
 function Shortcuts() {
     const [list, setList] = useState<ShortcutEntry[]>([]);
-    const [show, setShow] = useState(false);
+    const [showForm, setShowForm] = useState(false);
     const [key, setKey] = useState('');
     const [loc, setLoc] = useState('');
     const [label, setLabel] = useState('');
@@ -23,7 +23,7 @@ function Shortcuts() {
         });
     }, []);
 
-    function save(newList: ShortcutEntry[]) {
+    function saveList(newList: ShortcutEntry[]) {
         setList(newList);
         storage.setItem('shortcuts', newList);
     }
@@ -36,9 +36,9 @@ function Shortcuts() {
         if (!/^[a-zA-Z_0-9]+$/.test(k)) return;
         if (!list.find(s => s.key === k)) {
             const updated = [...list, { key: k, id, label: l }];
-            save(updated);
+            saveList(updated);
         }
-        setShow(false);
+        setShowForm(false);
         setKey('');
         setLoc('');
         setLabel('');
@@ -46,7 +46,7 @@ function Shortcuts() {
 
     function remove(k: string) {
         const updated = list.filter(s => s.key !== k);
-        save(updated);
+        saveList(updated);
     }
 
     function useCurrent() {
@@ -58,7 +58,28 @@ function Shortcuts() {
 
     return (
         <div className="m-2 d-flex flex-column gap-2">
-            <Button size="sm" onClick={() => setShow(true)}>Dodaj</Button>
+            <Button size="sm" onClick={() => setShowForm(true)}>Dodaj</Button>
+            {showForm && (
+                <div className="border rounded p-3">
+                    <Form.Group className="d-flex align-items-center gap-2 mb-2">
+                        <Form.Label className="w-32 mb-0">Nazwa</Form.Label>
+                        <Form.Control type="text" size="sm" value={key} onChange={e => setKey(e.target.value)} />
+                    </Form.Group>
+                    <Form.Group className="d-flex align-items-center gap-2 mb-2">
+                        <Form.Label className="w-32 mb-0">Lokalizacja</Form.Label>
+                        <Form.Control type="number" size="sm" value={loc} onChange={e => setLoc(e.target.value)} />
+                        <Button size="sm" variant="secondary" onClick={useCurrent}>Aktualna</Button>
+                    </Form.Group>
+                    <Form.Group className="d-flex align-items-center gap-2 mb-2">
+                        <Form.Label className="w-32 mb-0">Opis</Form.Label>
+                        <Form.Control type="text" size="sm" value={label} onChange={e => setLabel(e.target.value)} />
+                    </Form.Group>
+                    <div className="d-flex gap-2">
+                        <Button size="sm" variant="secondary" onClick={() => { setShowForm(false); setKey(''); setLoc(''); setLabel(''); }}>Anuluj</Button>
+                        <Button size="sm" onClick={add}>Zapisz</Button>
+                    </div>
+                </div>
+            )}
             <Table bordered size="sm" className="table-zebra">
                 <tbody className="align-middle">
                 {list.map(item => (
@@ -74,29 +95,6 @@ function Shortcuts() {
                 ))}
                 </tbody>
             </Table>
-            <Modal show={show} onHide={() => setShow(false)}>
-                <Modal.Header closeButton>
-                    <Modal.Title>Dodaj skrót</Modal.Title>
-                </Modal.Header>
-                <Modal.Body className="d-flex flex-column gap-2">
-                    <Form.Group className="d-flex align-items-center gap-2">
-                        <Form.Label className="w-32 mb-0">Nazwa</Form.Label>
-                        <Form.Control type="text" size="sm" value={key} onChange={e => setKey(e.target.value)} />
-                    </Form.Group>
-                    <Form.Group className="d-flex align-items-center gap-2">
-                        <Form.Label className="w-32 mb-0">Lokalizacja</Form.Label>
-                        <Form.Control type="number" size="sm" value={loc} onChange={e => setLoc(e.target.value)} />
-                        <Button size="sm" variant="secondary" onClick={useCurrent}>Aktualna</Button>
-                    </Form.Group>
-                    <Form.Group className="d-flex align-items-center gap-2">
-                        <Form.Label className="w-32 mb-0">Opis</Form.Label>
-                        <Form.Control type="text" size="sm" value={label} onChange={e => setLabel(e.target.value)} />
-                    </Form.Group>
-                </Modal.Body>
-                <Modal.Footer>
-                    <Button size="sm" onClick={add}>Zapisz</Button>
-                </Modal.Footer>
-            </Modal>
         </div>
     );
 }

--- a/options/src/Shortcuts.tsx
+++ b/options/src/Shortcuts.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import { Button, Form, Table, Modal } from 'react-bootstrap';
+import { TiDelete } from 'react-icons/ti';
+import storage from "./storage";
+
+interface ShortcutEntry {
+    key: string;
+    id: number;
+    label: string;
+}
+
+function Shortcuts() {
+    const [list, setList] = useState<ShortcutEntry[]>([]);
+    const [show, setShow] = useState(false);
+    const [key, setKey] = useState('');
+    const [loc, setLoc] = useState('');
+    const [label, setLabel] = useState('');
+
+    useEffect(() => {
+        storage.getItem('shortcuts').then(res => {
+            const arr = Array.isArray(res?.shortcuts) ? res.shortcuts : [];
+            setList(arr);
+        });
+    }, []);
+
+    function save(newList: ShortcutEntry[]) {
+        setList(newList);
+        storage.setItem('shortcuts', newList);
+    }
+
+    function add() {
+        const id = parseInt(loc);
+        const k = key.trim();
+        const l = label.trim();
+        if (!k || isNaN(id) || !l) return;
+        if (!/^[a-zA-Z_0-9]+$/.test(k)) return;
+        if (!list.find(s => s.key === k)) {
+            const updated = [...list, { key: k, id, label: l }];
+            save(updated);
+        }
+        setShow(false);
+        setKey('');
+        setLoc('');
+        setLabel('');
+    }
+
+    function remove(k: string) {
+        const updated = list.filter(s => s.key !== k);
+        save(updated);
+    }
+
+    function useCurrent() {
+        const id = (window as any).clientExtension?.Map?.currentRoom?.id;
+        if (id) {
+            setLoc(String(id));
+        }
+    }
+
+    return (
+        <div className="m-2 d-flex flex-column gap-2">
+            <Button size="sm" onClick={() => setShow(true)}>Dodaj</Button>
+            <Table bordered size="sm" className="table-zebra">
+                <tbody className="align-middle">
+                {list.map(item => (
+                    <tr key={item.key}>
+                        <td>{item.key}</td>
+                        <td>{item.id}</td>
+                        <td>{item.label}</td>
+                        <td className="d-flex gap-2">
+                            <Button size="sm" onClick={() => (window as any).clientExtension?.sendEvent('leadTo', item.id)}>Prowadź</Button>
+                            <Button size="sm" variant="danger" onClick={() => remove(item.key)}><TiDelete /></Button>
+                        </td>
+                    </tr>
+                ))}
+                </tbody>
+            </Table>
+            <Modal show={show} onHide={() => setShow(false)}>
+                <Modal.Header closeButton>
+                    <Modal.Title>Dodaj skrót</Modal.Title>
+                </Modal.Header>
+                <Modal.Body className="d-flex flex-column gap-2">
+                    <Form.Group className="d-flex align-items-center gap-2">
+                        <Form.Label className="w-32 mb-0">Nazwa</Form.Label>
+                        <Form.Control type="text" size="sm" value={key} onChange={e => setKey(e.target.value)} />
+                    </Form.Group>
+                    <Form.Group className="d-flex align-items-center gap-2">
+                        <Form.Label className="w-32 mb-0">Lokalizacja</Form.Label>
+                        <Form.Control type="number" size="sm" value={loc} onChange={e => setLoc(e.target.value)} />
+                        <Button size="sm" variant="secondary" onClick={useCurrent}>Aktualna</Button>
+                    </Form.Group>
+                    <Form.Group className="d-flex align-items-center gap-2">
+                        <Form.Label className="w-32 mb-0">Opis</Form.Label>
+                        <Form.Control type="text" size="sm" value={label} onChange={e => setLabel(e.target.value)} />
+                    </Form.Group>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button size="sm" onClick={add}>Zapisz</Button>
+                </Modal.Footer>
+            </Modal>
+        </div>
+    );
+}
+
+export default Shortcuts;

--- a/options/src/Shortcuts.tsx
+++ b/options/src/Shortcuts.tsx
@@ -32,7 +32,7 @@ function Shortcuts() {
         const id = parseInt(loc);
         const k = key.trim();
         const l = label.trim();
-        if (!k || isNaN(id) || !l) return;
+        if (!k || isNaN(id)) return;
         if (!/^[a-zA-Z_0-9]+$/.test(k)) return;
         if (!list.find(s => s.key === k)) {
             const updated = [...list, { key: k, id, label: l }];

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -139,6 +139,19 @@
             </div>
         </div>
     </div>
+    <div id="shortcuts-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Skróty</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="shortcuts-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
     <div id="guilds-modal" class="modal fade" tabindex="-1">
         <div class="modal-dialog modal-lg modal-dialog-scrollable">
             <div class="modal-content">
@@ -191,6 +204,9 @@
                 </li>
                 <li>
                     <button class="w-100 p-1" id="recordings-button">Nagrania</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="shortcuts-button">Skróty</button>
                 </li>
                 <li>
                     <button class="w-100 p-1" id="docs-button">Dokumentacja</button>

--- a/web-client/src/docs.ts
+++ b/web-client/src/docs.ts
@@ -4,6 +4,7 @@ import aliasesMd from "../../docs/ALIASES.md?raw";
 import bagManagerMd from "../../docs/BAG_MANAGER.md?raw";
 import bindsMd from "../../docs/BINDS.md?raw";
 import herbsMd from "../../docs/HERBS.md?raw";
+import shortcutsMd from "../../docs/SHORTCUTS.md?raw";
 
 interface DocDef {
   key: string;
@@ -14,7 +15,8 @@ const docs: DocDef[] = [
   { key: "aliases", title: "Aliasy", md: aliasesMd },
   { key: "bag", title: "Mened\u017cer pojemnik\u00f3w", md: bagManagerMd },
   { key: "binds", title: "Bindowanie", md: bindsMd },
-  { key: "herbs", title: "Licznik z\u00f3\u0142", md: herbsMd }
+  { key: "herbs", title: "Licznik z\u00f3\u0142", md: herbsMd },
+  { key: "shortcuts", title: "Skr\u00f3ty", md: shortcutsMd }
 ];
 
 function createModal() {

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -25,6 +25,7 @@ import Aliases from "@options/src/Aliases.tsx"
 import Recordings from "@options/src/Recordings.tsx"
 import Guilds from "@options/src/Guilds.tsx"
 import UserTriggers from "@options/src/UserTriggers.tsx"
+import Shortcuts from "@options/src/Shortcuts.tsx"
 
 const client = new Client(arkadiaClient, new MockPort())
 window.clientExtension = client;
@@ -403,6 +404,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const aliasesButton = document.getElementById('aliases-button') as HTMLButtonElement | null;
     const triggersButton = document.getElementById('triggers-button') as HTMLButtonElement | null;
     const recordingsButton = document.getElementById('recordings-button') as HTMLButtonElement | null;
+    const shortcutsButton = document.getElementById('shortcuts-button') as HTMLButtonElement | null;
     const recordingButton = document.getElementById('recording-button') as HTMLButtonElement | null;
     const playbackControls = document.getElementById('playback-controls') as HTMLElement | null;
     const playbackPause = document.getElementById('playback-pause') as HTMLButtonElement | null;
@@ -431,6 +433,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const triggersModal = triggersModalElement ? new Modal(triggersModalElement) : null;
     const recordingsModalElement = document.getElementById('recordings-modal');
     const recordingsModal = recordingsModalElement ? new Modal(recordingsModalElement) : null;
+    const shortcutsModalElement = document.getElementById('shortcuts-modal');
+    const shortcutsModal = shortcutsModalElement ? new Modal(shortcutsModalElement) : null;
     const loginCharacter = document.getElementById('login-character') as HTMLInputElement | null;
     const loginPassword = document.getElementById('login-password') as HTMLInputElement | null;
     const loginForm = document.getElementById('login-form') as HTMLFormElement | null;
@@ -464,6 +468,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (recordingsModal) {
             recordingsModal.hide();
+        }
+        if (shortcutsModal) {
+            shortcutsModal.hide();
         }
     });
 
@@ -513,6 +520,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (recordingsButton && recordingsModal) {
         recordingsButton.addEventListener('click', () => {
             recordingsModal.show();
+        });
+    }
+
+    if (shortcutsButton && shortcutsModal) {
+        shortcutsButton.addEventListener('click', () => {
+            shortcutsModal.show();
         });
     }
 
@@ -812,6 +825,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const recordingsRoot = document.getElementById('recordings-options');
     if (recordingsRoot) {
         createRoot(recordingsRoot).render(createElement(Recordings));
+    }
+
+    const shortcutsRoot = document.getElementById('shortcuts-options');
+    if (shortcutsRoot) {
+        createRoot(shortcutsRoot).render(createElement(Shortcuts));
     }
 });
 


### PR DESCRIPTION
## Summary
- add documentation for skróty (shortcuts)
- load shortcuts doc in help modal
- support location shortcuts with aliases
- expose shortcut options screen
- create UI and modal for managing shortcuts

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687ea849e024832a8656385ba5ca78e0