### PR TITLE
Add attack bind

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -58,6 +58,12 @@ export default class Client {
         alt?: boolean;
         shift?: boolean;
     };
+    attackBind = {key: "Digit1", ctrl: true} as {
+        key: string;
+        ctrl?: boolean;
+        alt?: boolean;
+        shift?: boolean;
+    };
     supportBind = {key: "KeyW", ctrl: true} as {
         key: string;
         ctrl?: boolean;
@@ -97,6 +103,18 @@ export default class Client {
                 ev.preventDefault()
             }
             if (
+                (ev.code === this.attackBind.key || ev.key === this.attackBind.key) &&
+                !!this.attackBind.ctrl === ev.ctrlKey &&
+                !!this.attackBind.alt === ev.altKey &&
+                !!this.attackBind.shift === ev.shiftKey
+            ) {
+                const id = this.TeamManager.getAttackTargetId?.()
+                if (id) {
+                    this.sendCommand(`zabij ob_${id}`)
+                }
+                ev.preventDefault()
+            }
+            if (
                 (ev.code === this.supportBind.key || ev.key === this.supportBind.key) &&
                 !!this.supportBind.ctrl === ev.ctrlKey &&
                 !!this.supportBind.alt === ev.altKey &&
@@ -125,6 +143,10 @@ export default class Client {
             const lamp = ev.detail?.binds?.lamp
             if (lamp) {
                 this.lampBind = {...lamp}
+            }
+            const attack = ev.detail?.binds?.attack
+            if (attack) {
+                this.attackBind = {...attack}
             }
             const support = ev.detail?.binds?.support
             if (support) {

--- a/client/src/scripts/binds.ts
+++ b/client/src/scripts/binds.ts
@@ -5,9 +5,11 @@ export default function initBinds(client: Client, aliases?: { pattern: RegExp; c
     function printBinds() {
         const main = client.FunctionalBind.getLabel();
         const lamp = formatLabel(client.lampBind);
+        const attack = formatLabel(client.attackBind);
         const support = formatLabel(client.supportBind);
         const lines = [
             `Domy\u015Blny: ${main}`,
+            `Atakuj: ${attack}`,
             `Nape\u0142nij lamp\u0119: ${lamp}`,
             `Wesprzyj: ${support}`,
         ];

--- a/client/test/binds.test.ts
+++ b/client/test/binds.test.ts
@@ -3,6 +3,7 @@ import initBinds from '../src/scripts/binds';
 class FakeClient {
   FunctionalBind = { getLabel: jest.fn(() => ']') };
   lampBind = { key: 'Digit4', ctrl: true };
+  attackBind = { key: 'Digit1', ctrl: true };
   supportBind = { key: 'KeyW', ctrl: true };
   println = jest.fn();
 }
@@ -17,6 +18,7 @@ describe('binds alias', () => {
     expect(client.println).toHaveBeenCalledTimes(1);
     const printed = client.println.mock.calls[0][0];
     expect(printed).toContain('Domy\u015Blny: ]');
+    expect(printed).toContain('Atakuj: CTRL+1');
     expect(printed).toContain('Nape\u0142nij lamp\u0119: CTRL+4');
     expect(printed).toContain('Wesprzyj: CTRL+W');
   });

--- a/docs/BINDS.md
+++ b/docs/BINDS.md
@@ -3,6 +3,7 @@
 Rozszerzenie umożliwia ustawienie kilku skrótów klawiaturowych. Domyślne bindy to:
 
 - **Domyślny** – klawisz `]` (BracketRight). Używany do wykonywania akcji kontekstowych, np. zbierania łupów z ciała czy powtarzania poleceń pojawiających się w komunikatach.
+- **Atakuj** – `CTRL+1`. Skrót wysyła komendę `zabij ob_ID`, gdzie `ID` to identyfikator celu ataku z GMCP.
 - **Napełnij lampę** – `CTRL+4`. Skrót wysyła komendę `napelnij lampe olejem`.
 - **Wesprzyj** – `CTRL+W`. Skrót wysyła komendę `wesprzyj`. Jeśli drużyna ma
   przywódcę, wysyła dodatkowo `wesprzyj ob_ID`, gdzie `ID` to identyfikator

--- a/web-client/src/options/Binds.tsx
+++ b/web-client/src/options/Binds.tsx
@@ -26,6 +26,7 @@ interface DirectionBinds {
 interface BindSettings {
     main: Bind;
     lamp: Bind;
+    attack: Bind;
     support: Bind;
     directions: DirectionBinds;
 }
@@ -33,6 +34,7 @@ interface BindSettings {
 const defaultBinds: BindSettings = {
     main: { key: 'BracketRight' },
     lamp: { key: 'Digit4', ctrl: true },
+    attack: { key: 'Digit1', ctrl: true },
     support: { key: 'KeyW', ctrl: true },
     directions: {
         n: { key: 'Numpad8' },
@@ -83,6 +85,7 @@ function Binds() {
                 ...defaultBinds,
                 main: res?.settings?.binds?.main || defaultBinds.main,
                 lamp: res?.settings?.binds?.lamp || defaultBinds.lamp,
+                attack: res?.settings?.binds?.attack || defaultBinds.attack,
                 support: res?.settings?.binds?.support || defaultBinds.support,
                 directions: {
                     ...defaultBinds.directions,
@@ -109,7 +112,7 @@ function Binds() {
 
     function save() {
             storage.getItem('settings').then(res => {
-                const settings = { ...(res.settings || {}), binds: { main: binds.main, lamp: binds.lamp, support: binds.support, directions: binds.directions } };
+                const settings = { ...(res.settings || {}), binds: { main: binds.main, lamp: binds.lamp, attack: binds.attack, support: binds.support, directions: binds.directions } };
                 storage.setItem('settings', settings).then(() => {
                     window.dispatchEvent(new Event('close-options'));
             });
@@ -150,6 +153,17 @@ function Binds() {
                     className="w-40"
                     value={label(binds.lamp)}
                     onKeyDown={ev => handleCapture('lamp', ev)}
+                />
+            </Form.Group>
+            <Form.Group className="d-flex align-items-center gap-2">
+                <Form.Label className="w-32 mb-0">Atakuj</Form.Label>
+                <Form.Control
+                    type="text"
+                    readOnly
+                    size="sm"
+                    className="w-40"
+                    value={label(binds.attack)}
+                    onKeyDown={ev => handleCapture('attack', ev)}
                 />
             </Form.Group>
             <Form.Group className="d-flex align-items-center gap-2">


### PR DESCRIPTION
## Summary
- add configurable attack bind (CTRL+1 by default)
- include attack bind in settings form and `/binds` output
- document new default bind
- test new bind printing

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688419008224832a86b1eaaecfcf306a