### PR TITLE
Fix functional bind click updates

### DIFF
--- a/client/src/scripts/functionalBind.ts
+++ b/client/src/scripts/functionalBind.ts
@@ -75,21 +75,25 @@ export class FunctionalBind {
             this.functionalBind = () => {
                 callback();
                 if (clearAfterUse) {
-                    this.clear()
-                }
-            }
-        } else {
-            this.functionalBind = () => {
-                this.client.sendCommand(printable)
-                if (clearAfterUse) {
-                    this.clear()
+                    this.clear();
                 }
             };
+        } else {
+            this.functionalBind = () => {
+                this.client.sendCommand(printable);
+                if (clearAfterUse) {
+                    this.clear();
+                }
+            };
+        }
+
+        if (this.button) {
+            this.button.onclick = this.functionalBind;
         }
         if (this.currentPrintable === printable) {
             if (printable && !this.printedInMessage) {
                 const line = `\t${color(49)}bind ${color(222)}${this.label}${color(49)}: ${printable}`;
-                const clickable = this.client.OutputHandler.makeClickable(line, printable, callback);
+                const clickable = this.client.OutputHandler.makeClickable(line, printable, this.functionalBind);
                 this.client.println(clickable);
                 this.printedInMessage = true;
             }
@@ -100,9 +104,9 @@ export class FunctionalBind {
         this.button?.remove();
         if (printable) {
             const line = `\t${color(49)}bind ${color(222)}${this.label}${color(49)}: ${printable}`;
-            const clickable = this.client.OutputHandler.makeClickable(line, printable, callback);
+            const clickable = this.client.OutputHandler.makeClickable(line, printable, this.functionalBind);
             this.client.println(clickable);
-            this.button = this.client.createButton(printable, callback);
+            this.button = this.client.createButton(printable, this.functionalBind);
         }
     }
 

--- a/client/test/FunctionalBind.test.ts
+++ b/client/test/FunctionalBind.test.ts
@@ -15,7 +15,28 @@ describe('FunctionalBind clickable text', () => {
     fb.set('cmd', cb);
 
     const expectedLine = `\t${color(49)}bind ${color(222)}]${color(49)}: cmd`;
-    expect(client.OutputHandler.makeClickable).toHaveBeenCalledWith(expectedLine, 'cmd', cb);
+    expect(client.OutputHandler.makeClickable).toHaveBeenCalledWith(expectedLine, 'cmd', expect.any(Function));
     expect(client.println).toHaveBeenCalledWith('clickable');
+  });
+
+  test('set updates button callback when called again with same text', () => {
+    const button: any = { remove: jest.fn(), onclick: () => {} };
+    const client = {
+      addEventListener: jest.fn(),
+      println: jest.fn(),
+      createButton: jest.fn(() => button),
+      OutputHandler: { makeClickable: jest.fn(() => 'clickable') },
+    } as any;
+
+    const fb = new FunctionalBind(client);
+    const cb1 = jest.fn();
+    fb.set('cmd', cb1);
+
+    const cb2 = jest.fn();
+    fb.set('cmd', cb2);
+
+    // clicking the button should invoke the latest callback
+    button.onclick();
+    expect(cb2).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- update functional bind to always refresh button callback
- ensure clickable text uses the active bind function
- add regression test

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688899bdac5c832aa66db03f534c4350