### PR TITLE
Fix build error due to regex

### DIFF
--- a/client/src/scripts/newMail.ts
+++ b/client/src/scripts/newMail.ts
@@ -5,7 +5,7 @@ export default function initNewMail(client: Client) {
     const COLOR = findClosestColor("tomato");
     const tag = "new-mail";
     const prefix = colorString("[ POCZTA ] ", COLOR);
-    const pattern = /^Masz nowa poczte od (?'sender'[A-Za-z]+)\.$/;
+    const pattern = /^Masz nowa poczte od (?<sender>[A-Za-z]+)\.$/;
 
     const format = (line: string) => `\n\n${client.prefix(colorString(line, COLOR), prefix)}\n\n`;
 


### PR DESCRIPTION
## Summary
- fix invalid RegExp syntax in newMail trigger

## Testing
- `yarn --cwd client test`
- `yarn --cwd client build`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68822406801c832a81989a0b41bac3d3