### PR TITLE
Display build commit on auth overlay

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -236,6 +236,7 @@
                 <button id="login-submit" class="btn btn-primary" type="submit">Zaloguj</button>
             </form>
         </div>
+        <div id="commit-info"></div>
     </div>
 
     <button id="connect-button-float">🔌</button>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -384,6 +384,11 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log('Tab sleep prevention activated for mobile device');
     }
 
+    const commitInfo = document.getElementById('commit-info') as HTMLElement | null;
+    if (commitInfo) {
+        commitInfo.textContent = `${__COMMIT_SHA__} ${__COMMIT_DATE__}`;
+    }
+
     const messageInput = document.getElementById('message-input') as HTMLInputElement;
     const sendButton = document.getElementById('send-button') as HTMLButtonElement;
     const historyUpButton = document.getElementById('history-up-button') as HTMLButtonElement | null;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -638,6 +638,16 @@ button:focus-visible {
   margin: 2vh 0;
 }
 
+#commit-info {
+  position: absolute;
+  bottom: 0.5rem;
+  left: 0;
+  width: 100%;
+  color: #fff;
+  text-align: center;
+  font-size: 0.75rem;
+}
+
 .output_msg, .output_msg_text {
     padding: 0;
 }

--- a/web-client/src/types/commit-info.d.ts
+++ b/web-client/src/types/commit-info.d.ts
@@ -1,0 +1,2 @@
+declare const __COMMIT_SHA__: string;
+declare const __COMMIT_DATE__: string;

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -2,6 +2,10 @@ import {defineConfig, type PluginOption} from 'vite'
 import react from '@vitejs/plugin-react'
 import {resolve} from "path";
 import tsconfigPaths from "vite-tsconfig-paths";
+import {execSync} from 'child_process';
+
+const commitSha = execSync('git rev-parse --short HEAD').toString().trim();
+const commitDate = execSync('git log -1 --format=%cd --date=short').toString().trim();
 
 export default defineConfig({
     plugins: [
@@ -9,6 +13,10 @@ export default defineConfig({
         tsconfigPaths()
     ] as PluginOption[],
     base: "./",
+    define: {
+        __COMMIT_SHA__: JSON.stringify(commitSha),
+        __COMMIT_DATE__: JSON.stringify(commitDate),
+    },
     build: {
         minify: true,
         sourcemap: true,


### PR DESCRIPTION
## Summary
- show commit SHA and date at the bottom of the authentication overlay
- style commit info text
- inject commit values during Vite build
- provide global types for commit constants

## Testing
- `yarn --cwd web-client build`
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688160c390d0832aa1e63ae59bc3ae63