### PR TITLE
Add /prze alias to break defense

### DIFF
--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -32,6 +32,14 @@ export default function initObjectAliases(
             }
         }
     }
+
+    function breakDefense(short: string) {
+        const obj = findByShortcut(short);
+        if (obj) {
+            client.sendCommand("przestan kryc sie za zaslona");
+            client.sendCommand(`przelam obrone ob_${obj.num}`);
+        }
+    }
     let releaseGuard = false;
     const ON_COLOR = findClosestColor("#7cfc00");
     const OFF_COLOR = findClosestColor("#ff6347");
@@ -77,6 +85,10 @@ export default function initObjectAliases(
         aliases.push({
             pattern: /\/za ([A-Za-z0-9@]+)$/,
             callback: (m: RegExpMatchArray) => shield(m[1])
+        });
+        aliases.push({
+            pattern: /\/prze ([A-Za-z0-9@]+)$/,
+            callback: (m: RegExpMatchArray) => breakDefense(m[1])
         });
         aliases.push({
             pattern: /^\/za$/,

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -31,7 +31,7 @@ describe('object aliases', () => {
     killTarget = aliases[2].callback as any;
     shieldTarget = aliases[3].callback as any;
     invite = aliases[4].callback as any;
-    toggle = aliases[7].callback as any;
+    toggle = aliases[8].callback as any;
     (global as any).Input = { send: jest.fn() };
   });
 


### PR DESCRIPTION
## Summary
- add new `breakDefense` helper and `/prze` alias for object shortcuts
- update tests for new alias index

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6884157d9f2c832a87db9391ffa004a2