### PR TITLE
Fix NPC merge when downloading

### DIFF
--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -24,10 +24,20 @@ function Npc() {
         })
     }, []);
 
-    function downloadNpcs() {
-        updateIndexedDB<NpcProps[]>(DB_CONFIG, NPC_URL)
-            .then(data => setNpcs(data))
-            .catch(e => console.error('Failed to update NPC data:', e));
+    async function downloadNpcs() {
+        try {
+            const remote = await updateIndexedDB<NpcProps[]>(DB_CONFIG, NPC_URL)
+            const merged = [...remote]
+            npcs.forEach(n => {
+                if (!remote.find(r => r.name === n.name && r.loc === n.loc)) {
+                    merged.push(n)
+                }
+            })
+            setNpcs(merged)
+            await saveNpcs(merged)
+        } catch (e) {
+            console.error('Failed to update NPC data:', e)
+        }
     }
 
     function clearNpcs() {


### PR DESCRIPTION
## Summary
- retain existing NPC entries when downloading updates

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6880c1addb70832a9ea36ec586140c4c