### PR TITLE
Highlight own kills in kill counter

### DIFF
--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -244,7 +244,7 @@ class KillCounter {
                 const mob = parseName(matches.groups?.name ?? "");
                 const entry = this.recordKill(mob, true);
                 (this.client as any).ItemCollector?.killedAction();
-                return this.formatPrefix(rawLine, entry, "[  ZABILES  ] ");
+                return this.formatPrefix(rawLine, entry, "[  ZABILES  ] ", true);
             }
         );
 
@@ -259,7 +259,7 @@ class KillCounter {
                 if (entry) {
                     (this.client as any).ItemCollector?.teamKilledAction(mob);
                 }
-                return this.formatPrefix(rawLine, entry, "[   ZABIL   ] ");
+                return this.formatPrefix(rawLine, entry, "[   ZABIL   ] ", false);
             }
         );
 
@@ -309,14 +309,17 @@ class KillCounter {
         return entry;
     }
 
-    private formatPrefix(line: string, entry: KillEntry | null, label: string) {
+    private formatPrefix(
+        line: string,
+        entry: KillEntry | null,
+        label: string,
+        highlight: boolean
+    ) {
         const color = KILL_PREFIX_COLOR;
-        const counts = entry
-            ? colorString(
-                  ` (${entry.mySession} / ${entry.mySession + entry.teamSession})`,
-                  color
-              )
+        const countsRaw = entry
+            ? ` (${entry.mySession} / ${entry.mySession + entry.teamSession})`
             : "";
+        const counts = highlight && entry ? colorString(countsRaw, color) : countsRaw;
         const modified = line + counts;
         return (
             "  \n" +


### PR DESCRIPTION
## Summary
- only color kill counts when the player gets the kill

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688222bed144832a9ddadf8e3d8a84a9