### PR TITLE
Fix clickable links in history view

### DIFF
--- a/client/src/OutputHandler.ts
+++ b/client/src/OutputHandler.ts
@@ -103,8 +103,9 @@ export default class OutputHandler {
         if (!this.output.children) {
             return
         }
+        const offset = this.output.querySelector('#split-bottom') ? 2 : 1
         for (let i = 0; i < event.detail; i++) {
-            const element = this.output.children[this.output.children.length - 2 - i]
+            const element = this.output.children[this.output.children.length - offset - i]
             if (!element) {
                 return;
             }

--- a/client/test/OutputHandler.test.ts
+++ b/client/test/OutputHandler.test.ts
@@ -38,6 +38,41 @@ describe('OutputHandler clickable text', () => {
     expect(msg.textContent).toBe('Click');
     span!.onclick!(new MouseEvent('click'));
     expect(cb).toHaveBeenCalledTimes(1);
-    expect((handler as any).clickerCallbacks[0]).toBeUndefined();
+  expect((handler as any).clickerCallbacks[0]).toBeUndefined();
+  });
+
+  test('handles links in sticky area', () => {
+    document.body.innerHTML =
+      '<div id="main_text_output_msg_wrapper"><div id="split-bottom"><div id="sticky-area"></div></div></div>';
+    const client = new FakeClient();
+    const handler = new OutputHandler((client as unknown) as any);
+
+    const wrapper = document.getElementById('main_text_output_msg_wrapper')!;
+    const sticky = document.getElementById('sticky-area')!;
+    const div = document.createElement('div');
+    div.className = 'output_msg';
+    const msg = document.createElement('div');
+    msg.className = 'output_msg_text';
+    const cb = jest.fn();
+    msg.textContent = handler.makeClickable('Click', 'Click', cb);
+    div.appendChild(msg);
+    const split = document.getElementById('split-bottom')!;
+    wrapper.insertBefore(div, split);
+
+    // simulate split view - clone into sticky area before output-sent event
+    sticky.appendChild(div.cloneNode(true));
+    const prev = (handler as any).output;
+    (handler as any).output = sticky;
+    handler['processOutput']!(new CustomEvent('output-sent', { detail: 1 }));
+    (handler as any).output = prev;
+
+    // process original line
+    client.dispatch('output-sent', 1);
+
+    const stickyMsg = sticky.querySelector('.output_msg_text') as HTMLElement;
+    const span = stickyMsg.querySelector('span') as HTMLSpanElement | null;
+    expect(span).not.toBeNull();
+    span!.onclick!(new MouseEvent('click'));
+    expect(cb).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- handle sticky history lines in OutputHandler
- add regression test for sticky area click tags

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687f7600cb94832a85c5337660ebd620