### PR TITLE
Normalize player name to title case

### DIFF
--- a/client/src/ObjectManager.ts
+++ b/client/src/ObjectManager.ts
@@ -1,4 +1,5 @@
 import Client from "./Client";
+import toTitleCase from "./utils/toTitleCase";
 
 export interface ObjectData {
     desc?: string;
@@ -61,7 +62,7 @@ export default class ObjectManager {
                 this.data[this.playerNum] = {};
             }
             if (detail.name) {
-                this.data[this.playerNum].desc = detail.name;
+                this.data[this.playerNum].desc = toTitleCase(detail.name);
             }
         }
     }

--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -1,13 +1,7 @@
 import {colorStringInLine, findClosestColor, RESET} from "./Colors";
 import Client from "./Client";
 import { Trigger } from "./Triggers";
-
-function toTitleCase(str) {
-    return str.replace(
-        /\w\S*/g,
-        text => text.charAt(0).toUpperCase() + text.substring(1).toLowerCase()
-    );
-}
+import toTitleCase from "./utils/toTitleCase";
 
 const tag = "packageHelper";
 const pickCommand = "wybierz paczke"

--- a/client/src/utils/toTitleCase.ts
+++ b/client/src/utils/toTitleCase.ts
@@ -1,0 +1,7 @@
+export default function toTitleCase(str: string): string {
+    return str.replace(
+        /\w\S*/g,
+        (text) => text.charAt(0).toUpperCase() + text.substring(1).toLowerCase(),
+    );
+}
+

--- a/client/test/ObjectManager.test.ts
+++ b/client/test/ObjectManager.test.ts
@@ -53,6 +53,15 @@ describe('ObjectManager', () => {
     ]);
   });
 
+  test('normalizes player name to title case', () => {
+    client.sendEvent('gmcp.char.info', { object_num: 1, name: 'hERO NAME' });
+    client.sendEvent('gmcp.char.state', { hp: 10 });
+    client.sendEvent('gmcp.objects.nums', []);
+    expect(manager.getObjectsOnLocation()).toEqual([
+      { num: 1, desc: 'Hero Name', state: 10, attack_num: undefined, avatar_target: undefined, shortcut: '@' },
+    ]);
+  });
+
   test('sets avatar target flag', () => {
     client.sendEvent('gmcp.objects.data', { '1': { desc: 'Ogre', avatar_target: true } });
     client.sendEvent('gmcp.objects.nums', ['1']);


### PR DESCRIPTION
## Summary
- centralize `toTitleCase` helper
- use `toTitleCase` when capturing own character name
- test normalization of player name

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68812a677968832a92829549c928a3d1