### PR TITLE
Fix null settings dispatch on first login

### DIFF
--- a/client/src/storage.ts
+++ b/client/src/storage.ts
@@ -42,6 +42,9 @@ function notifyCharacterChange(prev: string | null) {
         const newKey = currentCharacter ? `${currentCharacter}:${key}` : key;
         const oldRaw = localStorage.getItem(prevKey);
         const newRaw = localStorage.getItem(newKey);
+        if (oldRaw === newRaw) {
+            return;
+        }
         let oldValue: any = undefined;
         let newValue: any = undefined;
         if (oldRaw !== null) { try { oldValue = JSON.parse(oldRaw); } catch { oldValue = oldRaw; } }

--- a/client/test/notifyCharacterChange.test.ts
+++ b/client/test/notifyCharacterChange.test.ts
@@ -1,0 +1,16 @@
+import storage, { setCurrentCharacter } from '../src/storage';
+
+describe('notifyCharacterChange', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('does not dispatch empty settings on first login', () => {
+    const events: any[] = [];
+    const listener = (c: any) => events.push(c);
+    storage.onChanged?.addListener(listener);
+    setCurrentCharacter('Hero');
+    storage.onChanged?.removeListener?.(listener);
+    expect(events.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- skip notifyCharacterChange when neither old nor new values exist
- add regression test for first character login

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6883f95516f0832a97e5f13d8d3cb279