### PR TITLE
Add guild postfix highlighting

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -307,6 +307,10 @@ export default class Client {
         return prefix + rawLine
     }
 
+    postfix(rawLine: string, postfix: string) {
+        return rawLine + postfix
+    }
+
     updateContentWidth() {
         const content = document.getElementById('main_text_output_msg_wrapper') as HTMLElement | null
         const measure = document.getElementById('content-width-measure') as HTMLElement | null

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -43,6 +43,7 @@ import initUserTriggers from './scripts/userTriggers'
 import initWeaponEvaluation from './scripts/weaponEvaluation'
 import initArmorEvaluation from './scripts/armorEvaluation'
 import initParryShieldEvaluation from './scripts/parryShieldEvaluation'
+import initGuildPostfix from './scripts/guildPostfix'
 import initShortExits from './scripts/shortExits'
 import initGps from './scripts/gps'
 import initLocalizers from './scripts/localizers'
@@ -155,6 +156,7 @@ export function registerScripts(client: Client) {
     initBreakItem(client)
     initMagikZnika(client)
     initSeasonPrint(client)
+    initGuildPostfix(client)
     initShortcuts(client, aliases)
     initShortExits(client)
     initExternalScripts(client)

--- a/client/src/scripts/guildPostfix.ts
+++ b/client/src/scripts/guildPostfix.ts
@@ -1,0 +1,34 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+const SLATE_BLUE = findClosestColor("#6a5acd");
+
+export default function initGuildPostfix(client: Client) {
+    const tag = "guildPostfix";
+    function register(pattern: RegExp | string, guild: string) {
+        client.Triggers.registerTrigger(pattern, (raw) => {
+            return client.postfix(raw, colorString(` [${guild}]`, SLATE_BLUE));
+        }, tag);
+    }
+
+    register(/^Na szyi ma zawiazana .* ze znakiem czarnego gryfa\.$/, "KG");
+    register(/Jego brzuszek wyglada/, "ZH");
+    register(/^ Na .* szyi, na skorzanym rzemieniu wisi .* elfi flet\.$/, "LE");
+    register(/^Na biodrach ma zalozony .* krasnoludzki kilt .* klamra\.$/, "KGKS");
+    register(/Jego bialy plaszcz symbolizuje przynaleznosc do Zakonu Rycerskiego Sigmara Mlotodzierzcy./, "ZS");
+    register(/biala tunika zakonna symbolizuje/, "ZS");
+    register(/Na zbroje ma narzucona zgrzebna szate zakonna./, "ZS");
+    register(/na szyi nosi .* lancuch o najwiekszym ogniwie zwienczonym miniaturowa tarcza, na ktorej tle umieszczono skrzyzowany z waga kupiecka buzdygan\./, "GL");
+    register(/pocieta jest .* wojownik/, "GL");
+    register(/Przy pasie nosi bawoli rog/, "OHM");
+    register(/ herb.* Rodziny Alderazzi/, "RA");
+    register(/na ktorym wyryto otoczony czerwonymi rautami emblemat/, "WKS");
+    register(/Klamre .* pasa zdobi/, "KM");
+    register(/nieustepliwe niczym skelliganskie sztormy spojrzenie/, "KS");
+    register(/Noszony.*pierscien.*Kupcow/, "CKN");
+    register(/charakterystyczna dla mieszkancow Zajazdu/, "BK");
+    register(/zamek ze znakiem Stowarzyszenia Gnomich Wynalazcow/, "SGW");
+    register(/kubraczek, tradycyjny stroj Elfow z Gor Sinych/, "ES");
+    register(/nosi piekna .* obrecz (?:wysadzana)?/, "OK");
+    register(/^Nosi przypiety .* wiewiorczy ogon .* przynaleznosci do Komanda Scoia'tael\./, "SC");
+}


### PR DESCRIPTION
## Summary
- add `postfix` helper in Client
- highlight guild lines with slate blue postfix

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68812ba0ec08832a8bcede777c1fbcba