### PR TITLE
Unify event bus for client and arkadia client

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -18,6 +18,7 @@ import {attachGmcpListener} from "./gmcp";
 import {color} from "./Colors";
 import {SKIP_LINE} from "./ControlConstants";
 import {stripPolishCharacters} from "./stripPolishCharacters";
+import eventBus from "./eventBus";
 
 export interface ClientAdapter {
     send(text: string, echo?: boolean): void;
@@ -30,7 +31,7 @@ export interface ClientAdapter {
 export default class Client {
     clientAdapter: ClientAdapter;
     port?: any;
-    eventTarget = new EventTarget();
+    eventTarget = eventBus;
     FunctionalBind = new FunctionalBind(this);
     Triggers = new Triggers(this);
     packageHelper = new PackageHelper(this);

--- a/client/src/eventBus.ts
+++ b/client/src/eventBus.ts
@@ -1,0 +1,34 @@
+class EventBus extends EventTarget {
+    private wrappers = new WeakMap<(...args: any[]) => void, EventListener>();
+
+    on(event: string, listener: (...args: any[]) => void, options?: AddEventListenerOptions | boolean) {
+        const wrapper: EventListener = (ev: Event) => {
+            const detail = (ev as CustomEvent).detail;
+            if (Array.isArray(detail)) {
+                listener(...detail);
+            } else if (detail !== undefined) {
+                listener(detail);
+            } else {
+                listener();
+            }
+        };
+        this.wrappers.set(listener, wrapper);
+        this.addEventListener(event, wrapper, options);
+    }
+
+    off(event: string, listener: (...args: any[]) => void) {
+        const wrapper = this.wrappers.get(listener);
+        if (wrapper) {
+            this.removeEventListener(event, wrapper);
+            this.wrappers.delete(listener);
+        }
+    }
+
+    emit(event: string, ...args: any[]) {
+        const detail = args.length === 1 ? args[0] : args;
+        this.dispatchEvent(new CustomEvent(event, { detail }));
+    }
+}
+
+const eventBus = new EventBus();
+export default eventBus;

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -258,9 +258,8 @@ class ArkadiaClient implements ClientAdapter{
                     let text = atob(gmcp.text)
                     this.messageBuffer.push({text, type: gmcp.type})
                 } else {
-                    eventBus.emit(`gmcp.${type}`, gmcp)
-                    eventBus.emit('gmcp', { path: type, value: gmcp })
                     this.emit(`gmcp.${type}`, gmcp);
+                    this.emit('gmcp', { path: type, value: gmcp });
                 }
             } catch (error) {
                 console.error('Error parsing GMCP JSON:', error);
@@ -280,15 +279,15 @@ class ArkadiaClient implements ClientAdapter{
         processed.forEach((message, i) => {
             this.sendLine(message.text, message.type, i)
         })
-        eventBus.emit('output-sent', processed.length)
+        this.emit('output-sent', processed.length)
         this.messageBuffer = []
     }
 
     private sendLine(text: string, type: string, i: number) {
         text = window.clientExtension.onLine(text, type)
-        eventBus.on('output-sent', () => eventBus.emit(`gmcp_msg.${type}`, text), {once: true})
+        eventBus.on('output-sent', () => this.emit(`gmcp_msg.${type}`, text), {once: true})
         Output.send(parseAnsiPatterns(text), type);
-        eventBus.emit('line-sent')
+        this.emit('line-sent')
     }
 
     startRecording(name: string) {

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -3,10 +3,10 @@ import { RecordedEvent } from './recordingStorage';
 import Recorder from './Recorder';
 import {SKIP_LINE} from "@client/src/ControlConstants.ts";
 import {ClientAdapter} from "@client/src/Client.ts";
+import eventBus from "@client/src/eventBus.ts";
 
 // Event emitter types
 type EventListener = (...args: any[]) => void;
-type EventMap = Record<string, EventListener[]>;
 
 // WebSocket configuration
 const WEBSOCKET_URL = 'wss://arkadia.rpg.pl/wss';
@@ -17,7 +17,6 @@ const TELNET_OPTION_REGEX = /\u00FF\u00FA.*?\u00FF\u00F0|\u00FF.[^\u00FF]/g;
 
 class ArkadiaClient implements ClientAdapter{
     private socket!: WebSocket;
-    private events: EventMap = {};
     private receivedFirstGmcp: boolean = false;
     private userCommand: string | null = null;
     private passwordCommand: string | null = null;
@@ -35,29 +34,21 @@ class ArkadiaClient implements ClientAdapter{
      * Register an event listener
      */
     on(event: string, listener: EventListener): void {
-        if (!this.events[event]) {
-            this.events[event] = [];
-        }
-        this.events[event].push(listener);
+        eventBus.on(event, listener);
     }
 
     /**
      * Remove an event listener
      */
     off(event: string, listener: EventListener): void {
-        if (!this.events[event]) return;
-        const index = this.events[event].indexOf(listener);
-        if (index > -1) {
-            this.events[event].splice(index, 1);
-        }
+        eventBus.off(event, listener);
     }
 
     /**
      * Emit an event to all registered listeners
      */
     emit(event: string, ...args: any[]): void {
-        if (!this.events[event]) return;
-        this.events[event].forEach(listener => listener(...args));
+        eventBus.emit(event, ...args);
     }
 
     /**
@@ -267,8 +258,8 @@ class ArkadiaClient implements ClientAdapter{
                     let text = atob(gmcp.text)
                     this.messageBuffer.push({text, type: gmcp.type})
                 } else {
-                    window.clientExtension.sendEvent(`gmcp.${type}`, gmcp)
-                    window.clientExtension.sendEvent('gmcp', { path: type, value: gmcp })
+                    eventBus.emit(`gmcp.${type}`, gmcp)
+                    eventBus.emit('gmcp', { path: type, value: gmcp })
                     this.emit(`gmcp.${type}`, gmcp);
                 }
             } catch (error) {
@@ -289,15 +280,15 @@ class ArkadiaClient implements ClientAdapter{
         processed.forEach((message, i) => {
             this.sendLine(message.text, message.type, i)
         })
-        window.clientExtension.sendEvent('output-sent', processed.length)
+        eventBus.emit('output-sent', processed.length)
         this.messageBuffer = []
     }
 
     private sendLine(text: string, type: string, i: number) {
         text = window.clientExtension.onLine(text, type)
-        window.clientExtension.addEventListener('output-sent', () => window.clientExtension.sendEvent(`gmcp_msg.${type}`, text), {once: true})
+        eventBus.on('output-sent', () => eventBus.emit(`gmcp_msg.${type}`, text), {once: true})
         Output.send(parseAnsiPatterns(text), type);
-        window.clientExtension.sendEvent('line-sent')
+        eventBus.emit('line-sent')
     }
 
     startRecording(name: string) {

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -80,15 +80,9 @@ loadNpcData().then(npc => {
     client.sendEvent("npc", npc)
 })
 
-window.clientExtension.addEventListener('lampTimer', (ev: CustomEvent<number | null>) => {
-    arkadiaClient.emit('lampTimer', ev.detail);
-});
-window.clientExtension.addEventListener('breakItem', (ev: CustomEvent<any>) => {
-    arkadiaClient.emit('breakItem', ev.detail);
-});
-window.clientExtension.addEventListener('settings', (ev: CustomEvent) => {
-    if (ev.detail?.binds?.directions) {
-        applyDirectionBinds(ev.detail.binds.directions);
+arkadiaClient.on('settings', (detail: any) => {
+    if (detail?.binds?.directions) {
+        applyDirectionBinds(detail.binds.directions);
     }
 });
 


### PR DESCRIPTION
## Summary
- introduce shared `eventBus`
- use event bus in `Client` and `ArkadiaClient`
- remove redundant event bridging in web client

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client --silent tsc -p tsconfig.app.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687ed3648f38832a9cf128185ca27e05