### PR TITLE
Add HP alert

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -31,6 +31,7 @@ import initMagics from './scripts/magics'
 import registerGagTriggers from './scripts/gags'
 import initLeaderAttackWarning from './scripts/leaderAttackWarning'
 import initBreakItem from './scripts/breakItem'
+import initHpAlert from './scripts/hpAlert'
 import initMagikZnika from './scripts/magikZnika'
 import initSeasonPrint from './scripts/seasonPrint'
 import initPriceEvaluation from './scripts/priceEvaluation'
@@ -154,6 +155,7 @@ export function registerScripts(client: Client) {
     initWeaponColors(client)
     initLeaderAttackWarning(client)
     initBreakItem(client)
+    initHpAlert(client)
     initMagikZnika(client)
     initSeasonPrint(client)
     initGuildPostfix(client)

--- a/client/src/scripts/hpAlert.ts
+++ b/client/src/scripts/hpAlert.ts
@@ -1,0 +1,27 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+export default function initHpAlert(client: Client) {
+    const ORANGE = findClosestColor("#ffa500");
+    const CONDITIONS = [
+        '',
+        'ledwo zywy',
+        'ciezko ranny',
+        'w zlej kondycji',
+        'ranny',
+        'lekko ranny',
+        'w dobrym stanie',
+        'w swietnej kondycji',
+    ];
+    let prev = Infinity;
+    client.addEventListener('gmcp.char.state', (ev: CustomEvent) => {
+        const hp = ev.detail?.hp;
+        if (typeof hp !== 'number') return;
+        if (hp < prev && hp < 3) {
+            const msg = colorString(`Jestes ${CONDITIONS[hp] ?? ''}`, ORANGE);
+            client.playSound('beep');
+            client.println(`\n\n${msg}\n\n`);
+        }
+        prev = hp;
+    });
+}

--- a/client/test/hpAlert.test.ts
+++ b/client/test/hpAlert.test.ts
@@ -1,0 +1,58 @@
+import initHpAlert from '../src/scripts/hpAlert';
+import { colorString, findClosestColor } from '../src/Colors';
+import { EventEmitter } from 'events';
+
+class FakeClient {
+  private emitter = new EventEmitter();
+  println = jest.fn();
+  playSound = jest.fn();
+  addEventListener(event: string, cb: any) {
+    this.emitter.on(event, cb);
+  }
+  sendEvent(type: string, detail?: any) {
+    this.emitter.emit(type, { detail });
+  }
+}
+
+describe('hp alert', () => {
+  let client: FakeClient;
+  const color = findClosestColor('#ffa500');
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initHpAlert((client as unknown) as any);
+    jest.clearAllMocks();
+  });
+
+  function send(hp: number) {
+    client.sendEvent('gmcp.char.state', { hp });
+  }
+
+  test('beeps and prints when hp drops below 3', () => {
+    send(4);
+    send(2);
+    expect(client.playSound).toHaveBeenCalledTimes(1);
+    const msg = colorString('Jestes ciezko ranny', color);
+    expect(client.println).toHaveBeenCalledWith(`\n\n${msg}\n\n`);
+  });
+
+  test('prints again on further decrease', () => {
+    send(3);
+    send(2);
+    send(1);
+    expect(client.playSound).toHaveBeenCalledTimes(2);
+    const first = colorString('Jestes ciezko ranny', color);
+    const second = colorString('Jestes ledwo zywy', color);
+    expect(client.println).toHaveBeenNthCalledWith(1, `\n\n${first}\n\n`);
+    expect(client.println).toHaveBeenNthCalledWith(2, `\n\n${second}\n\n`);
+  });
+
+  test('does not trigger when hp rises', () => {
+    send(2);
+    client.println.mockClear();
+    client.playSound.mockClear();
+    send(4);
+    expect(client.playSound).not.toHaveBeenCalled();
+    expect(client.println).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- warn when health drops below 3 and condition worsens
- notify with condition name and beep sound
- test hp alert behavior

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68815f75bd08832a865d438932d60a95