### PR TITLE
Fix weapon color highlight for duplicate names

### DIFF
--- a/client/src/Colors.ts
+++ b/client/src/Colors.ts
@@ -46,8 +46,8 @@ export function colorString(string: string, colorCode: number) {
     return color(colorCode) + string + RESET;
 }
 
-export function colorStringInLine(rawLine: string, string: string, colorCode: number) {
-    const matchIndex = rawLine.indexOf(string)
+export function colorStringInLine(rawLine: string, string: string, colorCode: number, startIndex = 0) {
+    const matchIndex = rawLine.indexOf(string, startIndex)
     if (matchIndex === -1) {
         return rawLine
     }

--- a/client/src/scripts/weaponColors.ts
+++ b/client/src/scripts/weaponColors.ts
@@ -25,14 +25,26 @@ export default function initWeaponColors(client: Client) {
     client.Triggers.registerTrigger(
         /^Trzyma(?:sz)? (?<weapon1>[a-z ]+?) w (?:lewej|prawej) rece(?: oraz (?<weapon2>[a-z ]+?) w (?:lewej|prawej) rece)?\.$/,
         (raw, _line, m) => {
-            let line = raw;
             const { weapon1, weapon2 } = m.groups as { weapon1: string; weapon2?: string };
-            if (!isMagicColored(line, weapon1)) {
-                line = colorStringInLine(line, weapon1, WEAPON_COLOR);
+            if (!weapon2) {
+                if (isMagicColored(raw, weapon1)) {
+                    return raw;
+                }
+                return colorStringInLine(raw, weapon1, WEAPON_COLOR);
             }
-            if (weapon2 && !isMagicColored(line, weapon2)) {
-                line = colorStringInLine(line, weapon2, WEAPON_COLOR);
+
+            const firstIndex = raw.indexOf(weapon1);
+            const secondIndex = raw.indexOf(weapon2, firstIndex + weapon1.length);
+            let line = raw;
+
+            if (!isMagicColored(raw, weapon2) && secondIndex > -1) {
+                line = colorStringInLine(line, weapon2, WEAPON_COLOR, secondIndex);
             }
+
+            if (!isMagicColored(raw, weapon1) && firstIndex > -1) {
+                line = colorStringInLine(line, weapon1, WEAPON_COLOR, firstIndex);
+            }
+
             return line;
         },
         tag

--- a/client/test/weaponColors.test.ts
+++ b/client/test/weaponColors.test.ts
@@ -34,6 +34,18 @@ describe('weapon colors trigger', () => {
     expect(result).toBe(expected);
   });
 
+  test('colors identical weapons in both hands', () => {
+    const line = 'Trzymasz zebaty szeroki noz bojowy w lewej rece oraz zebaty szeroki noz bojowy w prawej rece.';
+    const weapon = 'zebaty szeroki noz bojowy';
+    const firstIndex = line.indexOf(weapon);
+    const secondIndex = line.indexOf(weapon, firstIndex + weapon.length);
+    let expected = colorStringInLine(line, weapon, WEAPON_COLOR, secondIndex);
+    expected = colorStringInLine(expected, weapon, WEAPON_COLOR, firstIndex);
+    const result = parse(line);
+    expect(stripAnsiCodes(result)).toBe(stripAnsiCodes(expected));
+    expect(result).toBe(expected);
+  });
+
   test('keeps magic color for single weapon', () => {
     const line = 'Trzymasz oburacz stalowy miecz.';
     const magicColored = color(MAGICS_COLOR) + 'stalowy miecz' + RESET;


### PR DESCRIPTION
## Summary
- handle highlighting when both weapons have the same name
- support passing search start index to `colorStringInLine`
- test identical weapon highlighting

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688b8c429328832a976b32b909e4f86c