### PR TITLE
Fix /szybciej and /wolniej delay adjustment

### DIFF
--- a/client/src/scripts/idz.ts
+++ b/client/src/scripts/idz.ts
@@ -181,8 +181,8 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
     aliases.push({
         pattern: /^\/szybciej$/,
         callback: () => {
-            lastDelay = Math.max(0.5, lastDelay - 1);
-            delay = Math.max(0.5, delay - 1);
+            lastDelay = Math.max(0.5, lastDelay - 0.5);
+            delay = Math.max(0.5, delay - 0.5);
             settings.autoWalkDelay = lastDelay;
             client.port?.postMessage({ type: 'SET_STORAGE', key: 'settings', value: settings });
             client.println(colorString(`[WALK] delay ${lastDelay.toFixed(2)}s`, COLOR));
@@ -192,8 +192,8 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
     aliases.push({
         pattern: /^\/wolniej$/,
         callback: () => {
-            lastDelay += 1;
-            delay += 1;
+            lastDelay += 0.5;
+            delay += 0.5;
             settings.autoWalkDelay = lastDelay;
             client.port?.postMessage({ type: 'SET_STORAGE', key: 'settings', value: settings });
             client.println(colorString(`[WALK] delay ${lastDelay.toFixed(2)}s`, COLOR));


### PR DESCRIPTION
## Summary
- tweak walker speed commands to adjust by 0.5s instead of 1s

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68803606cb74832a9dfb7f9e4723dde6