### PR TITLE
Show guard state at startup

### DIFF
--- a/web-client/src/ReleaseGuard.test.ts
+++ b/web-client/src/ReleaseGuard.test.ts
@@ -22,13 +22,13 @@ describe('ReleaseGuard', () => {
   });
 
   test('updates state display', () => {
-    client.emit('releaseGuard', true);
-    expect(container.textContent).toBe('guard ON');
+    // initial state should be visible
+    expect(container.textContent).toBe('Zaslona: on');
     expect(container.style.display).toBe('block');
     expect(container.className).toBe('on');
 
     client.emit('releaseGuard', false);
-    expect(container.textContent).toBe('guard OFF');
+    expect(container.textContent).toBe('Zaslona: off');
     expect(container.className).toBe('off');
   });
 });

--- a/web-client/src/ReleaseGuard.ts
+++ b/web-client/src/ReleaseGuard.ts
@@ -2,14 +2,20 @@ import ArkadiaClient from "./ArkadiaClient.ts";
 
 export default class ReleaseGuard {
   private container: HTMLElement | null;
+  private state = true;
   constructor(client: typeof ArkadiaClient) {
     this.container = document.getElementById("release-guard");
-    client.on("releaseGuard", (state: boolean) => this.update(state));
+    client.on("releaseGuard", (state: boolean) => {
+      this.state = state;
+      this.update(state);
+    });
+    // show current state on start
+    this.update(this.state);
   }
 
   private update(state: boolean) {
     if (!this.container) return;
-    this.container.textContent = `guard ${state ? 'ON' : 'OFF'}`;
+    this.container.textContent = `Zaslona: ${state ? 'on' : 'off'}`;
     this.container.style.display = 'block';
     this.container.className = state ? 'on' : 'off';
   }


### PR DESCRIPTION
## Summary
- display guard status with label "Zaslona" instead of "guard"
- show current guard state immediately when the page loads
- update ReleaseGuard test accordingly

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`


------
https://chatgpt.com/codex/tasks/task_e_6888abceb8f4832ab4f6f0e9fea616bc