### PR TITLE
Fix highlight display for rooms

### DIFF
--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -156,12 +156,15 @@ export default class EmbeddedMap {
                 this.renderer.controls.renderPath(room.id, destination);
             });
 
-            this.highlights.forEach(highlight => {
-                const room = this.reader.getRoomById(highlight)
-                if (room.render !== undefined && this.renderer.area.getRoomById(highlight) !== undefined) {
+            this.highlights.forEach((highlight) => {
+                const room = this.reader.getRoomById(highlight);
+                if (
+                    room.z === this.currentRoom.z &&
+                    this.renderer.area.getRoomById(highlight) !== undefined
+                ) {
                     this.renderer.renderHighlight(highlight);
                 }
-            })
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure highlighted rooms appear only when they're on the same z-level as the current location

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68889e91576c832a9f894d097ecbab2c