### PR TITLE
Add herb description token triggers

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -23,6 +23,7 @@ import initHerbShop from './scripts/herbShop'
 import initArmorShop from './scripts/armorShop'
 import initSmith from './scripts/smith'
 import initHerbCounter from './scripts/herbCounter'
+import initHerbDescriptions from './scripts/herbDescriptions'
 import initLvlCalc from './scripts/lvlCalc'
 import initItemCondition from './scripts/itemCondition'
 import initDurability from './scripts/durability'
@@ -138,6 +139,7 @@ export function registerScripts(client: Client) {
     initArmorShop(client)
     initSmith(client, aliases)
     initHerbCounter(client, aliases)
+    initHerbDescriptions(client)
     initLvlCalc(client, aliases)
     initCompareAll(client, aliases)
     initItemCondition(client)

--- a/client/src/scripts/herbDescriptions.ts
+++ b/client/src/scripts/herbDescriptions.ts
@@ -1,0 +1,31 @@
+import Client from "../Client";
+import loadHerbs from "./herbsLoader";
+import { color, RESET, findClosestColor } from "../Colors";
+import { stripAnsiCodes } from "../Triggers";
+
+export const HERB_NAME_COLOR = findClosestColor("#ffffff");
+
+export default async function initHerbDescriptions(client: Client) {
+    const tag = "herbDescriptions";
+    try {
+        const herbs = await loadHerbs();
+        if (!herbs) return;
+        Object.entries(herbs.herb_id_to_odmiana).forEach(([id, forms]) => {
+            Object.values(forms).forEach(desc => {
+                client.Triggers.registerTokenTrigger(desc, (raw, _line, m) => {
+                    const index = m.index || 0;
+                    const token = m[0];
+                    const prefix = raw.substring(0, index);
+                    const suffix = raw.substring(index + token.length);
+                    const after = stripAnsiCodes(suffix).trimStart();
+                    if (after.startsWith("(")) {
+                        return raw;
+                    }
+                    return prefix + token + ` (${color(HERB_NAME_COLOR)}${id}${RESET})` + suffix;
+                }, tag);
+            });
+        });
+    } catch (e) {
+        console.error("Failed to init herb descriptions", e);
+    }
+}

--- a/client/test/herbDescriptions.test.ts
+++ b/client/test/herbDescriptions.test.ts
@@ -1,0 +1,53 @@
+import initHerbDescriptions, { HERB_NAME_COLOR } from '../src/scripts/herbDescriptions';
+import Triggers from '../src/Triggers';
+import { color, RESET } from '../src/Colors';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+}
+
+describe('herb descriptions', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        herb_id_to_odmiana: {
+          deliona: {
+            mianownik: 'zolty jasny kwiat',
+            dopelniacz: 'zoltego jasnego kwiata',
+            biernik: 'zolty jasny kwiat',
+            mnoga_mianownik: 'zolte jasne kwiaty',
+            mnoga_dopelniacz: 'zoltych jasnych kwiatow',
+            mnoga_biernik: 'zolte jasne kwiaty'
+          }
+        },
+        version: 1,
+        herb_id_to_use: {}
+      })
+    });
+  });
+
+  test('adds herb name when missing', async () => {
+    const client = new FakeClient();
+    await initHerbDescriptions((client as unknown) as any);
+    const line = 'Widzisz zolty jasny kwiat';
+    const result = client.Triggers.parseLine(line, '');
+    expect(result).toBe(
+      'Widzisz zolty jasny kwiat ' +
+        '(' +
+        color(HERB_NAME_COLOR) +
+        'deliona' +
+        RESET +
+        ')'
+    );
+  });
+
+  test('does not duplicate herb name', async () => {
+    const client = new FakeClient();
+    await initHerbDescriptions((client as unknown) as any);
+    const line = 'Widzisz zolty jasny kwiat (deliona)';
+    const result = client.Triggers.parseLine(line, '');
+    expect(result).toBe(line);
+  });
+});


### PR DESCRIPTION
## Summary
- load herb descriptions and register token triggers
- append herb name in white if missing
- wire up script in main initialization
- test herb description token triggers

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6888f5eda9ec832a84d77a1887dda003