### PR TITLE
Prioritize magic weapon coloring

### DIFF
--- a/client/src/scripts/weaponColors.ts
+++ b/client/src/scripts/weaponColors.ts
@@ -1,21 +1,37 @@
 import Client from "../Client";
-import { colorStringInLine, findClosestColor } from "../Colors";
+import { colorStringInLine, findClosestColor, color, RESET } from "../Colors";
+import { MAGICS_COLOR } from "./magics";
 
 export const WEAPON_COLOR = findClosestColor("#ffff00");
+
+function isMagicColored(line: string, weapon: string): boolean {
+    const colored = color(MAGICS_COLOR) + weapon + RESET;
+    return line.includes(colored);
+}
 
 export default function initWeaponColors(client: Client) {
     const tag = "weaponColors";
     client.Triggers.registerTrigger(
         /^Trzyma(?:sz)? oburacz (?<weapon1>[a-z ]+)\.$/,
-        (raw, _line, m) => colorStringInLine(raw, m.groups!.weapon1, WEAPON_COLOR),
+        (raw, _line, m) => {
+            const weapon = m.groups!.weapon1;
+            if (isMagicColored(raw, weapon)) {
+                return raw;
+            }
+            return colorStringInLine(raw, weapon, WEAPON_COLOR);
+        },
         tag
     );
     client.Triggers.registerTrigger(
         /^Trzyma(?:sz)? (?<weapon1>[a-z ]+?) w (?:lewej|prawej) rece(?: oraz (?<weapon2>[a-z ]+?) w (?:lewej|prawej) rece)?\.$/,
         (raw, _line, m) => {
-            let line = colorStringInLine(raw, m.groups!.weapon1, WEAPON_COLOR);
-            if (m.groups!.weapon2) {
-                line = colorStringInLine(line, m.groups!.weapon2, WEAPON_COLOR);
+            let line = raw;
+            const { weapon1, weapon2 } = m.groups as { weapon1: string; weapon2?: string };
+            if (!isMagicColored(line, weapon1)) {
+                line = colorStringInLine(line, weapon1, WEAPON_COLOR);
+            }
+            if (weapon2 && !isMagicColored(line, weapon2)) {
+                line = colorStringInLine(line, weapon2, WEAPON_COLOR);
             }
             return line;
         },

--- a/client/test/weaponColors.test.ts
+++ b/client/test/weaponColors.test.ts
@@ -1,6 +1,7 @@
 import initWeaponColors, { WEAPON_COLOR } from '../src/scripts/weaponColors';
 import Triggers, { stripAnsiCodes } from '../src/Triggers';
-import { colorStringInLine } from '../src/Colors';
+import { colorStringInLine, color, RESET } from '../src/Colors';
+import { MAGICS_COLOR } from '../src/scripts/magics';
 
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
@@ -29,6 +30,25 @@ describe('weapon colors trigger', () => {
     let expected = colorStringInLine(line, 'stalowy miecz', WEAPON_COLOR);
     expected = colorStringInLine(expected, 'drewniana tarcze', WEAPON_COLOR);
     const result = parse(line);
+    expect(stripAnsiCodes(result)).toBe(stripAnsiCodes(expected));
+    expect(result).toBe(expected);
+  });
+
+  test('keeps magic color for single weapon', () => {
+    const line = 'Trzymasz oburacz stalowy miecz.';
+    const magicColored = color(MAGICS_COLOR) + 'stalowy miecz' + RESET;
+    const precolored = line.replace('stalowy miecz', magicColored);
+    const result = parse(precolored);
+    expect(result).toBe(precolored);
+  });
+
+  test('keeps magic color for one of two weapons', () => {
+    const line = 'Trzymasz stalowy miecz w lewej rece oraz drewniana tarcze w prawej rece.';
+    const magicColoredWeapon = color(MAGICS_COLOR) + 'stalowy miecz' + RESET;
+    const precolored = line.replace('stalowy miecz', magicColoredWeapon);
+    let expected = precolored;
+    expected = colorStringInLine(expected, 'drewniana tarcze', WEAPON_COLOR);
+    const result = parse(precolored);
     expect(stripAnsiCodes(result)).toBe(stripAnsiCodes(expected));
     expect(result).toBe(expected);
   });


### PR DESCRIPTION
## Summary
- avoid overriding magic coloring when highlighting held weapons
- test magic color priority

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6880b9b40bc8832a9023b7000f632361