### PR TITLE
Adjust magic disappearance highlight

### DIFF
--- a/client/src/scripts/magikZnika.ts
+++ b/client/src/scripts/magikZnika.ts
@@ -1,18 +1,17 @@
 import Client from "../Client";
-import { colorString, colorStringInLine, findClosestColor } from "../Colors";
+import { colorString, findClosestColor } from "../Colors";
 
 export default function initMagikZnika(client: Client) {
     const COLOR = findClosestColor("#ff6347");
     const tag = "magik-znika";
-    const prefix = "\n\t" + colorString("[  MAGIK ZNIKA   ] ", COLOR);
+    const prefix = "\n\t" + colorString("[  MAGIK ZNIKA   ]", COLOR);
 
-    const format = (line: string) => `${client.prefix(line, prefix)}\n`;
+    const format = (line: string) => `${prefix}\n${colorString(line, COLOR)}\n`;
 
     client.Triggers.registerTrigger(
         /^Bialy, zimny plomien ogarnia (.*), w kilka chwil spopielajac .* calkowicie\.$/,
-        (_raw, line, matches) => {
-            const colored = colorStringInLine(line, matches[1], COLOR);
-            return format(colored);
+        (_raw, line) => {
+            return format(line);
         },
         tag
     );


### PR DESCRIPTION
## Summary
- show 'magik znika' prefix on its own line
- color the entire message in tomato red

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687f6a09a17c832a91ed8e9ec7d6cebd