### PR TITLE
Store NPCs in IndexedDB

### DIFF
--- a/web-client/src/MockPort.ts
+++ b/web-client/src/MockPort.ts
@@ -1,5 +1,49 @@
 import storage from "./options/storage.ts";
 
+const DB_CONFIG = { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' } as const;
+
+function openDb(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open(DB_CONFIG.dbName, 1);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(DB_CONFIG.storeName)) {
+                db.createObjectStore(DB_CONFIG.storeName, { keyPath: 'id' });
+            }
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(new Error('Failed to open IndexedDB'));
+    });
+}
+
+async function getNpcs(): Promise<any[]> {
+    try {
+        const db = await openDb();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction([DB_CONFIG.storeName], 'readonly');
+            const store = tx.objectStore(DB_CONFIG.storeName);
+            const req = store.get(DB_CONFIG.key);
+            req.onsuccess = () => {
+                resolve(req.result ? req.result.data : []);
+            };
+            req.onerror = () => reject(new Error('Failed to read data'));
+        });
+    } catch {
+        return [];
+    }
+}
+
+async function saveNpcs(list: any[]) {
+    const db = await openDb();
+    return new Promise<void>((resolve, reject) => {
+        const tx = db.transaction([DB_CONFIG.storeName], 'readwrite');
+        const store = tx.objectStore(DB_CONFIG.storeName);
+        const req = store.put({ id: DB_CONFIG.key, data: list, timestamp: Date.now() });
+        req.onsuccess = () => resolve();
+        req.onerror = () => reject(new Error('Failed to store data'));
+    });
+}
+
 export default class MockPort {
     listeners: Array<(msg: any) => void> = [];
     onMessage = {
@@ -25,12 +69,15 @@ export default class MockPort {
 
     postMessage(message: any) {
         if (message.type === 'NEW_NPC') {
-            const raw = localStorage.getItem('npc');
-            const npc = raw ? JSON.parse(raw) : [];
-            npc.push({name: message.name, loc: message.loc});
-            localStorage.setItem('npc', JSON.stringify(npc));
-            this.dispatch({npc});
-            this.dispatch({storage: {key: 'npc', value: npc}});
+            getNpcs().then(async npc => {
+                npc = Array.isArray(npc) ? npc : [];
+                if (!npc.some((n: any) => n.name === message.name && n.loc === message.loc)) {
+                    npc.push({ name: message.name, loc: message.loc });
+                    await saveNpcs(npc);
+                }
+                this.dispatch({ npc });
+                this.dispatch({ storage: { key: 'npc', value: npc } });
+            }).catch(e => console.error('Failed to add NPC:', e));
             return;
         }
         if (message.type === 'SET_STORAGE') {

--- a/web-client/src/npcDataLoader.ts
+++ b/web-client/src/npcDataLoader.ts
@@ -6,7 +6,6 @@ const TTL = 24 * 60 * 60 * 1000; // 24h
 export function loadNpcData() {
     return loadCachedJSON({
         url: 'https://delwing.github.io/arkadia-mapa/data/npc.json',
-        localStorageKey: 'npc',
         indexedDB: { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' },
         ttl: TTL,
     });


### PR DESCRIPTION
## Summary
- update `MockPort` to save new NPCs to IndexedDB
- remove unused localStorage reference from `npcDataLoader`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68813c00ae88832a9157e09c25593b54