### PR TITLE
Update leader attack message

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -120,11 +120,7 @@ export default class Client {
                 !!this.supportBind.alt === ev.altKey &&
                 !!this.supportBind.shift === ev.shiftKey
             ) {
-                this.sendCommand('wesprzyj')
-                const id = this.TeamManager.getLeaderId?.()
-                if (id) {
-                    this.sendCommand(`wesprzyj ob_${id}`)
-                }
+                this.support()
                 ev.preventDefault()
             }
         })
@@ -225,6 +221,14 @@ export default class Client {
 
     send(command: string, echo: boolean = true) {
         this.clientAdapter.send(command, echo)
+    }
+
+    support() {
+        this.sendCommand('wesprzyj')
+        const id = this.TeamManager.getLeaderId?.()
+        if (id) {
+            this.sendCommand(`wesprzyj ob_${id}`)
+        }
     }
 
     sendCommand(command: string, echo: boolean = true) {

--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -196,5 +196,10 @@ export default class TeamManager {
         return this.defenseTargetId;
     }
 
+    getAvatarAttackTargetId() {
+        return this.avatarAttackTargetId;
+    }
+
+
 
 }

--- a/client/src/scripts/leaderAttackWarning.ts
+++ b/client/src/scripts/leaderAttackWarning.ts
@@ -1,26 +1,39 @@
 import Client from "../Client";
 import {colorString, findClosestColor} from "../Colors";
+import { formatLabel } from "./functionalBind";
 
 export default function initLeaderAttackWarning(client: Client) {
     const RED = findClosestColor("#ff0000");
     const PADDING = 4; // two spaces on each side
-
-    const text = "Atakujesz inny cel";
-    const width = text.length + PADDING;
-    const line = "=".repeat(width);
-    const message = colorString(`${line}\n  ${text}  \n${line}`, RED)
     const warningInternval = 5000;
     let interval: ReturnType<typeof setInterval> | undefined;
+    let lastText: string | undefined;
 
-    function printWarning() {
+    function print(text: string) {
+        const width = text.length + PADDING;
+        const line = "=".repeat(width);
+        const message = colorString(`${line}\n  ${text}  \n${line}`, RED);
         client.println(message);
     }
 
-    function startPrinting() {
-        if (!interval) {
-            printWarning();
-            interval = setInterval(printWarning, warningInternval);
+    function startPrinting(targetId?: string) {
+        const attackTargetId = client.TeamManager.getAttackTargetId?.();
+        const avatarTargetId = client.TeamManager.getAvatarAttackTargetId?.();
+        if (attackTargetId && avatarTargetId === attackTargetId) {
+            stopPrinting();
+            return;
         }
+        const attackBind = formatLabel(client.attackBind);
+        const supportBind = formatLabel(client.supportBind);
+        const text = attackTargetId && targetId === attackTargetId ?
+            `Zaatakuj cel ataku (${attackBind})` : `wesprzyj (${supportBind})`;
+        if (interval && text === lastText) {
+            return;
+        }
+        stopPrinting();
+        lastText = text;
+        print(text);
+        interval = setInterval(() => print(text), warningInternval);
     }
 
     function stopPrinting() {
@@ -30,6 +43,6 @@ export default function initLeaderAttackWarning(client: Client) {
         }
     }
 
-    client.addEventListener('teamLeaderTargetNoAvatar', startPrinting);
+    client.addEventListener('teamLeaderTargetNoAvatar', (e: CustomEvent) => startPrinting(e.detail));
     client.addEventListener('teamLeaderTargetAvatar', stopPrinting);
 }

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -253,3 +253,12 @@ test('updateContentWidth measures characters per line', () => {
   expect(client.contentWidth).toBe(10);
 });
 
+test('support sends commands to support leader', () => {
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  jest.spyOn(client, 'sendCommand');
+  jest.spyOn(client.TeamManager, 'getLeaderId').mockReturnValue('5');
+  client.support();
+  expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'wesprzyj');
+  expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'wesprzyj ob_5');
+});
+

--- a/client/test/TeamManager.test.ts
+++ b/client/test/TeamManager.test.ts
@@ -173,4 +173,11 @@ describe('TeamManager', () => {
     expect(manager.getDefenseTargetId()).toBe('2');
   });
 
+  test('returns avatar attack target id', () => {
+    client.sendEvent('gmcp.objects.data', {
+      '99': { desc: 'You', living: true, team: true, attack_num: '4' },
+    });
+    expect(manager.getAvatarAttackTargetId()).toBe('4');
+  });
+
 });

