### PR TITLE
Add season coloring for calendar triggers

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -32,6 +32,7 @@ import registerGagTriggers from './scripts/gags'
 import initLeaderAttackWarning from './scripts/leaderAttackWarning'
 import initBreakItem from './scripts/breakItem'
 import initMagikZnika from './scripts/magikZnika'
+import initSeasonPrint from './scripts/seasonPrint'
 import initPriceEvaluation from './scripts/priceEvaluation'
 import initStoneValue from './scripts/stoneValue'
 import initCoinColors from './scripts/coinColors'
@@ -147,6 +148,7 @@ export function registerScripts(client: Client) {
     initLeaderAttackWarning(client)
     initBreakItem(client)
     initMagikZnika(client)
+    initSeasonPrint(client)
     initShortcuts(client, aliases)
     initShortExits(client)
     initExternalScripts(client)

--- a/client/src/scripts/seasonPrint.ts
+++ b/client/src/scripts/seasonPrint.ts
@@ -3,6 +3,7 @@ import { colorString, findClosestColor } from "../Colors";
 import { gmcp } from "../gmcp";
 
 const SEASON_NAMES = ["wiosna", "lato", "jesien", "zima"];
+const SEASON_TEXT = SEASON_NAMES.map(n => `[ ${n.toUpperCase()} ]`);
 const SEASON_COLORS = [
     findClosestColor("#00ff7f"),
     findClosestColor("#ffff00"),
@@ -21,7 +22,7 @@ export default function initSeasonPrint(client: Client) {
         client.Triggers.registerTrigger(p, raw => {
             const idx = typeof gmcp?.room?.time?.season === "number" ? gmcp.room.time.season : -1;
             if (idx < 0 || idx >= SEASON_NAMES.length) return raw;
-            return raw + " " + colorString(SEASON_NAMES[idx], SEASON_COLORS[idx]);
+            return raw + " " + colorString(SEASON_TEXT[idx], SEASON_COLORS[idx]);
         }, tag);
     });
 }

--- a/client/src/scripts/seasonPrint.ts
+++ b/client/src/scripts/seasonPrint.ts
@@ -1,0 +1,27 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+import { gmcp } from "../gmcp";
+
+const SEASON_NAMES = ["wiosna", "lato", "jesien", "zima"];
+const SEASON_COLORS = [
+    findClosestColor("#00ff7f"),
+    findClosestColor("#ffff00"),
+    findClosestColor("#ff8c00"),
+    findClosestColor("#00bfff"),
+];
+
+export default function initSeasonPrint(client: Client) {
+    const tag = "season-print";
+    const patterns = [
+        /^Jest w przyblizeniu (\w+)(?: (?:(?:|w|po|przed|nad|poznym) |)(dzien|nocy|poludniu|poludniem|poludnie|rano|ranem|wieczorem)|),(.*,)? ((?:noc \w+|[A-Z].+?)|(.*) dzien pory (\w+)) wedlug rachuby czasu Starszego Ludu\.$/,
+        /^Jest w przyblizeniu (\w+) (?:|w|po|przed|nad|poznym)\s*(dzien|nocy|poludniu|poludniem|poludnie|rano|ranem|wieczorem).*, ((?:dzien|noc) (\w+)|(.*) dzien miesiaca (\w+)) wedlug Kalendarza Imperialnego\.$/
+    ];
+
+    patterns.forEach(p => {
+        client.Triggers.registerTrigger(p, raw => {
+            const idx = typeof gmcp?.room?.time?.season === "number" ? gmcp.room.time.season : -1;
+            if (idx < 0 || idx >= SEASON_NAMES.length) return raw;
+            return raw + " " + colorString(SEASON_NAMES[idx], SEASON_COLORS[idx]);
+        }, tag);
+    });
+}


### PR DESCRIPTION
## Summary
- show current season after calendar messages
- initialize new season print script

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687f6996b990832a82651e2b6ff4e036