### PR TITLE
Add dual mobile button sets

### DIFF
--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -43,6 +43,7 @@ export default class TeamManager {
     private avatarAttackTargetId?: string
     private attackTargetId?: string
     private defenseTargetId?: string
+    private hasTeam = false;
 
     constructor(client: Client) {
         this.client = client;
@@ -154,6 +155,7 @@ export default class TeamManager {
 
     private addMember(name: string) {
         this.members.add(name);
+        this.emitTeamChange();
     }
 
     private removeMember(name: string) {
@@ -161,6 +163,7 @@ export default class TeamManager {
         if (this.leader === name) {
             this.leader = undefined;
         }
+        this.emitTeamChange();
     }
 
     getTeamMembers(): string[] {
@@ -182,6 +185,15 @@ export default class TeamManager {
     clearTeam() {
         this.members.clear();
         this.leader = undefined;
+        this.emitTeamChange();
+    }
+
+    private emitTeamChange() {
+        const hasTeamNow = this.members.size > 0;
+        if (this.hasTeam !== hasTeamNow) {
+            this.hasTeam = hasTeamNow;
+            this.client.sendEvent('teamChange', this.hasTeam);
+        }
     }
 
     getAccumulatedObjectsData() {

--- a/client/src/eventBus.ts
+++ b/client/src/eventBus.ts
@@ -15,6 +15,7 @@ export interface KnownEvents {
     'contentWidth': number;
     'enterLocation': { id: number; room: any };
     'npc': any;
+    'teamChange': boolean;
 }
 
 export type ClientEvents = KnownEvents & {

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -839,7 +839,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initialize mobile direction buttons
     new MobileDirectionButtons(client);
 
-    loadMobileButtonSettings().then(applyMobileButtonSettings);
+    loadMobileButtonSettings().then(settings => applyMobileButtonSettings(settings.solo));
 
     initUiSettings();
 

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -18,7 +18,12 @@ export interface ButtonSetting {
     direction?: string;
 }
 
-export const defaultSettings: Record<string, ButtonSetting> = {
+export interface DualButtonSettings {
+    solo: Record<string, ButtonSetting>;
+    team: Record<string, ButtonSetting>;
+}
+
+export const defaultButtonSettings: Record<string, ButtonSetting> = {
     // top row buttons
     'z-list-toggle': { macro: 'zList', label: '/z', color: '#87CEEB' },
     'zas-list-toggle': { macro: 'zaList', label: '/za', color: '#87CEEB' },
@@ -43,18 +48,32 @@ export const defaultSettings: Record<string, ButtonSetting> = {
     'special-exit-button': { macro: 'specialExit', label: 'sp ex', color: '#6CA6CD' },
 };
 
-export async function loadSettings(): Promise<Record<string, ButtonSetting>> {
+export const defaultSettings: DualButtonSettings = {
+    solo: { ...defaultButtonSettings },
+    team: { ...defaultButtonSettings },
+};
+
+export async function loadSettings(): Promise<DualButtonSettings> {
     try {
         const data = await storage.getItem('mobileButtonSettings');
         const raw = data?.mobileButtonSettings;
         if (raw) {
-            return { ...defaultSettings, ...(raw as any) };
+            if (typeof raw.solo === 'object' && typeof raw.team === 'object') {
+                return {
+                    solo: { ...defaultButtonSettings, ...(raw as any).solo },
+                    team: { ...defaultButtonSettings, ...(raw as any).team },
+                };
+            }
+            return {
+                solo: { ...defaultButtonSettings, ...(raw as any) },
+                team: { ...defaultButtonSettings, ...(raw as any) },
+            };
         }
     } catch {}
-    return { ...defaultSettings };
+    return { solo: { ...defaultButtonSettings }, team: { ...defaultButtonSettings } };
 }
 
-export function saveSettings(settings: Record<string, ButtonSetting>) {
+export function saveSettings(settings: DualButtonSettings) {
     storage.setItem('mobileButtonSettings', settings);
 }
 
@@ -93,7 +112,7 @@ export default async function initMobileButtonSettings() {
         const id = btn.dataset.buttonId!;
         previewMap[id] = btn;
     });
-    Object.keys(defaultSettings).forEach(id => {
+    Object.keys(defaultButtonSettings).forEach(id => {
         const el = document.getElementById(id) as HTMLButtonElement | null;
         if (el) realMap[id] = el;
     });
@@ -107,7 +126,8 @@ export default async function initMobileButtonSettings() {
         }
     };
 
-    let current = await loadSettings();
+    let all = await loadSettings();
+    let current = { ...all.solo };
     const applyLive = (id: string, labelVal: string, colorVal: string) => {
         const btn = realMap[id];
         if (btn) {
@@ -117,7 +137,7 @@ export default async function initMobileButtonSettings() {
     };
     sections.forEach(section => {
         const id = section.dataset.buttonId!;
-        const cfg = current[id] || defaultSettings[id];
+        const cfg = current[id] || defaultButtonSettings[id];
         const preview = previewMap[id];
         const macro = section.querySelector('.mobile-button-macro') as HTMLSelectElement;
         const label = section.querySelector('.mobile-button-label') as HTMLInputElement;
@@ -153,7 +173,7 @@ export default async function initMobileButtonSettings() {
         macro.addEventListener('change', update);
         if (reset) {
             reset.addEventListener('click', () => {
-                color.value = defaultSettings[id].color;
+                color.value = defaultButtonSettings[id].color;
                 if (preview) preview.style.backgroundColor = color.value;
                 applyLive(id, label.value, color.value);
             });
@@ -214,8 +234,9 @@ export default async function initMobileButtonSettings() {
 
     saveBtn.addEventListener('click', () => {
         current = read();
-        saveSettings(current);
-        applySettings(current);
+        all = { ...all, solo: current };
+        saveSettings(all);
+        applySettings(all.solo);
         modal.hide();
     });
 
@@ -223,7 +244,7 @@ export default async function initMobileButtonSettings() {
         modal.show();
     });
 
-    applySettings(current);
+    applySettings(all.solo);
 }
 
 

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -4,8 +4,9 @@ import {
     loadSettings,
     saveSettings,
     applySettings,
-    defaultSettings,
+    defaultButtonSettings,
     ButtonSetting,
+    DualButtonSettings,
     MacroType,
 } from "../mobileButtonSettings";
 
@@ -21,10 +22,11 @@ const macroOptions: { value: MacroType; label: string }[] = [
 
 const directionOptions = ["nw","n","ne","w","e","sw","s","se","u","d"] as const;
 
-type SettingsMap = Record<string, ButtonSetting>;
+type SettingsMap = DualButtonSettings;
 
 function MobileButtons() {
-    const [settings, setSettings] = useState<SettingsMap>({});
+    const [settings, setSettings] = useState<SettingsMap>({ solo: {}, team: {} });
+    const [mode, setMode] = useState<'solo' | 'team'>('solo');
     const [active, setActive] = useState<string | null>(null);
     const [pos, setPos] = useState<{ left: number; top: number }>({ left: 0, top: 0 });
     const previewRef = useRef<HTMLDivElement>(null);
@@ -85,31 +87,38 @@ function MobileButtons() {
     }
 
     function update(id: string, field: keyof ButtonSetting, value: any) {
-        setSettings(prev => ({ ...prev, [id]: { ...prev[id], [field]: value } }));
+        setSettings(prev => ({
+            ...prev,
+            [mode]: { ...prev[mode], [id]: { ...prev[mode][id], [field]: value } }
+        }));
     }
 
     function resetColor(id: string) {
-        update(id, "color", defaultSettings[id].color);
+        update(id, "color", defaultButtonSettings[id].color);
     }
 
     function save() {
         saveSettings(settings);
-        applySettings(settings);
+        applySettings(settings[mode]);
         const modal = (window as any).bootstrap?.Modal.getInstance(document.getElementById('mobile-buttons-modal')!);
         modal?.hide();
     }
 
-    const activeCfg = active ? (settings[active] || defaultSettings[active]) : null;
+    const activeCfg = active ? (settings[mode][active] || defaultButtonSettings[active]) : null;
 
     return (
         <div onClick={close} className="w-100 position-relative">
+            <div className="mb-2">
+                <Button size="sm" variant={mode === 'solo' ? 'primary' : 'secondary'} onClick={() => setMode('solo')} className="me-1">Bez drużyny</Button>
+                <Button size="sm" variant={mode === 'team' ? 'primary' : 'secondary'} onClick={() => setMode('team')}>Drużyna</Button>
+            </div>
             <div
                 ref={previewRef}
                 id="mobile-buttons-preview"
                 className="mobile-direction-buttons mb-2"
             >
                 {order.map(id => {
-                    const cfg = settings[id] || defaultSettings[id] || { label: '⇩', color: '#87CEEB', macro: 'functional' };
+                    const cfg = settings[mode][id] || defaultButtonSettings[id] || { label: '⇩', color: '#87CEEB', macro: 'functional' };
                     let classes = 'mobile-button';
                     if (topButtons.includes(id)) {
                         classes += ' mobile-button-text top-button';

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -1,6 +1,6 @@
 import Client from "@client/src/Client";
 import { formatLabel } from "@client/src/scripts/functionalBind";
-import { loadSettings as loadMobileButtonSettings, ButtonSetting } from "../mobileButtonSettings";
+import { loadSettings as loadMobileButtonSettings, ButtonSetting, DualButtonSettings } from "../mobileButtonSettings";
 import { getItemSync, setItemSync } from "@client/src/storage";
 
 export default class MobileDirectionButtons {
@@ -34,7 +34,8 @@ export default class MobileDirectionButtons {
     private lastScrollTop = 0;
     private collapsed = false;
     private directionButtons: Record<string, HTMLButtonElement | null> = {};
-    private buttonSettings: Record<string, ButtonSetting> = {};
+    private buttonSettings: DualButtonSettings = { solo: {}, team: {} };
+    private currentMode: 'solo' | 'team' = 'solo';
 
     private readonly polishToEnglish: Record<string, string> = {
         "polnoc": "north",
@@ -103,11 +104,9 @@ export default class MobileDirectionButtons {
 
         loadMobileButtonSettings().then(settings => {
             this.buttonSettings = settings;
+            this.currentMode = this.client.TeamManager.getTeamMembers().length > 0 ? 'team' : 'solo';
             this.setupEventHandlers();
-            Object.keys(this.buttonSettings).forEach(id => {
-                const btn = document.getElementById(id) as HTMLButtonElement | null;
-                if (btn) this.applyConfigToButton(id, btn);
-            });
+            this.applyAllButtons();
         });
         this.updateBracketRightButton();
         this.updateToggleButton();
@@ -156,10 +155,12 @@ export default class MobileDirectionButtons {
 
         this.client.addEventListener('mobileButtonsSettings', (ev: CustomEvent) => {
             this.buttonSettings = ev.detail || this.buttonSettings;
-            Object.keys(this.buttonSettings).forEach(id => {
-                const b = document.getElementById(id) as HTMLButtonElement | null;
-                if (b) this.applyConfigToButton(id, b);
-            });
+            this.applyAllButtons();
+        });
+
+        this.client.addEventListener('teamChange', (ev: CustomEvent) => {
+            this.currentMode = ev.detail ? 'team' : 'solo';
+            this.applyAllButtons();
         });
 
         // Listen for bind settings changes
@@ -489,8 +490,15 @@ export default class MobileDirectionButtons {
         this.renderList(this.zasList, /^[A-Z]$/, 'zas');
     }
 
+    private applyAllButtons() {
+        Object.keys(this.buttonSettings[this.currentMode]).forEach(id => {
+            const btn = document.getElementById(id) as HTMLButtonElement | null;
+            if (btn) this.applyConfigToButton(id, btn);
+        });
+    }
+
     private applyConfigToButton(id: string, btn: HTMLButtonElement) {
-        const cfg = this.buttonSettings[id];
+        const cfg = this.buttonSettings[this.currentMode][id];
         if (!cfg) return;
         btn.textContent = cfg.label;
         btn.style.backgroundColor = cfg.color;


### PR DESCRIPTION
## Summary
- add `teamChange` event for switching button sets
- allow MobileDirectionButtons to load and apply separate team/solo sets
- toggle button set in mobile button options
- store settings for solo and team separately

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688bd43e7b28832aa0e0570f4b2e920e