### PR TITLE
Add support bind

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -58,6 +58,12 @@ export default class Client {
         alt?: boolean;
         shift?: boolean;
     };
+    supportBind = {key: "KeyW", ctrl: true} as {
+        key: string;
+        ctrl?: boolean;
+        alt?: boolean;
+        shift?: boolean;
+    };
     inLineProcess = false; //TODO figure out something else
     defaultColor = 255;
     buffer: { out: string, type?: string }[] = [];
@@ -90,6 +96,19 @@ export default class Client {
                 this.sendCommand('napelnij lampe olejem')
                 ev.preventDefault()
             }
+            if (
+                (ev.code === this.supportBind.key || ev.key === this.supportBind.key) &&
+                !!this.supportBind.ctrl === ev.ctrlKey &&
+                !!this.supportBind.alt === ev.altKey &&
+                !!this.supportBind.shift === ev.shiftKey
+            ) {
+                this.sendCommand('wesprzyj')
+                const id = this.TeamManager.getLeaderId?.()
+                if (id) {
+                    this.sendCommand(`wesprzyj ob_${id}`)
+                }
+                ev.preventDefault()
+            }
         })
 
         this.addEventListener('settings', (ev: CustomEvent) => {
@@ -106,6 +125,10 @@ export default class Client {
             const lamp = ev.detail?.binds?.lamp
             if (lamp) {
                 this.lampBind = {...lamp}
+            }
+            const support = ev.detail?.binds?.support
+            if (support) {
+                this.supportBind = {...support}
             }
         })
 

--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -175,6 +175,10 @@ export default class TeamManager {
         return this.leader;
     }
 
+    getLeaderId(): string | undefined {
+        return this.leaderId;
+    }
+
     clearTeam() {
         this.members.clear();
         this.leader = undefined;

--- a/client/src/scripts/binds.ts
+++ b/client/src/scripts/binds.ts
@@ -5,9 +5,11 @@ export default function initBinds(client: Client, aliases?: { pattern: RegExp; c
     function printBinds() {
         const main = client.FunctionalBind.getLabel();
         const lamp = formatLabel(client.lampBind);
+        const support = formatLabel(client.supportBind);
         const lines = [
             `Domy\u015Blny: ${main}`,
             `Nape\u0142nij lamp\u0119: ${lamp}`,
+            `Wesprzyj: ${support}`,
         ];
         client.println(lines.join("\n"));
     }

--- a/client/test/TeamManager.test.ts
+++ b/client/test/TeamManager.test.ts
@@ -58,6 +58,13 @@ describe('TeamManager', () => {
     expect(manager.isInTeam('Pablo')).toBe(true);
   });
 
+  test('returns leader id when available', () => {
+    client.sendEvent('gmcp.objects.data', {
+      '5': { desc: 'Vesper', living: true, team: true, team_leader: true },
+    });
+    expect(manager.getLeaderId()).toBe('5');
+  });
+
   test('emits event when leader attacks different target', () => {
     const callback = jest.fn();
     client.addEventListener('teamLeaderTargetNoAvatar', callback);

--- a/client/test/binds.test.ts
+++ b/client/test/binds.test.ts
@@ -3,6 +3,7 @@ import initBinds from '../src/scripts/binds';
 class FakeClient {
   FunctionalBind = { getLabel: jest.fn(() => ']') };
   lampBind = { key: 'Digit4', ctrl: true };
+  supportBind = { key: 'KeyW', ctrl: true };
   println = jest.fn();
 }
 
@@ -17,5 +18,6 @@ describe('binds alias', () => {
     const printed = client.println.mock.calls[0][0];
     expect(printed).toContain('Domy\u015Blny: ]');
     expect(printed).toContain('Nape\u0142nij lamp\u0119: CTRL+4');
+    expect(printed).toContain('Wesprzyj: CTRL+W');
   });
 });

--- a/docs/BINDS.md
+++ b/docs/BINDS.md
@@ -4,6 +4,9 @@ Rozszerzenie umożliwia ustawienie kilku skrótów klawiaturowych. Domyślne bin
 
 - **Domyślny** – klawisz `]` (BracketRight). Używany do wykonywania akcji kontekstowych, np. zbierania łupów z ciała czy powtarzania poleceń pojawiających się w komunikatach.
 - **Napełnij lampę** – `CTRL+4`. Skrót wysyła komendę `napelnij lampe olejem`.
+- **Wesprzyj** – `CTRL+W`. Skrót wysyła komendę `wesprzyj`. Jeśli drużyna ma
+  przywódcę, wysyła dodatkowo `wesprzyj ob_ID`, gdzie `ID` to identyfikator
+  przywódcy z GMCP.
 
 Bindy można modyfikować w zakładce **Bindowanie** na stronie opcji rozszerzenia.
 Aktualnie ustawione skróty możesz też wypisać w grze komendą `/binds`.

--- a/web-client/src/options/Binds.tsx
+++ b/web-client/src/options/Binds.tsx
@@ -26,12 +26,14 @@ interface DirectionBinds {
 interface BindSettings {
     main: Bind;
     lamp: Bind;
+    support: Bind;
     directions: DirectionBinds;
 }
 
 const defaultBinds: BindSettings = {
     main: { key: 'BracketRight' },
     lamp: { key: 'Digit4', ctrl: true },
+    support: { key: 'KeyW', ctrl: true },
     directions: {
         n: { key: 'Numpad8' },
         s: { key: 'Numpad2' },
@@ -81,6 +83,7 @@ function Binds() {
                 ...defaultBinds,
                 main: res?.settings?.binds?.main || defaultBinds.main,
                 lamp: res?.settings?.binds?.lamp || defaultBinds.lamp,
+                support: res?.settings?.binds?.support || defaultBinds.support,
                 directions: {
                     ...defaultBinds.directions,
                     ...res?.settings?.binds?.directions,
@@ -106,7 +109,7 @@ function Binds() {
 
     function save() {
             storage.getItem('settings').then(res => {
-                const settings = { ...(res.settings || {}), binds: { main: binds.main, lamp: binds.lamp, directions: binds.directions } };
+                const settings = { ...(res.settings || {}), binds: { main: binds.main, lamp: binds.lamp, support: binds.support, directions: binds.directions } };
                 storage.setItem('settings', settings).then(() => {
                     window.dispatchEvent(new Event('close-options'));
             });
@@ -147,6 +150,17 @@ function Binds() {
                     className="w-40"
                     value={label(binds.lamp)}
                     onKeyDown={ev => handleCapture('lamp', ev)}
+                />
+            </Form.Group>
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Label className="w-32 mb-0">Wesprzyj</Form.Label>
+                <Form.Control
+                    type="text"
+                    readOnly
+                    size="sm"
+                    className="w-40"
+                    value={label(binds.support)}
+                    onKeyDown={ev => handleCapture('support', ev)}
                 />
             </Form.Group>
             <Form.Group className="d-flex align-items-center gap-2">


### PR DESCRIPTION
## Summary
- add `supportBind` keybind to send support commands
- expose leader ID in `TeamManager`
- display new bind in `/binds` output
- configure bind in options page
- document `CTRL+W` bind
- test updates

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688413077a18832a9977802a19def462