### PR TITLE
Add escape success highlight

### DIFF
--- a/client/src/scripts/escape.ts
+++ b/client/src/scripts/escape.ts
@@ -3,6 +3,8 @@ import {colorString, findClosestColor} from "../Colors";
 
 const COLOR = findClosestColor('#6a5acd');
 const PANIC_COLOR = findClosestColor('#ff8c00');
+const SUCCESS_COLOR = findClosestColor('#ff0000');
+const PREFIX_COLOR = findClosestColor('#ffa500');
 
 export default function initEscape(client: Client) {
     const tag = 'escape';
@@ -24,6 +26,16 @@ export default function initEscape(client: Client) {
         printArrow(dir, PANIC_COLOR);
         return colorString(line, PANIC_COLOR);
     });
+
+    client.Triggers.registerTrigger(
+        /^Udalo ci sie gdzies uciec!$/,
+        (_r, line) =>
+            client.prefix(
+                colorString(line, SUCCESS_COLOR),
+                colorString('--- ', PREFIX_COLOR)
+            ),
+        tag
+    );
 
     function printArrow(dir, color) {
         if (dir === "poludnie") {

--- a/client/test/escape.test.ts
+++ b/client/test/escape.test.ts
@@ -5,6 +5,7 @@ import { findClosestColor } from '../src/Colors';
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
   print = jest.fn();
+  prefix = (line: string, prefix: string) => prefix + line;
 }
 
 describe('escape triggers', () => {
@@ -14,6 +15,10 @@ describe('escape triggers', () => {
   const prefix = `\x1B[22;38;5;${color}m`;
   const panicColor = findClosestColor('#ff8c00');
   const panicPrefix = `\x1B[22;38;5;${panicColor}m`;
+  const successColor = findClosestColor('#ff0000');
+  const successPrefix = `\x1B[22;38;5;${successColor}m`;
+  const orange = findClosestColor('#ffa500');
+  const orangePrefix = `\x1B[22;38;5;${orange}m`;
   const suffix = '\x1B[0m';
 
   beforeEach(() => {
@@ -61,5 +66,12 @@ describe('escape triggers', () => {
       '                  #',
       '\n'
     ]);
+  });
+
+  test('highlights escape success line', () => {
+    const result = parse('Udalo ci sie gdzies uciec!');
+    const expected =
+      orangePrefix + '--- ' + suffix + successPrefix + 'Udalo ci sie gdzies uciec!' + suffix;
+    expect(result).toBe(expected);
   });
 });


### PR DESCRIPTION
## Summary
- add success & prefix colors to escape script
- highlight `Udalo ci sie gdzies uciec!` lines in red and prepend orange `---`
- test escape success highlighting

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688160373fe4832a95d6d59e08cc3d39