### PR TITLE
Move notification center under map label

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -20,6 +20,7 @@
     <div id="iframe-container">
         <canvas id="map" resize="true"></canvas>
         <div id="location-label"></div>
+        <div id="notification-center"></div>
         <div id="map-progress-container" class="position-absolute top-50 start-50 translate-middle w-75">
             <div class="progress">
                 <div id="map-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated"
@@ -37,7 +38,6 @@
         <span id="lamp-timer"></span>
         <span id="break-item-warning"></span>
         <span id="package-status"></span>
-        <div id="notification-center"></div>
     </div>
     <div id="objects-list"></div>
     <button id="recording-button" class="btn btn-danger btn-sm" style="position:absolute;top:0.5rem;right:0.5rem;z-index:1012;display:none;">Zatrzymaj i zapisz</button>

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -651,8 +651,8 @@ button:focus-visible {
 
 #notification-center {
   position: absolute;
-  bottom: calc(100% + 0.5rem);
-  right: 0.5rem;
+  top: 2rem;
+  left: 0.5rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- place notification center below the map's current location label
- adjust notification center positioning styles

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6880400239e8832ab510afe5b0c13248