### PR TITLE
Add beep macro for user triggers

### DIFF
--- a/client/src/scripts/userTriggers.ts
+++ b/client/src/scripts/userTriggers.ts
@@ -6,7 +6,7 @@ function toUpperSafe(text: string) {
 }
 
 export interface UserMacro {
-    type: 'uppercase' | 'color' | 'replace';
+    type: 'uppercase' | 'color' | 'replace' | 'beep';
     color?: string;
     to?: string;
 }
@@ -50,6 +50,9 @@ export default function initUserTriggers(client: Client) {
                                 break;
                             case 'replace':
                                 result = m.to || '';
+                                break;
+                            case 'beep':
+                                client.playSound('beep');
                                 break;
                         }
                     });

--- a/client/test/userTriggers.test.ts
+++ b/client/test/userTriggers.test.ts
@@ -7,6 +7,7 @@ class FakeClient {
   addEventListener = jest.fn();
   removeEventListener = jest.fn();
   port = { postMessage: jest.fn() } as any;
+  playSound = jest.fn();
 }
 
 describe('userTriggers', () => {
@@ -39,6 +40,17 @@ describe('userTriggers', () => {
     apply({ detail: { key: 'triggers', value: list } } as any);
     const result = client.Triggers.parseLine('foo foo', '');
     expect(result).toBe('bar bar');
+  });
+
+  test('beep plays sound', () => {
+    const client = new FakeClient();
+    initUserTriggers((client as unknown) as any);
+    const apply = client.addEventListener.mock.calls.find(c => c[0] === 'storage')[1];
+    const list: UserTrigger[] = [{ pattern: 'foo', macros: [{ type: 'beep' }] }];
+    apply({ detail: { key: 'triggers', value: list } } as any);
+    const result = client.Triggers.parseLine('foo', '');
+    expect(result).toBe('foo');
+    expect(client.playSound).toHaveBeenCalledWith('beep');
   });
 });
 

--- a/web-client/src/options/UserTriggers.tsx
+++ b/web-client/src/options/UserTriggers.tsx
@@ -4,7 +4,7 @@ import { TiDelete, TiEdit } from "react-icons/ti";
 import storage from "./storage";
 
 export interface UserMacro {
-    type: 'uppercase' | 'color' | 'replace';
+    type: 'uppercase' | 'color' | 'replace' | 'beep';
     color?: string;
     to?: string;
 }
@@ -25,6 +25,7 @@ function MacroEditor({ macro, onChange, onRemove }: { macro: UserMacro; onChange
                 <option value="uppercase">Uppercase</option>
                 <option value="color">Color</option>
                 <option value="replace">Replace</option>
+                <option value="beep">Beep</option>
             </Form.Select>
             {macro.type === 'color' && (
             <Form.Control


### PR DESCRIPTION
## Summary
- extend UserTriggers options to allow `beep` macro
- play sound when trigger uses the new macro
- cover new behaviour in tests

## Testing
- `yarn --cwd client test` *(fails: ships.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_687ee9fcb7e8832abfcd99ae24566f15