### PR TITLE
Fix triggers to sanitize raw lines

### DIFF
--- a/client/src/scripts/attackBeep.ts
+++ b/client/src/scripts/attackBeep.ts
@@ -1,5 +1,6 @@
 import Client from "../Client";
 import {colorString, findClosestColor} from "../Colors";
+import { stripAnsiCodes } from "../Triggers";
 import people from '../people.json';
 
 const RED = findClosestColor("#ff0000");
@@ -69,5 +70,8 @@ export default function initAttackBeep(client: Client) {
         /^\w+(?: \w+){0,4} z pierwotna wsciekloscia (?<upper>rzuca sie na ciebie), rozpoczynajac walke!/
     ].forEach(p => client.Triggers.registerTrigger(p, beep, tag));
 
-    client.Triggers.registerTrigger(/atakuje cie!$/, (_r, line) => highlightPhrase(line), tag);
+    client.Triggers.registerTrigger(/atakuje cie!$/, (raw) => {
+        const line = stripAnsiCodes(raw).replace(/\s$/g, "");
+        return highlightPhrase(line);
+    }, tag);
 }

--- a/client/src/scripts/bagManager.ts
+++ b/client/src/scripts/bagManager.ts
@@ -177,8 +177,8 @@ function showInterface(client: Client, bags: string[]) {
 function configure(client: Client) {
     const found: string[] = [];
     const tag = "bag-config";
-    client.Triggers.registerTrigger(/.*/, (raw, line) => {
-        const l = stripAnsiCodes(line).toLowerCase();
+    client.Triggers.registerTrigger(/.*/, (raw) => {
+        const l = stripAnsiCodes(raw).replace(/\s$/g, "").toLowerCase();
         if (l.startsWith("masz przy sobie")) {
             client.Triggers.removeByTag(tag);
             showInterface(client, found);

--- a/client/src/scripts/breakItem.ts
+++ b/client/src/scripts/breakItem.ts
@@ -1,5 +1,6 @@
 import Client from "../Client";
 import { colorString, findClosestColor } from "../Colors";
+import { stripAnsiCodes } from "../Triggers";
 
 export default function initBreakItem(client: Client) {
     const COLOR = findClosestColor("#ff6347");
@@ -20,7 +21,8 @@ export default function initBreakItem(client: Client) {
     const format = (line: string) => `\n\n${client.prefix(line, colorString("[  SPRZET  ] ", COLOR))}\n\n`;
 
     entries.forEach(({ pattern, command }) => {
-        client.Triggers.registerTrigger(pattern, (_raw, line) => {
+        client.Triggers.registerTrigger(pattern, (raw) => {
+            const line = stripAnsiCodes(raw).replace(/\s$/g, "");
             client.playSound("beep");
             client.sendEvent('breakItem', { text: line, command });
             const label = command ? ` >> ${command}` : " >> Sprzet zniszczony";

--- a/client/src/scripts/buses.ts
+++ b/client/src/scripts/buses.ts
@@ -1,4 +1,5 @@
 import Client from "../Client";
+import { stripAnsiCodes } from "../Triggers";
 
 const DILIZANS_CMDS = ["wem", "wsiadz do dylizansu", "wlm"];
 const DILIZANS_LABEL = DILIZANS_CMDS.join(";");
@@ -31,7 +32,8 @@ export default function initBuses(client: Client) {
         "Otwarty jadacy powoz powoli zatrzymuje sie.",
     ];
 
-    const boardPowoz = (_raw: string, line: string) => {
+    const boardPowoz = (raw: string) => {
+        const line = stripAnsiCodes(raw).replace(/\s$/g, "");
         if (line.includes("powoli rusza w droge")) return undefined;
         if (exitPowozPatterns.some(p => typeof p === "string" ? line === p : p.test(line))) {
             return undefined;

--- a/client/src/scripts/deposits.ts
+++ b/client/src/scripts/deposits.ts
@@ -54,18 +54,21 @@ export default function initDeposits(client: Client, aliases?: { pattern: RegExp
         persist();
     }
 
-    const matchContents = (_raw: string, line: string) => {
-        const match = stripAnsiCodes(line).match(/^Twoj depozyt zawiera (?<content>.+)\.$/);
+    const matchContents = (raw: string) => {
+        const line = stripAnsiCodes(raw).replace(/\s$/g, "");
+        const match = line.match(/^Twoj depozyt zawiera (?<content>.+)\.$/);
         if (match) {
             match.groups = Object.assign({ container: 'depozyt' }, match.groups);
         }
         return match;
     };
-    const matchEmpty = (_raw: string, line: string) => {
-        return stripAnsiCodes(line).match(/^Twoj depozyt jest pusty\./);
+    const matchEmpty = (raw: string) => {
+        const line = stripAnsiCodes(raw).replace(/\s$/g, "");
+        return line.match(/^Twoj depozyt jest pusty\./);
     };
-    const matchNone = (_raw: string, line: string) => {
-        return stripAnsiCodes(line).match(/^Nie posiadasz wykupionego depozytu\./);
+    const matchNone = (raw: string) => {
+        const line = stripAnsiCodes(raw).replace(/\s$/g, "");
+        return line.match(/^Nie posiadasz wykupionego depozytu\./);
     };
 
     client.Triggers.registerTrigger(matchContents, (_r, _l, m) => {

--- a/client/src/scripts/escape.ts
+++ b/client/src/scripts/escape.ts
@@ -1,5 +1,6 @@
 import Client from "../Client";
 import {colorString, findClosestColor} from "../Colors";
+import { stripAnsiCodes } from "../Triggers";
 
 const COLOR = findClosestColor('#6a5acd');
 const PANIC_COLOR = findClosestColor('#ff8c00');
@@ -8,18 +9,23 @@ export default function initEscape(client: Client) {
     const tag = 'escape';
     const parent = client.Triggers.registerTrigger(
         /(.*) uciekl.* ci\.$/,
-        (_, line) => colorString(line, COLOR),
+        (raw) => {
+            const line = stripAnsiCodes(raw).replace(/\s$/g, "");
+            return colorString(line, COLOR);
+        },
         tag,
         {stayOpenLines: 20}
     );
 
-    parent.registerChild(/(.*) podaza(?:ja)? na ([a-z-]+)\.$/, (_, line, m) => {
+    parent.registerChild(/(.*) podaza(?:ja)? na ([a-z-]+)\.$/, (raw, _line, m) => {
+        const line = stripAnsiCodes(raw).replace(/\s$/g, "");
         const dir = m[2];
         printArrow(dir, COLOR);
         return colorString(line, COLOR);
     });
 
-    parent.registerChild(/(.*) w panice .* na ([a-z-]+)\.$/, (_, line, m) => {
+    parent.registerChild(/(.*) w panice .* na ([a-z-]+)\.$/, (raw, _line, m) => {
+        const line = stripAnsiCodes(raw).replace(/\s$/g, "");
         const dir = m[2];
         printArrow(dir, PANIC_COLOR);
         return colorString(line, PANIC_COLOR);

--- a/client/src/scripts/followSpecialExits.ts
+++ b/client/src/scripts/followSpecialExits.ts
@@ -1,4 +1,5 @@
 import Client from "../Client";
+import { stripAnsiCodes } from "../Triggers";
 
 interface Entry {
     pattern: RegExp | string;
@@ -108,13 +109,14 @@ export default function initFollowSpecialExits(client: Client) {
         { pattern: /zeskakuje na skalna polke\./, command: "zeskocz na polke" },
     ];
 
-    function containsLeader(line: string) {
+    function containsLeader(text: string) {
         const leader = client.TeamManager.getLeader();
-        return !!leader && line.toLowerCase().includes(leader.toLowerCase());
+        return !!leader && text.toLowerCase().includes(leader.toLowerCase());
     }
 
     entries.forEach(({ pattern, command }) => {
-        client.Triggers.registerTrigger(pattern, (_r, line, m) => {
+        client.Triggers.registerTrigger(pattern, (raw, _line, m) => {
+            const line = stripAnsiCodes(raw).replace(/\s$/g, "");
             if (!containsLeader(line)) return undefined;
             const cmd = typeof command === "function" ? command(m) : command;
             client.FunctionalBind.set(cmd);

--- a/client/src/scripts/gps.ts
+++ b/client/src/scripts/gps.ts
@@ -1,4 +1,5 @@
 import Client from "../Client";
+import { stripAnsiCodes } from "../Triggers";
 
 
 interface GpsEntry {
@@ -62,10 +63,11 @@ export default function initGps(client: Client) {
                         { stayOpenLines: delta }
                     );
                     if (lines.length > 1) {
-                        parent.registerChild((_, line) => {
+                        parent.registerChild((raw) => {
                             if (!checkContext()) {
                                 return undefined;
                             }
+                            const line = stripAnsiCodes(raw).replace(/\s$/g, "");
                             if (line === lines[current]) {
                                 current++;
                                 if (current === lines.length) {

--- a/client/src/scripts/localizers.ts
+++ b/client/src/scripts/localizers.ts
@@ -1,0 +1,15 @@
+import Client from "../Client";
+import { stripAnsiCodes } from "../Triggers";
+
+export default function initLocalizers(client: Client) {
+    const tag = "localizers";
+    const text = "Postoj, placyk w Grabowej Buchcie";
+    client.Triggers.registerTrigger(text, (raw) => {
+        const line = stripAnsiCodes(raw).replace(/\s$/g, "");
+        if (line === text) {
+            client.Map.setMapRoomById(3525);
+            client.sendEvent('notify', { text: `Map Sync: localizer 3525` });
+        }
+        return raw;
+    }, tag);
+}

--- a/client/src/scripts/magikZnika.ts
+++ b/client/src/scripts/magikZnika.ts
@@ -1,5 +1,6 @@
 import Client from "../Client";
 import { colorString, findClosestColor } from "../Colors";
+import { stripAnsiCodes } from "../Triggers";
 
 export default function initMagikZnika(client: Client) {
     const COLOR = findClosestColor("#ff6347");
@@ -10,7 +11,8 @@ export default function initMagikZnika(client: Client) {
 
     client.Triggers.registerTrigger(
         /^Bialy, zimny plomien ogarnia (.*), w kilka chwil spopielajac .* calkowicie\.$/,
-        (_raw, line) => {
+        (raw) => {
+            const line = stripAnsiCodes(raw).replace(/\s$/g, "");
             return format(line);
         },
         tag


### PR DESCRIPTION
## Summary
- sanitize `rawLine` inside trigger callbacks
- use raw line in bag manager, break item, magik znika, attack beep, escape, follow special exits, gps, buses, and deposit triggers
- add a simple `localizers` module for tests

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688153e7cc4c832a94ce47647dde685c