### PR TITLE
Enable toggling release guard from footer

### DIFF
--- a/web-client/src/ReleaseGuard.test.ts
+++ b/web-client/src/ReleaseGuard.test.ts
@@ -2,11 +2,11 @@ import ReleaseGuard from './ReleaseGuard';
 
 class MockClient {
   private events: Record<string, Function[]> = {};
+  emit = jest.fn((event: string, ...args: any[]) => {
+    (this.events[event] || []).forEach(fn => fn(...args));
+  });
   on(event: string, listener: Function) {
     (this.events[event] ||= []).push(listener);
-  }
-  emit(event: string, ...args: any[]) {
-    (this.events[event] || []).forEach(fn => fn(...args));
   }
 }
 
@@ -30,5 +30,14 @@ describe('ReleaseGuard', () => {
     client.emit('releaseGuard', false);
     expect(container.textContent).toBe('Pusc zas: off');
     expect(container.className).toBe('off');
+  });
+
+  test('toggles state on click and emits event', () => {
+    container.click();
+    expect(container.textContent).toBe('Pusc zas: off');
+    expect(client.emit).toHaveBeenLastCalledWith('releaseGuard', false);
+    container.click();
+    expect(container.textContent).toBe('Pusc zas: on');
+    expect(client.emit).toHaveBeenLastCalledWith('releaseGuard', true);
   });
 });

--- a/web-client/src/ReleaseGuard.ts
+++ b/web-client/src/ReleaseGuard.ts
@@ -3,8 +3,17 @@ import ArkadiaClient from "./ArkadiaClient.ts";
 export default class ReleaseGuard {
   private container: HTMLElement | null;
   private state = true;
+  private client: typeof ArkadiaClient;
   constructor(client: typeof ArkadiaClient) {
+    this.client = client;
     this.container = document.getElementById("release-guard");
+    if (this.container) {
+      this.container.addEventListener('click', () => {
+        this.state = !this.state;
+        this.update(this.state);
+        this.client.emit('releaseGuard', this.state);
+      });
+    }
     client.on("releaseGuard", (state: boolean) => {
       this.state = state;
       this.update(state);


### PR DESCRIPTION
## Summary
- allow clicking on footer label to toggle guards
- add tests for toggle behavior

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`

------
https://chatgpt.com/codex/tasks/task_e_6888d86d10cc832abaa7171bc40df762