### PR TITLE
Fix guild save crash

### DIFF
--- a/web-client/src/options/Guilds.tsx
+++ b/web-client/src/options/Guilds.tsx
@@ -3,6 +3,7 @@ import { Button } from "react-bootstrap";
 import storage from "./storage";
 import GuildSection from "./GuildSection";
 import guilds from "./guilds";
+import { defaultSettings } from "./defaultSettings";
 
 function Guilds() {
     const [selected, setSelected] = useState<string[]>([]);
@@ -56,7 +57,15 @@ function Guilds() {
 
     function save() {
         storage.getItem("settings").then(res => {
-            const settings = { ...(res.settings || {}), guilds: selected, enemyGuilds: enemySelected, guildColors: colors };
+            const base = res && res.settings
+                ? { ...defaultSettings, ...res.settings }
+                : { ...defaultSettings };
+            const settings = {
+                ...base,
+                guilds: selected,
+                enemyGuilds: enemySelected,
+                guildColors: colors,
+            };
             storage.setItem("settings", settings).then(() => {
                 window.dispatchEvent(new Event('close-options'));
             });


### PR DESCRIPTION
## Summary
- handle missing settings when saving guild data by merging with default settings

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_68803cd1d5dc832aa7258b347de49222