### PR TITLE
Add lead route info to map label

### DIFF
--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -121,7 +121,16 @@ export default class EmbeddedMap {
             this.currentRoom = room;
             const label = document.getElementById('location-label');
             if (label && area) {
-                label.textContent = `#${room.id} ${area.areaName}`;
+                let text = `#${room.id} ${area.areaName}`;
+                if (this.destinations.length > 0) {
+                    const destId = this.destinations[0];
+                    const path = this.reader.getPath(room.id, destId);
+                    const distance = path ? path.length - 1 : 0;
+                    const destArea = this.reader.getAreaByRoomId(destId);
+                    const destName = destArea ? destArea.areaName : destId;
+                    text += ` -> #${destId} ${destName} (${distance})`;
+                }
+                label.textContent = text;
             }
 
             if (this.destinations.indexOf(room.id) > -1) {


### PR DESCRIPTION
## Summary
- show destination and distance when leading to a target

## Testing
- `yarn --cwd client test` *(fails: ships.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_687edd21ece8832a8008a8182496c08a