### PR TITLE
Fix package inspection

### DIFF
--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -60,8 +60,13 @@ export default class PackageHelper {
         this.client.Triggers.registerTrigger(/^Wypisano na niej duzymi literami: ([a-zA-Z ']+).*$/, (rawLine, __, matches): string => {
             const name = toTitleCase(matches[1])
             this.leadToPackage(name)
-            this.currentPackage = { name }
+            if (!this.currentPackage || this.currentPackage.name !== name) {
+                this.currentPackage = { name }
+            }
             this.client.sendEvent('packageStatus', { recipient: name })
+            if (!this.deliveryTrigger) {
+                this.registerDeliveryTrigger()
+            }
             const colorCode = this.npc[name] ? KNOWN_NPC_COLOR : findClosestColor('#ffff00')
             return colorStringInLine(rawLine, matches[1], colorCode)
         }, tag)
@@ -93,20 +98,7 @@ export default class PackageHelper {
             this.currentPackage = this.packages[this.pick - 1]
             this.leadToPackage(this.currentPackage.name)
             this.startTimer()
-            this.deliveryTrigger = this.client.Triggers.registerOneTimeTrigger(/^(Oddajesz|Zwracasz) pocztowa paczke/, (_, __, matches): undefined => {
-                if (matches[1] === 'Oddajesz') {
-                    if (!this.npc[this.currentPackage.name]) {
-                        this.client.println(`Nowy adresat: ${this.currentPackage.name} | ${this.client.Map.currentRoom.id}`)
-                        this.client.port.postMessage({
-                            type: 'NEW_NPC',
-                            name: this.currentPackage.name,
-                            loc: this.client.Map.currentRoom.id
-                        })
-                    }
-                }
-                this.currentPackage = undefined;
-                this.stopTimer()
-            })
+            this.registerDeliveryTrigger()
         })
         this.failTrigger = this.client.Triggers.registerOneTimeTrigger(notTrustedMessage, (): undefined => {
             if (this.pickTrigger) {
@@ -219,6 +211,24 @@ export default class PackageHelper {
             this.timer = undefined
         }
         this.client.sendEvent('packageStatus', null)
+    }
+
+    private registerDeliveryTrigger() {
+        this.deliveryTrigger = this.client.Triggers.registerOneTimeTrigger(/^(Oddajesz|Zwracasz) pocztowa paczke/, (_, __, matches): undefined => {
+            if (matches[1] === 'Oddajesz') {
+                if (!this.npc[this.currentPackage.name]) {
+                    this.client.println(`Nowy adresat: ${this.currentPackage.name} | ${this.client.Map.currentRoom.id}`)
+                    this.client.port.postMessage({
+                        type: 'NEW_NPC',
+                        name: this.currentPackage.name,
+                        loc: this.client.Map.currentRoom.id
+                    })
+                }
+            }
+            this.currentPackage = undefined;
+            this.stopTimer();
+            this.deliveryTrigger = undefined;
+        })
     }
 
     private leadToPackage(name: string) {

--- a/client/test/PackageHelper.test.ts
+++ b/client/test/PackageHelper.test.ts
@@ -98,6 +98,7 @@ describe('PackageHelper', () => {
     helper.init();
     const trigger = client.Triggers.registerTrigger.mock.calls[0][1];
     const startSpy = jest.spyOn(helper as any, 'startTimer');
+    const registerSpy = jest.spyOn(helper as any, 'registerDeliveryTrigger');
     const raw = 'Wypisano na niej duzymi literami: Bob';
     const regex = /^Wypisano na niej duzymi literami: ([a-zA-Z ']+).*$/;
     const match = raw.match(regex)!;
@@ -109,6 +110,49 @@ describe('PackageHelper', () => {
     const expectedColor = colorStringInLine(raw, 'Bob', findClosestColor('#ffff00'));
     expect(result).toBe(expectedColor);
     expect(startSpy).not.toHaveBeenCalled();
+    expect(registerSpy).toHaveBeenCalled();
+  });
+
+  test('label trigger does not overwrite current package when name matches', () => {
+    helper.init();
+    helper.currentPackage = { name: 'Bob', time: '5' } as any;
+    const trigger = client.Triggers.registerTrigger.mock.calls[0][1];
+    const raw = 'Wypisano na niej duzymi literami: Bob';
+    const regex = /^Wypisano na niej duzymi literami: ([a-zA-Z ']+).*$/;
+    const match = raw.match(regex)!;
+
+    trigger(raw, '', match);
+
+    expect(helper.currentPackage).toEqual({ name: 'Bob', time: '5' });
+    expect(client.sendEvent).toHaveBeenCalledWith('packageStatus', { recipient: 'Bob' });
+  });
+
+  test('label trigger skips registering delivery trigger when already registered', () => {
+    helper.init();
+    helper.deliveryTrigger = 'exists' as any;
+    const trigger = client.Triggers.registerTrigger.mock.calls[0][1];
+    const spy = jest.spyOn(helper as any, 'registerDeliveryTrigger');
+    const raw = 'Wypisano na niej duzymi literami: Bob';
+    const regex = /^Wypisano na niej duzymi literami: ([a-zA-Z ']+).*$/;
+    const match = raw.match(regex)!;
+
+    trigger(raw, '', match);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test('label trigger replaces current package when name differs', () => {
+    helper.init();
+    helper.currentPackage = { name: 'Bob', time: '5' } as any;
+    const trigger = client.Triggers.registerTrigger.mock.calls[0][1];
+    const raw = 'Wypisano na niej duzymi literami: Tom';
+    const regex = /^Wypisano na niej duzymi literami: ([a-zA-Z ']+).*$/;
+    const match = raw.match(regex)!;
+
+    trigger(raw, '', match);
+
+    expect(helper.currentPackage).toEqual({ name: 'Tom' });
+    expect(client.sendEvent).toHaveBeenCalledWith('packageStatus', { recipient: 'Tom' });
   });
 
   test('packageTableCallback simplifies output when width is small', () => {


### PR DESCRIPTION
## Summary
- refine package inspection so repeated checks don't reset the timer
- add regression tests for inspecting packages with same/different names
- register delivery trigger on inspect if missing

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6880e28823f8832a934e7354f60bc18c