### PR TITLE
Add mail notification trigger

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -38,6 +38,7 @@ import initPriceEvaluation from './scripts/priceEvaluation'
 import initStoneValue from './scripts/stoneValue'
 import initCoinColors from './scripts/coinColors'
 import initWeaponColors from './scripts/weaponColors'
+import initNewMail from './scripts/newMail'
 import initExternalScripts from './scripts/externalScripts'
 import initUserAliases from './scripts/userAliases'
 import initUserTriggers from './scripts/userTriggers'
@@ -158,6 +159,7 @@ export function registerScripts(client: Client) {
     initLeaderAttackWarning(client)
     initBreakItem(client)
     initHpAlert(client)
+    initNewMail(client)
     initMagikZnika(client)
     initSeasonPrint(client)
     initGuildPostfix(client)

--- a/client/src/scripts/newMail.ts
+++ b/client/src/scripts/newMail.ts
@@ -1,0 +1,13 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+export default function initNewMail(client: Client) {
+    const COLOR = findClosestColor("tomato");
+    const tag = "new-mail";
+    const prefix = colorString("[ POCZTA ] ", COLOR);
+    const pattern = /^Masz nowa poczte od (?'sender'[A-Za-z]+)\.$/;
+
+    const format = (line: string) => `\n\n${client.prefix(colorString(line, COLOR), prefix)}\n\n`;
+
+    client.Triggers.registerTrigger(pattern, (_raw, line) => format(line), tag);
+}


### PR DESCRIPTION
## Summary
- add mail highlight script to color 'Masz nowa poczte od ...' messages
- load the new script in `main.ts`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68821be741f8832a91cc2cc9270550e0