### PR TITLE
Color kill counts

### DIFF
--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -312,7 +312,10 @@ class KillCounter {
     private formatPrefix(line: string, entry: KillEntry | null, label: string) {
         const color = KILL_PREFIX_COLOR;
         const counts = entry
-            ? ` (${entry.mySession} / ${entry.mySession + entry.teamSession})`
+            ? colorString(
+                  ` (${entry.mySession} / ${entry.mySession + entry.teamSession})`,
+                  color
+              )
             : "";
         const modified = line + counts;
         return (

--- a/client/test/kill.test.ts
+++ b/client/test/kill.test.ts
@@ -44,7 +44,7 @@ describe('kill counter team kills', () => {
 
     client.TeamManager.isInTeam.mockReturnValue(true);
     result = parse(line);
-    expect(result).toContain('(0 / 1)');
+    expect(stripAnsiCodes(result)).toContain('(0 / 1)');
   });
 
   test('counts kills from team members', () => {
@@ -52,18 +52,18 @@ describe('kill counter team kills', () => {
     const line = '> Eamon zabil smoka chaosu.';
     const result = parse(line);
     expect(result).toContain('[   ZABIL   ]');
-    expect(result).toContain('(0 / 1)');
+    expect(stripAnsiCodes(result)).toContain('(0 / 1)');
   });
 
   test('session count persists after storage update', () => {
     client.TeamManager.isInTeam.mockReturnValue(true);
     let result = parse('> Eamon zabil smoka chaosu.');
-    expect(result).toContain('(0 / 1)');
+    expect(stripAnsiCodes(result)).toContain('(0 / 1)');
 
     client.dispatch('storage', { key: 'kill_counter', value: { 'smoka chaosu': 1 } });
 
     result = parse('> Eamon zabil smoka chaosu.');
-    expect(result).toContain('(0 / 2)');
+    expect(stripAnsiCodes(result)).toContain('(0 / 2)');
   });
 });
 


### PR DESCRIPTION
## Summary
- show session kill counts in tomato red
- adjust kill counter tests for colored counts

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6880afc451a8832a80565a8c92694459