### PR TITLE
Avoid redundant GPS map updates

### DIFF
--- a/client/src/scripts/gps.ts
+++ b/client/src/scripts/gps.ts
@@ -51,8 +51,10 @@ export default function initGps(client: Client) {
                                 return;
                             }
                             if (lines.length === 1) {
-                                client.Map.setMapRoomById(room.id);
-                                client.sendEvent('notify', { text: `Map Sync: gps ${gpsId}` });
+                                if (client.Map.currentRoom?.id !== room.id) {
+                                    client.Map.setMapRoomById(room.id);
+                                    client.sendEvent('notify', { text: `Map Sync: gps ${gpsId}` });
+                                }
                             } else {
                                 current = 0;
                             }
@@ -69,8 +71,10 @@ export default function initGps(client: Client) {
                             if (line === lines[current]) {
                                 current++;
                                 if (current === lines.length) {
-                                    client.Map.setMapRoomById(room.id);
-                                    client.sendEvent('notify', { text: `Map Sync: gps ${gpsId}` });
+                                    if (client.Map.currentRoom?.id !== room.id) {
+                                        client.Map.setMapRoomById(room.id);
+                                        client.sendEvent('notify', { text: `Map Sync: gps ${gpsId}` });
+                                    }
                                     current = 1;
                                 }
                                 return [line];

--- a/client/test/gps.test.ts
+++ b/client/test/gps.test.ts
@@ -15,6 +15,7 @@ describe('gps triggers', () => {
     client = new FakeClient();
     initGps(client as unknown as any);
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    client.Map.currentRoom.id = 1;
     const mapData = [
       {
         areaName: 'Area',
@@ -44,10 +45,19 @@ describe('gps triggers', () => {
     window.dispatchEvent(new CustomEvent('map-ready', { detail: { mapData, colors: [] } }));
   });
 
-  test('gps lines set map location', () => {
+  test('gps lines set map location when different from current', () => {
     parse('l1');
     parse('l2');
     expect(client.Map.setMapRoomById).toHaveBeenCalledWith(10);
     expect(client.sendEvent).toHaveBeenCalledWith('notify', { text: 'Map Sync: gps 10_0' });
+  });
+
+  test('gps lines do not update when already at location', () => {
+    jest.clearAllMocks();
+    client.Map.currentRoom.id = 10;
+    parse('l1');
+    parse('l2');
+    expect(client.Map.setMapRoomById).not.toHaveBeenCalled();
+    expect(client.sendEvent).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- update gps script to skip setting map location when already there
- extend gps tests to check new behaviour

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68838e5a0d5c832a94dab07db34fb589