### PR TITLE
Add open and close click tags

### DIFF
--- a/client/src/OutputHandler.ts
+++ b/client/src/OutputHandler.ts
@@ -32,56 +32,71 @@ export default class OutputHandler {
         }
     }
 
-    private parseSpanMarker(el: HTMLElement) {
-        const clickIndex = el.textContent.indexOf("{click:")
-        if (clickIndex === -1) {
-            return
-        }
-        const clickTitleSeparator = el.textContent.indexOf(":", clickIndex + 7)
-        const closerIndex = el.textContent.indexOf("}", clickIndex)
-        const hasTitle = clickTitleSeparator > clickIndex && clickTitleSeparator < closerIndex
-        const title = hasTitle ? el.textContent.substring(clickTitleSeparator + 1, closerIndex) : undefined
-        const callbackIndex = parseInt(el.textContent.substring(clickIndex + 7, hasTitle ? clickTitleSeparator : closerIndex))
-        el.textContent = el.textContent.substring(0, clickIndex) + el.textContent.substring(closerIndex + 1)
-        this.decorateClickable(el, callbackIndex, title)
-    }
+    private parseClickTags(msg: HTMLElement) {
+        const openReg = /\{clickOpen:(\d+)(?::([^}]+))?\}/
+        const closeReg = /\{clickClose\}/
+        let currentIndex: number | null = null
+        let currentTitle: string | undefined
 
-    private parseTextNodes(msg: HTMLElement) {
-        if (!msg.textContent || msg.textContent.indexOf("{click:") === -1) {
-            return
-        }
-        const clickReg = /\{click:(\d+)(?::([^}]+))?\}/
-        Array.from(msg.childNodes).forEach((node) => {
-            if (node.nodeType !== Node.TEXT_NODE) {
-                return
-            }
-            let text = node.textContent || ""
-            let match = clickReg.exec(text)
-            if (!match) {
-                return
-            }
-            const frag = document.createDocumentFragment()
-            while (match) {
-                const before = text.substring(0, match.index)
-                if (before) {
-                    frag.appendChild(document.createTextNode(before))
+        const processNode = (node: Node) => {
+            if (node.nodeType === Node.TEXT_NODE) {
+                let text = node.textContent || ""
+                const frag = document.createDocumentFragment()
+                while (true) {
+                    const openMatch = openReg.exec(text)
+                    const closeMatch = closeReg.exec(text)
+                    let match: RegExpExecArray | null = null
+                    let isOpen = false
+                    if (openMatch && (!closeMatch || openMatch.index <= closeMatch.index)) {
+                        match = openMatch
+                        isOpen = true
+                    } else if (closeMatch) {
+                        match = closeMatch
+                    }
+                    if (!match) {
+                        const content = text
+                        if (content) {
+                            if (currentIndex !== null) {
+                                const span = document.createElement("span")
+                                span.textContent = content
+                                this.decorateClickable(span, currentIndex, currentTitle)
+                                frag.appendChild(span)
+                            } else {
+                                frag.appendChild(document.createTextNode(content))
+                            }
+                        }
+                        break
+                    }
+                    const before = text.substring(0, match.index)
+                    if (before) {
+                        if (currentIndex !== null) {
+                            const span = document.createElement("span")
+                            span.textContent = before
+                            this.decorateClickable(span, currentIndex, currentTitle)
+                            frag.appendChild(span)
+                        } else {
+                            frag.appendChild(document.createTextNode(before))
+                        }
+                    }
+                    if (isOpen) {
+                        currentIndex = parseInt(match[1])
+                        currentTitle = match[2]
+                    } else {
+                        currentIndex = null
+                        currentTitle = undefined
+                    }
+                    text = text.substring(match.index + match[0].length)
                 }
-                text = text.substring(match.index + match[0].length)
-                const nextMatch = clickReg.exec(text)
-                const nextIndex = nextMatch ? nextMatch.index : text.length
-                const clickableText = text.substring(0, nextIndex)
-                const span = document.createElement("span")
-                span.textContent = clickableText
-                this.decorateClickable(span, parseInt(match[1]), match[2])
-                frag.appendChild(span)
-                text = text.substring(nextIndex)
-                match = nextMatch
+                (node as ChildNode).replaceWith(frag)
+            } else if (node.nodeType === Node.ELEMENT_NODE) {
+                Array.from(node.childNodes).forEach(processNode)
+                if (currentIndex !== null) {
+                    this.decorateClickable(node as HTMLElement, currentIndex, currentTitle)
+                }
             }
-            if (text) {
-                frag.appendChild(document.createTextNode(text))
-            }
-            node.replaceWith(frag)
-        })
+        }
+
+        Array.from(msg.childNodes).forEach(processNode)
     }
 
     private processOutput(event: CustomEvent) {
@@ -95,23 +110,21 @@ export default class OutputHandler {
             }
             const msg = element.querySelector(".output_msg_text") as HTMLElement | null
             if (msg) {
-                const elements: HTMLElement[] = Array.from(msg.querySelectorAll("span")) as HTMLElement[]
-                elements.filter(el => el.textContent.indexOf("click:") > -1).forEach(el => {
-                    this.parseSpanMarker(el)
-                })
-                this.parseTextNodes(msg)
+                this.parseClickTags(msg)
             }
         }
     }
 
     makeStringClickable(string: string, callback: Function, title?: string) {
         this.clickerCallbacks.push(callback)
-        return `{click:${this.clickerCallbacks.length - 1}${title ? ":" + title : ""}}${string}`
+        const index = this.clickerCallbacks.length - 1
+        return `{clickOpen:${index}${title ? ":" + title : ""}}${string}{clickClose}`
     }
 
     makeClickable(rawLine: string, string: string, callback: Function, title?: string) {
         const matchIndex = rawLine.indexOf(string)
         this.clickerCallbacks.push(callback)
-        return rawLine.substring(0, matchIndex) + `{click:${this.clickerCallbacks.length - 1}${title ? ":" + title : ""}}${string}` + rawLine.substring(matchIndex + string.length)
+        const index = this.clickerCallbacks.length - 1
+        return rawLine.substring(0, matchIndex) + `{clickOpen:${index}${title ? ":" + title : ""}}${string}{clickClose}` + rawLine.substring(matchIndex + string.length)
     }
 }

--- a/client/src/stripAnsiCodes.ts
+++ b/client/src/stripAnsiCodes.ts
@@ -1,2 +1,2 @@
 export const stripAnsiCodes = (str: string): string =>
-    str.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]|{click:\d+}/g, "");
+    str.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]|{clickOpen:\d+(?::[^}]+)?}|{clickClose}/g, "");


### PR DESCRIPTION
## Summary
- update click token handling for open/close tags
- support parsing new tags across color spans
- drop old single-token style

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687f6aea6eec832a9b8b1140bc6a4ecb