### PR TITLE
Auto load NPC data for package helper

### DIFF
--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -1,6 +1,7 @@
 import {colorStringInLine, findClosestColor, RESET} from "./Colors";
 import Client from "./Client";
 import { Trigger } from "./Triggers";
+import loadNpcData from "./npcDataLoader";
 
 function toTitleCase(str) {
     return str.replace(
@@ -41,6 +42,16 @@ export default class PackageHelper {
         this.client = clientExtension
         this.client.addEventListener('npc', (event) => {
             event.detail.forEach((item: { name: string | number; loc: number; }) => this.npc[item.name] = item.loc)
+        })
+
+        this.client.addEventListener('port-connected', () => {
+            this.client.port?.postMessage({ type: 'GET_STORAGE', key: 'npc' })
+            loadNpcData()
+                .then(list => {
+                    this.client.sendEvent('npc', list)
+                    this.client.port?.postMessage({ type: 'SET_STORAGE', key: 'npc', value: list })
+                })
+                .catch(e => console.error('Failed to load NPC data:', e))
         })
 
 

--- a/client/src/npcDataLoader.ts
+++ b/client/src/npcDataLoader.ts
@@ -1,0 +1,13 @@
+import { loadCachedJSON } from "./utils/dataCache";
+
+const TTL = 24 * 60 * 60 * 1000; // 24h
+
+export default function loadNpcData() {
+    return loadCachedJSON({
+        url: 'https://delwing.github.io/arkadia-mapa/data/npc.json',
+        localStorageKey: 'npc',
+        indexedDB: { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' },
+        ttl: TTL,
+        cacheInLocalStorage: false,
+    });
+}


### PR DESCRIPTION
## Summary
- load NPCs via `loadNpcData` helper
- notify package helper once NPCs load and persist them

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687ecc5c2f38832a9f0ee9206ed1f165