### PR TITLE
Add /w withdraw alias

### DIFF
--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -33,6 +33,16 @@ export default function initObjectAliases(
             }
         }
     }
+
+    function withdraw(short: string) {
+        const obj = findByShortcut(short);
+        if (obj) {
+            client.sendCommand(`gzwycofaj sie za ob_${obj.num}`);
+            if (releaseGuard) {
+                client.sendCommand("przestan zaslaniac");
+            }
+        }
+    }
     let releaseGuard = false;
     const ON_COLOR = findClosestColor("#7cfc00");
     const OFF_COLOR = findClosestColor("#ff6347");
@@ -111,6 +121,10 @@ export default function initObjectAliases(
                 shield(m[2]);
                 client.sendGMCP('char.options.group_cover', original);
             }
+        });
+        aliases.push({
+            pattern: /\/w ([A-Za-z0-9@]+)$/,
+            callback: (m: RegExpMatchArray) => withdraw(m[1])
         });
     }
 }

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -24,6 +24,7 @@ describe('object aliases', () => {
   let invite: (m: RegExpMatchArray) => void;
   let toggle: () => void;
   let shieldGroup: (m: RegExpMatchArray) => void;
+  let withdraw: (m: RegExpMatchArray) => void;
 
   beforeEach(() => {
     client = new FakeClient();
@@ -36,6 +37,7 @@ describe('object aliases', () => {
     invite = aliases[4].callback as any;
     toggle = aliases[7].callback as any;
     shieldGroup = aliases[8].callback as any;
+    withdraw = aliases[9].callback as any;
     (global as any).Input = { send: jest.fn() };
     (window as any).gmcp = gmcp;
     gmcp.char = { options: { group_cover: 1 } } as any;
@@ -103,5 +105,19 @@ describe('object aliases', () => {
     expect(client.sendGMCP).toHaveBeenNthCalledWith(1, 'char.options.group_cover', 2);
     expect(client.sendCommand).toHaveBeenCalledWith('zaslon ob_11');
     expect(client.sendGMCP).toHaveBeenNthCalledWith(2, 'char.options.group_cover', 1);
+  });
+
+  test('/w alias withdraws behind object', () => {
+    client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 17, shortcut: 'X' }]);
+    withdraw(['', 'X'] as unknown as RegExpMatchArray);
+    expect(client.sendCommand).toHaveBeenCalledWith('gzwycofaj sie za ob_17');
+  });
+
+  test('/w alias releases after withdraw when toggle is on', () => {
+    client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 18, shortcut: 'Y' }]);
+    toggle();
+    withdraw(['', 'Y'] as unknown as RegExpMatchArray);
+    expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'gzwycofaj sie za ob_18');
+    expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'przestan zaslaniac');
   });
 });


### PR DESCRIPTION
## Summary
- implement `/w` alias that withdraws behind objects and may release guards
- test the new alias

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6884196d0094832a8124c5ce0ea05370