### PR TITLE
Handle typed messages in port listener

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -139,9 +139,15 @@ export default class Client {
 
         this.port = port
         port.onMessage.addListener((message) => {
-            Object.entries(message).forEach(([key, value]) => {
-                this.eventTarget.dispatchEvent(new CustomEvent(key, {detail: value}))
-            })
+            if (message && typeof message.type === 'string') {
+                this.eventTarget.dispatchEvent(new CustomEvent(message.type, {detail: message.data}))
+                return
+            }
+            if (message && typeof message === 'object') {
+                Object.entries(message).forEach(([key, value]) => {
+                    this.eventTarget.dispatchEvent(new CustomEvent(key, {detail: value}))
+                })
+            }
         })
     }
 


### PR DESCRIPTION
## Summary
- improve port message handling to check `message.type`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6884054763e4832ab16a5f3abcd12548