### PR TITLE
Enforce narrow PackageHelper view on mobile

### DIFF
--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -124,13 +124,20 @@ export default class PackageHelper {
         };
     }
 
+    private isMobileBrowser() {
+        return typeof navigator !== 'undefined' &&
+            /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    }
+
     private packageTableCallback() {
         const lineCallback = this.packageLineCallback();
         const widthLimit = 78;
         return (raw: string): string => {
             this.onPackageList();
             const lines = raw.split('\n');
-            if (this.client.contentWidth && this.client.contentWidth < widthLimit) {
+            const narrow = this.isMobileBrowser() ||
+                (this.client.contentWidth && this.client.contentWidth < widthLimit);
+            if (narrow) {
                 const out = [shortInfo];
                 lines.forEach(line => {
                     if (line.startsWith('Tablica zawiera liste')) {

--- a/client/test/PackageHelper.test.ts
+++ b/client/test/PackageHelper.test.ts
@@ -116,4 +116,31 @@ describe('PackageHelper', () => {
       { name: 'Tom', time: '5' },
     ]);
   });
+
+  test('packageTableCallback simplifies output on mobile when width is wide', () => {
+    client.contentWidth = 100;
+    client.OutputHandler.makeClickable.mockImplementation(l => l);
+    const originalUA = navigator.userAgent;
+    Object.defineProperty(navigator, 'userAgent', { value: 'Android', configurable: true });
+
+    const cb = helper['packageTableCallback']();
+    const raw =
+      'Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:\n' +
+      ' |   1. Bob                     0/ 1/ 2        nieogr.\n' +
+      " | * 2. Tom, Foo                1/ 2/ 3        5\n" +
+      'Symbolem * oznaczono przesylki ciezkie.';
+
+    const result = cb(raw);
+    const lines = result.split('\n').map(l => l.replace(/\x1B\[[0-9;]*m/g, ''));
+    expect(lines[0]).toBe('Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:');
+    expect(lines[1]).toBe('1. Bob');
+    expect(lines[2]).toBe('   0/1/2 nieogr.');
+    expect(lines[3]).toBe('* 2. Tom, Foo');
+    expect(lines[4]).toBe('   1/2/3 5 godz.');
+    expect(helper['packages']).toEqual([
+      { name: 'Bob', time: undefined },
+      { name: 'Tom', time: '5' },
+    ]);
+    Object.defineProperty(navigator, 'userAgent', { value: originalUA });
+  });
 });


### PR DESCRIPTION
## Summary
- handle package lists in narrow format on mobile browsers
- test mobile narrowing in PackageHelper

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688094fb3494832aaf17f526c112891f