### PR TITLE
Fix package helper init when settings undefined

### DIFF
--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -55,6 +55,8 @@ export default class PackageHelper {
                 this.disable()
             }
         })
+
+        this.init()
     }
 
     init() {

--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -47,9 +47,11 @@ export default class PackageHelper {
 
 
         this.client.addEventListener('settings', (event) => {
-            if (!this.enabled && event.detail.packageHelper) {
+            const setting = event.detail?.packageHelper
+            const shouldEnable = setting === undefined ? true : setting
+            if (!this.enabled && shouldEnable) {
                 this.init()
-            } else if (this.enabled && !event.detail.packageHelper) {
+            } else if (this.enabled && !shouldEnable) {
                 this.disable()
             }
         })

--- a/client/test/PackageHelper.test.ts
+++ b/client/test/PackageHelper.test.ts
@@ -29,6 +29,35 @@ describe('PackageHelper', () => {
       sendCommand: jest.fn(),
     };
     helper = new PackageHelper(client);
+    client.Triggers.registerTrigger.mockClear();
+    client.Triggers.registerMultilineTrigger.mockClear();
+  });
+
+  test('constructor initializes helper by default', () => {
+    const c = {
+      Triggers: {
+        registerTrigger: jest.fn(),
+        registerOneTimeTrigger: jest.fn(),
+        registerMultilineTrigger: jest.fn(),
+        removeTrigger: jest.fn(),
+        removeByTag: jest.fn(),
+      },
+      OutputHandler: {
+        makeClickable: jest.fn(),
+      },
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      sendEvent: jest.fn(),
+      createButton: jest.fn(() => ({ remove: jest.fn() })),
+      println: jest.fn(),
+      Map: { currentRoom: { id: 1 } },
+      port: { postMessage: jest.fn() },
+      FunctionalBind: { set: jest.fn(), clear: jest.fn(), newMessage: jest.fn() },
+      sendCommand: jest.fn(),
+    };
+    const h = new PackageHelper(c as any);
+    expect(c.Triggers.registerTrigger).toHaveBeenCalled();
+    expect(h.enabled).toBe(true);
   });
 
   test('packageLineCallback returns clickable line and stores package', () => {


### PR DESCRIPTION
## Summary
- ensure PackageHelper enables by default when settings lack `packageHelper`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6880f0599e5c832aa4f9be61f2f9f449