### PR TITLE
Add cover timer feature

### DIFF
--- a/client/src/eventBus.ts
+++ b/client/src/eventBus.ts
@@ -8,6 +8,7 @@ export interface KnownEvents {
     'leadTo': number;
     'notify': { text: string };
     'lampTimer': number | null;
+    'coverTimer': number | null;
     'breakItem': { text: string; command?: string };
     'packageStatus': { recipient: string; seconds?: number } | null;
     'releaseGuard': boolean;

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -9,6 +9,7 @@ import initGates from './scripts/gates'
 import initSeat from './scripts/seat'
 import initAttackBeep from './scripts/attackBeep'
 import initLamp from './scripts/lamp'
+import initCoverTimer from './scripts/coverTimer'
 import initBinds from './scripts/binds'
 import initIdz from './scripts/idz'
 import { initKillCounter } from './scripts/kill'
@@ -125,6 +126,7 @@ export function registerScripts(client: Client) {
     initSeat(client)
     initAttackBeep(client)
     initLamp(client)
+    initCoverTimer(client)
     initBinds(client, aliases)
     initIdz(client, aliases)
     const killCounter = initKillCounter(client, aliases)

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -81,18 +81,6 @@ export function registerScripts(client: Client) {
         }, 'blocker')
     })
 
-    /*
-        People
-     */
-    new People(client)
-    registerGagTriggers(client)
-    registerLuaGagTriggers(client)
-
-    /*
-        Follows
-     */
-
-
     client.Triggers.registerTrigger(/^.*[pP]odazasz (|skradajac sie )za (.*)\.$/, (_, __, matches): undefined => {
         const tokenized = matches[2].split(' ')
         const direction = tokenized[tokenized.length - 1]
@@ -178,5 +166,9 @@ export function registerScripts(client: Client) {
     initWeaponEvaluation(client)
     initArmorEvaluation(client)
     initParryShieldEvaluation(client)
+
+    new People(client)
+    registerGagTriggers(client)
+    registerLuaGagTriggers(client)
 
 }

--- a/client/src/scripts/coverTimer.ts
+++ b/client/src/scripts/coverTimer.ts
@@ -1,0 +1,59 @@
+import Client from "../Client";
+
+export default function initCoverTimer(client: Client) {
+    const tag = 'cover-timer';
+    const COVER_TIME = 5; // seconds
+    let timer: number | null = null;
+    let end = 0;
+
+    const successPatterns = [
+        /^[ >]*Zrecznie zaslaniasz ([\[a-zA-Z (),!\]]+) przed ciosami ([a-zA-Z (),!\]]+)\.$/,
+        /^[ >]*Z wprawa stajesz pomiedzy ([\[a-zA-Z (),!\]]+) a ([\[a-zA-Z (),!\]]+), przyjmujac na siebie nadchodzace ciosy\.$/,
+        /^[ >]*Stajesz u boku ([a-zA-Z (),!\]]+), gotow w kazdej chwili zaslonic .* przed nadchodzacym niebezpieczenstwem\.$/,
+        /^[ >]*Unosisz swoja .+? i szybko przesuwasz sie za .+?, kryjac sie przed atakami/,
+        /^[ >]*Zdecydowanym krokiem wysuwasz sie przed [\[a-zA-Z (),!\]]+, zimnym spojrzeniem dajac wszystkim do zrozumienia, ze moga sie do (niego|niej) zblizyc jedynie po twoim trupie\.$/
+    ];
+
+    const failurePatterns = [
+        /^[ >]*Probujesz zaslonic ([a-zA-Z (),!]+) przed ciosami ([a-zA-Z (),!]+), jednak nie jestes w stanie tego uczynic\.$/,
+        /^Na rozkaz .* probujesz zaslonic (.*) przed ciosami (.*), jednak nie jestes w stanie tego uczynic\.$/,
+        /^[ >]*([a-zA-Z (),!]+) probuje zaslonic ([a-zA-Z (),!]+) przed ciosami ([a-zA-Z (),!]+), jednak nie jest w stanie tego uczynic\.$/,
+        /^[ >]*([a-zA-Z (),!]+) probuje zaslonic .* przed twoimi ciosami, jednak nie jest w stanie tego uczynic\.$/,
+        /(\w+(?: \w+){0,4}?) unosi swoja .+? i szybko przesuwa sie w (twoja strone|strone .+?), bezskutecznie probujac skryc sie za toba przed atakami .+\.$/,
+        /[ >]*Unosisz swoja .+? i przesuwasz sie w strone .+?, bezskutecznie probujac/,
+        /(\w+(?: \w+){0,4}?) unosi swoja .+? i szybko przesuwa sie w (twoja strone|strone .+?), bezskutecznie probujac skryc sie za (nia|nim|toba) przed atakami .+\.$/
+    ];
+
+    function stopTimer() {
+        if (timer != null) {
+            clearInterval(timer);
+            timer = null;
+        }
+        client.sendEvent('coverTimer', null);
+    }
+
+    function update() {
+        const left = end - Date.now();
+        if (left <= 0) {
+            stopTimer();
+        } else {
+            client.sendEvent('coverTimer', left / 1000);
+        }
+    }
+
+    function startTimer() {
+        end = Date.now() + COVER_TIME * 1000;
+        if (timer != null) {
+            clearInterval(timer);
+        }
+        update();
+        timer = window.setInterval(update, 100);
+    }
+
+    [...successPatterns, ...failurePatterns].forEach(p => {
+        client.Triggers.registerTrigger(p, () => {
+            startTimer();
+            return undefined;
+        }, tag);
+    });
+}

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -41,6 +41,7 @@
         <span id="break-item-warning"></span>
         <span id="package-status"></span>
         <span id="release-guard"></span>
