### PR TITLE
Fix MapHelper room update check

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -208,6 +208,9 @@ export default class MapHelper {
     }
 
     setMapRoomById(id: number) {
+        if (this.currentRoom?.id === id) {
+            return;
+        }
         this.setMapRoom(this.mapReader.getRoomById(id))
     }
 


### PR DESCRIPTION
## Summary
- avoid redundant map room updates when the target room matches the current room

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6883a585b808832a842d71b28d3aee10