### PR TITLE
Fix improvement counter false positives

### DIFF
--- a/client/src/scripts/improveCounter.ts
+++ b/client/src/scripts/improveCounter.ts
@@ -88,7 +88,10 @@ export default class ImproveCounter {
         this.client.addEventListener("gmcp.char.info", () => this.reset());
 
         const states = STATES.join("|");
-        const regex = new RegExp(`^(?:.*? )?(?<state>${states}) postepy`, "i");
+        const regex = new RegExp(
+            `^(?:.*? )?(?<state>${states}) postepy(?! w poznawaniu)`,
+            "i",
+        );
         this.client.Triggers.registerTrigger(
             regex,
             (_raw, _line, matches) => {

--- a/client/test/improveCounter.test.ts
+++ b/client/test/improveCounter.test.ts
@@ -55,4 +55,11 @@ describe('improve counter', () => {
     expect(printed).toMatch(/czas 0:30/);
     expect(printed).toMatch(/zabici 1\/1/);
   });
+
+  test('ignores poznawanie swiata messages', () => {
+    parse(
+      'Masz wrazenie, iz ostatnimi czasy poczyniles nieznaczne postepy w poznawaniu swiata.'
+    );
+    expect(client.println).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- ignore exploration improvement messages in ImproveCounter
- test that poznawanie swiata message is skipped

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68869edaffdc832a89d7c4cc43025373