### PR TITLE
Fix failing tests

### DIFF
--- a/client/src/scripts/itemCondition.ts
+++ b/client/src/scripts/itemCondition.ts
@@ -20,7 +20,11 @@ export const itemConditions: ItemCondition[] = [
     { patterns: ["w oplakanym stanie"], replacement: "[2/5]", color: "red" },
     { patterns: ["gotow.{1,2} sie rozpasc"], replacement: "[1/5]", color: "red" },
     { patterns: ["w dobrym stanie"], replacement: "[6/7]", color: "green" },
-    { patterns: ["liczne walki wyryly", "swoje pietno"], replacement: "[5/7]", color: "yellow" },
+    {
+        patterns: ["liczne walki wyryly.*swoje pietno"],
+        replacement: "[5/7]",
+        color: "yellow",
+    },
     { patterns: ["w zlym stanie"], replacement: "[4/7]", color: "red" },
     { patterns: ["w bardzo zlym stanie"], replacement: "[3/7]", color: "red" },
     { patterns: ["wymaga.{0,2} natychmiastowej konserwacji"], replacement: "[2/7]", color: "red" },
@@ -34,8 +38,8 @@ export function processItemCondition(rawLine: string, phrase: string): string {
             const colorCode = COLORS[condition.color] ?? COLORS.red;
             const colored = colorString(phrase, colorCode);
             const coloredValue = colorString(condition.replacement, colorCode);
-            const replaced = `${colored} ${coloredValue}`;
-            return rawLine.replace(phrase, replaced);
+            const replaced = `${colored}. ${coloredValue}`;
+            return rawLine.replace(`${phrase}.`, replaced);
         }
     }
     return rawLine;


### PR DESCRIPTION
## Summary
- adjust item condition patterns so regex matches unchanged
- keep suffix formatting after period
- generalize regex for 'liczne walki wyryly ... swoje pietno'

## Testing
- `yarn --cwd client test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6881695d9320832a9d821e3cdaf0bbf6