### PR TITLE
Add wesprzyj macro for mobile buttons

### DIFF
--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -1,7 +1,14 @@
 import Modal from "bootstrap/js/dist/modal";
 import storage from "@client/src/storage";
 
-export type MacroType = 'functional' | 'zList' | 'zaList' | 'command' | 'specialExit' | 'kierunek';
+export type MacroType =
+    | 'functional'
+    | 'zList'
+    | 'zaList'
+    | 'command'
+    | 'specialExit'
+    | 'kierunek'
+    | 'wesprzyj';
 
 export interface ButtonSetting {
     macro: MacroType;
@@ -17,7 +24,7 @@ export const defaultSettings: Record<string, ButtonSetting> = {
     'zas-list-toggle': { macro: 'zaList', label: '/za', color: '#87CEEB' },
     'go-button': { macro: 'command', label: '/go', color: '#87CEEB', command: '/go' },
     'bracket-right-button': { macro: 'functional', label: ']', color: '#87CEEB' },
-    'button-1': { macro: 'command', label: 'wesprzyj', color: '#87CEEB', command: 'wesprzyj' },
+    'button-1': { macro: 'wesprzyj', label: 'wesprzyj', color: '#87CEEB' },
     'button-2': { macro: 'command', label: '/z cel', color: '#87CEEB', command: '/z' },
     'button-3': { macro: 'command', label: '/za cel', color: '#87CEEB', command: '/za' },
 

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -16,6 +16,7 @@ const macroOptions: { value: MacroType; label: string }[] = [
     { value: "command", label: "Send command" },
     { value: "kierunek", label: "Direction button" },
     { value: "specialExit", label: "Use special exit" },
+    { value: "wesprzyj", label: "Support leader" },
 ];
 
 const directionOptions = ["nw","n","ne","w","e","sw","s","se","u","d"] as const;

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -558,6 +558,9 @@ export default class MobileDirectionButtons {
                         this.client.sendCommand(cfg.direction);
                     }
                     break;
+                case 'wesprzyj':
+                    this.client.support();
+                    break;
                 case 'specialExit':
                     const specialExits = this.client.Map.currentRoom?.specialExits ?? {};
                     const firstExit = Object.keys(specialExits)[0];


### PR DESCRIPTION
## Summary
- add `wesprzyj` macro type for mobile buttons
- default mobile button 1 now uses the new `wesprzyj` macro
- expose the new macro in options
- invoke `client.support()` when `wesprzyj` macro button is pressed

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6888a7ffe438832aa022c243b315da22