### PR TITLE
Add click toggle for ReleaseGuard label

### DIFF
--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -61,6 +61,9 @@ export default function initObjectAliases(
     const ON_COLOR = findClosestColor("#7cfc00");
     const OFF_COLOR = findClosestColor("#ff6347");
     client.sendEvent('releaseGuard', releaseGuard);
+    client.addEventListener('releaseGuard', (event: CustomEvent<boolean>) => {
+        releaseGuard = event.detail;
+    });
 
 
     if (aliases) {

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -14,6 +14,7 @@ class FakeClient {
   sendGMCP = jest.fn();
   print = jest.fn();
   sendEvent = jest.fn();
+  addEventListener = jest.fn();
 }
 
 describe('object aliases', () => {

--- a/web-client/src/ReleaseGuard.ts
+++ b/web-client/src/ReleaseGuard.ts
@@ -5,6 +5,11 @@ export default class ReleaseGuard {
   private state = true;
   constructor(client: typeof ArkadiaClient) {
     this.container = document.getElementById("release-guard");
+    if (this.container) {
+      this.container.addEventListener("click", () => {
+        client.emit("releaseGuard", !this.state);
+      });
+    }
     client.on("releaseGuard", (state: boolean) => {
       this.state = state;
       this.update(state);

--- a/web-client/test/ReleaseGuard.test.ts
+++ b/web-client/test/ReleaseGuard.test.ts
@@ -5,9 +5,9 @@ class MockClient {
   on(event: string, listener: Function) {
     (this.events[event] ||= []).push(listener);
   }
-  emit(event: string, ...args: any[]) {
+  emit = jest.fn((event: string, ...args: any[]) => {
     (this.events[event] || []).forEach(fn => fn(...args));
-  }
+  });
 }
 
 describe('ReleaseGuard', () => {
@@ -30,5 +30,15 @@ describe('ReleaseGuard', () => {
     client.emit('releaseGuard', false);
     expect(container.textContent).toBe('Pusc zas: off');
     expect(container.className).toBe('off');
+  });
+
+  test('click toggles state and emits event', () => {
+    container.click();
+    expect(client.emit).toHaveBeenLastCalledWith('releaseGuard', false);
+    expect(container.textContent).toBe('Pusc zas: off');
+
+    container.click();
+    expect(client.emit).toHaveBeenLastCalledWith('releaseGuard', true);
+    expect(container.textContent).toBe('Pusc zas: on');
   });
 });


### PR DESCRIPTION
## Summary
- allow clicking the release guard label to toggle state
- update object aliases to sync releaseGuard state from events
- adjust tests and add coverage for click behavior

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`


------
https://chatgpt.com/codex/tasks/task_e_6888e49f81ec832abcbd5943d4ff54ef