### PR TITLE
Make key binds global

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -129,8 +129,8 @@ export default class Client {
             }
         })
 
-        this.addEventListener('settings', (ev: CustomEvent) => {
-            const bind = ev.detail?.binds?.main
+        const applyBinds = (b: any) => {
+            const bind = b?.main
             if (bind) {
                 this.FunctionalBind.updateOptions({
                     key: bind.key,
@@ -140,18 +140,26 @@ export default class Client {
                     label: formatLabel(bind)
                 })
             }
-            const lamp = ev.detail?.binds?.lamp
+            const lamp = b?.lamp
             if (lamp) {
-                this.lampBind = {...lamp}
+                this.lampBind = { ...lamp }
             }
-            const attack = ev.detail?.binds?.attack
+            const attack = b?.attack
             if (attack) {
-                this.attackBind = {...attack}
+                this.attackBind = { ...attack }
             }
-            const support = ev.detail?.binds?.support
+            const support = b?.support
             if (support) {
-                this.supportBind = {...support}
+                this.supportBind = { ...support }
             }
+        }
+
+        this.addEventListener('settings', (ev: CustomEvent) => {
+            applyBinds(ev.detail?.binds)
+        })
+
+        this.addEventListener('binds', (ev: CustomEvent) => {
+            applyBinds(ev.detail)
         })
 
         this.addEventListener('uiSettings', (ev: CustomEvent) => {
@@ -164,7 +172,7 @@ export default class Client {
             if (ev.detail?.name) {
                 setCurrentCharacter(ev.detail.name);
                 if (this.port) {
-                    ['settings', 'kill_counter', 'deposits', 'containers', 'herb_counts', 'mapperRoomId'].forEach(k => {
+                    ['settings', 'kill_counter', 'deposits', 'containers', 'herb_counts', 'mapperRoomId', 'binds'].forEach(k => {
                         this.port!.postMessage({ type: 'GET_STORAGE', key: k });
                     });
                 }

--- a/web-client/src/MockPort.ts
+++ b/web-client/src/MockPort.ts
@@ -56,7 +56,7 @@ export default class MockPort {
         storage.onChanged?.addListener(changes => {
             Object.entries(changes).forEach(([key, {newValue}]) => {
                 this.dispatch({storage: {key, value: newValue}});
-                if (key === 'settings' || key === 'npc' || key === 'uiSettings') {
+                if (key === 'settings' || key === 'npc' || key === 'uiSettings' || key === 'binds') {
                     this.dispatch({[key]: newValue});
                 }
             });
@@ -83,7 +83,7 @@ export default class MockPort {
         if (message.type === 'SET_STORAGE') {
             setItemSync(message.key, message.value);
             this.dispatch({storage: {key: message.key, value: message.value}});
-            if (message.key === 'settings' || message.key === 'npc' || message.key === 'uiSettings') {
+            if (message.key === 'settings' || message.key === 'npc' || message.key === 'uiSettings' || message.key === 'binds') {
                 this.dispatch({[message.key]: message.value});
             }
         }
@@ -96,7 +96,7 @@ export default class MockPort {
         const data = getItemSync(key);
         const value = data ? data[key] : {};
         this.dispatch({ storage: { key, value } });
-        if (key === 'settings' || key === 'npc' || key === 'uiSettings') {
+        if (key === 'settings' || key === 'npc' || key === 'uiSettings' || key === 'binds') {
             this.dispatch({ [key]: value });
         }
     };

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -87,6 +87,12 @@ arkadiaClient.on('settings', (detail: any) => {
     }
 });
 
+client.addEventListener('binds', (ev: CustomEvent) => {
+    if (ev.detail?.directions) {
+        applyDirectionBinds(ev.detail.directions);
+    }
+});
+
 if (navigator.userAgent.includes('iPhone') || navigator.userAgent.includes('iPad') || navigator.userAgent.includes('iPod')) {
     const baseOffset = window.outerHeight - window.visualViewport.height
     window.visualViewport.addEventListener("resize", () => {

--- a/web-client/src/options/Binds.tsx
+++ b/web-client/src/options/Binds.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import {Form, Button} from 'react-bootstrap';
-import storage, { getCurrentCharacter } from "@client/src/storage";
+import storage from "@client/src/storage";
 
 interface Bind {
     key: string;
@@ -67,29 +67,18 @@ function label(bind: Bind) {
 
 function Binds() {
     const [binds, setBinds] = useState<BindSettings>(defaultBinds);
-    const [locked, setLocked] = useState(!getCurrentCharacter());
 
     useEffect(() => {
-        const update = () => setLocked(!getCurrentCharacter());
-        storage.onChanged?.addListener(update);
-        window.addEventListener('storage', update);
-        return () => {
-            storage.onChanged?.removeListener?.(update);
-            window.removeEventListener('storage', update);
-        };
-    }, []);
-
-    useEffect(() => {
-        storage.getItem('settings').then(res => {
+        storage.getItem('binds').then(res => {
             setBinds({
                 ...defaultBinds,
-                main: res?.settings?.binds?.main || defaultBinds.main,
-                lamp: res?.settings?.binds?.lamp || defaultBinds.lamp,
-                attack: res?.settings?.binds?.attack || defaultBinds.attack,
-                support: res?.settings?.binds?.support || defaultBinds.support,
+                main: res?.binds?.main || defaultBinds.main,
+                lamp: res?.binds?.lamp || defaultBinds.lamp,
+                attack: res?.binds?.attack || defaultBinds.attack,
+                support: res?.binds?.support || defaultBinds.support,
                 directions: {
                     ...defaultBinds.directions,
-                    ...res?.settings?.binds?.directions,
+                    ...res?.binds?.directions,
                 },
             });
         });
@@ -111,28 +100,14 @@ function Binds() {
     }
 
     function save() {
-            storage.getItem('settings').then(res => {
-                const settings = { ...(res.settings || {}), binds: { main: binds.main, lamp: binds.lamp, attack: binds.attack, support: binds.support, directions: binds.directions } };
-                storage.setItem('settings', settings).then(() => {
-                    window.dispatchEvent(new Event('close-options'));
-            });
+        storage.setItem('binds', binds).then(() => {
+            window.dispatchEvent(new Event('close-options'));
         });
     }
 
-    const char = getCurrentCharacter();
-
     return (
         <div className="m-2 d-flex flex-column gap-3">
-            {locked ? (
-                <div className="alert alert-info" role="alert">
-                    Opcje zależne od postaci są zablokowane do momentu jej wybrania.
-                </div>
-            ) : char && (
-                <div className="alert alert-info" role="alert">
-                    Ustawienia dotyczą postaci: <strong>{char}</strong>
-                </div>
-            )}
-            <fieldset disabled={locked} className="p-0 border-0 m-0">
+            <fieldset className="p-0 border-0 m-0">
             <Form.Group className="d-flex align-items-center gap-2">
                 <Form.Label className="w-32 mb-0">Domyślny</Form.Label>
                 <Form.Control


### PR DESCRIPTION
## Summary
- keep bind settings independent of character
- handle `binds` events from storage
- apply saved direction binds from new global settings

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68841d0d3d34832a889105cca5ec4eac