### PR TITLE
Fix connect button overlaying popups

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -302,7 +302,7 @@ h1 {
   position: fixed;
   top: 0.5rem;
   right: 0.5rem;
-  z-index: 1103;
+  z-index: 1049;
   display: none;
   white-space: nowrap;
   padding: 0.25rem 0.5rem;


### PR DESCRIPTION
## Summary
- lower z-index of floating connect button so popups remain clickable

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6884eeb119f4832abc2f52dd5f57fe2e