### PR TITLE
Handle idz interruption

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -102,6 +102,10 @@ export function registerScripts(client: Client) {
         client.sendEvent('refreshPositionWhenAble')
     })
 
+    client.Triggers.registerTrigger(/^Wykonywanie komendy 'idz.*' zostaje przerwane\./, () => {
+        client.Map.refreshPosition = false
+    })
+
     client.Triggers.registerTrigger('ENTER by przejsc dalej', (): string => {
         client.sendCommand('')
         return ""


### PR DESCRIPTION
## Summary
- stop refreshing map position when `idz` command execution is interrupted

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_687f9fced1c4832a880ec0b6f25a7517