### PR TITLE
Adjust mobile button defaults

### DIFF
--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -21,13 +21,13 @@ export interface ButtonSetting {
 
 export const defaultSettings: Record<string, ButtonSetting> = {
     // top row buttons
-    'z-list-toggle': { macro: 'zList', label: '/z', color: '#87CEEB' },
-    'zas-list-toggle': { macro: 'zaList', label: '/za', color: '#87CEEB' },
-    'go-button': { macro: 'command', label: '/go', color: '#87CEEB', command: '/go' },
-    'bracket-right-button': { macro: 'functional', label: ']', color: '#87CEEB' },
-    'button-1': { macro: 'wesprzyj', label: 'wesprzyj', color: '#87CEEB' },
-    'button-2': { macro: 'command', label: '/z cel', color: '#87CEEB', command: '/z' },
-    'button-3': { macro: 'command', label: '/za cel', color: '#87CEEB', command: '/za' },
+    'z-list-toggle': { macro: 'zList', label: '/z', color: '#6EB4DC' },
+    'zas-list-toggle': { macro: 'zaList', label: '/za', color: '#6EB4DC' },
+    'go-button': { macro: 'command', label: '/go', color: '#6EB4DC', command: '/go' },
+    'bracket-right-button': { macro: 'functional', label: ']', color: '#6EB4DC' },
+    'button-1': { macro: 'wesprzyj', label: 'wesprzyj', color: '#6EB4DC' },
+    'button-2': { macro: 'command', label: '/z cel', color: '#6EB4DC', command: '/z' },
+    'button-3': { macro: 'command', label: '/za cel', color: '#6EB4DC', command: '/za' },
 
     // direction buttons in visual order
     'nw-button': { macro: 'kierunek', label: '↖', color: '#6CA6CD', command: 'nw', direction: 'nw' },

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -110,7 +110,7 @@ function MobileButtons() {
                 className="mobile-direction-buttons mb-2"
             >
                 {order.map(id => {
-                    const cfg = settings[id] || defaultSettings[id] || { label: '⇩', color: '#87CEEB', macro: 'functional' };
+                    const cfg = settings[id] || defaultSettings[id] || { label: '⇩', color: '#6EB4DC', macro: 'functional' };
                     let classes = 'mobile-button';
                     if (topButtons.includes(id)) {
                         classes += ' mobile-button-text top-button';

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -553,7 +553,7 @@ button:focus-visible {
   font-size: 14px;
   border: 1px solid #a0d0e0;
   border-radius: 4px;
-  background-color: #87CEEB; /* Sky blue */
+  background-color: #6EB4DC; /* Darker sky blue for better contrast */
   color: inherit;
   cursor: pointer;
   display: flex;


### PR DESCRIPTION
## Summary
- darken default mobile button background color to improve contrast
- update default button settings to match new default color

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_688bda62abcc832a9d53caa3f0336747