### PR TITLE
Enable package assistant by default

### DIFF
--- a/options/src/Settings.tsx
+++ b/options/src/Settings.tsx
@@ -31,7 +31,7 @@ interface Settings {
 function SettingsForm() {
 
     const [settings, setSettings] = useState<Settings>({
-        packageHelper: false,
+        packageHelper: true,
         replaceMap: false,
         inlineCompassRose: false,
         shortenExits: false,


### PR DESCRIPTION
## Summary
- enable package assistant by default in the extension settings

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687eb43b308c832a9fdde84638352522