### PR TITLE
Add /w alias

### DIFF
--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -32,6 +32,16 @@ export default function initObjectAliases(
             }
         }
     }
+
+    function withdraw(short: string) {
+        const obj = findByShortcut(short);
+        if (obj) {
+            client.sendCommand(`gzwycofaj sie za ob_${obj.num}`);
+            if (releaseGuard) {
+                client.sendCommand("przestan zaslaniac");
+            }
+        }
+    }
     let releaseGuard = false;
     const ON_COLOR = findClosestColor("#7cfc00");
     const OFF_COLOR = findClosestColor("#ff6347");
@@ -75,6 +85,10 @@ export default function initObjectAliases(
             callback: (m: RegExpMatchArray) => exec(m[1], "zapros")
         });
         aliases.push({
+            pattern: /\/w ([A-Za-z0-9@]+)$/,
+            callback: (m: RegExpMatchArray) => withdraw(m[1])
+        });
+        aliases.push({
             pattern: /\/za ([A-Za-z0-9@]+)$/,
             callback: (m: RegExpMatchArray) => shield(m[1])
         });
@@ -87,6 +101,18 @@ export default function initObjectAliases(
                     const isTeam = data && data[id]?.team;
                     const cmd = isTeam ? `zaslon ob_${id}` : `zaslon przed ob_${id}`;
                     client.sendCommand(cmd);
+                    if (releaseGuard) {
+                        client.sendCommand("przestan zaslaniac");
+                    }
+                }
+            }
+        });
+        aliases.push({
+            pattern: /^\/w$/,
+            callback: () => {
+                const id = client.TeamManager.getDefenseTargetId();
+                if (id) {
+                    client.sendCommand(`gzwycofaj sie za ob_${id}`);
                     if (releaseGuard) {
                         client.sendCommand("przestan zaslaniac");
                     }

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -31,7 +31,7 @@ describe('object aliases', () => {
     killTarget = aliases[2].callback as any;
     shieldTarget = aliases[3].callback as any;
     invite = aliases[4].callback as any;
-    toggle = aliases[7].callback as any;
+    toggle = aliases[9].callback as any;
     (global as any).Input = { send: jest.fn() };
   });
 


### PR DESCRIPTION
## Summary
- allow quickly retreating with `/w`
- adjust object alias tests for new alias ordering

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688414e8387c832ab7ab4a61a6cf6cf1