### PR TITLE
Add graphical footer mode

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -35,6 +35,7 @@
     </div>
     <div id="char-state" data-emoji-labels="0" data-footer-mode="0">
         <span id="char-state-text"></span>
+        <div id="char-state-bars" class="flex-grow-1"></div>
         <span id="lamp-timer"></span>
         <span id="break-item-warning"></span>
         <span id="package-status"></span>
@@ -271,6 +272,7 @@
                             <option value="0">Liczbowy</option>
                             <option value="1">Pasek</option>
                             <option value="2">Pasek jednolity</option>
+                            <option value="3">Pasek graficzny</option>
                         </select>
                     </label>
                     <label class="form-label">Powiększenie mapy

--- a/web-client/src/CharState.ts
+++ b/web-client/src/CharState.ts
@@ -71,14 +71,24 @@ export default class CharState {
   private client: typeof ArkadiaClient;
   private container: HTMLElement | null;
   private text: HTMLElement | null;
+  private bars: HTMLElement | null;
   private config: Record<keyof CharStateData, CharStateConfig>;
   private state: Partial<CharStateData> = {};
   private useEmoji = false;
   private mode = 0;
 
   private applyMode(mode: number) {
-    if (typeof mode === 'number' && mode >= 0 && mode <= 2) {
+    if (typeof mode === "number" && mode >= 0 && mode <= 3) {
       this.mode = mode;
+      if (this.text && this.bars) {
+        if (mode === 3) {
+          this.text.style.display = "none";
+          this.bars.style.display = "flex";
+        } else {
+          this.text.style.display = "";
+          this.bars.style.display = "none";
+        }
+      }
       this.update({});
     }
   }
@@ -101,6 +111,7 @@ export default class CharState {
     this.client = client;
     this.container = document.getElementById("char-state");
     this.text = document.getElementById("char-state-text");
+    this.bars = document.getElementById("char-state-bars");
 
     this.config = { ...DEFAULT_CONFIG };
 
@@ -163,6 +174,55 @@ export default class CharState {
         (this.config[key].default === undefined ||
           this.state[key] !== this.config[key].default)
       );
+    if (this.mode === 3 && this.bars) {
+      this.bars.innerHTML = "";
+      entries.forEach((key) => {
+        let value = this.state[key] as number;
+        const { max, label, transform, default: def } = this.config[key];
+        let maxValue = max;
+        if (transform && typeof value === "number") {
+          ({ value, max: maxValue } = transform(value, maxValue));
+        }
+        value = Math.max(0, Math.min(maxValue, value));
+        const ratio = value / maxValue;
+        const reverse = def === 0 || this.config[key].flip === true;
+        let colorClass = "bg-success";
+        if (reverse) {
+          if (ratio >= 2 / 3) {
+            colorClass = "bg-danger";
+          } else if (ratio >= 1 / 3) {
+            colorClass = "bg-warning";
+          }
+        } else {
+          if (ratio <= 1 / 3) {
+            colorClass = "bg-danger";
+          } else if (ratio <= 2 / 3) {
+            colorClass = "bg-warning";
+          }
+        }
+        const opposite =
+          def !== undefined ? (def > 0 ? 0 : maxValue) : null;
+        const highlight = opposite !== null && value === opposite;
+
+        const group = document.createElement("div");
+        group.className = "char-state-bar";
+        const labelEl = document.createElement("span");
+        labelEl.textContent = label + ":";
+        if (highlight) labelEl.style.color = "tomato";
+        const progress = document.createElement("div");
+        progress.className = "progress flex-grow-1";
+        const bar = document.createElement("div");
+        bar.className = `progress-bar ${colorClass}`;
+        bar.style.width = `${Math.floor(ratio * 100)}%`;
+        progress.appendChild(bar);
+        group.appendChild(labelEl);
+        group.appendChild(progress);
+        this.bars!.appendChild(group);
+      });
+      this.text.innerHTML = "";
+      return;
+    }
+
     this.text.innerHTML = entries
       .map((key) => {
         let value = this.state[key] as number;

--- a/web-client/src/CharState.ts
+++ b/web-client/src/CharState.ts
@@ -210,10 +210,11 @@ export default class CharState {
         labelEl.textContent = label + ":";
         if (highlight) labelEl.style.color = "tomato";
         const progress = document.createElement("div");
-        progress.className = "progress flex-grow-1";
+        progress.className = "progress";
         const bar = document.createElement("div");
         bar.className = `progress-bar ${colorClass}`;
         bar.style.width = `${Math.floor(ratio * 100)}%`;
+        bar.textContent = `${value}/${maxValue}`;
         progress.appendChild(bar);
         group.appendChild(labelEl);
         group.appendChild(progress);

--- a/web-client/src/CharState.ts
+++ b/web-client/src/CharState.ts
@@ -210,12 +210,15 @@ export default class CharState {
         labelEl.textContent = label + ":";
         if (highlight) labelEl.style.color = "tomato";
         const progress = document.createElement("div");
-        progress.className = "progress";
+        progress.className = "progress position-relative";
         const bar = document.createElement("div");
         bar.className = `progress-bar ${colorClass}`;
         bar.style.width = `${Math.floor(ratio * 100)}%`;
-        bar.textContent = `${value}/${maxValue}`;
+        const valueSpan = document.createElement("span");
+        valueSpan.className = "progress-value";
+        valueSpan.textContent = `${value}/${maxValue}`;
         progress.appendChild(bar);
+        progress.appendChild(valueSpan);
         group.appendChild(labelEl);
         group.appendChild(progress);
         this.bars!.appendChild(group);

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -109,7 +109,12 @@ h1 {
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  flex-grow: 1;
+  flex-grow: 0;
+}
+
+.char-state-bar .progress {
+  width: 10ch;
+  font-size: 0.8rem;
 }
 
 #lamp-timer {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -112,9 +112,23 @@ h1 {
   flex-grow: 0;
 }
 
+
 .char-state-bar .progress {
   width: 10ch;
   font-size: 0.8rem;
+  position: relative;
+}
+
+.char-state-bar .progress-value {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
 }
 
 .char-state-bar .progress-bar {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -98,6 +98,20 @@ h1 {
   position: relative;
 }
 
+#char-state-bars {
+  display: none;
+  flex-grow: 1;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.char-state-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-grow: 1;
+}
+
 #lamp-timer {
   display: none;
 }

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -117,6 +117,10 @@ h1 {
   font-size: 0.8rem;
 }
 
+.char-state-bar .progress-bar {
+  justify-content: center;
+}
+
 #lamp-timer {
   display: none;
 }


### PR DESCRIPTION
## Summary
- add container for character state progress bars
- implement graphical footer mode with Bootstrap progress bars
- expose new mode in UI settings
- style character state bars

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6883444c33d0832ab15136ceeb98f92a