### PR TITLE
Retain functional bind on new location

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -265,7 +265,6 @@ export default class MapHelper {
     }
 
     handleNewLocation({room: room}) {
-        this.client.FunctionalBind.clear();
         this.client.addEventListener('output-sent', () => {
             if (room.userData?.bind) {
                 this.client.FunctionalBind.set(room.userData?.bind, () => this.client.sendCommand(room.userData?.bind))


### PR DESCRIPTION
## Summary
- remove `FunctionalBind.clear` call so functional bind is preserved when changing locations

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6880c01130c4832a8e3f211d1b760100