### PR TITLE
Fix NPC list download updating package helper

### DIFF
--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -26,13 +26,19 @@ function Npc() {
 
     function downloadNpcs() {
         updateIndexedDB<NpcProps[]>(DB_CONFIG, NPC_URL)
-            .then(data => setNpcs(data))
+            .then(data => {
+                setNpcs(data)
+                ;(window as any).clientExtension?.sendEvent('npc', data)
+            })
             .catch(e => console.error('Failed to update NPC data:', e));
     }
 
     function clearNpcs() {
         clearIndexedDB(DB_CONFIG)
-            .then(() => setNpcs([]))
+            .then(() => {
+                setNpcs([])
+                ;(window as any).clientExtension?.sendEvent('npc', [])
+            })
             .catch(e => console.error('Failed to clear NPC data:', e));
     }
 
@@ -51,6 +57,7 @@ function Npc() {
         const updated = npcs.filter(n => !(n.name === npc.name && n.loc === npc.loc))
         setNpcs(updated)
         saveNpcs(updated)
+        ;(window as any).clientExtension?.sendEvent('npc', updated)
     }
 
     async function saveNpcs(list: NpcProps[]) {


### PR DESCRIPTION
## Summary
- refresh package helper NPC data when the list is downloaded, cleared or modified

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688165c3e1f0832a929f050716b171e1