### PR TITLE
Add localizers from json

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -45,6 +45,7 @@ import initArmorEvaluation from './scripts/armorEvaluation'
 import initParryShieldEvaluation from './scripts/parryShieldEvaluation'
 import initShortExits from './scripts/shortExits'
 import initGps from './scripts/gps'
+import initLocalizers from './scripts/localizers'
 import initMapAliases from './scripts/mapAliases'
 import initShortcuts from './scripts/shortcuts'
 import initCompareAll from './scripts/compareAll'
@@ -122,6 +123,7 @@ export function registerScripts(client: Client) {
     initKillCounter(client, aliases)
     initEscape(client)
     initGps(client)
+    initLocalizers(client)
     initFollowSpecialExits(client)
 
 

--- a/client/src/scripts/localizers.ts
+++ b/client/src/scripts/localizers.ts
@@ -1,0 +1,48 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+import localizers from "../localizers.json";
+
+interface LocalizerEntry {
+    location: number;
+    patterns: string[];
+}
+
+export default function initLocalizers(client: Client) {
+    const COLOR = findClosestColor("#ffa500");
+    (localizers as LocalizerEntry[]).forEach(entry => {
+        const patterns = entry.patterns;
+        if (!patterns || patterns.length === 0) {
+            return;
+        }
+        const delta = patterns.length - 1;
+        let current = 1;
+        const parent = client.Triggers.registerTrigger(
+            patterns[0],
+            () => {
+                if (patterns.length === 1) {
+                    client.Map.setMapRoomById(entry.location);
+                    client.println(colorString(` Map Sync: localizer ${entry.location}`, COLOR));
+                } else {
+                    current = 0;
+                }
+                return undefined;
+            },
+            "localizers",
+            { stayOpenLines: delta }
+        );
+        if (patterns.length > 1) {
+            parent.registerChild((_, line) => {
+                if (line === patterns[current]) {
+                    current++;
+                    if (current === patterns.length) {
+                        client.Map.setMapRoomById(entry.location);
+                        client.println(colorString(` Map Sync: localizer ${entry.location}`, COLOR));
+                        current = 1;
+                    }
+                    return [line];
+                }
+                return undefined;
+            });
+        }
+    });
+}

--- a/client/test/localizers.test.ts
+++ b/client/test/localizers.test.ts
@@ -1,0 +1,26 @@
+import initLocalizers from '../src/scripts/localizers';
+import Triggers from '../src/Triggers';
+
+class FakeClient {
+  Triggers = new Triggers({} as unknown as any);
+  Map = { setMapRoomById: jest.fn() } as any;
+  println = jest.fn();
+}
+
+describe('localizers triggers', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initLocalizers(client as unknown as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    jest.clearAllMocks();
+  });
+
+  test('single line localizer sets map location', () => {
+    parse('Postoj, placyk w Grabowej Buchcie');
+    expect(client.Map.setMapRoomById).toHaveBeenCalledWith(3525);
+    expect(client.println).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- support location sync using localizers.json
- call localizers in main scripts
- test localizer triggers

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_688035132674832a802434783f8394a2