+        <span id="cover-timer"></span>
     </div>
     <div id="objects-list"></div>
     <button id="recording-button" class="btn btn-danger btn-sm" style="position:absolute;top:0.5rem;right:0.5rem;z-index:1012;display:none;">Zatrzymaj i zapisz</button>

--- a/web-client/src/CoverTimer.test.ts
+++ b/web-client/src/CoverTimer.test.ts
@@ -23,12 +23,14 @@ describe('CoverTimer', () => {
 
   test('shows ready when no time', () => {
     client.emit('coverTimer', null);
-    expect(container.textContent).toBe('cover');
+    expect(container.textContent).toBe('Zas: OK');
     expect(container.style.display).toBe('block');
+    expect(container.className).toBe('green');
   });
 
   test('shows time with two decimals', () => {
     client.emit('coverTimer', 4.567);
-    expect(container.textContent).toBe('cover 4.57');
+    expect(container.textContent).toBe('Zas: 4.57');
+    expect(container.className).toBe('yellow');
   });
 });

--- a/web-client/src/CoverTimer.test.ts
+++ b/web-client/src/CoverTimer.test.ts
@@ -1,0 +1,34 @@
+import CoverTimer from './CoverTimer';
+
+class MockClient {
+  private events: Record<string, Function[]> = {};
+  on(event: string, listener: Function) {
+    (this.events[event] ||= []).push(listener);
+  }
+  emit(event: string, ...args: any[]) {
+    (this.events[event] || []).forEach(fn => fn(...args));
+  }
+}
+
+describe('CoverTimer', () => {
+  let container: HTMLElement;
+  let client: MockClient;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<span id="cover-timer"></span>';
+    container = document.getElementById('cover-timer')!;
+    client = new MockClient();
+    new CoverTimer(client as any);
+  });
+
+  test('shows ready when no time', () => {
+    client.emit('coverTimer', null);
+    expect(container.textContent).toBe('cover');
+    expect(container.style.display).toBe('block');
+  });
+
+  test('shows time with two decimals', () => {
+    client.emit('coverTimer', 4.567);
+    expect(container.textContent).toBe('cover 4.57');
+  });
+});

--- a/web-client/src/CoverTimer.ts
+++ b/web-client/src/CoverTimer.ts
@@ -1,0 +1,20 @@
+import ArkadiaClient from "./ArkadiaClient.ts";
+
+export default class CoverTimer {
+  private container: HTMLElement | null;
+  constructor(client: typeof ArkadiaClient) {
+    this.container = document.getElementById("cover-timer");
+    client.on("coverTimer", (sec: number | null) => this.update(sec));
+    this.update(null);
+  }
+
+  private update(seconds: number | null) {
+    if (!this.container) return;
+    if (seconds == null || seconds <= 0) {
+      this.container.textContent = "cover";
+    } else {
+      this.container.textContent = `cover ${seconds.toFixed(2)}`;
+    }
+    this.container.style.display = "block";
+  }
+}

--- a/web-client/src/CoverTimer.ts
+++ b/web-client/src/CoverTimer.ts
@@ -11,9 +11,11 @@ export default class CoverTimer {
   private update(seconds: number | null) {
     if (!this.container) return;
     if (seconds == null || seconds <= 0) {
-      this.container.textContent = "cover";
+      this.container.textContent = "Zas: OK";
+      this.container.className = "green";
     } else {
-      this.container.textContent = `cover ${seconds.toFixed(2)}`;
+      this.container.textContent = `Zas: ${seconds.toFixed(2)}`;
+      this.container.className = "yellow";
     }
     this.container.style.display = "block";
   }

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -6,6 +6,7 @@ import {Modal, Dropdown} from 'bootstrap';
 import CharState from "./CharState";
 import ObjectList from "./ObjectList";
 import LampTimer from "./LampTimer";
+import CoverTimer from "./CoverTimer";
 import BreakItemWarning from "./BreakItemWarning";
 import PackageStatus from "./PackageStatus";
 import CharStateInfo from "./CharStateInfo";
@@ -829,6 +830,7 @@ document.addEventListener('DOMContentLoaded', () => {
     new CharState(arkadiaClient);
     new CharStateInfo(arkadiaClient);
     new LampTimer(arkadiaClient);
+    new CoverTimer(arkadiaClient);
     new BreakItemWarning(arkadiaClient);
     new ReleaseGuard(arkadiaClient);
     new PackageStatus(arkadiaClient);

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -154,6 +154,10 @@ h1 {
   color: tomato;
 }
 
+#cover-timer {
+  display: none;
+}
+
 #state-info {
   display: none;
 }

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -158,6 +158,14 @@ h1 {
   display: none;
 }
 
+#cover-timer.green {
+  color: springgreen;
+}
+
+#cover-timer.yellow {
+  color: yellow;
+}
+
 #state-info {
   display: none;
 }


### PR DESCRIPTION
## Summary
- add front-end component to display cover cooldown
- track cover attempts with new coverTimer client script
- wire cover timer with event bus and initialization
- expose cover timer UI and tests

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`


------
https://chatgpt.com/codex/tasks/task_e_6888b27e2064832a82942db558931c0c