### PR TITLE
Implement herb right-click actions

### DIFF
--- a/client/src/OutputHandler.ts
+++ b/client/src/OutputHandler.ts
@@ -5,6 +5,7 @@ export default class OutputHandler {
     client: Client
     output = document.getElementById("main_text_output_msg_wrapper")
     clickerCallbacks: any[] = [];
+    private contextMenu = document.getElementById('context-menu') as HTMLElement | null;
 
     constructor(clientExtension: Client) {
         this.client = clientExtension
@@ -15,6 +16,31 @@ export default class OutputHandler {
                 this.processOutput(event);
             }
         )
+        document.addEventListener('click', this.hideContextMenu)
+    }
+
+    private hideContextMenu = () => {
+        if (this.contextMenu) {
+            this.contextMenu.classList.remove('show')
+            this.contextMenu.innerHTML = ''
+        }
+    }
+
+    showContextMenu(items: { label: string; action: () => void }[], x: number, y: number) {
+        if (!this.contextMenu) return
+        this.hideContextMenu()
+        items.forEach(item => {
+            const btn = document.createElement('button')
+            btn.textContent = item.label
+            btn.onclick = () => {
+                this.hideContextMenu()
+                item.action()
+            }
+            this.contextMenu!.appendChild(btn)
+        })
+        this.contextMenu.style.left = `${x}px`
+        this.contextMenu.style.top = `${y}px`
+        this.contextMenu.classList.add('show')
     }
 
     private decorateClickable(span: HTMLElement, cbIndex: number, title?: string) {
@@ -34,14 +60,14 @@ export default class OutputHandler {
                 }
             } else {
                 if (cb.left) {
-                    span.onclick = () => {
-                        cb.left?.apply(null)
+                    span.onclick = (ev) => {
+                        cb.left?.call(null, ev)
                     }
                 }
                 if (cb.right) {
                     span.oncontextmenu = (ev) => {
                         ev.preventDefault()
-                        cb.right?.apply(null)
+                        cb.right?.call(null, ev)
                     }
                 }
             }
@@ -138,7 +164,7 @@ export default class OutputHandler {
         return `{clickOpen:${index}${title ? ":" + title : ""}}${string}{clickClose}`
     }
 
-    makeStringRightClickable(string: string, callback: Function, title?: string) {
+    makeStringRightClickable(string: string, callback: (ev: MouseEvent) => void, title?: string) {
         this.clickerCallbacks.push({ right: callback })
         const index = this.clickerCallbacks.length - 1
         return `{clickOpen:${index}${title ? ":" + title : ""}}${string}{clickClose}`

--- a/client/src/OutputHandler.ts
+++ b/client/src/OutputHandler.ts
@@ -4,7 +4,7 @@ export default class OutputHandler {
 
     client: Client
     output = document.getElementById("main_text_output_msg_wrapper")
-    clickerCallbacks: Function[] = [];
+    clickerCallbacks: any[] = [];
 
     constructor(clientExtension: Client) {
         this.client = clientExtension
@@ -27,8 +27,24 @@ export default class OutputHandler {
         }
         const cb = this.clickerCallbacks[cbIndex]
         this.clickerCallbacks[cbIndex] = undefined as any
-        span.onclick = () => {
-            cb?.apply(null)
+        if (cb) {
+            if (typeof cb === 'function') {
+                span.onclick = () => {
+                    cb?.apply(null)
+                }
+            } else {
+                if (cb.left) {
+                    span.onclick = () => {
+                        cb.left?.apply(null)
+                    }
+                }
+                if (cb.right) {
+                    span.oncontextmenu = (ev) => {
+                        ev.preventDefault()
+                        cb.right?.apply(null)
+                    }
+                }
+            }
         }
     }
 
@@ -118,6 +134,12 @@ export default class OutputHandler {
 
     makeStringClickable(string: string, callback: Function, title?: string) {
         this.clickerCallbacks.push(callback)
+        const index = this.clickerCallbacks.length - 1
+        return `{clickOpen:${index}${title ? ":" + title : ""}}${string}{clickClose}`
+    }
+
+    makeStringRightClickable(string: string, callback: Function, title?: string) {
+        this.clickerCallbacks.push({ right: callback })
         const index = this.clickerCallbacks.length - 1
         return `{clickOpen:${index}${title ? ":" + title : ""}}${string}{clickClose}`
     }

--- a/client/src/OutputHandler.ts
+++ b/client/src/OutputHandler.ts
@@ -69,6 +69,31 @@ export default class OutputHandler {
                         ev.preventDefault()
                         cb.right?.call(null, ev)
                     }
+                    let timer: number | undefined
+                    const clear = () => {
+                        if (timer !== undefined) {
+                            clearTimeout(timer)
+                            timer = undefined
+                        }
+                    }
+                    span.addEventListener('touchstart', (ev: any) => {
+                        clear()
+                        timer = window.setTimeout(() => {
+                            const t = ev.touches && ev.touches[0]
+                            if (t) {
+                                const me = new MouseEvent('contextmenu', {
+                                    bubbles: true,
+                                    cancelable: true,
+                                    clientX: t.clientX,
+                                    clientY: t.clientY,
+                                })
+                                cb.right?.call(null, me)
+                            }
+                        }, 500)
+                    })
+                    span.addEventListener('touchend', clear)
+                    span.addEventListener('touchcancel', clear)
+                    span.addEventListener('touchmove', clear)
                 }
             }
         }

--- a/client/src/scripts/herbCounter.ts
+++ b/client/src/scripts/herbCounter.ts
@@ -143,6 +143,14 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
     const bagTotals: Record<number, Record<string, number>> = {};
     let currentBag = 0;
 
+    const bindHerb = (id: string) => {
+        const action = herbs?.herb_id_to_use[id]?.[0]?.action;
+        if (action) {
+            const cmd = `/z ${action} ${id}`;
+            client.FunctionalBind.set(cmd, () => client.sendCommand(cmd));
+        }
+    };
+
     function buildSummary(bags: Record<number, Record<string, number>>): string[] {
         const totalsMap: Record<string, number> = {};
         Object.values(bags).forEach(contents => {
@@ -168,7 +176,8 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
             const uses = herbs?.herb_id_to_use[id]?.map(u => `${u.action}: ${u.effect}`).join(' | ') || '--';
 
             if (normal) {
-                const base = `${String(c).padStart(5, ' ')} | ${id.padEnd(18, ' ')} | `;
+                const name = client.OutputHandler.makeStringRightClickable(id.padEnd(18, ' '), () => bindHerb(id));
+                const base = `${String(c).padStart(5, ' ')} | ${name} | `;
                 const available = width - stripAnsiCodes(base).length;
                 if (available >= stripAnsiCodes(uses).length) {
                     lines.push(base + uses);
@@ -176,11 +185,11 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
                     lines.push(base + uses.slice(0, available));
                     lines.push(' '.repeat(stripAnsiCodes(base).length) + uses.slice(available));
                 } else {
-                    lines.push(`${String(c).padStart(5, ' ')} | ${id}`);
+                    lines.push(`${String(c).padStart(5, ' ')} | ${client.OutputHandler.makeStringRightClickable(id, () => bindHerb(id))}`);
                     lines.push(' '.repeat(prefixWidth) + uses);
                 }
             } else {
-                const base = `${String(c).padStart(3, ' ')} ${id}`;
+                const base = `${String(c).padStart(3, ' ')} ${client.OutputHandler.makeStringRightClickable(id, () => bindHerb(id))}`;
                 lines.push(base);
                 lines.push(' '.repeat(4) + uses);
             }
@@ -193,7 +202,7 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
             Object.entries(bags).forEach(([num, contents]) => {
                 const parts = Object.entries(contents)
                     .sort((a, b) => a[0].localeCompare(b[0]))
-                    .map(([id, c]) => `${c} ${id}`)
+                    .map(([id, c]) => `${c} ${client.OutputHandler.makeStringRightClickable(id, () => bindHerb(id))}`)
                     .join(', ');
                 lines.push(`${num}. ${parts || '(pusty)'}`);
             });

--- a/client/src/scripts/herbCounter.ts
+++ b/client/src/scripts/herbCounter.ts
@@ -146,10 +146,13 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
     const showHerbActions = (id: string, ev: MouseEvent) => {
         const actions = herbs?.herb_id_to_use[id];
         if (!actions || actions.length === 0) return;
-        const items = actions.map(a => ({
-            label: a.action,
-            action: () => client.sendCommand(`/z ${a.action} ${id}`)
-        }));
+        const amounts = [1, 3, 5];
+        const items = actions.flatMap(a =>
+            amounts.map(n => ({
+                label: `${a.action} ${n}`,
+                action: () => client.sendCommand(`/z ${a.action} ${id} ${n}`)
+            }))
+        );
         client.OutputHandler.showContextMenu(items, ev.pageX, ev.pageY);
     };
 

--- a/client/src/scripts/herbCounter.ts
+++ b/client/src/scripts/herbCounter.ts
@@ -143,12 +143,14 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
     const bagTotals: Record<number, Record<string, number>> = {};
     let currentBag = 0;
 
-    const bindHerb = (id: string) => {
-        const action = herbs?.herb_id_to_use[id]?.[0]?.action;
-        if (action) {
-            const cmd = `/z ${action} ${id}`;
-            client.FunctionalBind.set(cmd, () => client.sendCommand(cmd));
-        }
+    const showHerbActions = (id: string, ev: MouseEvent) => {
+        const actions = herbs?.herb_id_to_use[id];
+        if (!actions || actions.length === 0) return;
+        const items = actions.map(a => ({
+            label: a.action,
+            action: () => client.sendCommand(`/z ${a.action} ${id}`)
+        }));
+        client.OutputHandler.showContextMenu(items, ev.pageX, ev.pageY);
     };
 
     function buildSummary(bags: Record<number, Record<string, number>>): string[] {
@@ -176,7 +178,7 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
             const uses = herbs?.herb_id_to_use[id]?.map(u => `${u.action}: ${u.effect}`).join(' | ') || '--';
 
             if (normal) {
-                const name = client.OutputHandler.makeStringRightClickable(id.padEnd(18, ' '), () => bindHerb(id));
+                const name = client.OutputHandler.makeStringRightClickable(id.padEnd(18, ' '), (ev) => showHerbActions(id, ev));
                 const base = `${String(c).padStart(5, ' ')} | ${name} | `;
                 const available = width - stripAnsiCodes(base).length;
                 if (available >= stripAnsiCodes(uses).length) {
@@ -185,11 +187,11 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
                     lines.push(base + uses.slice(0, available));
                     lines.push(' '.repeat(stripAnsiCodes(base).length) + uses.slice(available));
                 } else {
-                    lines.push(`${String(c).padStart(5, ' ')} | ${client.OutputHandler.makeStringRightClickable(id, () => bindHerb(id))}`);
+                    lines.push(`${String(c).padStart(5, ' ')} | ${client.OutputHandler.makeStringRightClickable(id, (ev) => showHerbActions(id, ev))}`);
                     lines.push(' '.repeat(prefixWidth) + uses);
                 }
             } else {
-                const base = `${String(c).padStart(3, ' ')} ${client.OutputHandler.makeStringRightClickable(id, () => bindHerb(id))}`;
+                const base = `${String(c).padStart(3, ' ')} ${client.OutputHandler.makeStringRightClickable(id, (ev) => showHerbActions(id, ev))}`;
                 lines.push(base);
                 lines.push(' '.repeat(4) + uses);
             }
@@ -202,7 +204,7 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
             Object.entries(bags).forEach(([num, contents]) => {
                 const parts = Object.entries(contents)
                     .sort((a, b) => a[0].localeCompare(b[0]))
-                    .map(([id, c]) => `${c} ${client.OutputHandler.makeStringRightClickable(id, () => bindHerb(id))}`)
+                    .map(([id, c]) => `${c} ${client.OutputHandler.makeStringRightClickable(id, (ev) => showHerbActions(id, ev))}`)
                     .join(', ');
                 lines.push(`${num}. ${parts || '(pusty)'}`);
             });

--- a/client/src/scripts/herbDescriptions.ts
+++ b/client/src/scripts/herbDescriptions.ts
@@ -10,6 +10,14 @@ export default async function initHerbDescriptions(client: Client) {
     try {
         const herbs = await loadHerbs();
         if (!herbs) return;
+
+        const bindHerb = (herbId: string) => {
+            const action = herbs.herb_id_to_use[herbId]?.[0]?.action;
+            if (action) {
+                const cmd = `/z ${action} ${herbId}`;
+                client.FunctionalBind.set(cmd, () => client.sendCommand(cmd));
+            }
+        };
         Object.entries(herbs.herb_id_to_odmiana).forEach(([id, forms]) => {
             Object.values(forms).forEach(desc => {
                 client.Triggers.registerTokenTrigger(desc, (raw, _line, m) => {
@@ -21,7 +29,8 @@ export default async function initHerbDescriptions(client: Client) {
                     if (after.startsWith("(")) {
                         return raw;
                     }
-                    return prefix + token + ` (${color(HERB_NAME_COLOR)}${id}${RESET})` + suffix;
+                    const clickable = client.OutputHandler.makeStringRightClickable(id, () => bindHerb(id));
+                    return prefix + token + ` (${color(HERB_NAME_COLOR)}${clickable}${RESET})` + suffix;
                 }, tag);
             });
         });

--- a/client/src/scripts/herbDescriptions.ts
+++ b/client/src/scripts/herbDescriptions.ts
@@ -14,10 +14,13 @@ export default async function initHerbDescriptions(client: Client) {
         const showHerbActions = (herbId: string, ev: MouseEvent) => {
             const actions = herbs.herb_id_to_use[herbId];
             if (!actions || actions.length === 0) return;
-            const items = actions.map(a => ({
-                label: a.action,
-                action: () => client.sendCommand(`/z ${a.action} ${herbId}`)
-            }));
+            const amounts = [1, 3, 5];
+            const items = actions.flatMap(a =>
+                amounts.map(n => ({
+                    label: `${a.action} ${n}`,
+                    action: () => client.sendCommand(`/z ${a.action} ${herbId} ${n}`)
+                }))
+            );
             client.OutputHandler.showContextMenu(items, ev.pageX, ev.pageY);
         };
         Object.entries(herbs.herb_id_to_odmiana).forEach(([id, forms]) => {

--- a/client/src/scripts/herbDescriptions.ts
+++ b/client/src/scripts/herbDescriptions.ts
@@ -11,12 +11,14 @@ export default async function initHerbDescriptions(client: Client) {
         const herbs = await loadHerbs();
         if (!herbs) return;
 
-        const bindHerb = (herbId: string) => {
-            const action = herbs.herb_id_to_use[herbId]?.[0]?.action;
-            if (action) {
-                const cmd = `/z ${action} ${herbId}`;
-                client.FunctionalBind.set(cmd, () => client.sendCommand(cmd));
-            }
+        const showHerbActions = (herbId: string, ev: MouseEvent) => {
+            const actions = herbs.herb_id_to_use[herbId];
+            if (!actions || actions.length === 0) return;
+            const items = actions.map(a => ({
+                label: a.action,
+                action: () => client.sendCommand(`/z ${a.action} ${herbId}`)
+            }));
+            client.OutputHandler.showContextMenu(items, ev.pageX, ev.pageY);
         };
         Object.entries(herbs.herb_id_to_odmiana).forEach(([id, forms]) => {
             Object.values(forms).forEach(desc => {
@@ -29,7 +31,7 @@ export default async function initHerbDescriptions(client: Client) {
                     if (after.startsWith("(")) {
                         return raw;
                     }
-                    const clickable = client.OutputHandler.makeStringRightClickable(id, () => bindHerb(id));
+                    const clickable = client.OutputHandler.makeStringRightClickable(id, (ev) => showHerbActions(id, ev));
                     return prefix + token + ` (${color(HERB_NAME_COLOR)}${clickable}${RESET})` + suffix;
                 }, tag);
             });

--- a/client/test/OutputHandler.test.ts
+++ b/client/test/OutputHandler.test.ts
@@ -67,6 +67,35 @@ describe('OutputHandler clickable text', () => {
     expect(cb).toHaveBeenCalledWith(event);
   });
 
+  test('handles long touch', () => {
+    jest.useFakeTimers();
+    document.body.innerHTML =
+      '<div id="main_text_output_msg_wrapper"><div id="split-bottom"></div></div><div id="context-menu"></div>';
+    const client = new FakeClient();
+    const handler = new OutputHandler((client as unknown) as any);
+    const wrapper = document.getElementById('main_text_output_msg_wrapper')!;
+    const div = document.createElement('div');
+    div.className = 'output_msg';
+    const msg = document.createElement('div');
+    msg.className = 'output_msg_text';
+    const cb = jest.fn();
+    msg.textContent = handler.makeStringRightClickable('Click', cb);
+    div.appendChild(msg);
+    const split = document.getElementById('split-bottom')!;
+    wrapper.insertBefore(div, split);
+
+    client.dispatch('output-sent', 1);
+
+    const span = msg.querySelector('span') as HTMLSpanElement | null;
+    expect(span).not.toBeNull();
+    const event: any = new Event('touchstart');
+    event.touches = [{ clientX: 5, clientY: 6 }];
+    span!.dispatchEvent(event);
+    jest.advanceTimersByTime(600);
+    expect(cb).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
   test('handles links in sticky area', () => {
     document.body.innerHTML =
       '<div id="main_text_output_msg_wrapper"><div id="split-bottom"><div id="sticky-area"></div></div></div><div id="context-menu"></div>';

--- a/client/test/OutputHandler.test.ts
+++ b/client/test/OutputHandler.test.ts
@@ -17,7 +17,7 @@ class FakeClient {
 describe('OutputHandler clickable text', () => {
   test('handles clicks without span elements', () => {
     document.body.innerHTML =
-      '<div id="main_text_output_msg_wrapper"><div id="split-bottom"><div id="sticky-area"></div></div></div>';
+      '<div id="main_text_output_msg_wrapper"><div id="split-bottom"><div id="sticky-area"></div></div></div><div id="context-menu"></div>';
     const client = new FakeClient();
     const handler = new OutputHandler((client as unknown) as any);
     const wrapper = document.getElementById('main_text_output_msg_wrapper')!;
@@ -43,7 +43,7 @@ describe('OutputHandler clickable text', () => {
 
   test('handles right click', () => {
     document.body.innerHTML =
-      '<div id="main_text_output_msg_wrapper"><div id="split-bottom"></div></div>';
+      '<div id="main_text_output_msg_wrapper"><div id="split-bottom"></div></div><div id="context-menu"></div>';
     const client = new FakeClient();
     const handler = new OutputHandler((client as unknown) as any);
     const wrapper = document.getElementById('main_text_output_msg_wrapper')!;
@@ -61,13 +61,15 @@ describe('OutputHandler clickable text', () => {
 
     const span = msg.querySelector('span') as HTMLSpanElement | null;
     expect(span).not.toBeNull();
-    span!.oncontextmenu!(new MouseEvent('contextmenu'));
+    const event = new MouseEvent('contextmenu');
+    span!.oncontextmenu!(event);
     expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith(event);
   });
 
   test('handles links in sticky area', () => {
     document.body.innerHTML =
-      '<div id="main_text_output_msg_wrapper"><div id="split-bottom"><div id="sticky-area"></div></div></div>';
+      '<div id="main_text_output_msg_wrapper"><div id="split-bottom"><div id="sticky-area"></div></div></div><div id="context-menu"></div>';
     const client = new FakeClient();
     const handler = new OutputHandler((client as unknown) as any);
 

--- a/client/test/OutputHandler.test.ts
+++ b/client/test/OutputHandler.test.ts
@@ -41,6 +41,30 @@ describe('OutputHandler clickable text', () => {
   expect((handler as any).clickerCallbacks[0]).toBeUndefined();
   });
 
+  test('handles right click', () => {
+    document.body.innerHTML =
+      '<div id="main_text_output_msg_wrapper"><div id="split-bottom"></div></div>';
+    const client = new FakeClient();
+    const handler = new OutputHandler((client as unknown) as any);
+    const wrapper = document.getElementById('main_text_output_msg_wrapper')!;
+    const div = document.createElement('div');
+    div.className = 'output_msg';
+    const msg = document.createElement('div');
+    msg.className = 'output_msg_text';
+    const cb = jest.fn();
+    msg.textContent = handler.makeStringRightClickable('Click', cb);
+    div.appendChild(msg);
+    const split = document.getElementById('split-bottom')!;
+    wrapper.insertBefore(div, split);
+
+    client.dispatch('output-sent', 1);
+
+    const span = msg.querySelector('span') as HTMLSpanElement | null;
+    expect(span).not.toBeNull();
+    span!.oncontextmenu!(new MouseEvent('contextmenu'));
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
   test('handles links in sticky area', () => {
     document.body.innerHTML =
       '<div id="main_text_output_msg_wrapper"><div id="split-bottom"><div id="sticky-area"></div></div></div>';

--- a/client/test/herbCounter.test.ts
+++ b/client/test/herbCounter.test.ts
@@ -7,6 +7,14 @@ class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
   sendCommand = jest.fn();
   println = jest.fn();
+  private index = 0;
+  OutputHandler = {
+    makeStringRightClickable: (str: string) => {
+      const idx = this.index++;
+      return `{clickOpen:${idx}}${str}{clickClose}`;
+    }
+  } as any;
+  FunctionalBind = { set: jest.fn() } as any;
   contentWidth = 80;
   addEventListener(event: string, cb: any) { this.emitter.on(event, cb); }
   removeEventListener(event: string, cb: any) { this.emitter.off(event, cb); }
@@ -54,8 +62,8 @@ describe('herb counter', () => {
     const printed = client.println.mock.calls[0][0];
     expect(printed).toMatch(/3/);
     expect(printed).toMatch(/deliona/);
-    expect(printed).toMatch(/1\.\s+2 deliona/);
-    expect(printed).toMatch(/2\.\s+1 deliona/);
+    expect(printed).toMatch(/1\.\s+2 {clickOpen:\d+}deliona{clickClose}/);
+    expect(printed).toMatch(/2\.\s+1 {clickOpen:\d+}deliona{clickClose}/);
   });
 
   test('splits summary when width is limited', async () => {

--- a/client/test/herbDescriptions.test.ts
+++ b/client/test/herbDescriptions.test.ts
@@ -4,6 +4,14 @@ import { color, RESET } from '../src/Colors';
 
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
+  private index = 0;
+  OutputHandler = {
+    makeStringRightClickable: (str: string) => {
+      const idx = this.index++;
+      return `{clickOpen:${idx}}${str}{clickClose}`;
+    }
+  } as any;
+  FunctionalBind = { set: jest.fn() } as any;
 }
 
 describe('herb descriptions', () => {
@@ -37,7 +45,7 @@ describe('herb descriptions', () => {
       'Widzisz zolty jasny kwiat ' +
         '(' +
         color(HERB_NAME_COLOR) +
-        'deliona' +
+        '{clickOpen:0}deliona{clickClose}' +
         RESET +
         ')'
     );

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -350,6 +350,7 @@
         <div id="z-buttons-list" class="mobile-z-buttons"></div>
         <div id="zas-buttons-list" class="mobile-z-buttons"></div>
         </div>
+    <div id="context-menu" class="context-menu"></div>
 </div>
 <script type="module" src="/src/plugin.ts"></script>
 <script type="module" src="/src/main.ts"></script>

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -758,3 +758,32 @@ button:focus-visible {
   pointer-events: none;
   border: 1px solid #fff;
 }
+
+.context-menu {
+  position: absolute;
+  display: none;
+  background-color: var(--bs-body-bg);
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 0.25rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  padding: 0.25rem 0;
+  z-index: 1105;
+  min-width: 8rem;
+}
+
+.context-menu.show {
+  display: block;
+}
+
+.context-menu button {
+  display: block;
+  width: 100%;
+  background: none;
+  border: 0;
+  padding: 0.25rem 0.5rem;
+  text-align: left;
+}
+
+.context-menu button:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -779,10 +779,10 @@ button:focus-visible {
   display: block;
   width: 100%;
   background: none;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  border: 1px solid #fff;
   border-radius: 0.25rem;
   padding: 0.25rem 0.5rem;
-  margin: 0.125rem 0.25rem;
+  margin: 0.25rem;
   text-align: left;
 }
 

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -779,11 +779,14 @@ button:focus-visible {
   display: block;
   width: 100%;
   background: none;
-  border: 0;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 0.25rem;
   padding: 0.25rem 0.5rem;
+  margin: 0.125rem 0.25rem;
   text-align: left;
 }
 
 .context-menu button:hover {
   background-color: rgba(0, 0, 0, 0.05);
+  border-color: rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
## Summary
- add support for right-click callbacks in `OutputHandler`
- make herb names clickable in descriptions and bag summaries
- bind the first available herb action on right-click
- test right-click behaviour

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6888f9800938832aba50947a05d8feac