### PR TITLE
Add subtle shadow to mobile buttons

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -524,11 +524,13 @@ button:focus-visible {
   display: flex;
   justify-content: center;
   align-items: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   touch-action: manipulation; /* Improve touch behavior */
 }
 
 .mobile-button.active {
   filter: brightness(85%);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 
 .direction-button {


### PR DESCRIPTION
## Summary
- add subtle shadow under mobile buttons
- reduce shadow on active mobile buttons

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6884c0bb5cb4832a9c7b3fe28919e054