### PR TITLE
Prevent z/zas list auto-close on selection

### DIFF
--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -476,7 +476,6 @@ export default class MobileDirectionButtons {
             b.textContent = v;
             b.addEventListener('click', () => {
                 this.client.sendCommand(`/${prefix} ${v}`);
-                this.hideLists();
             });
             target.appendChild(b);
         });


### PR DESCRIPTION
## Summary
- fix mobile direction lists closing after clicking an item

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6884be449f90832ab9f288302860824e