### PR TITLE
Add autowalker feature

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -211,9 +211,11 @@ export default class MapHelper {
     moveBack() {
         this.locationHistory.pop()
         if (!this.locationHistory[this.locationHistory.length - 1]) {
+            this.client.sendEvent('stepBack')
             return
         }
         this.renderRoomById(this.locationHistory[this.locationHistory.length - 1])
+        this.client.sendEvent('stepBack')
     }
 
     renderRoom(room: Room) {

--- a/client/src/scripts/idz.ts
+++ b/client/src/scripts/idz.ts
@@ -1,10 +1,99 @@
 import Client from "../Client";
-import {longToShort} from "../MapHelper";
+import { longToShort } from "../MapHelper";
+import { getShortcut } from "./shortcuts";
 
 export default function initIdz(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
     if (!aliases) return;
+
+    let path: number[] = [];
+    let index = 0;
+    let delay = 1;
+    let lastDelay = 1;
+    let settings: any = {};
+    let timer: number | null = null;
+    let paused = false;
+    let target: number | null = null;
+
+    client.addEventListener('settings', (ev: CustomEvent) => {
+        settings = ev.detail || {};
+        const value = parseFloat(settings.autoWalkDelay);
+        if (!isNaN(value)) {
+            lastDelay = value;
+        }
+    });
+
+    const clearTimer = () => {
+        if (timer !== null) {
+            clearTimeout(timer);
+            timer = null;
+        }
+    };
+
+    const scheduleStep = () => {
+        if (paused || index >= path.length - 1) {
+            clearTimer();
+            if (index >= path.length - 1) {
+                path = [];
+                target = null;
+            }
+            return;
+        }
+
+        const current = client.Map.mapReader.getRoomById(path[index]);
+        const nextId = path[index + 1];
+        const exits = Object.assign({}, current.exits ?? {}, current.specialExits ?? {});
+        const dir = Object.keys(exits).find(d => exits[d] === nextId);
+        if (!dir) {
+            clearTimer();
+            path = [];
+            return;
+        }
+
+        const time = (delay + (Math.random() * 0.6 - 0.3)) * 1000;
+        timer = window.setTimeout(() => {
+            timer = null;
+            if (paused) return;
+            client.sendCommand(longToShort[dir] ?? dir);
+            index += 1;
+            scheduleStep();
+        }, time);
+    };
+
+    const startWalk = (targetId: number, d?: number) => {
+        const room: any = client.Map.currentRoom;
+        if (!room) return;
+        const p = client.Map.mapReader.getPath(room.id, targetId);
+        if (!p || p.length < 2) return;
+        path = p.map(n => parseInt(n));
+        index = 0;
+        if (d !== undefined) {
+            delay = Math.max(0.5, d);
+            lastDelay = delay;
+            settings.autoWalkDelay = lastDelay;
+            client.port?.postMessage({ type: 'SET_STORAGE', key: 'settings', value: settings });
+        } else {
+            delay = Math.max(0.5, lastDelay);
+        }
+        paused = false;
+        target = targetId;
+        clearTimer();
+        scheduleStep();
+    };
+
+    const stopWalk = () => {
+        paused = true;
+        clearTimer();
+    };
+
+    const resumeWalk = (d?: number) => {
+        if (target === null) return;
+        startWalk(target, d);
+    };
+
+    client.addEventListener('stepBack', stopWalk);
+
     aliases.push({
-        pattern: /\/idz$/, 
+        pattern: /\/idz$/,
         callback: () => {
             const room: any = client.Map.currentRoom;
             if (!room) return;
@@ -12,16 +101,68 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
             const exitDirs = Object.keys(allExits);
             if (exitDirs.length === 0) return;
 
-            let dir: string;
             if (exitDirs.length === 2 && client.Map.locationHistory.length >= 2) {
                 const prevId = client.Map.locationHistory[client.Map.locationHistory.length - 2];
                 const cameFrom = exitDirs.find(d => allExits[d] === prevId);
                 const alt = exitDirs.find(d => d !== cameFrom);
                 if (alt) {
-                    dir = alt;
+                    client.sendCommand(longToShort[alt] ?? alt);
                 }
-                client.sendCommand(longToShort[dir] ?? dir);
             }
+        }
+    });
+
+    aliases.push({
+        pattern: /^\/idz (\S+)(?:\s+([0-9]+(?:\.[0-9]{1,2})?))?$/,
+        callback: (m: RegExpMatchArray) => {
+            const key = m[1];
+            const targetId = getShortcut(key) ?? parseInt(key, 10);
+            if (isNaN(targetId)) return;
+            const d = m[2] ? parseFloat(m[2]) : undefined;
+            startWalk(targetId, d);
+        }
+    });
+
+    aliases.push({
+        pattern: /^\/stop$/,
+        callback: stopWalk
+    });
+
+    aliases.push({
+        pattern: /^\/dalej(?:\s+([0-9]+(?:\.[0-9]{1,2})?))?$/,
+        callback: (m: RegExpMatchArray) => {
+            const d = m[1] ? parseFloat(m[1]) : undefined;
+            resumeWalk(d);
+        }
+    });
+
+    aliases.push({
+        pattern: /^\/opoz ([0-9]+(?:\.[0-9]{1,2})?)$/,
+        callback: (m: RegExpMatchArray) => {
+            lastDelay = Math.max(0.5, parseFloat(m[1]));
+            delay = lastDelay;
+            settings.autoWalkDelay = lastDelay;
+            client.port?.postMessage({ type: 'SET_STORAGE', key: 'settings', value: settings });
+        }
+    });
+
+    aliases.push({
+        pattern: /^\/szybciej$/,
+        callback: () => {
+            lastDelay = Math.max(0.5, lastDelay - 1);
+            delay = Math.max(0.5, delay - 1);
+            settings.autoWalkDelay = lastDelay;
+            client.port?.postMessage({ type: 'SET_STORAGE', key: 'settings', value: settings });
+        }
+    });
+
+    aliases.push({
+        pattern: /^\/wolniej$/,
+        callback: () => {
+            lastDelay += 1;
+            delay += 1;
+            settings.autoWalkDelay = lastDelay;
+            client.port?.postMessage({ type: 'SET_STORAGE', key: 'settings', value: settings });
         }
     });
 }


### PR DESCRIPTION
## Summary
- implement `/idz <id> <time>` autowalker with `/stop` and `/dalej`
- emit `stepBack` event when moving back
- allow `/idz` to accept shortcuts
- store last timeout and reuse it if omitted or after resuming
- add `/szybciej` and `/wolniej` to adjust walking delay
- persist autowalk delay in settings
- let `/dalej` optionally set a new delay and `/idz`/`/dalej` accept decimals
- add `/opoz` alias to set delay directly

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_687f79d73e74832abe91303813c55f31