### PR TITLE
Add initial web-client tests

### DIFF
--- a/web-client/jest.config.cjs
+++ b/web-client/jest.config.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  roots: ['<rootDir>/src'],
+  setupFiles: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    '^@client/(.*)$': '<rootDir>/../client/$1'
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.test.json',
+      },
+    ],
+  },
+};

--- a/web-client/jest.setup.js
+++ b/web-client/jest.setup.js
@@ -1,0 +1,36 @@
+const indexedDBAuto = require('fake-indexeddb/auto');
+
+class LocalStorageMock {
+  constructor() {
+    this.store = {};
+  }
+  clear() { this.store = {}; }
+  getItem(key) { return this.store[key] ?? null; }
+  setItem(key, value) { this.store[key] = String(value); }
+  removeItem(key) { delete this.store[key]; }
+}
+
+if (typeof globalThis.localStorage === 'undefined') {
+  globalThis.localStorage = new LocalStorageMock();
+}
+
+if (typeof globalThis.structuredClone !== 'function') {
+  globalThis.structuredClone = (val) => JSON.parse(JSON.stringify(val));
+}
+
+if (typeof globalThis.fetch !== 'function') {
+  if (typeof global.fetch === 'function') {
+    globalThis.fetch = global.fetch.bind(global);
+  } else {
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        magics: {},
+        magic_keys: [],
+        herb_id_to_odmiana: {},
+        version: 1,
+        herb_id_to_use: {}
+      }),
+    });
+  }
+}

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "ansi-to-html": "^0.7.2",
@@ -24,6 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "@types/chrome": "^0.0.313",
+    "@types/jest": "^29.5.5",
     "@types/node": "^20.11.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
@@ -31,7 +33,11 @@
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
+    "fake-indexeddb": "^6.0.1",
     "globals": "^16.0.0",
+    "jest": "^30.0.4",
+    "jest-environment-jsdom": "^30.0.2",
+    "ts-jest": "^29.1.1",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5"

--- a/web-client/src/BreakItemWarning.test.ts
+++ b/web-client/src/BreakItemWarning.test.ts
@@ -1,0 +1,46 @@
+import BreakItemWarning from './BreakItemWarning';
+
+class MockClient {
+  private events: Record<string, Function[]> = {};
+  sendCommand = jest.fn();
+  on(event: string, listener: Function) {
+    (this.events[event] ||= []).push(listener);
+  }
+  emit(event: string, ...args: any[]) {
+    (this.events[event] || []).forEach(fn => fn(...args));
+  }
+}
+
+describe('BreakItemWarning', () => {
+  let container: HTMLElement;
+  let client: MockClient;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="break-item-warning"></div>';
+    container = document.getElementById('break-item-warning')!;
+    client = new MockClient();
+    new BreakItemWarning(client as any);
+  });
+
+  test('hides on null data', () => {
+    client.emit('breakItem', null);
+    expect(container.style.display).toBe('none');
+    expect(container.textContent).toBe('');
+  });
+
+  test('shows text and executes command on click', () => {
+    client.emit('breakItem', { text: 'Warning!', command: 'run' });
+    expect(container.textContent).toBe('Warning!');
+    expect(container.style.display).toBe('block');
+    container.click();
+    expect(client.sendCommand).toHaveBeenCalledWith('run');
+    expect(container.style.display).toBe('none');
+  });
+
+  test('handles click with no command', () => {
+    client.emit('breakItem', { text: 'Only text' });
+    container.click();
+    expect(client.sendCommand).not.toHaveBeenCalled();
+    expect(container.style.display).toBe('none');
+  });
+});

--- a/web-client/src/LampTimer.test.ts
+++ b/web-client/src/LampTimer.test.ts
@@ -1,0 +1,43 @@
+import LampTimer from './LampTimer';
+
+class MockClient {
+  private events: Record<string, Function[]> = {};
+  on(event: string, listener: Function) {
+    (this.events[event] ||= []).push(listener);
+  }
+  emit(event: string, ...args: any[]) {
+    (this.events[event] || []).forEach(fn => fn(...args));
+  }
+}
+
+describe('LampTimer', () => {
+  let container: HTMLElement;
+  let client: MockClient;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="lamp-timer"></div>';
+    container = document.getElementById('lamp-timer')!;
+    client = new MockClient();
+    new LampTimer(client as any);
+  });
+
+  test('hides timer when no time', () => {
+    client.emit('lampTimer', null);
+    expect(container.style.display).toBe('none');
+    expect(container.textContent).toBe('');
+    expect(container.className).toBe('');
+  });
+
+  test('updates display and class based on time', () => {
+    client.emit('lampTimer', 65);
+    expect(container.textContent).toBe('lamp 1:05');
+    expect(container.style.display).toBe('block');
+    expect(container.className).toBe('green');
+
+    client.emit('lampTimer', 55);
+    expect(container.className).toBe('yellow');
+
+    client.emit('lampTimer', 25);
+    expect(container.className).toBe('red');
+  });
+});

