### PR TITLE
Translate macro option labels to Polish

### DIFF
--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -10,13 +10,13 @@ import {
 } from "../mobileButtonSettings";
 
 const macroOptions: { value: MacroType; label: string }[] = [
-    { value: "functional", label: "Send functional" },
-    { value: "zList", label: "Create /z dropdown list" },
-    { value: "zaList", label: "Create /za dropdown list" },
-    { value: "command", label: "Send command" },
-    { value: "kierunek", label: "Direction button" },
-    { value: "specialExit", label: "Use special exit" },
-    { value: "wesprzyj", label: "Support leader" },
+    { value: "functional", label: "Bind funkcyjny" },
+    { value: "zList", label: "Lista /z" },
+    { value: "zaList", label: "Lista /za" },
+    { value: "command", label: "Wyślij komendę" },
+    { value: "kierunek", label: "Kierunek" },
+    { value: "specialExit", label: "Wyjście specjalne" },
+    { value: "wesprzyj", label: "Wesprzyj prowadzącego" },
 ];
 
 const directionOptions = ["nw","n","ne","w","e","sw","s","se","u","d"] as const;

--- a/web-client/src/options/UserTriggers.tsx
+++ b/web-client/src/options/UserTriggers.tsx
@@ -22,10 +22,10 @@ function MacroEditor({ macro, onChange, onRemove }: { macro: UserMacro; onChange
                 value={macro.type}
                 onChange={e => onChange({ ...macro, type: e.target.value as any })}
             >
-                <option value="uppercase">Uppercase</option>
-                <option value="color">Color</option>
-                <option value="replace">Replace</option>
-                <option value="beep">Beep</option>
+                <option value="uppercase">Wielkie litery</option>
+                <option value="color">Koloruj</option>
+                <option value="replace">Zamień</option>
+                <option value="beep">Dźwięk</option>
             </Form.Select>
             {macro.type === 'color' && (
             <Form.Control


### PR DESCRIPTION
## Summary
- localize macro dropdown options in mobile buttons settings
- translate macro action options in user trigger settings
- adjust translations per reviewer feedback

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_68891053732c832ab57e3f76c511de38