### PR TITLE
Fix leadToPackage error with unknown NPC

### DIFF
--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -220,8 +220,11 @@ export default class PackageHelper {
     private leadToPackage(name: string) {
         let location = this.npc[name]
         if (!location) {
-            const [_, fallback] = Object.entries(this.npc).find(([npc, _]) => name.toLowerCase() === npc.toLowerCase())
-            location = fallback;
+            const entry = Object.entries(this.npc).find(([npc]) =>
+                name.toLowerCase() === npc.toLowerCase())
+            if (entry) {
+                location = entry[1]
+            }
         }
         if (location) {
             this.client.sendEvent('leadTo', location)

--- a/client/test/PackageHelper.test.ts
+++ b/client/test/PackageHelper.test.ts
@@ -93,6 +93,12 @@ describe('PackageHelper', () => {
     expect(client.Triggers.removeTrigger).toHaveBeenCalledWith('pickTrigger');
   });
 
+  test('leadToPackage does nothing when npc is unknown', () => {
+    helper.npc = { Bob: 1 };
+    expect(() => helper['leadToPackage']('Alice')).not.toThrow();
+    expect(client.sendEvent).not.toHaveBeenCalledWith('leadTo', expect.anything());
+  });
+
   test('packageTableCallback simplifies output when width is small', () => {
     client.contentWidth = 50;
     client.OutputHandler.makeClickable.mockImplementation(l => l);


### PR DESCRIPTION
## Summary
- prevent destructuring undefined in `leadToPackage`
- add test to cover missing NPC case

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6880d0602edc832ab615b9f402c83763