### PR TITLE
Add movement mode toggle button

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -75,6 +75,8 @@ export default class Client {
     defaultColor = 255;
     buffer: { out: string, type?: string }[] = [];
     suppressMapMoveEvent = false;
+    moveMode = 0;
+    moveModeButton?: HTMLInputElement;
 
 
     constructor(clientAdapter: ClientAdapter, port: any) {
@@ -250,7 +252,8 @@ export default class Client {
                 if (part !== preparse) {
                     this.sendCommand(part, echo)
                 } else {
-                    this.clientAdapter.send(this.Map.move(part).direction, echo)
+                    const moveRes = this.Map.move(part)
+                    this.clientAdapter.send(this.applyMoveMode(moveRes.direction, moveRes.moved), echo)
                 }
             })
             return
@@ -269,12 +272,20 @@ export default class Client {
                 this.print(mudletColorLine(`--- <tomato>Nieznany alias<reset>: ${command}`))
                 return
             }
-            this.clientAdapter.send(this.Map.move(command).direction, echo)
+            const moveRes = this.Map.move(command)
+            this.clientAdapter.send(this.applyMoveMode(moveRes.direction, moveRes.moved), echo)
         }
     }
 
     sendGMCP(type: string, payload?: any) {
         this.clientAdapter.sendGmcp(type, payload)
+    }
+
+    private applyMoveMode(cmd: string, moved?: boolean): string {
+        if (!moved) return cmd
+        if (this.moveMode === 1) return `przemknij ${cmd}`
+        if (this.moveMode === 2) return `przemknij z druzyna ${cmd}`
+        return cmd
     }
 
     onLine(line: string, type: string) {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -11,6 +11,7 @@ import initAttackBeep from './scripts/attackBeep'
 import initLamp from './scripts/lamp'
 import initCoverTimer from './scripts/coverTimer'
 import initBinds from './scripts/binds'
+import initMoveMode from './scripts/moveMode'
 import initIdz from './scripts/idz'
 import { initKillCounter } from './scripts/kill'
 import { initImproveCounter } from './scripts/improveCounter'
@@ -118,6 +119,7 @@ export function registerScripts(client: Client) {
     initLamp(client)
     initCoverTimer(client)
     initBinds(client, aliases)
+    initMoveMode(client)
     initIdz(client, aliases)
     const killCounter = initKillCounter(client, aliases)
     ;(client as any).killCounter = killCounter

--- a/client/src/scripts/moveMode.ts
+++ b/client/src/scripts/moveMode.ts
@@ -1,0 +1,17 @@
+import Client from "../Client";
+
+const LABELS = ["zwykly", "przemknij", "przemknij z druzyna"];
+
+export default function initMoveMode(client: Client) {
+    const button = client.createButton(`Ruch: ${LABELS[0]}`, toggle);
+    client.moveModeButton = button;
+
+    function update() {
+        button.value = `Ruch: ${LABELS[client.moveMode]}`;
+    }
+
+    function toggle() {
+        client.moveMode = (client.moveMode + 1) % LABELS.length;
+        update();
+    }
+}


### PR DESCRIPTION
## Summary
- support movement mode prefixing in `Client`
- add persistent move mode toggle button
- wire up move mode script in client startup
- handle special exits when applying prefixes

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_688bd3ae03d8832ab16b2eb8e55d6033