### PR TITLE
Fix footer alignment

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -36,7 +36,7 @@
     <div id="char-state" data-emoji-labels="0" data-footer-mode="0">
         <span id="char-state-text"></span>
         <span id="state-info"></span>
-        <div id="char-state-bars" class="flex-grow-1"></div>
+        <div id="char-state-bars"></div>
         <span id="lamp-timer"></span>
         <span id="break-item-warning"></span>
         <span id="package-status"></span>

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -102,7 +102,7 @@ h1 {
 
 #char-state-bars {
   display: none;
-  flex-grow: 1;
+  flex-grow: 0;
   flex-wrap: wrap;
   gap: 0.5rem;
   align-items: center;


### PR DESCRIPTION
## Summary
- make char state bars not expand to full width
- remove flex-grow from footer bars to keep items aligned

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6888b1d976cc832aab7062dd49e84b32