### PR TITLE
Add map path for auto walking

### DIFF
--- a/client/src/scripts/idz.ts
+++ b/client/src/scripts/idz.ts
@@ -39,7 +39,12 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
             clearTimer();
             if (index >= path.length - 1) {
                 path = [];
+                const reached = target;
                 target = null;
+                client.sendEvent('leadTo');
+                if (reached !== null) {
+                    client.println(colorString(`[WALK] reached ${reached}`, COLOR));
+                }
             }
             return;
         }
@@ -51,6 +56,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
         if (!dir) {
             clearTimer();
             path = [];
+            client.sendEvent('leadTo');
             return;
         }
 
@@ -82,6 +88,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
         }
         paused = false;
         target = targetId;
+        client.sendEvent('leadTo', targetId);
         clearTimer();
         client.println(colorString(`[WALK] ${info} -> ${targetId} (${delay.toFixed(2)}s)`, COLOR));
         scheduleStep();
@@ -92,6 +99,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
         paused = true;
         clearTimer();
         if (wasWalking) {
+            client.sendEvent('leadTo');
             client.println(colorString(`[WALK] stopped`, COLOR));
         }
     };


### PR DESCRIPTION
## Summary
- send map `leadTo` event when automatic walking is started
- hide the path and print a message once destination is reached
- clear the path on walk stop or when the next room cannot be determined

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68802e6d2258832a914bb90b9aece1dc