### PR TITLE
Remove localStorage caching and add IndexedDB utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Rozszerzenie przeglądarki, które rozbudowuje klienta webowego [Arkadia](https:
 yarn install
 ```
 
+## Zarządzanie pamięcią podręczną
+
+Funkcja `loadCachedJSON` zapisuje pobrane dane w IndexedDB. Dodatkowe funkcje
+`clearIndexedDB` oraz `updateIndexedDB` pozwalają odpowiednio usuwać i odświeżać
+zapisane wpisy.
+
 ## Licencja
 
 MIT

--- a/client/src/scripts/herbsLoader.ts
+++ b/client/src/scripts/herbsLoader.ts
@@ -31,7 +31,6 @@ export default async function loadHerbs(): Promise<HerbsData | null> {
             localStorageKey: "herbs_data",
             indexedDB: { dbName: "ArkadiaHerbsDB", storeName: "herbs", key: "herbs" },
             ttl: TTL,
-            cacheInLocalStorage: false,
         });
     } catch (e) {
         console.error("Failed to load herbs:", e);

--- a/client/src/scripts/magicKeyLoader.ts
+++ b/client/src/scripts/magicKeyLoader.ts
@@ -15,7 +15,6 @@ export default async function loadMagicKeys(): Promise<string[]> {
             localStorageKey: "magic_keys",
             indexedDB: { dbName: "ArkadiaMagicKeysDB", storeName: "magicKeys", key: "keys" },
             ttl: TTL,
-            cacheInLocalStorage: false,
         });
         if (!Array.isArray(data.magic_keys)) {
             throw new Error("Invalid data format");

--- a/client/src/scripts/magicsLoader.ts
+++ b/client/src/scripts/magicsLoader.ts
@@ -15,7 +15,6 @@ export default async function loadMagics(): Promise<string[]> {
             localStorageKey: "magics",
             indexedDB: { dbName: "ArkadiaMagicsDB", storeName: "magics", key: "magics" },
             ttl: TTL,
-            cacheInLocalStorage: false,
         });
         const magics: string[] = [];
         for (const value of Object.values(data.magics)) {

--- a/client/src/utils/dataCache.ts
+++ b/client/src/utils/dataCache.ts
@@ -57,32 +57,24 @@ async function getFromIndexedDB(config: IndexedDBConfig, ttl?: number) {
     });
 }
 
-function storeInLocalStorage(key: string, data: any) {
-    try {
-        localStorage.setItem(key, JSON.stringify({ data, timestamp: Date.now() }));
-    } catch (e) {
-        try {
-            localStorage.removeItem(key);
-            localStorage.setItem(key, JSON.stringify({ data, timestamp: Date.now() }));
-        } catch {
-            console.error('Failed to cache data in localStorage:', e);
-        }
-    }
+export async function clearIndexedDB(config: IndexedDBConfig): Promise<void> {
+    const db = await openDatabase(config);
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction([config.storeName], 'readwrite');
+        const store = tx.objectStore(config.storeName);
+        const req = store.delete(config.key);
+        req.onsuccess = () => resolve();
+        req.onerror = () => reject(new Error('Failed to clear IndexedDB'));
+    });
 }
 
-function getFromLocalStorage(key: string, ttl?: number) {
-    const cached = localStorage.getItem(key);
-    if (!cached) return null;
-    try {
-        const parsed = JSON.parse(cached);
-        if (!ttl || (parsed.timestamp && parsed.timestamp + ttl > Date.now())) {
-            return parsed.data;
-        }
-    } catch {
-        console.error('Failed to parse cached data');
-    }
-    return null;
+export async function updateIndexedDB<T>(config: IndexedDBConfig, url: string): Promise<T> {
+    const response = await fetch(url);
+    const data = await response.json();
+    await storeInIndexedDB(config, data);
+    return data as T;
 }
+
 
 export interface LoadOptions {
     url: string;
@@ -90,7 +82,6 @@ export interface LoadOptions {
     indexedDB?: IndexedDBConfig;
     ttl?: number;
     onProgress?: (progress: number, loaded?: number, total?: number) => void;
-    cacheInLocalStorage?: boolean;
 }
 
 export async function loadCachedJSON<T>(options: LoadOptions): Promise<T> {
@@ -99,21 +90,10 @@ export async function loadCachedJSON<T>(options: LoadOptions): Promise<T> {
             const data = await getFromIndexedDB(options.indexedDB, options.ttl);
             if (data) {
                 options.onProgress?.(100);
-                if (options.cacheInLocalStorage !== false && options.localStorageKey) {
-                    storeInLocalStorage(options.localStorageKey, data);
-                }
                 return data as T;
             }
         } catch (e) {
             console.warn('Failed to load from IndexedDB:', e);
-        }
-    }
-
-    if (options.cacheInLocalStorage !== false && options.localStorageKey) {
-        const localData = getFromLocalStorage(options.localStorageKey, options.ttl);
-        if (localData) {
-            options.onProgress?.(100);
-            return localData as T;
         }
     }
 
@@ -153,8 +133,6 @@ export async function loadCachedJSON<T>(options: LoadOptions): Promise<T> {
             console.warn('Failed to store in IndexedDB:', e);
         }
     }
-    if (options.cacheInLocalStorage !== false && options.localStorageKey) {
-        storeInLocalStorage(options.localStorageKey, data);
-    }
+
     return data;
 }

--- a/web-client/src/mapDataLoader.ts
+++ b/web-client/src/mapDataLoader.ts
@@ -10,7 +10,6 @@ export function loadMapData(onProgress?: (progress: number, loaded?: number, tot
         indexedDB: { dbName: 'ArkadiaMapDB', storeName: 'mapData', key: 'mapExport' },
         ttl: TTL,
         onProgress,
-        cacheInLocalStorage: false,
     });
 }
 

--- a/web-client/src/npcDataLoader.ts
+++ b/web-client/src/npcDataLoader.ts
@@ -9,6 +9,5 @@ export function loadNpcData() {
         localStorageKey: 'npc',
         indexedDB: { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' },
         ttl: TTL,
-        cacheInLocalStorage: false,
     });
 }

--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -1,9 +1,12 @@
 import '../style.css'
 import {ChangeEvent, useEffect, useState} from "react";
 import {Button, Form, Table} from 'react-bootstrap';
-import storage from "./storage.ts";
+import {clearIndexedDB, updateIndexedDB} from "@client/src/utils/dataCache.ts";
 import {TiDelete} from "react-icons/ti";
 import {loadNpcData} from "../npcDataLoader.ts";
+
+const DB_CONFIG = { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' } as const;
+const NPC_URL = 'https://delwing.github.io/arkadia-mapa/data/npc.json';
 
 interface NpcProps {
     name: string;
@@ -22,16 +25,50 @@ function Npc() {
     }, []);
 
     function downloadNpcs() {
-        //TODO implement
+        updateIndexedDB<NpcProps[]>(DB_CONFIG, NPC_URL)
+            .then(data => setNpcs(data))
+            .catch(e => console.error('Failed to update NPC data:', e));
     }
 
     function clearNpcs() {
-        //TODO implement
+        clearIndexedDB(DB_CONFIG)
+            .then(() => setNpcs([]))
+            .catch(e => console.error('Failed to clear NPC data:', e));
     }
 
     function deleteNpc(npc: NpcProps) {
         const updated = npcs.filter(n => !(n.name === npc.name && n.loc === npc.loc))
-        //TODO implement
+        setNpcs(updated)
+        saveNpcs(updated)
+    }
+
+    async function saveNpcs(list: NpcProps[]) {
+        try {
+            const db = await openDb()
+            await new Promise<void>((resolve, reject) => {
+                const tx = db.transaction([DB_CONFIG.storeName], 'readwrite')
+                const store = tx.objectStore(DB_CONFIG.storeName)
+                const req = store.put({ id: DB_CONFIG.key, data: list, timestamp: Date.now() })
+                req.onsuccess = () => resolve()
+                req.onerror = () => reject(new Error('Failed to store data'))
+            })
+        } catch (e) {
+            console.error('Failed to save NPC list:', e)
+        }
+    }
+
+    function openDb(): Promise<IDBDatabase> {
+        return new Promise((resolve, reject) => {
+            const request = indexedDB.open(DB_CONFIG.dbName, 1)
+            request.onupgradeneeded = () => {
+                const db = request.result
+                if (!db.objectStoreNames.contains(DB_CONFIG.storeName)) {
+                    db.createObjectStore(DB_CONFIG.storeName, { keyPath: 'id' })
+                }
+            }
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(new Error('Failed to open IndexedDB'))
+        })
     }
 
     return (


### PR DESCRIPTION
## Summary
- remove `cacheInLocalStorage` option from data loader
- add `clearIndexedDB` and `updateIndexedDB` utilities
- stop passing `cacheInLocalStorage` to data loaders
- document cache management
- implement NPC data cache management using new utils

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_687ed318053c832aadf2a6eabe33a30f