### PR TITLE
Update mobile /zas button label

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -308,7 +308,7 @@
                 <div class="modal-body position-relative d-flex flex-column align-items-center gap-2">
                     <div id="mobile-buttons-preview" class="mobile-direction-buttons">
                         <button class="mobile-button mobile-button-text top-button" data-button-id="z-list-toggle">/z</button>
-                        <button class="mobile-button mobile-button-text top-button" data-button-id="zas-list-toggle">/zas</button>
+                        <button class="mobile-button mobile-button-text top-button" data-button-id="zas-list-toggle">/za</button>
                         <button class="mobile-button mobile-button-text top-button" data-button-id="go-button">/go</button>
                         <button class="mobile-button mobile-button-text top-button" data-button-id="buttons-toggle">⇩</button>
                         <button class="mobile-button mobile-button-text top-button" data-button-id="bracket-right-button">]</button>
@@ -1069,7 +1069,7 @@
 
     <div id="mobile-direction-buttons" class="mobile-direction-buttons">
         <button class="mobile-button mobile-button-text top-button" id="z-list-toggle">/z</button>
-        <button class="mobile-button mobile-button-text top-button" id="zas-list-toggle">/zas</button>
+        <button class="mobile-button mobile-button-text top-button" id="zas-list-toggle">/za</button>
         <button class="mobile-button mobile-button-text top-button" id="go-button">/go</button>
         <button class="mobile-button mobile-button-text top-button" id="buttons-toggle">⇩</button>
         <button class="mobile-button mobile-button-text top-button" id="bracket-right-button">]</button>

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -13,7 +13,7 @@ export interface ButtonSetting {
 
 const defaultSettings: Record<string, ButtonSetting> = {
     'z-list-toggle': { macro: 'zList', label: '/z', color: '#87CEEB' },
-    'zas-list-toggle': { macro: 'zaList', label: '/zas', color: '#87CEEB' },
+    'zas-list-toggle': { macro: 'zaList', label: '/za', color: '#87CEEB' },
     'go-button': { macro: 'command', label: '/go', color: '#87CEEB', command: '/go' },
     'bracket-right-button': { macro: 'functional', label: ']', color: '#87CEEB' },
     'button-1': { macro: 'command', label: 'wesprzyj', color: '#87CEEB', command: 'wesprzyj' },


### PR DESCRIPTION
## Summary
- tweak label for `/zas` mobile button to `/za`

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68851da4e808832a9dd85e2a59f866c0