### PR TITLE
Fix NPC list refresh after deliveries

### DIFF
--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -24,6 +24,19 @@ function Npc() {
         })
     }, []);
 
+    useEffect(() => {
+        const handler = (ev: Event) => {
+            const detail = (ev as CustomEvent).detail
+            if (Array.isArray(detail)) {
+                setNpcs(detail)
+            }
+        }
+        window.addEventListener('npc', handler as EventListener)
+        return () => {
+            window.removeEventListener('npc', handler as EventListener)
+        }
+    }, [])
+
     function downloadNpcs() {
         updateIndexedDB<NpcProps[]>(DB_CONFIG, NPC_URL)
             .then(data => {


### PR DESCRIPTION
## Summary
- listen for `npc` events in Npc options page so NPC list updates immediately

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6889eb616598832a973a9fec28a220c9