### PR TITLE
Fix notification center overlap

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -651,7 +651,7 @@ button:focus-visible {
 
 #notification-center {
   position: absolute;
-  top: 2rem;
+  top: 3rem;
   left: 0.5rem;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- adjust the notification center position so it doesn't collide with the map location label

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688041ff60e0832ab3fca313a97536f8