### PR TITLE
Store herb data per character

### DIFF
--- a/client/src/storage.ts
+++ b/client/src/storage.ts
@@ -31,6 +31,7 @@ const characterScopedKeys = new Set([
     'deposits',
     'containers',
     'herb_counts',
+    'herbs_data',
     'mapperRoomId',
 ]);
 

--- a/docs/HERBS.md
+++ b/docs/HERBS.md
@@ -9,4 +9,4 @@ Moduł licznika ziół pozwala zliczyć zawartość wszystkich noszonych woreczk
 3. Za pomocą `/wezz nazwa [ilosc]` wyjmiesz wskazane zioło z woreczków. Jeśli ilość nie zostanie podana, domyślnie wyjmowana jest jedna sztuka.
 4. Polecenie `/zi akcja nazwa` wyjmuje zioło i wykonuje podaną akcję.
 
-Informacje o zliczonych ziołach są przechowywane w pamięci przeglądarki i wczytywane po ponownym uruchomieniu klienta.
+Informacje o zliczonych ziołach są przechowywane w pamięci przeglądarki osobno dla każdej postaci i wczytywane po ponownym uruchomieniu klienta.


### PR DESCRIPTION
## Summary
- store loaded herb data per character
- document that herb counts are saved per character

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688401e06c64832a9aa890e488bcb814