### PR TITLE
Enable default release guard and display character state text

### DIFF
--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -57,7 +57,7 @@ export default function initObjectAliases(
             client.sendCommand(`przelam obrone ob_${id}`);
         }
     }
-    let releaseGuard = false;
+    let releaseGuard = true;
     const ON_COLOR = findClosestColor("#7cfc00");
     const OFF_COLOR = findClosestColor("#ff6347");
 

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -86,15 +86,14 @@ describe('object aliases', () => {
 
   test('/puszczaj toggles release flag', () => {
     toggle();
-    expect(client.print).toHaveBeenCalledWith(expect.stringContaining('ON'));
-    toggle();
     expect(client.print).toHaveBeenCalledWith(expect.stringContaining('OFF'));
+    toggle();
+    expect(client.print).toHaveBeenCalledWith(expect.stringContaining('ON'));
   });
 
   test('/zas alias with release first guards then releases', () => {
     client.TeamManager.getDefenseTargetId.mockReturnValue('15');
     client.TeamManager.getAccumulatedObjectsData.mockReturnValue({ 15: { team: true } });
-    toggle();
     shieldTarget();
     expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'zaslon ob_15');
     expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'przestan zaslaniac');
@@ -115,9 +114,8 @@ describe('object aliases', () => {
     expect(client.sendCommand).toHaveBeenCalledWith('gzwycofaj sie za ob_17');
   });
 
-  test('/w alias releases after withdraw when toggle is on', () => {
+  test('/w alias releases after withdraw when release is on', () => {
     client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 18, shortcut: 'Y' }]);
-    toggle();
     withdraw(['', 'Y'] as unknown as RegExpMatchArray);
     expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'gzwycofaj sie za ob_18');
     expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'przestan zaslaniac');

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -35,6 +35,7 @@
     </div>
     <div id="char-state" data-emoji-labels="0" data-footer-mode="0">
         <span id="char-state-text"></span>
+        <span id="state-info"></span>
         <div id="char-state-bars" class="flex-grow-1"></div>
         <span id="lamp-timer"></span>
         <span id="break-item-warning"></span>

--- a/web-client/src/CharStateInfo.test.ts
+++ b/web-client/src/CharStateInfo.test.ts
@@ -1,0 +1,35 @@
+import CharStateInfo from './CharStateInfo';
+
+class MockClient {
+  private events: Record<string, Function[]> = {};
+  on(event: string, listener: Function) {
+    (this.events[event] ||= []).push(listener);
+  }
+  emit(event: string, ...args: any[]) {
+    (this.events[event] || []).forEach(fn => fn(...args));
+  }
+}
+
+describe('CharStateInfo', () => {
+  let container: HTMLElement;
+  let client: MockClient;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<span id="state-info"></span>';
+    container = document.getElementById('state-info')!;
+    client = new MockClient();
+    new CharStateInfo(client as any);
+  });
+
+  test('hides when no state text', () => {
+    client.emit('gmcp.char.state', {});
+    expect(container.style.display).toBe('none');
+    expect(container.textContent).toBe('');
+  });
+
+  test('shows state text', () => {
+    client.emit('gmcp.char.state', { state: 'swietny' });
+    expect(container.textContent).toBe('swietny');
+    expect(container.style.display).toBe('block');
+  });
+});

--- a/web-client/src/CharStateInfo.ts
+++ b/web-client/src/CharStateInfo.ts
@@ -1,0 +1,21 @@
+import ArkadiaClient from "./ArkadiaClient.ts";
+
+export default class CharStateInfo {
+  private container: HTMLElement | null;
+  constructor(client: typeof ArkadiaClient) {
+    this.container = document.getElementById("state-info");
+    client.on("gmcp.char.state", (state: any) => this.update(state));
+  }
+
+  private update(state: any) {
+    if (!this.container) return;
+    const text = typeof state?.state === "string" ? state.state : "";
+    if (text) {
+      this.container.textContent = text;
+      this.container.style.display = "block";
+    } else {
+      this.container.textContent = "";
+      this.container.style.display = "none";
+    }
+  }
+}

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -8,6 +8,7 @@ import ObjectList from "./ObjectList";
 import LampTimer from "./LampTimer";
 import BreakItemWarning from "./BreakItemWarning";
 import PackageStatus from "./PackageStatus";
+import CharStateInfo from "./CharStateInfo";
 
 import "@client/src/main.ts"
 import MockPort from "./MockPort.ts";
@@ -814,6 +815,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Display character state and lamp timer
     new CharState(arkadiaClient);
+    new CharStateInfo(arkadiaClient);
     new LampTimer(arkadiaClient);
     new BreakItemWarning(arkadiaClient);
     new PackageStatus(arkadiaClient);

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -154,6 +154,10 @@ h1 {
   color: tomato;
 }
 
+#state-info {
+  display: none;
+}
+
 #break-item-warning {
   display: none;
   color: tomato;


### PR DESCRIPTION
## Summary
- set `releaseGuard` default to `true`
- adjust tests for new default
- add `CharStateInfo` component to show state text
- show state text element in UI and style it
- hook new component into main page

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`

------
https://chatgpt.com/codex/tasks/task_e_68889bfb262c832a979916048de55fb2