### PR TITLE
Add map render limit setting default

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -270,7 +270,7 @@
                         <input id="ui-map-height" type="number" step="1" class="form-control" />
                     </label>
                     <label class="form-label">Zasięg renderowania mapy
-                        <input id="ui-map-limit" type="number" step="1" min="1" class="form-control" />
+                        <input id="ui-map-limit" type="number" step="1" min="1" value="35" class="form-control" />
                     </label>
                 </div>
                 <div class="modal-footer">

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -1,4 +1,4 @@
-let limit = 25;
+let limit = 35;
 
 import { MapReader, Renderer, Settings } from "mudlet-map-renderer";
 

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -16,7 +16,7 @@ const defaultSettings: UiSettings = {
     objectsFontSize: 0.6,
     buttonSize: 1,
     mapScale: 0.30,
-    mapLimit: 25,
+    mapLimit: 35,
     showButtons: true,
     mapHeight: typeof window !== 'undefined' && window.innerWidth < 768 ? 25 : 30,
     emojiLabels: false,


### PR DESCRIPTION
## Summary
- increase default map render range to 35 tiles
- add default value in UI form to match new range

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687f71bb9254832a9ba5c3d161e6054b