### PR TITLE
Add blank line around /postepy table

### DIFF
--- a/client/src/scripts/improveCounter.ts
+++ b/client/src/scripts/improveCounter.ts
@@ -202,7 +202,7 @@ export default class ImproveCounter {
     }
 
     show() {
-        this.client.print("\n" + this.formatTable() + "\n");
+        this.client.print("\n\n" + this.formatTable() + "\n\n");
     }
 }
 


### PR DESCRIPTION
## Summary
- print one extra newline before and after the `/postepy` table output

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68841e15d890832a87edc1d3e0e6eb44