### PR TITLE
Add notification center to web-client

### DIFF
--- a/client/src/scripts/idz.ts
+++ b/client/src/scripts/idz.ts
@@ -1,12 +1,10 @@
 import Client from "../Client";
 import { longToShort } from "../MapHelper";
 import { getShortcut } from "./shortcuts";
-import { colorString, findClosestColor } from "../Colors";
+
 
 export default function initIdz(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
     if (!aliases) return;
-
-    const COLOR = findClosestColor("#ff6347");
 
     let path: number[] = [];
     let index = 0;
@@ -43,7 +41,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
                 target = null;
                 client.sendEvent('leadTo');
                 if (reached !== null) {
-                    client.println(colorString(`[WALK] reached ${reached}`, COLOR));
+                    client.sendEvent('notify', { text: `[WALK] reached ${reached}` });
                 }
             }
             return;
@@ -90,7 +88,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
         target = targetId;
         client.sendEvent('leadTo', targetId);
         clearTimer();
-        client.println(colorString(`[WALK] ${info} -> ${targetId} (${delay.toFixed(2)}s)`, COLOR));
+        client.sendEvent('notify', { text: `[WALK] ${info} -> ${targetId} (${delay.toFixed(2)}s)` });
         scheduleStep();
     };
 
@@ -100,7 +98,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
         clearTimer();
         if (wasWalking) {
             client.sendEvent('leadTo');
-            client.println(colorString(`[WALK] stopped`, COLOR));
+            client.sendEvent('notify', { text: `[WALK] stopped` });
         }
     };
 
@@ -174,7 +172,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
             delay = lastDelay;
             settings.autoWalkDelay = lastDelay;
             client.port?.postMessage({ type: 'SET_STORAGE', key: 'settings', value: settings });
-            client.println(colorString(`[WALK] delay ${lastDelay.toFixed(2)}s`, COLOR));
+            client.sendEvent('notify', { text: `[WALK] delay ${lastDelay.toFixed(2)}s` });
         }
     });
 
@@ -185,7 +183,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
             delay = Math.max(0.5, delay - 1);
             settings.autoWalkDelay = lastDelay;
             client.port?.postMessage({ type: 'SET_STORAGE', key: 'settings', value: settings });
-            client.println(colorString(`[WALK] delay ${lastDelay.toFixed(2)}s`, COLOR));
+            client.sendEvent('notify', { text: `[WALK] delay ${lastDelay.toFixed(2)}s` });
         }
     });
 
@@ -196,7 +194,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
             delay += 1;
             settings.autoWalkDelay = lastDelay;
             client.port?.postMessage({ type: 'SET_STORAGE', key: 'settings', value: settings });
-            client.println(colorString(`[WALK] delay ${lastDelay.toFixed(2)}s`, COLOR));
+            client.sendEvent('notify', { text: `[WALK] delay ${lastDelay.toFixed(2)}s` });
         }
     });
 }

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -1073,8 +1073,9 @@
         <button class="mobile-button mobile-button-text direction-button" id="special-exit-button" title="">3</button>
         <div id="z-buttons-list" class="mobile-z-buttons"></div>
         <div id="zas-buttons-list" class="mobile-z-buttons"></div>
-    </div>
+        </div>
 </div>
+<div id="notification-center"></div>
 <script type="module" src="/src/plugin.ts"></script>
 <script type="module" src="/src/main.ts"></script>
 <script type="module" src="/src/mobileButtonSettings.ts"></script>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -31,13 +31,13 @@
         <div id="split-bottom" class="split-hidden">
             <div id="sticky-area"></div>
         </div>
-        <div id="notification-center"></div>
     </div>
     <div id="char-state" data-emoji-labels="0">
         <span id="char-state-text"></span>
         <span id="lamp-timer"></span>
         <span id="break-item-warning"></span>
         <span id="package-status"></span>
+        <div id="notification-center"></div>
     </div>
     <div id="objects-list"></div>
     <button id="recording-button" class="btn btn-danger btn-sm" style="position:absolute;top:0.5rem;right:0.5rem;z-index:1012;display:none;">Zatrzymaj i zapisz</button>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -31,6 +31,7 @@
         <div id="split-bottom" class="split-hidden">
             <div id="sticky-area"></div>
         </div>
+        <div id="notification-center"></div>
     </div>
     <div id="char-state" data-emoji-labels="0">
         <span id="char-state-text"></span>
@@ -1075,7 +1076,6 @@
         <div id="zas-buttons-list" class="mobile-z-buttons"></div>
         </div>
 </div>
-<div id="notification-center"></div>
 <script type="module" src="/src/plugin.ts"></script>
 <script type="module" src="/src/main.ts"></script>
 <script type="module" src="/src/mobileButtonSettings.ts"></script>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -434,6 +434,19 @@ document.addEventListener('DOMContentLoaded', () => {
     const loginPassword = document.getElementById('login-password') as HTMLInputElement | null;
     const loginForm = document.getElementById('login-form') as HTMLFormElement | null;
     const authClose = document.getElementById('auth-close') as HTMLButtonElement | null;
+    const notificationCenter = document.getElementById('notification-center') as HTMLElement | null;
+
+    if (notificationCenter) {
+        client.eventTarget.addEventListener('notify', (ev: CustomEvent<{ text: string; time?: number }>) => {
+            const detail = ev.detail || {} as any;
+            const div = document.createElement('div');
+            div.className = 'notification';
+            div.textContent = detail.text || '';
+            notificationCenter.appendChild(div);
+            const timeout = typeof detail.time === 'number' ? detail.time : 1000;
+            setTimeout(() => div.remove(), timeout);
+        });
+    }
 
     if (menuButton) {
         new Dropdown(menuButton);

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -443,7 +443,7 @@ document.addEventListener('DOMContentLoaded', () => {
             div.className = 'notification';
             div.textContent = detail.text || '';
             notificationCenter.appendChild(div);
-            const timeout = typeof detail.time === 'number' ? detail.time : 1000;
+            const timeout = typeof detail.time === 'number' ? detail.time : 2000;
             setTimeout(() => div.remove(), timeout);
         });
     }

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -95,6 +95,7 @@ h1 {
   font-size: 0.8rem;
   background-color: var(--bs-body-bg);
   border-top: 0.1vh solid rgba(255, 255, 255, 0.1);
+  position: relative;
 }
 
 #lamp-timer {
@@ -650,7 +651,7 @@ button:focus-visible {
 
 #notification-center {
   position: absolute;
-  bottom: 0.5rem;
+  bottom: calc(100% + 0.5rem);
   right: 0.5rem;
   display: flex;
   flex-direction: column;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -649,7 +649,7 @@ button:focus-visible {
 }
 
 #notification-center {
-  position: fixed;
+  position: absolute;
   bottom: 0.5rem;
   right: 0.5rem;
   display: flex;
@@ -667,4 +667,5 @@ button:focus-visible {
   -webkit-backdrop-filter: blur(2px);
   font-size: 0.8rem;
   pointer-events: none;
+  border: 1px solid #fff;
 }

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -647,3 +647,24 @@ button:focus-visible {
   max-height: 35vh;
   max-width: 75vw;
 }
+
+#notification-center {
+  position: fixed;
+  bottom: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 1104;
+}
+
+#notification-center .notification {
+  background-color: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  font-size: 0.8rem;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- add `notification-center` container in `index.html`
- style notification center and items
- handle `notify` events in `main.ts` to show temporary messages
- update walker script to dispatch `notify` events instead of printing to output

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_688035ce6460832a9763c35ed358e19a