### PR TITLE
Remove xtermPalette fallbacks

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -107,10 +107,6 @@ export default class Client {
             if (lamp) {
                 this.lampBind = {...lamp}
             }
-            if (ev.detail?.xtermPalette) {
-                // legacy support, will be removed
-                setXtermPalette(ev.detail.xtermPalette);
-            }
         })
 
         this.addEventListener('uiSettings', (ev: CustomEvent) => {

--- a/client/src/Colors.ts
+++ b/client/src/Colors.ts
@@ -20,14 +20,8 @@ export const colorCodes = {
 
 const palette = (() => {
     try {
-        let raw: any = undefined;
         const ui = getItemSync('uiSettings');
-        raw = ui?.uiSettings;
-        if (!raw) {
-            const legacy = getItemSync('settings');
-            // TODO remove legacy fallback after migrating data
-            raw = legacy?.settings ? JSON.parse(legacy.settings) : undefined;
-        }
+        const raw = ui?.uiSettings;
         if (raw) {
             const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
             return parsed.xtermPalette === 'proper' ? 'proper' : 'arkadia';

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -267,6 +267,12 @@
                         <input id="ui-emoji-labels" type="checkbox" class="form-check-input me-2" />
                         Etykiety emoji w stanie postaci
                     </label>
+                    <label class="form-label">Paleta kolorów
+                        <select id="ui-xterm-palette" class="form-select">
+                            <option value="arkadia">Arkadia</option>
+                            <option value="proper">XTerm</option>
+                        </select>
+                    </label>
                     <label class="form-label">Tryb stopki
                         <select id="ui-footer-mode" class="form-select">
                             <option value="0">Liczbowy</option>

--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -60,16 +60,8 @@ function SettingsForm() {
     useEffect(() => {
         const load = () => {
             Promise.all([storage.getItem("settings"), storage.getItem('uiSettings')]).then(([res, ui]) => {
-                const palette = (() => {
-                    try { return ui?.uiSettings?.xtermPalette; }
-                    catch {
-                        try {
-                            // TODO remove legacy fallback after migrating data
-                            return JSON.parse(res?.settings ?? '').xtermPalette;
-                        } catch { return 'arkadia'; }
-                    }
-                })();
-                setSettings(Object.assign({}, defaultSettings, res.settings, { xtermPalette: palette === 'proper' ? 'proper' : 'arkadia' }));
+                const palette = ui?.uiSettings?.xtermPalette === 'proper' ? 'proper' : 'arkadia';
+                setSettings(Object.assign({}, defaultSettings, res.settings, { xtermPalette: palette }));
             });
         };
 

--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -5,7 +5,6 @@ import storage, { getCurrentCharacter } from "@client/src/storage";
 import { Settings as BaseSettings, defaultSettings } from './defaultSettings';
 
 interface FormSettings extends BaseSettings {
-    xtermPalette: 'arkadia' | 'proper';
 }
 
 const collectModeOptions = [
@@ -22,7 +21,7 @@ const collectMoneyOptions = ["wszystkie", "srebrne", "zlote"]
 
 function SettingsForm() {
 
-    const [settings, setSettings] = useState<FormSettings>({ ...defaultSettings, xtermPalette: 'arkadia' })
+    const [settings, setSettings] = useState<FormSettings>({ ...defaultSettings })
 
     const [locked, setLocked] = useState(!getCurrentCharacter())
 
@@ -48,27 +47,21 @@ function SettingsForm() {
 
 
     function handleSubmission() {
-        const { xtermPalette, ...rest } = settings;
-        storage.setItem("settings", rest);
-        storage.getItem('uiSettings').then(res => {
-            const current = res?.uiSettings ? res.uiSettings : {} as any;
-            storage.setItem('uiSettings', { ...current, xtermPalette });
-        });
+        storage.setItem("settings", settings);
         window.dispatchEvent(new Event('close-options'));
     }
 
     useEffect(() => {
         const load = () => {
-            Promise.all([storage.getItem("settings"), storage.getItem('uiSettings')]).then(([res, ui]) => {
-                const palette = ui?.uiSettings?.xtermPalette === 'proper' ? 'proper' : 'arkadia';
-                setSettings(Object.assign({}, defaultSettings, res.settings, { xtermPalette: palette }));
+            storage.getItem("settings").then(res => {
+                setSettings(Object.assign({}, defaultSettings, res.settings));
             });
         };
 
         load();
 
         const listener = (changes: { [key: string]: { oldValue: any; newValue: any } }) => {
-            if (changes.settings || changes.uiSettings) {
+            if (changes.settings) {
                 load();
             }
         };
@@ -120,18 +113,6 @@ function SettingsForm() {
                         onChange={e => onChangeSetting(s => s.shortenExits = e.target.checked)}
                         className="me-2"
                     />
-                    <Form.Group className="d-flex align-items-center">
-                        <Form.Label className="me-1 mb-0">Paleta kolorów:</Form.Label>
-                        <Form.Select
-                            size="sm"
-                            value={settings.xtermPalette}
-                            onChange={e => onChangeSetting(s => s.xtermPalette = e.target.value as any)}
-                            className="w-auto"
-                        >
-                            <option value="arkadia">Arkadia</option>
-                            <option value="proper">XTerm</option>
-                        </Form.Select>
-                    </Form.Group>
                 </div>
             </div>
             <div className="mb-4 border rounded p-3">

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -86,21 +86,11 @@ import storage from "@client/src/storage";
 
 async function load(): Promise<UiSettings> {
     try {
-        const [uiData, settingsData] = await Promise.all([
-            storage.getItem('uiSettings'),
-            storage.getItem('settings'),
-        ]);
+        const uiData = await storage.getItem('uiSettings');
         let raw = uiData?.uiSettings;
         let parsed: any = {};
         if (raw) {
             parsed = raw as any;
-        }
-        if (!parsed.xtermPalette && settingsData?.settings) {
-            try {
-                const legacy = JSON.parse(settingsData.settings);
-                // TODO remove legacy fallback after migrating data
-                parsed.xtermPalette = legacy.xtermPalette;
-            } catch {}
         }
         if (raw || Object.keys(parsed).length > 0) {
             const mapScale = (() => {
@@ -139,6 +129,7 @@ export default async function initUiSettings() {
     const mapLimitInput = modalEl.querySelector('#ui-map-limit') as HTMLInputElement;
     const showButtonsInput = modalEl.querySelector('#ui-show-buttons') as HTMLInputElement;
     const emojiLabelsInput = modalEl.querySelector('#ui-emoji-labels') as HTMLInputElement;
+    const xtermPaletteInput = modalEl.querySelector('#ui-xterm-palette') as HTMLSelectElement;
     const footerModeInput = modalEl.querySelector('#ui-footer-mode') as HTMLSelectElement;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
 
@@ -151,6 +142,7 @@ export default async function initUiSettings() {
     mapLimitInput.value = String(current.mapLimit);
     showButtonsInput.checked = current.showButtons;
     emojiLabelsInput.checked = current.emojiLabels;
+    xtermPaletteInput.value = current.xtermPalette;
     footerModeInput.value = String(current.footerMode);
     apply(current);
 
@@ -178,7 +170,7 @@ export default async function initUiSettings() {
             mapHeight: parseFloat(mapHeightInput.value) || defaultSettings.mapHeight,
             showButtons: showButtonsInput.checked,
             emojiLabels: emojiLabelsInput.checked,
-            xtermPalette: current.xtermPalette,
+            xtermPalette: (xtermPaletteInput.value as 'arkadia' | 'proper') || defaultSettings.xtermPalette,
             footerMode: parseInt(footerModeInput.value) || defaultSettings.footerMode
         };
     }


### PR DESCRIPTION
## Summary
- clean up xtermPalette loading logic
- rely on uiSettings only
- add xterm palette dropdown to the UI settings modal

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6883e83e82b8832aafe79ed3bac2e74b