### PR TITLE
Move web-client tests

### DIFF
--- a/web-client/jest.config.cjs
+++ b/web-client/jest.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   testEnvironment: 'jsdom',
-  roots: ['<rootDir>/src'],
+  roots: ['<rootDir>/src', '<rootDir>/test'],
   setupFiles: ['<rootDir>/jest.setup.js'],
   moduleNameMapper: {
     '^@client/(.*)$': '<rootDir>/../client/$1'

--- a/web-client/test/BreakItemWarning.test.ts
+++ b/web-client/test/BreakItemWarning.test.ts
@@ -1,4 +1,4 @@
-import BreakItemWarning from './BreakItemWarning';
+import BreakItemWarning from '../src/BreakItemWarning';
 
 class MockClient {
   private events: Record<string, Function[]> = {};

--- a/web-client/test/CharStateInfo.test.ts
+++ b/web-client/test/CharStateInfo.test.ts
@@ -1,4 +1,4 @@
-import CharStateInfo from './CharStateInfo';
+import CharStateInfo from '../src/CharStateInfo';
 
 class MockClient {
   private events: Record<string, Function[]> = {};

--- a/web-client/test/CoverTimer.test.ts
+++ b/web-client/test/CoverTimer.test.ts
@@ -1,4 +1,4 @@
-import CoverTimer from './CoverTimer';
+import CoverTimer from '../src/CoverTimer';
 
 class MockClient {
   private events: Record<string, Function[]> = {};

--- a/web-client/test/LampTimer.test.ts
+++ b/web-client/test/LampTimer.test.ts
@@ -1,4 +1,4 @@
-import LampTimer from './LampTimer';
+import LampTimer from '../src/LampTimer';
 
 class MockClient {
   private events: Record<string, Function[]> = {};

--- a/web-client/test/PackageStatus.test.ts
+++ b/web-client/test/PackageStatus.test.ts
@@ -1,4 +1,4 @@
-import PackageStatus from './PackageStatus';
+import PackageStatus from '../src/PackageStatus';
 
 class MockClient {
   private events: Record<string, Function[]> = {};

--- a/web-client/test/ReleaseGuard.test.ts
+++ b/web-client/test/ReleaseGuard.test.ts
@@ -1,4 +1,4 @@
-import ReleaseGuard from './ReleaseGuard';
+import ReleaseGuard from '../src/ReleaseGuard';
 
 class MockClient {
   private events: Record<string, Function[]> = {};

--- a/web-client/test/ansiParser.test.ts
+++ b/web-client/test/ansiParser.test.ts
@@ -1,4 +1,4 @@
-import { parseAnsiPatterns } from './ansiParser';
+import { parseAnsiPatterns } from '../src/ansiParser';
 import { colorCodes } from '@client/src/Colors.ts';
 
 describe('parseAnsiPatterns', () => {

--- a/web-client/test/mapDataLoader.test.ts
+++ b/web-client/test/mapDataLoader.test.ts
@@ -1,4 +1,4 @@
-import { loadMapData, loadColors } from './mapDataLoader';
+import { loadMapData, loadColors } from '../src/mapDataLoader';
 import { loadCachedJSON } from '@client/src/utils/dataCache.ts';
 
 jest.mock('@client/src/utils/dataCache.ts', () => ({

--- a/web-client/test/npcDataLoader.test.ts
+++ b/web-client/test/npcDataLoader.test.ts
@@ -1,4 +1,4 @@
-import { loadNpcData } from './npcDataLoader';
+import { loadNpcData } from '../src/npcDataLoader';
 import { loadCachedJSON } from '@client/src/utils/dataCache.ts';
 
 jest.mock('@client/src/utils/dataCache.ts', () => ({

--- a/web-client/tsconfig.test.json
+++ b/web-client/tsconfig.test.json
@@ -7,6 +7,7 @@
     "esModuleInterop": true
   },
   "include": [
-    "src"
+    "src",
+    "test"
   ]
 }


### PR DESCRIPTION
## Summary
- relocate `web-client` tests into a dedicated `test` folder
- update Jest and TypeScript configs to include the new location

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`


------
https://chatgpt.com/codex/tasks/task_e_6888dc7e7b48832ab56baff85fd671ef