### PR TITLE
Implement map label search alias

### DIFF
--- a/client/src/scripts/mapAliases.ts
+++ b/client/src/scripts/mapAliases.ts
@@ -62,11 +62,11 @@ export default function initMapAliases(client: Client, aliases: { pattern: RegEx
             pattern: /^\/przeszukaj (.+)$/,
             callback: (m: RegExpMatchArray) => {
                 const term = m[1].toLowerCase();
-                const reader: any = (client as any).Map.mapReader;
+                const reader = client.Map.mapReader;
                 if (!reader) return;
                 const results: string[] = [];
-                reader.getAreas().forEach((area: any) => {
-                    area.labels.forEach((label: any) => {
+                reader.getAreas().forEach((area: MapData.Area) => {
+                    area.labels.forEach((label: MapData.Label) => {
                         const text = label.Text;
                         if (text && text.toLowerCase().includes(term)) {
                             results.push(`${text} (${area.areaName})`);

--- a/client/src/scripts/mapAliases.ts
+++ b/client/src/scripts/mapAliases.ts
@@ -65,21 +65,26 @@ export default function initMapAliases(client: Client, aliases: { pattern: RegEx
                 const reader = client.Map.mapReader;
                 const current = client.Map.currentRoom as any;
                 if (!reader || !current) return;
-                const matches: { name: string; area: string; dist: number }[] = [];
+                const matches: { name: string; area: string; dist: number; id: number }[] = [];
                 reader.getAreas().forEach((area: MapData.Area) => {
                     area.rooms.forEach((room: any) => {
                         const name = room.name as string | undefined;
                         if (name && name.toLowerCase().includes(term)) {
                             const path = reader.getPath(current.id, room.id);
                             const dist = path ? path.length - 1 : Number.MAX_SAFE_INTEGER;
-                            matches.push({ name: room.name, area: area.areaName, dist });
+                            matches.push({ name: room.name, area: area.areaName, dist, id: room.id });
                         }
                     });
                 });
                 matches.sort((a, b) => a.dist - b.dist);
-                const lines = matches.slice(0, 10).map(m => `${m.name} (${m.area})`);
+                const lines = matches.slice(0, 10).map(match => {
+                    const text = `${match.name} (${match.area})`;
+                    return client.OutputHandler.makeStringClickable(text, () => {
+                        client.sendCommand(`/prowadz ${match.id}`);
+                    });
+                });
                 if (lines.length) {
-                    client.println(lines.join('\n'));
+                    client.println(lines.join('\n\n'));
                 } else {
                     client.println('Nie znaleziono.');
                 }

--- a/client/src/scripts/mapAliases.ts
+++ b/client/src/scripts/mapAliases.ts
@@ -63,18 +63,23 @@ export default function initMapAliases(client: Client, aliases: { pattern: RegEx
             callback: (m: RegExpMatchArray) => {
                 const term = m[1].toLowerCase();
                 const reader = client.Map.mapReader;
-                if (!reader) return;
-                const results: string[] = [];
+                const current = client.Map.currentRoom as any;
+                if (!reader || !current) return;
+                const matches: { name: string; area: string; dist: number }[] = [];
                 reader.getAreas().forEach((area: MapData.Area) => {
-                    area.labels.forEach((label: MapData.Label) => {
-                        const text = label.Text;
-                        if (text && text.toLowerCase().includes(term)) {
-                            results.push(`${text} (${area.areaName})`);
+                    area.rooms.forEach((room: any) => {
+                        const name = room.name as string | undefined;
+                        if (name && name.toLowerCase().includes(term)) {
+                            const path = reader.getPath(current.id, room.id);
+                            const dist = path ? path.length - 1 : Number.MAX_SAFE_INTEGER;
+                            matches.push({ name: room.name, area: area.areaName, dist });
                         }
                     });
                 });
-                if (results.length) {
-                    client.println(results.join('\n'));
+                matches.sort((a, b) => a.dist - b.dist);
+                const lines = matches.slice(0, 10).map(m => `${m.name} (${m.area})`);
+                if (lines.length) {
+                    client.println(lines.join('\n'));
                 } else {
                     client.println('Nie znaleziono.');
                 }

--- a/client/src/scripts/mapAliases.ts
+++ b/client/src/scripts/mapAliases.ts
@@ -57,6 +57,28 @@ export default function initMapAliases(client: Client, aliases: { pattern: RegEx
             callback: () => {
                 client.Map.refresh();
             }
+        },
+        {
+            pattern: /^\/przeszukaj (.+)$/,
+            callback: (m: RegExpMatchArray) => {
+                const term = m[1].toLowerCase();
+                const reader: any = (client as any).Map.mapReader;
+                if (!reader) return;
+                const results: string[] = [];
+                reader.getAreas().forEach((area: any) => {
+                    area.labels.forEach((label: any) => {
+                        const text = label.Text;
+                        if (text && text.toLowerCase().includes(term)) {
+                            results.push(`${text} (${area.areaName})`);
+                        }
+                    });
+                });
+                if (results.length) {
+                    client.println(results.join('\n'));
+                } else {
+                    client.println('Nie znaleziono.');
+                }
+            }
         }
     );
 }

--- a/client/src/types/MapData.d.ts
+++ b/client/src/types/MapData.d.ts
@@ -46,6 +46,7 @@ declare namespace MapData {
         areaId: string;
         weight: number;
         symbol: string;
+        name: string;
         userData: Record<string, string>;
         customLines: Record<string, Line>;
         stubs: number[];

--- a/client/src/types/MapReader.ts
+++ b/client/src/types/MapReader.ts
@@ -13,6 +13,8 @@ declare module "mudlet-map-renderer" {
 
         getPath(from: number, to: number): string[];
 
+        getAreas(): MapData.Area[];
+
     }
 
 }

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -36,7 +36,7 @@ Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorze
 - **/move _kierunek_** - przesuwa postać w wybranym kierunku.
 - **/ustaw _id_** - ustawia bieżącą pozycję na mapie na podany identyfikator.
 - **/zlok** - wymusza odświeżenie bieżącej pozycji na mapie.
-- **/przeszukaj _tekst_** - wyszukuje w danych mapy etykiety zawierające podany tekst.
+- **/przeszukaj _tekst_** - wyszukuje w danych mapy pokoje z nazwami zawierającymi podany tekst i wypisuje do 10 najbliższych.
 - **/prowadz _id_** - rozpoczyna prowadzenie innej osoby do wskazanego pokoju.
 - **/prowadz-** - kończy prowadzenie rozpoczęte komendą `/prowadz`.
 - **/go** - gdy aktywne jest prowadzenie, wybiera wyjście zgodnie z wyznaczoną trasą.

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -36,7 +36,7 @@ Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorze
 - **/move _kierunek_** - przesuwa postać w wybranym kierunku.
 - **/ustaw _id_** - ustawia bieżącą pozycję na mapie na podany identyfikator.
 - **/zlok** - wymusza odświeżenie bieżącej pozycji na mapie.
-- **/przeszukaj _tekst_** - wyszukuje w danych mapy pokoje z nazwami zawierającymi podany tekst i wypisuje do 10 najbliższych.
+- **/przeszukaj _tekst_** - wyszukuje w danych mapy pokoje z nazwami zawierającymi podany tekst i wypisuje do 10 najbliższych jako klikalne komendy `/prowadz`.
 - **/prowadz _id_** - rozpoczyna prowadzenie innej osoby do wskazanego pokoju.
 - **/prowadz-** - kończy prowadzenie rozpoczęte komendą `/prowadz`.
 - **/go** - gdy aktywne jest prowadzenie, wybiera wyjście zgodnie z wyznaczoną trasą.

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -36,6 +36,7 @@ Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorze
 - **/move _kierunek_** - przesuwa postać w wybranym kierunku.
 - **/ustaw _id_** - ustawia bieżącą pozycję na mapie na podany identyfikator.
 - **/zlok** - wymusza odświeżenie bieżącej pozycji na mapie.
+- **/przeszukaj _tekst_** - wyszukuje w danych mapy etykiety zawierające podany tekst.
 - **/prowadz _id_** - rozpoczyna prowadzenie innej osoby do wskazanego pokoju.
 - **/prowadz-** - kończy prowadzenie rozpoczęte komendą `/prowadz`.
 - **/go** - gdy aktywne jest prowadzenie, wybiera wyjście zgodnie z wyznaczoną trasą.


### PR DESCRIPTION
## Summary
- add `/przeszukaj` alias to search map labels
- document the new alias in ALIASES.md

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6888ee1958f0832aa86ec64b4f46dddd