### PR TITLE
Add yellow color for weapon name

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -34,6 +34,7 @@ import initBreakItem from './scripts/breakItem'
 import initPriceEvaluation from './scripts/priceEvaluation'
 import initStoneValue from './scripts/stoneValue'
 import initCoinColors from './scripts/coinColors'
+import initWeaponColors from './scripts/weaponColors'
 import initExternalScripts from './scripts/externalScripts'
 import initUserAliases from './scripts/userAliases'
 import initUserTriggers from './scripts/userTriggers'
@@ -141,6 +142,7 @@ export function registerScripts(client: Client) {
     initPriceEvaluation(client)
     initStoneValue(client, aliases)
     initCoinColors(client)
+    initWeaponColors(client)
     initLeaderAttackWarning(client)
     initBreakItem(client)
     initShortcuts(client, aliases)

--- a/client/src/scripts/weaponColors.ts
+++ b/client/src/scripts/weaponColors.ts
@@ -1,0 +1,24 @@
+import Client from "../Client";
+import { colorStringInLine, findClosestColor } from "../Colors";
+
+export const WEAPON_COLOR = findClosestColor("#ffff00");
+
+export default function initWeaponColors(client: Client) {
+    const tag = "weaponColors";
+    client.Triggers.registerTrigger(
+        /^Trzyma(?:sz)? oburacz (?<weapon1>[a-z ]+)\.$/,
+        (raw, _line, m) => colorStringInLine(raw, m.groups!.weapon1, WEAPON_COLOR),
+        tag
+    );
+    client.Triggers.registerTrigger(
+        /^Trzyma(?:sz)? (?<weapon1>[a-z ]+?) w (?:lewej|prawej) rece(?: oraz (?<weapon2>[a-z ]+?) w (?:lewej|prawej) rece)?\.$/,
+        (raw, _line, m) => {
+            let line = colorStringInLine(raw, m.groups!.weapon1, WEAPON_COLOR);
+            if (m.groups!.weapon2) {
+                line = colorStringInLine(line, m.groups!.weapon2, WEAPON_COLOR);
+            }
+            return line;
+        },
+        tag
+    );
+}

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -17,6 +17,7 @@ jest.mock('../src/main', () => ({
 }));
 
 import Client from '../src/Client';
+import { mudletColorLine } from '../src/Colors';
 import { Howl } from 'howler';
 
 jest.mock('howler', () => {
@@ -135,7 +136,7 @@ test('sendCommand prints echo commands locally', () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   const printSpy = jest.spyOn(client, 'print').mockImplementation();
   client.sendCommand('echo <red> text');
-  expect(printSpy).toHaveBeenCalledWith('<red> text');
+  expect(printSpy).toHaveBeenCalledWith(mudletColorLine('<red> text'));
   expect((global as any).clientAdapterMock.send).not.toHaveBeenCalled();
 });
 

--- a/client/test/weaponColors.test.ts
+++ b/client/test/weaponColors.test.ts
@@ -1,0 +1,35 @@
+import initWeaponColors, { WEAPON_COLOR } from '../src/scripts/weaponColors';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
+import { colorStringInLine } from '../src/Colors';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+}
+
+describe('weapon colors trigger', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initWeaponColors((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+  });
+
+  test('colors single weapon', () => {
+    const line = 'Trzymasz oburacz stalowy miecz.';
+    const result = parse(line);
+    const expected = colorStringInLine(line, 'stalowy miecz', WEAPON_COLOR);
+    expect(stripAnsiCodes(result)).toBe(line);
+    expect(result).toBe(expected);
+  });
+
+  test('colors two weapons', () => {
+    const line = 'Trzymasz stalowy miecz w lewej rece oraz drewniana tarcze w prawej rece.';
+    let expected = colorStringInLine(line, 'stalowy miecz', WEAPON_COLOR);
+    expected = colorStringInLine(expected, 'drewniana tarcze', WEAPON_COLOR);
+    const result = parse(line);
+    expect(stripAnsiCodes(result)).toBe(stripAnsiCodes(expected));
+    expect(result).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- highlight weapon names in held weapon messages using yellow
- wire up weapon colorization script in main initialization
- adjust echo command test for colorized output
- test weapon colorization

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687f5c2a2eb4832aac3209b8b905a1b6