### PR TITLE
Show release guard state

### DIFF
--- a/client/src/eventBus.ts
+++ b/client/src/eventBus.ts
@@ -10,6 +10,7 @@ export interface KnownEvents {
     'lampTimer': number | null;
     'breakItem': { text: string; command?: string };
     'packageStatus': { recipient: string; seconds?: number } | null;
+    'releaseGuard': boolean;
     'contentWidth': number;
     'enterLocation': { id: number; room: any };
     'npc': any;

--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -60,6 +60,7 @@ export default function initObjectAliases(
     let releaseGuard = true;
     const ON_COLOR = findClosestColor("#7cfc00");
     const OFF_COLOR = findClosestColor("#ff6347");
+    client.sendEvent('releaseGuard', releaseGuard);
 
 
     if (aliases) {
@@ -125,6 +126,7 @@ export default function initObjectAliases(
                 const color = releaseGuard ? ON_COLOR : OFF_COLOR;
                 const state = releaseGuard ? 'ON' : 'OFF';
                 client.print(colorString(`Puszczanie zaslon: ${state}`, color));
+                client.sendEvent('releaseGuard', releaseGuard);
             }
         });
         aliases.push({

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -13,6 +13,7 @@ class FakeClient {
   sendCommand = jest.fn();
   sendGMCP = jest.fn();
   print = jest.fn();
+  sendEvent = jest.fn();
 }
 
 describe('object aliases', () => {

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -40,6 +40,7 @@
         <span id="lamp-timer"></span>
         <span id="break-item-warning"></span>
         <span id="package-status"></span>
+        <span id="release-guard"></span>
     </div>
     <div id="objects-list"></div>
     <button id="recording-button" class="btn btn-danger btn-sm" style="position:absolute;top:0.5rem;right:0.5rem;z-index:1012;display:none;">Zatrzymaj i zapisz</button>

--- a/web-client/src/ReleaseGuard.test.ts
+++ b/web-client/src/ReleaseGuard.test.ts
@@ -1,0 +1,34 @@
+import ReleaseGuard from './ReleaseGuard';
+
+class MockClient {
+  private events: Record<string, Function[]> = {};
+  on(event: string, listener: Function) {
+    (this.events[event] ||= []).push(listener);
+  }
+  emit(event: string, ...args: any[]) {
+    (this.events[event] || []).forEach(fn => fn(...args));
+  }
+}
+
+describe('ReleaseGuard', () => {
+  let container: HTMLElement;
+  let client: MockClient;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<span id="release-guard"></span>';
+    container = document.getElementById('release-guard')!;
+    client = new MockClient();
+    new ReleaseGuard(client as any);
+  });
+
+  test('updates state display', () => {
+    client.emit('releaseGuard', true);
+    expect(container.textContent).toBe('guard ON');
+    expect(container.style.display).toBe('block');
+    expect(container.className).toBe('on');
+
+    client.emit('releaseGuard', false);
+    expect(container.textContent).toBe('guard OFF');
+    expect(container.className).toBe('off');
+  });
+});

--- a/web-client/src/ReleaseGuard.ts
+++ b/web-client/src/ReleaseGuard.ts
@@ -1,0 +1,16 @@
+import ArkadiaClient from "./ArkadiaClient.ts";
+
+export default class ReleaseGuard {
+  private container: HTMLElement | null;
+  constructor(client: typeof ArkadiaClient) {
+    this.container = document.getElementById("release-guard");
+    client.on("releaseGuard", (state: boolean) => this.update(state));
+  }
+
+  private update(state: boolean) {
+    if (!this.container) return;
+    this.container.textContent = `guard ${state ? 'ON' : 'OFF'}`;
+    this.container.style.display = 'block';
+    this.container.className = state ? 'on' : 'off';
+  }
+}

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -9,6 +9,7 @@ import LampTimer from "./LampTimer";
 import BreakItemWarning from "./BreakItemWarning";
 import PackageStatus from "./PackageStatus";
 import CharStateInfo from "./CharStateInfo";
+import ReleaseGuard from "./ReleaseGuard";
 
 import "@client/src/main.ts"
 import MockPort from "./MockPort.ts";
@@ -818,6 +819,7 @@ document.addEventListener('DOMContentLoaded', () => {
     new CharStateInfo(arkadiaClient);
     new LampTimer(arkadiaClient);
     new BreakItemWarning(arkadiaClient);
+    new ReleaseGuard(arkadiaClient);
     new PackageStatus(arkadiaClient);
     new ObjectList(client);
 

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -164,6 +164,18 @@ h1 {
   cursor: pointer;
 }
 
+#release-guard {
+  display: none;
+}
+
+#release-guard.on {
+  color: springgreen;
+}
+
+#release-guard.off {
+  color: tomato;
+}
+
 #objects-list {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Summary
- expose releaseGuard status event from extension
- display release guard status in footer
- hook up ReleaseGuard display in web client
- test release guard status

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`


------
https://chatgpt.com/codex/tasks/task_e_6888a73cf464832a81702bb2972ef056