--- a/client/test/leaderAttackWarning.test.ts
+++ b/client/test/leaderAttackWarning.test.ts
@@ -4,7 +4,12 @@ import { EventEmitter } from 'events';
 
 class FakeClient {
   private emitter = new EventEmitter();
-  TeamManager = {} as any;
+  TeamManager = {
+    getAttackTargetId: jest.fn(),
+    getAvatarAttackTargetId: jest.fn(),
+  } as any;
+  supportBind = { key: 'KeyQ', ctrl: true };
+  attackBind = { key: 'Digit1', ctrl: true };
   println = jest.fn();
   addEventListener(event: string, cb: any) {
     this.emitter.on(event, cb);
@@ -30,25 +35,28 @@ describe('leader attack warning', () => {
     jest.useRealTimers();
   });
 
-  test('prints warning when event fired', () => {
-    client.sendEvent('teamLeaderTargetNoAvatar');
-    expect(client.println).toHaveBeenCalledTimes(1);
+  test('suggests attacking when leader hits attack target', () => {
+    client.TeamManager.getAttackTargetId.mockReturnValue('1');
+    client.TeamManager.getAvatarAttackTargetId.mockReturnValue(undefined);
+    client.sendEvent('teamLeaderTargetNoAvatar', '1');
     const text = stripAnsiCodes(client.println.mock.calls[0][0]);
-    expect(text).toContain('Atakujesz inny cel');
+    expect(text).toContain('Zaatakuj cel ataku');
+    expect(text).toContain('CTRL+1');
   });
 
-  test('does not print again while interval is active', () => {
-    client.sendEvent('teamLeaderTargetNoAvatar');
-    client.sendEvent('teamLeaderTargetNoAvatar');
-    expect(client.println).toHaveBeenCalledTimes(1);
+  test('suggests support when leader hits different target', () => {
+    client.TeamManager.getAttackTargetId.mockReturnValue('2');
+    client.TeamManager.getAvatarAttackTargetId.mockReturnValue(undefined);
+    client.sendEvent('teamLeaderTargetNoAvatar', '1');
+    const text = stripAnsiCodes(client.println.mock.calls[0][0]);
+    expect(text).toContain('wesprzyj');
+    expect(text).toContain('CTRL+Q');
   });
 
-  test('prints again after state changes', () => {
-    client.sendEvent('teamLeaderTargetNoAvatar');
-    client.sendEvent('teamLeaderTargetNoAvatar');
-    expect(client.println).toHaveBeenCalledTimes(1);
-    client.sendEvent('teamLeaderTargetAvatar');
-    client.sendEvent('teamLeaderTargetNoAvatar');
-    expect(client.println).toHaveBeenCalledTimes(2);
+  test('prints nothing when avatar attacks attack target', () => {
+    client.TeamManager.getAttackTargetId.mockReturnValue('3');
+    client.TeamManager.getAvatarAttackTargetId.mockReturnValue('3');
+    client.sendEvent('teamLeaderTargetNoAvatar', '1');
+    expect(client.println).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- refine `leaderAttackWarning` logic
- expose avatar attack target from `TeamManager`
- cover new behaviour with tests
- print support bind and centralize `wesprzyj` command

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6884cbdcd1d4832a94d9c9a455a84ff2