### PR TITLE
Use notification center for map sync notices

### DIFF
--- a/client/src/scripts/gps.ts
+++ b/client/src/scripts/gps.ts
@@ -1,5 +1,5 @@
 import Client from "../Client";
-import { colorString, findClosestColor } from "../Colors";
+
 
 interface GpsEntry {
     gps_string_lines: string[];
@@ -10,7 +10,6 @@ interface GpsEntry {
 }
 
 export default function initGps(client: Client) {
-    const COLOR = findClosestColor("#ffa500");
 
     function register(mapData: MapData.Map) {
         mapData.forEach(area => {
@@ -53,7 +52,7 @@ export default function initGps(client: Client) {
                             }
                             if (lines.length === 1) {
                                 client.Map.setMapRoomById(room.id);
-                                client.println(colorString(` Map Sync: gps ${gpsId}`, COLOR));
+                                client.sendEvent('notify', { text: `Map Sync: gps ${gpsId}` });
                             } else {
                                 current = 0;
                             }
@@ -71,7 +70,7 @@ export default function initGps(client: Client) {
                                 current++;
                                 if (current === lines.length) {
                                     client.Map.setMapRoomById(room.id);
-                                    client.println(colorString(` Map Sync: gps ${gpsId}`, COLOR));
+                                    client.sendEvent('notify', { text: `Map Sync: gps ${gpsId}` });
                                     current = 1;
                                 }
                                 return [line];

--- a/client/src/scripts/localizers.ts
+++ b/client/src/scripts/localizers.ts
@@ -1,5 +1,5 @@
 import Client from "../Client";
-import { colorString, findClosestColor } from "../Colors";
+
 import localizers from "../localizers.json";
 
 interface LocalizerEntry {
@@ -8,7 +8,6 @@ interface LocalizerEntry {
 }
 
 export default function initLocalizers(client: Client) {
-    const COLOR = findClosestColor("#ffa500");
     (localizers as LocalizerEntry[]).forEach(entry => {
         const patterns = entry.patterns;
         if (!patterns || patterns.length === 0) {
@@ -21,7 +20,7 @@ export default function initLocalizers(client: Client) {
             () => {
                 if (patterns.length === 1) {
                     client.Map.setMapRoomById(entry.location);
-                    client.println(colorString(` Map Sync: localizer ${entry.location}`, COLOR));
+                    client.sendEvent('notify', { text: `Map Sync: localizer ${entry.location}` });
                 } else {
                     current = 0;
                 }
@@ -36,7 +35,7 @@ export default function initLocalizers(client: Client) {
                     current++;
                     if (current === patterns.length) {
                         client.Map.setMapRoomById(entry.location);
-                        client.println(colorString(` Map Sync: localizer ${entry.location}`, COLOR));
+                        client.sendEvent('notify', { text: `Map Sync: localizer ${entry.location}` });
                         current = 1;
                     }
                     return [line];

--- a/client/test/gps.test.ts
+++ b/client/test/gps.test.ts
@@ -4,7 +4,7 @@ import Triggers from '../src/Triggers';
 class FakeClient {
   Triggers = new Triggers({} as unknown as any);
   Map = { setMapRoomById: jest.fn(), currentRoom: { id: 10, areaId: 'Area' } } as any;
-  println = jest.fn();
+  sendEvent = jest.fn();
 }
 
 describe('gps triggers', () => {
@@ -48,6 +48,6 @@ describe('gps triggers', () => {
     parse('l1');
     parse('l2');
     expect(client.Map.setMapRoomById).toHaveBeenCalledWith(10);
-    expect(client.println).toHaveBeenCalled();
+    expect(client.sendEvent).toHaveBeenCalledWith('notify', { text: 'Map Sync: gps 10_0' });
   });
 });

--- a/client/test/localizers.test.ts
+++ b/client/test/localizers.test.ts
@@ -4,7 +4,7 @@ import Triggers from '../src/Triggers';
 class FakeClient {
   Triggers = new Triggers({} as unknown as any);
   Map = { setMapRoomById: jest.fn() } as any;
-  println = jest.fn();
+  sendEvent = jest.fn();
 }
 
 describe('localizers triggers', () => {
@@ -21,6 +21,6 @@ describe('localizers triggers', () => {
   test('single line localizer sets map location', () => {
     parse('Postoj, placyk w Grabowej Buchcie');
     expect(client.Map.setMapRoomById).toHaveBeenCalledWith(3525);
-    expect(client.println).toHaveBeenCalled();
+    expect(client.sendEvent).toHaveBeenCalledWith('notify', { text: 'Map Sync: localizer 3525' });
   });
 });


### PR DESCRIPTION
## Summary
- show map sync messages via notification center instead of printing
- adjust unit tests for gps and localizer scripts

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68803e30ef5c832a93468a5695cca41d