--- a/web-client/src/PackageStatus.test.ts
+++ b/web-client/src/PackageStatus.test.ts
@@ -1,0 +1,38 @@
+import PackageStatus from './PackageStatus';
+
+class MockClient {
+  private events: Record<string, Function[]> = {};
+  on(event: string, listener: Function) {
+    (this.events[event] ||= []).push(listener);
+  }
+  emit(event: string, ...args: any[]) {
+    (this.events[event] || []).forEach(fn => fn(...args));
+  }
+}
+
+describe('PackageStatus', () => {
+  let container: HTMLElement;
+  let client: MockClient;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="package-status"></div>';
+    container = document.getElementById('package-status')!;
+    client = new MockClient();
+    new PackageStatus(client as any);
+  });
+
+  test('hides when no data', () => {
+    client.emit('packageStatus', null);
+    expect(container.style.display).toBe('none');
+    expect(container.textContent).toBe('');
+  });
+
+  test('shows recipient and time', () => {
+    client.emit('packageStatus', { recipient: 'Bob', seconds: 70 });
+    expect(container.textContent).toBe('📦: Bob 1:10');
+    expect(container.style.display).toBe('block');
+
+    client.emit('packageStatus', { recipient: 'Alice' });
+    expect(container.textContent).toBe('📦: Alice');
+  });
+});

--- a/web-client/src/ansiParser.test.ts
+++ b/web-client/src/ansiParser.test.ts
@@ -1,0 +1,14 @@
+import { parseAnsiPatterns } from './ansiParser';
+import { colorCodes } from '@client/src/Colors.ts';
+
+describe('parseAnsiPatterns', () => {
+  test('parses standard ansi color', () => {
+    const result = parseAnsiPatterns('\x1B[22;31mred\x1B[0m');
+    expect(result).toBe(`<span style="color: ${colorCodes.ansi.bright[1]}">red</span>`);
+  });
+
+  test('parses 256 color code', () => {
+    const result = parseAnsiPatterns(`\x1B[22;38;5;2mX\x1B[0m`);
+    expect(result).toBe(`<span style="color: ${colorCodes.xterm[1]}">X</span>`);
+  });
+});

--- a/web-client/src/mapDataLoader.test.ts
+++ b/web-client/src/mapDataLoader.test.ts
@@ -1,0 +1,33 @@
+import { loadMapData, loadColors } from './mapDataLoader';
+import { loadCachedJSON } from '@client/src/utils/dataCache.ts';
+
+jest.mock('@client/src/utils/dataCache.ts', () => ({
+  loadCachedJSON: jest.fn()
+}));
+
+describe('mapDataLoader', () => {
+  beforeEach(() => {
+    (loadCachedJSON as jest.Mock).mockClear();
+  });
+
+  test('loadMapData passes correct options', () => {
+    const onProgress = jest.fn();
+    loadMapData(onProgress);
+    expect(loadCachedJSON).toHaveBeenCalledWith({
+      url: 'https://delwing.github.io/arkadia-mapa/data/mapExport.json',
+      localStorageKey: 'cachedMapData',
+      indexedDB: { dbName: 'ArkadiaMapDB', storeName: 'mapData', key: 'mapExport' },
+      ttl: 86400000,
+      onProgress
+    });
+  });
+
+  test('loadColors passes correct options', () => {
+    loadColors();
+    expect(loadCachedJSON).toHaveBeenCalledWith({
+      url: 'https://delwing.github.io/arkadia-mapa/data/colors.json',
+      localStorageKey: 'cachedColors',
+      ttl: 86400000
+    });
+  });
+});

--- a/web-client/src/npcDataLoader.test.ts
+++ b/web-client/src/npcDataLoader.test.ts
@@ -1,0 +1,21 @@
+import { loadNpcData } from './npcDataLoader';
+import { loadCachedJSON } from '@client/src/utils/dataCache.ts';
+
+jest.mock('@client/src/utils/dataCache.ts', () => ({
+  loadCachedJSON: jest.fn()
+}));
+
+describe('npcDataLoader', () => {
+  beforeEach(() => {
+    (loadCachedJSON as jest.Mock).mockClear();
+  });
+
+  test('loadNpcData passes correct options', () => {
+    loadNpcData();
+    expect(loadCachedJSON).toHaveBeenCalledWith({
+      url: 'https://delwing.github.io/arkadia-mapa/data/npc.json',
+      indexedDB: { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' },
+      ttl: 86400000
+    });
+  });
+});

--- a/web-client/tsconfig.test.json
+++ b/web-client/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "types": ["jest"],
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
## Summary
- add Jest configuration for `web-client`
- set up Jest environment helper
- add unit tests for `LampTimer` and `PackageStatus`
- add tests for `BreakItemWarning`, `mapDataLoader`, `npcDataLoader` and `ansiParser`
- configure module resolution for web-client tests

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`


------
https://chatgpt.com/codex/tasks/task_e_688808657b14832a85cf6078395c4389