### PR TITLE
Fix /prze alias to break attack target defense

### DIFF
--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -44,8 +44,14 @@ export default function initObjectAliases(
         }
     }
 
-    function breakDefenseTarget() {
-        const id = client.TeamManager.getDefenseTargetId();
+    function breakDefenseTarget(short?: string) {
+        let id: string | undefined;
+        if (short) {
+            const obj = findByShortcut(short);
+            id = obj?.num?.toString();
+        } else {
+            id = client.TeamManager.getAttackTargetId();
+        }
         if (id) {
             client.sendCommand("przestan kryc sie za zaslona");
             client.sendCommand(`przelam obrone ob_${id}`);
@@ -135,8 +141,8 @@ export default function initObjectAliases(
             callback: (m: RegExpMatchArray) => withdraw(m[1])
         });
         aliases.push({
-            pattern: /^\/prze$/,
-            callback: () => breakDefenseTarget()
+            pattern: /\/prze(?: ([A-Za-z0-9@]+))?$/,
+            callback: (m?: RegExpMatchArray) => breakDefenseTarget(m?.[1])
         });
     }
 }

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -25,7 +25,7 @@ describe('object aliases', () => {
   let toggle: () => void;
   let shieldGroup: (m: RegExpMatchArray) => void;
   let withdraw: (m: RegExpMatchArray) => void;
-  let breakDefense: () => void;
+  let breakDefense: (m?: RegExpMatchArray) => void;
 
   beforeEach(() => {
     client = new FakeClient();
@@ -123,10 +123,17 @@ describe('object aliases', () => {
     expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'przestan zaslaniac');
   });
 
-  test('/prze alias breaks defense of current target', () => {
-    client.TeamManager.getDefenseTargetId.mockReturnValue('21');
+  test('/prze alias breaks defense of attack target', () => {
+    client.TeamManager.getAttackTargetId.mockReturnValue('21');
     breakDefense();
     expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'przestan kryc sie za zaslona');
     expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'przelam obrone ob_21');
+  });
+
+  test('/prze alias breaks defense of given shortcut', () => {
+    client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 30, shortcut: '1' }]);
+    breakDefense(['', '1'] as unknown as RegExpMatchArray);
+    expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'przestan kryc sie za zaslona');
+    expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'przelam obrone ob_30');
   });
 });


### PR DESCRIPTION
## Summary
- change /prze alias logic to break defense of attack target
- allow optional shortcut argument for /prze alias
- test defense breaking via attack target and shortcut

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68841fc54c58832a926601208dddf0e7