### PR TITLE
Add transport ride progress tracking

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -6,6 +6,7 @@ import initShips from './scripts/ships'
 import initTransportStops from './scripts/transportStops'
 import initBuses from './scripts/buses'
 import initGates from './scripts/gates'
+import initTransportRides from './scripts/transportRides'
 import initAttackBeep from './scripts/attackBeep'
 import initLamp from './scripts/lamp'
 import initBinds from './scripts/binds'
@@ -103,6 +104,7 @@ export function registerScripts(client: Client) {
     initTransportStops(client)
     initBuses(client)
     initGates(client)
+    initTransportRides(client)
     initAttackBeep(client)
     initLamp(client)
     initBinds(client, aliases)

--- a/client/src/scripts/transportRides.ts
+++ b/client/src/scripts/transportRides.ts
@@ -1,0 +1,275 @@
+// Transport ride progress management
+import Client from "../Client";
+import Ancelmus from './ships/Ancelmus.json';
+import Annibale from './ships/Annibale.json';
+import Asa from './ships/Asa.json';
+import Batista from './ships/Batista.json';
+import Bjorn from './ships/Bjorn.json';
+import Cern from './ships/Cern.json';
+import Charonda from './ships/Charonda.json';
+import Creyard from './ships/Creyard.json';
+import Daniel from './ships/Daniel.json';
+import Elich from './ships/Elich.json';
+import Flavius from './ships/Flavius.json';
+import Francois from './ships/Francois.json';
+import Gervais from './ships/Gervais.json';
+import Gmeath from './ships/Gmeath.json';
+import Gvidon from './ships/Gvidon.json';
+import Hallgerda from './ships/Hallgerda.json';
+import Haming from './ships/Haming.json';
+import Jacob from './ships/Jacob.json';
+import Kelim from './ships/Kelim.json';
+import Louis from './ships/Louis.json';
+import Luiggi from './ships/Luiggi.json';
+import Malacius from './ships/Malacius.json';
+import Mallcolm from './ships/Mallcolm.json';
+import Olaf from './ships/Olaf.json';
+import Pluskolec from './ships/Pluskolec.json';
+import Rygwit from './ships/Rygwit.json';
+import Strag from './ships/Strag.json';
+import Jouinard from './other/Jouinard - Nuln.json';
+import KrainaZgromadzenia from './other/Kraina Zgromadzenia - Nuln.json';
+import MariborGrabowa from './other/Maribor - Grabowa Buchta.json';
+import Salignac from './other/Salignac - Nuln.json';
+import Varieno from './other/Varieno - Miragliano - Campogrotta.json';
+import WyzimaOxenfurt from './other/Wyzima - Oxenfurt.json';
+
+interface Stop {
+    start: number;
+    destination: number;
+    time: number;
+    stop_pattern: string;
+    set_pattern?: string;
+    label?: string;
+}
+
+interface TransportDefinition {
+    enter: string;
+    exit?: string;
+    start: string;
+    exit_command?: string;
+    bind?: string;
+    stops: Stop[];
+    show_path?: boolean;
+}
+
+interface MinimumTimes {
+    [id: string]: { [index: number]: number };
+}
+
+class Ride {
+    private stopTrigger: any = null;
+    private progressContainer: HTMLElement | null = null;
+    private progressBar: HTMLElement | null = null;
+    private interval: number | null = null;
+    private startTime: number = 0;
+
+    constructor(
+        private client: Client,
+        public id: string,
+        public def: TransportDefinition,
+        public index: number,
+        private onRemove: (ride: Ride) => void
+    ) {
+        this.setupTriggers();
+    }
+
+    private setupTriggers() {
+        this.client.Triggers.registerOneTimeTrigger(this.def.enter, () => {
+            this.onEnter();
+            return undefined;
+        }, 'transport-ride');
+        if (this.def.exit) {
+            this.client.Triggers.registerOneTimeTrigger(this.def.exit, () => {
+                this.onExit();
+                return undefined;
+            }, 'transport-ride');
+        }
+        this.client.Triggers.registerOneTimeTrigger(this.def.start, () => {
+            this.onStart();
+            return undefined;
+        }, 'transport-ride');
+    }
+
+    private onEnter() {
+        // nothing for now
+    }
+
+    private onExit() {
+        this.cleanup();
+    }
+
+    private onStart() {
+        const stop = this.def.stops[this.index];
+        if (this.stopTrigger) {
+            this.client.Triggers.removeTrigger(this.stopTrigger);
+        }
+        this.stopTrigger = this.client.Triggers.registerOneTimeTrigger(new RegExp(stop.stop_pattern), () => {
+            this.onStop();
+            return undefined;
+        }, 'transport-ride');
+        this.startTime = Date.now();
+        this.showProgress();
+        this.interval = window.setInterval(() => this.updateProgress(), 250);
+    }
+
+    private onStop() {
+        const stop = this.def.stops[this.index];
+        const elapsed = Math.floor((Date.now() - this.startTime) / 1000);
+        if (elapsed < stop.time) {
+            storeNewMinimum(this.id, this.index, elapsed);
+            stop.time = elapsed;
+        }
+        this.client.Map.setMapRoomById(stop.destination);
+        this.hideProgress();
+        if (this.interval) {
+            clearInterval(this.interval);
+            this.interval = null;
+        }
+        this.index = this.index >= this.def.stops.length - 1 ? 0 : this.index + 1;
+        this.onRemove(this);
+    }
+
+    private showProgress() {
+        this.progressContainer = document.createElement('div');
+        this.progressContainer.style.position = 'absolute';
+        this.progressContainer.style.bottom = '10px';
+        this.progressContainer.style.right = '10px';
+        this.progressContainer.style.width = '350px';
+        this.progressContainer.style.height = '30px';
+        this.progressContainer.style.border = '1px solid #666';
+        this.progressContainer.style.background = '#222';
+        this.progressBar = document.createElement('div');
+        this.progressBar.style.height = '100%';
+        this.progressBar.style.width = '0';
+        this.progressBar.style.background = '#6a4';
+        this.progressContainer.appendChild(this.progressBar);
+        document.body.appendChild(this.progressContainer);
+        this.updateProgress();
+    }
+
+    private updateProgress() {
+        if (!this.progressBar) return;
+        const stop = this.def.stops[this.index];
+        const elapsed = Math.floor((Date.now() - this.startTime) / 1000);
+        const total = stop.time;
+        const perc = Math.min(1, elapsed / total);
+        this.progressBar.style.width = `${Math.floor(perc * 100)}%`;
+        this.progressBar.textContent = `${stop.label ?? ''} ${elapsed}/${total}`.trim();
+    }
+
+    private hideProgress() {
+        if (this.progressContainer) {
+            this.progressContainer.remove();
+            this.progressContainer = null;
+            this.progressBar = null;
+        }
+    }
+
+    cleanup() {
+        if (this.stopTrigger) {
+            this.client.Triggers.removeTrigger(this.stopTrigger);
+            this.stopTrigger = null;
+        }
+        if (this.interval) {
+            clearInterval(this.interval);
+            this.interval = null;
+        }
+        this.hideProgress();
+    }
+}
+
+function readMinimums(): MinimumTimes {
+    try {
+        const raw = localStorage.getItem('travel-times');
+        return raw ? JSON.parse(raw) as MinimumTimes : {};
+    } catch {
+        return {};
+    }
+}
+
+function storeMinimums(times: MinimumTimes) {
+    localStorage.setItem('travel-times', JSON.stringify(times));
+}
+
+function storeNewMinimum(id: string, index: number, time: number) {
+    const times = readMinimums();
+    if (!times[id]) times[id] = {};
+    if (!times[id][index] || time < times[id][index]) {
+        times[id][index] = time;
+        storeMinimums(times);
+    }
+}
+
+export default function initTransportRides(client: Client) {
+    const definitions: Record<string, TransportDefinition> = {
+        Ancelmus,
+        Annibale,
+        Asa,
+        Batista,
+        Bjorn,
+        Cern,
+        Charonda,
+        Creyard,
+        Daniel,
+        Elich,
+        Flavius,
+        Francois,
+        Gervais,
+        Gmeath,
+        Gvidon,
+        Hallgerda,
+        Haming,
+        Jacob,
+        Kelim,
+        Louis,
+        Luiggi,
+        Malacius,
+        Mallcolm,
+        Olaf,
+        Pluskolec,
+        Rygwit,
+        Strag,
+        Jouinard,
+        KrainaZgromadzenia,
+        MariborGrabowa,
+        Salignac,
+        Varieno,
+        WyzimaOxenfurt
+    };
+
+    const activeRides: Ride[] = [];
+
+    function removeRide(ride: Ride) {
+        const idx = activeRides.indexOf(ride);
+        if (idx > -1) activeRides.splice(idx, 1);
+        ride.cleanup();
+    }
+
+    function createRide(key: string, index: number) {
+        const ride = new Ride(client, key, definitions[key], index, removeRide);
+        activeRides.push(ride);
+        return ride;
+    }
+
+    const minimums = readMinimums();
+    Object.entries(definitions).forEach(([key, def]) => {
+        def.stops.forEach((stop, idx) => {
+            if (minimums[key] && minimums[key][idx] !== undefined) {
+                stop.time = Math.min(stop.time, Number(minimums[key][idx]));
+            }
+            if (stop.set_pattern) {
+                const regex = new RegExp(stop.set_pattern);
+                client.Triggers.registerTrigger(regex, () => {
+                    const id = client.Map.currentRoom?.id;
+                    if (id === stop.start) {
+                        if (!activeRides.find(r => r.id === key && r.index === idx)) {
+                            createRide(key, idx);
+                        }
+                    }
+                    return undefined;
+                }, 'transport-ride');
+            }
+        });
+    });
+}

--- a/client/src/scripts/transportRides.ts
+++ b/client/src/scripts/transportRides.ts
@@ -59,8 +59,6 @@ interface MinimumTimes {
 
 class Ride {
     private stopTrigger: any = null;
-    private progressContainer: HTMLElement | null = null;
-    private progressBar: HTMLElement | null = null;
     private interval: number | null = null;
     private startTime: number = 0;
 
@@ -131,39 +129,28 @@ class Ride {
     }
 
     private showProgress() {
-        this.progressContainer = document.createElement('div');
-        this.progressContainer.style.position = 'absolute';
-        this.progressContainer.style.bottom = '10px';
-        this.progressContainer.style.right = '10px';
-        this.progressContainer.style.width = '350px';
-        this.progressContainer.style.height = '30px';
-        this.progressContainer.style.border = '1px solid #666';
-        this.progressContainer.style.background = '#222';
-        this.progressBar = document.createElement('div');
-        this.progressBar.style.height = '100%';
-        this.progressBar.style.width = '0';
-        this.progressBar.style.background = '#6a4';
-        this.progressContainer.appendChild(this.progressBar);
-        document.body.appendChild(this.progressContainer);
+        const stop = this.def.stops[this.index];
+        this.client.sendEvent('rideProgressShow', {
+            label: stop.label ?? '',
+            current: 0,
+            total: stop.time,
+        });
         this.updateProgress();
     }
 
     private updateProgress() {
-        if (!this.progressBar) return;
         const stop = this.def.stops[this.index];
         const elapsed = Math.floor((Date.now() - this.startTime) / 1000);
         const total = stop.time;
-        const perc = Math.min(1, elapsed / total);
-        this.progressBar.style.width = `${Math.floor(perc * 100)}%`;
-        this.progressBar.textContent = `${stop.label ?? ''} ${elapsed}/${total}`.trim();
+        this.client.sendEvent('rideProgressUpdate', {
+            label: stop.label ?? '',
+            current: elapsed,
+            total,
+        });
     }
 
     private hideProgress() {
-        if (this.progressContainer) {
-            this.progressContainer.remove();
-            this.progressContainer = null;
-            this.progressBar = null;
-        }
+        this.client.sendEvent('rideProgressHide');
     }
 
     cleanup() {

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -26,6 +26,11 @@
                      style="width: 0"></div>
             </div>
         </div>
+        <div id="ride-progress-container" class="position-absolute" style="bottom:10px;right:10px;width:350px;display:none;pointer-events:none;">
+            <div class="progress">
+                <div id="ride-progress-bar" class="progress-bar" style="width:0"></div>
+            </div>
+        </div>
     </div>
     <div id="main_text_output_msg_wrapper">
         <div id="split-bottom" class="split-hidden">

--- a/web-client/src/TransportProgress.ts
+++ b/web-client/src/TransportProgress.ts
@@ -1,0 +1,41 @@
+import ArkadiaClient from "./ArkadiaClient";
+
+interface ProgressData {
+  label: string;
+  current: number;
+  total: number;
+}
+
+export default class TransportProgress {
+  private container: HTMLElement | null;
+  private bar: HTMLElement | null;
+
+  constructor(client: typeof ArkadiaClient) {
+    this.container = document.getElementById("ride-progress-container");
+    this.bar = document.getElementById("ride-progress-bar");
+
+    client.on("rideProgressShow", (data: ProgressData) => this.show(data));
+    client.on("rideProgressUpdate", (data: ProgressData) => this.update(data));
+    client.on("rideProgressHide", () => this.hide());
+  }
+
+  private show(data: ProgressData) {
+    if (!this.container || !this.bar) return;
+    this.container.style.display = "block";
+    this.update(data);
+  }
+
+  private update(data: ProgressData) {
+    if (!this.container || !this.bar) return;
+    const perc = data.total > 0 ? Math.min(1, data.current / data.total) : 0;
+    this.bar.style.width = `${Math.floor(perc * 100)}%`;
+    this.bar.textContent = `${data.label} ${data.current}/${data.total}`;
+  }
+
+  private hide() {
+    if (!this.container || !this.bar) return;
+    this.container.style.display = "none";
+    this.bar.style.width = "0";
+    this.bar.textContent = "";
+  }
+}

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -7,6 +7,7 @@ import CharState from "./CharState";
 import ObjectList from "./ObjectList";
 import LampTimer from "./LampTimer";
 import BreakItemWarning from "./BreakItemWarning";
+import TransportProgress from "./TransportProgress";
 
 import "@client/src/main.ts"
 import MockPort from "./MockPort.ts";
@@ -770,6 +771,7 @@ document.addEventListener('DOMContentLoaded', () => {
     new LampTimer(arkadiaClient);
     new BreakItemWarning(arkadiaClient);
     new ObjectList(arkadiaClient);
+    new TransportProgress(arkadiaClient);
 
     // Initialize mobile direction buttons
     new MobileDirectionButtons(client);

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -87,6 +87,15 @@ window.clientExtension.addEventListener('lampTimer', (ev: CustomEvent<number | n
 window.clientExtension.addEventListener('breakItem', (ev: CustomEvent<any>) => {
     arkadiaClient.emit('breakItem', ev.detail);
 });
+window.clientExtension.addEventListener('rideProgressShow', (ev: CustomEvent<any>) => {
+    arkadiaClient.emit('rideProgressShow', ev.detail);
+});
+window.clientExtension.addEventListener('rideProgressUpdate', (ev: CustomEvent<any>) => {
+    arkadiaClient.emit('rideProgressUpdate', ev.detail);
+});
+window.clientExtension.addEventListener('rideProgressHide', () => {
+    arkadiaClient.emit('rideProgressHide');
+});
 window.clientExtension.addEventListener('settings', (ev: CustomEvent) => {
     if (ev.detail?.binds?.directions) {
         applyDirectionBinds(ev.detail.binds.directions);

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -113,6 +113,10 @@ h1 {
   color: tomato;
 }
 
+#ride-progress-container {
+  pointer-events: none;
+}
+
 #break-item-warning {
   display: none;
   color: tomato;


### PR DESCRIPTION
## Summary
- add new `transportRides` script to track travel progress using JSON definitions
- wire new script into main client setup

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687eb81c509c832a99f8cb6dea2b1458