### PR TITLE
Fix tests for colored herb counter output

### DIFF
--- a/client/test/herbCounter.test.ts
+++ b/client/test/herbCounter.test.ts
@@ -1,5 +1,5 @@
 import initHerbCounter from '../src/scripts/herbCounter';
-import Triggers from '../src/Triggers';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
 import { EventEmitter } from 'events';
 
 class FakeClient {
@@ -105,7 +105,7 @@ describe('herb counter', () => {
     const printed = client.println.mock.calls[0][0];
     const lines = printed.split('\n');
     lines.forEach((l) => {
-      expect(l.length).toBeLessThanOrEqual(client.contentWidth);
+      expect(stripAnsiCodes(l).length).toBeLessThanOrEqual(client.contentWidth);
     });
   });
 


### PR DESCRIPTION
## Summary
- update herbCounter test to strip ANSI codes before checking length

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6889fc995adc832ab56c92fb56722856