### PR TITLE
Fix legacy settings migration

### DIFF
--- a/client/src/storage.ts
+++ b/client/src/storage.ts
@@ -55,7 +55,17 @@ function notifyCharacterChange(prev: string | null) {
 
 export function setCurrentCharacter(name: string) {
     const prev = currentCharacter;
+    const firstCharacter = !currentCharacter && !localStorage.getItem('currentCharacter');
     currentCharacter = name ? String(name) : null;
+    if (firstCharacter && currentCharacter) {
+        characterScopedKeys.forEach(key => {
+            const raw = localStorage.getItem(key);
+            if (raw !== null) {
+                localStorage.setItem(`${currentCharacter}:${key}`, raw);
+                localStorage.removeItem(key);
+            }
+        });
+    }
     if (currentCharacter) {
         localStorage.setItem('currentCharacter', currentCharacter);
     } else {

--- a/client/test/currentCharacterMigration.test.ts
+++ b/client/test/currentCharacterMigration.test.ts
@@ -1,0 +1,15 @@
+import { setCurrentCharacter } from '../src/storage';
+
+describe('setCurrentCharacter migration', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('moves unscoped settings to first character', () => {
+    localStorage.setItem('settings', JSON.stringify({ a: 1 }));
+    setCurrentCharacter('Hero');
+    expect(localStorage.getItem('Hero:settings')).toBe(JSON.stringify({ a: 1 }));
+    expect(localStorage.getItem('settings')).toBeNull();
+    expect(localStorage.getItem('currentCharacter')).toBe('Hero');
+  });
+});


### PR DESCRIPTION
## Summary
- migrate unscoped settings on first character login
- add regression test for storage migration

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6883ce998380832a99a9f0bab1b9c1b2