### PR TITLE
Implement map label search alias

### DIFF
--- a/client/src/scripts/mapAliases.ts
+++ b/client/src/scripts/mapAliases.ts
@@ -2,6 +2,18 @@ import Client from "../Client";
 import { longToShort } from "../MapHelper";
 import { getShortcut } from "./shortcuts";
 
+async function asyncSort<T>(arr: T[], compare: (a: T, b: T) => number): Promise<void> {
+    for (let i = 1; i < arr.length; i++) {
+        let j = i;
+        while (j > 0 && compare(arr[j - 1], arr[j]) > 0) {
+            [arr[j - 1], arr[j]] = [arr[j], arr[j - 1]];
+            j--;
+            if (j % 100 === 0) await Promise.resolve();
+        }
+        if (i % 100 === 0) await Promise.resolve();
+    }
+}
+
 export default function initMapAliases(client: Client, aliases: { pattern: RegExp; callback: Function }[]) {
     aliases.push(
         {
@@ -56,6 +68,35 @@ export default function initMapAliases(client: Client, aliases: { pattern: RegEx
             pattern: /\/zlok$/,
             callback: () => {
                 client.Map.refresh();
+            }
+        },
+        {
+            pattern: /^\/przeszukaj (.+)$/,
+            callback: async (m: RegExpMatchArray) => {
+                const term = m[1].toLowerCase();
+                const reader = client.Map.mapReader;
+                const current = client.Map.currentRoom as any;
+                if (!reader || !current) return;
+                const matches: { name: string; area: string; dist: number }[] = [];
+                for (const area of reader.getAreas()) {
+                    for (const room of area.rooms as any[]) {
+                        const name = room.name as string | undefined;
+                        if (name && name.toLowerCase().includes(term)) {
+                            const path = reader.getPath(current.id, room.id);
+                            const dist = path ? path.length - 1 : Number.MAX_SAFE_INTEGER;
+                            matches.push({ name: room.name, area: area.areaName, dist });
+                        }
+                    }
+                    // allow other handlers to run
+                    await Promise.resolve();
+                }
+                await asyncSort(matches, (a, b) => a.dist - b.dist);
+                const lines = matches.slice(0, 10).map(m => `${m.name} (${m.area})`);
+                if (lines.length) {
+                    client.println(lines.join('\n'));
+                } else {
+                    client.println('Nie znaleziono.');
+                }
             }
         }
     );

--- a/client/src/types/MapData.d.ts
+++ b/client/src/types/MapData.d.ts
@@ -46,6 +46,7 @@ declare namespace MapData {
         areaId: string;
         weight: number;
         symbol: string;
+        name: string;
         userData: Record<string, string>;
         customLines: Record<string, Line>;
         stubs: number[];

--- a/client/src/types/MapReader.ts
+++ b/client/src/types/MapReader.ts
@@ -13,6 +13,8 @@ declare module "mudlet-map-renderer" {
 
         getPath(from: number, to: number): string[];
 
+        getAreas(): MapData.Area[];
+
     }
 
 }

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -36,6 +36,7 @@ Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorze
 - **/move _kierunek_** - przesuwa postać w wybranym kierunku.
 - **/ustaw _id_** - ustawia bieżącą pozycję na mapie na podany identyfikator.
 - **/zlok** - wymusza odświeżenie bieżącej pozycji na mapie.
+- **/przeszukaj _tekst_** - wyszukuje w danych mapy pokoje z nazwami zawierającymi podany tekst i wypisuje do 10 najbliższych.
 - **/prowadz _id_** - rozpoczyna prowadzenie innej osoby do wskazanego pokoju.
 - **/prowadz-** - kończy prowadzenie rozpoczęte komendą `/prowadz`.
 - **/go** - gdy aktywne jest prowadzenie, wybiera wyjście zgodnie z wyznaczoną trasą.


### PR DESCRIPTION
## Summary
- add `/przeszukaj` alias to search map labels
- document the new alias in ALIASES.md
- refine typing for `MapReader` and alias callback
- make map search asynchronous
- make sorting asynchronous as well

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6888ee1958f0832aa86ec64b4f46dddd