### PR TITLE
Remove unused map replacement setting

### DIFF
--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -49,14 +49,6 @@ function SettingsForm() {
                 <div className="d-flex flex-wrap gap-3">
                     <Form.Check
                         type="checkbox"
-                        id="replaceMap"
-                        label="Zamień wbudowaną mapę"
-                        checked={settings.replaceMap}
-                        onChange={e => onChangeSetting(s => s.replaceMap = e.target.checked)}
-                        className="me-2"
-                    />
-                    <Form.Check
-                        type="checkbox"
                         id="packageHelper"
                         label="Asystent paczek"
                         checked={settings.packageHelper}

--- a/web-client/src/options/defaultSettings.ts
+++ b/web-client/src/options/defaultSettings.ts
@@ -1,6 +1,5 @@
 export interface Settings {
     packageHelper: boolean;
-    replaceMap: boolean;
     inlineCompassRose: boolean;
     shortenExits: boolean;
     prettyContainers: boolean;
@@ -13,7 +12,6 @@ export interface Settings {
 
 export const defaultSettings: Settings = {
     packageHelper: true,
-    replaceMap: false,
     inlineCompassRose: false,
     shortenExits: false,
     prettyContainers: true,


### PR DESCRIPTION
## Summary
- remove `replaceMap` from default settings
- drop 'Zamień wbudowaną mapę' checkbox in options UI

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687f80e00bd0832ab0ee1e071e116383