### PR TITLE
Implement package status display on inspect

### DIFF
--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -61,12 +61,9 @@ export default class PackageHelper {
             const name = toTitleCase(matches[1])
             this.leadToPackage(name)
             this.currentPackage = { name }
-            if (this.timer) {
-                this.client.sendEvent('packageStatus', { recipient: name })
-            } else {
-                this.startTimer()
-            }
-            return colorStringInLine(rawLine, matches[1], KNOWN_NPC_COLOR)
+            this.client.sendEvent('packageStatus', { recipient: name })
+            const colorCode = this.npc[name] ? KNOWN_NPC_COLOR : findClosestColor('#ffff00')
+            return colorStringInLine(rawLine, matches[1], colorCode)
         }, tag)
         this.client.Triggers.registerMultilineTrigger(packageTableRegex, this.packageTableCallback(), tag)
     }

--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -58,7 +58,10 @@ export default class PackageHelper {
     init() {
         this.enabled = true;
         this.client.Triggers.registerTrigger(/^Wypisano na niej duzymi literami: ([a-zA-Z ']+).*$/, (rawLine, __, matches): string => {
-            this.leadToPackage(toTitleCase(matches[1]));
+            const name = toTitleCase(matches[1])
+            this.leadToPackage(name);
+            this.currentPackage = {name}
+            this.startTimer()
             return colorStringInLine(rawLine, matches[1], KNOWN_NPC_COLOR)
         }, tag)
         this.client.Triggers.registerMultilineTrigger(packageTableRegex, this.packageTableCallback(), tag)
@@ -220,8 +223,10 @@ export default class PackageHelper {
     private leadToPackage(name: string) {
         let location = this.npc[name]
         if (!location) {
-            const [_, fallback] = Object.entries(this.npc).find(([npc, _]) => name.toLowerCase() === npc.toLowerCase())
-            location = fallback;
+            const found = Object.entries(this.npc).find(([npc]) => name.toLowerCase() === npc.toLowerCase())
+            if (found) {
+                [, location] = found
+            }
         }
         if (location) {
             this.client.sendEvent('leadTo', location)

--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -59,9 +59,13 @@ export default class PackageHelper {
         this.enabled = true;
         this.client.Triggers.registerTrigger(/^Wypisano na niej duzymi literami: ([a-zA-Z ']+).*$/, (rawLine, __, matches): string => {
             const name = toTitleCase(matches[1])
-            this.leadToPackage(name);
-            this.currentPackage = {name}
-            this.startTimer()
+            this.leadToPackage(name)
+            this.currentPackage = { name }
+            if (this.timer) {
+                this.client.sendEvent('packageStatus', { recipient: name })
+            } else {
+                this.startTimer()
+            }
             return colorStringInLine(rawLine, matches[1], KNOWN_NPC_COLOR)
         }, tag)
         this.client.Triggers.registerMultilineTrigger(packageTableRegex, this.packageTableCallback(), tag)

--- a/client/test/PackageHelper.test.ts
+++ b/client/test/PackageHelper.test.ts
@@ -94,9 +94,10 @@ describe('PackageHelper', () => {
     expect(client.Triggers.removeTrigger).toHaveBeenCalledWith('pickTrigger');
   });
 
-  test('label trigger updates package status', () => {
+  test('label trigger updates package status without starting timer', () => {
     helper.init();
     const trigger = client.Triggers.registerTrigger.mock.calls[0][1];
+    const startSpy = jest.spyOn(helper as any, 'startTimer');
     const raw = 'Wypisano na niej duzymi literami: Bob';
     const regex = /^Wypisano na niej duzymi literami: ([a-zA-Z ']+).*$/;
     const match = raw.match(regex)!;
@@ -105,8 +106,9 @@ describe('PackageHelper', () => {
 
     expect(helper.currentPackage).toEqual({ name: 'Bob' });
     expect(client.sendEvent).toHaveBeenCalledWith('packageStatus', { recipient: 'Bob' });
-    const expectedColor = colorStringInLine(raw, 'Bob', findClosestColor('#63ba41'));
+    const expectedColor = colorStringInLine(raw, 'Bob', findClosestColor('#ffff00'));
     expect(result).toBe(expectedColor);
+    expect(startSpy).not.toHaveBeenCalled();
   });
 
   test('packageTableCallback simplifies output when width is small', () => {

--- a/client/test/PackageHelper.test.ts
+++ b/client/test/PackageHelper.test.ts
@@ -11,6 +11,7 @@ describe('PackageHelper', () => {
       Triggers: {
         registerTrigger: jest.fn(),
         registerOneTimeTrigger: jest.fn(),
+        registerMultilineTrigger: jest.fn(),
         removeTrigger: jest.fn(),
         removeByTag: jest.fn(),
       },
@@ -91,6 +92,21 @@ describe('PackageHelper', () => {
     failCb('', '', {} as any);
 
     expect(client.Triggers.removeTrigger).toHaveBeenCalledWith('pickTrigger');
+  });
+
+  test('label trigger updates package status', () => {
+    helper.init();
+    const trigger = client.Triggers.registerTrigger.mock.calls[0][1];
+    const raw = 'Wypisano na niej duzymi literami: Bob';
+    const regex = /^Wypisano na niej duzymi literami: ([a-zA-Z ']+).*$/;
+    const match = raw.match(regex)!;
+
+    const result = trigger(raw, '', match);
+
+    expect(helper.currentPackage).toEqual({ name: 'Bob' });
+    expect(client.sendEvent).toHaveBeenCalledWith('packageStatus', { recipient: 'Bob' });
+    const expectedColor = colorStringInLine(raw, 'Bob', findClosestColor('#63ba41'));
+    expect(result).toBe(expectedColor);
   });
 
   test('packageTableCallback simplifies output when width is small', () => {


### PR DESCRIPTION
## Summary
- show package info when inspecting package
- handle unknown recipients gracefully
- test package label trigger

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6880d07b1804832a8d9af5aa5aba06c2