### PR TITLE
Add team-aware mobile button sets

### DIFF
--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -101,11 +101,15 @@ export default class TeamManager {
             return;
         }
 
-        this.members.add(name);
+        this.addMember(name);
 
         if (obj.team_leader) {
+            const changed = this.leader !== name || this.leaderId !== id;
             this.leader = name;
-            this.leaderId = id
+            this.leaderId = id;
+            if (changed) {
+                this.client.sendEvent('teamChange');
+            }
         }
     }
 
@@ -153,13 +157,20 @@ export default class TeamManager {
     }
 
     private addMember(name: string) {
+        const size = this.members.size;
         this.members.add(name);
+        if (this.members.size !== size) {
+            this.client.sendEvent('teamChange');
+        }
     }
 
     private removeMember(name: string) {
-        this.members.delete(name);
+        const hadMember = this.members.delete(name);
         if (this.leader === name) {
             this.leader = undefined;
+        }
+        if (hadMember || this.leader === undefined) {
+            this.client.sendEvent('teamChange');
         }
     }
 
@@ -180,8 +191,12 @@ export default class TeamManager {
     }
 
     clearTeam() {
+        const hadMembers = this.members.size > 0 || this.leader !== undefined;
         this.members.clear();
         this.leader = undefined;
+        if (hadMembers) {
+            this.client.sendEvent('teamChange');
+        }
     }
 
     getAccumulatedObjectsData() {

--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -34,6 +34,7 @@ interface AccumulatedObjectData {
 export default class TeamManager {
     private client: Client;
     private members: Set<string> = new Set();
+    private joined = false;
     private leader?: string;
     private leaderId?: string;
     private tag = 'teamManager';
@@ -147,8 +148,10 @@ export default class TeamManager {
             }
         }, tag);
         triggers.registerTrigger(/^Dolaczasz do druzyny/, (): undefined => {
+            this.joined = true;
             this.client.sendGMCP("objects.nums")
             this.client.sendGMCP("objects.data")
+            this.client.sendEvent('teamChange');
         })
     }
 
@@ -159,6 +162,7 @@ export default class TeamManager {
     private addMember(name: string) {
         const size = this.members.size;
         this.members.add(name);
+        this.joined = true;
         if (this.members.size !== size) {
             this.client.sendEvent('teamChange');
         }
@@ -172,6 +176,9 @@ export default class TeamManager {
         if (hadMember || this.leader === undefined) {
             this.client.sendEvent('teamChange');
         }
+        if (this.members.size === 0) {
+            this.joined = false;
+        }
     }
 
     getTeamMembers(): string[] {
@@ -180,6 +187,10 @@ export default class TeamManager {
 
     isInTeam(name: string): boolean {
         return this.members.has(name);
+    }
+
+    isInAnyTeam(): boolean {
+        return this.joined || this.members.size > 0 || this.leader !== undefined;
     }
 
     getLeader(): string | undefined {
@@ -194,6 +205,7 @@ export default class TeamManager {
         const hadMembers = this.members.size > 0 || this.leader !== undefined;
         this.members.clear();
         this.leader = undefined;
+        this.joined = false;
         if (hadMembers) {
             this.client.sendEvent('teamChange');
         }

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -840,7 +840,7 @@ document.addEventListener('DOMContentLoaded', () => {
     new MobileDirectionButtons(client);
 
     loadMobileButtonSettings().then(s => {
-        const inTeam = !!client.TeamManager.getLeader?.();
+        const inTeam = !!client.TeamManager.isInAnyTeam?.();
         applyMobileButtonSettings(s, inTeam);
     });
 

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -839,7 +839,10 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initialize mobile direction buttons
     new MobileDirectionButtons(client);
 
-    loadMobileButtonSettings().then(applyMobileButtonSettings);
+    loadMobileButtonSettings().then(s => {
+        const inTeam = !!client.TeamManager.getLeader?.();
+        applyMobileButtonSettings(s, inTeam);
+    });
 
     initUiSettings();
 

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -44,23 +44,38 @@ export const defaultSettings: Record<string, ButtonSetting> = {
     'special-exit-button': { macro: 'specialExit', label: 'sp ex', color: '#6CA6CD' },
 };
 
-export async function loadSettings(): Promise<Record<string, ButtonSetting>> {
+export interface Settings {
+    solo: Record<string, ButtonSetting>;
+    team: Record<string, ButtonSetting>;
+}
+
+export async function loadSettings(): Promise<Settings> {
     try {
         const data = await storage.getItem('mobileButtonSettings');
         const raw = data?.mobileButtonSettings;
         if (raw) {
-            return { ...defaultSettings, ...(raw as any) };
+            if (raw.solo || raw.team) {
+                return {
+                    solo: { ...defaultSettings, ...(raw.solo || {}) },
+                    team: { ...defaultSettings, ...(raw.team || raw.solo || {}) },
+                };
+            }
+            return {
+                solo: { ...defaultSettings, ...(raw as any) },
+                team: { ...defaultSettings, ...(raw as any) },
+            };
         }
     } catch {}
-    return { ...defaultSettings };
+    return { solo: { ...defaultSettings }, team: { ...defaultSettings } };
 }
 
-export function saveSettings(settings: Record<string, ButtonSetting>) {
+export function saveSettings(settings: Settings) {
     storage.setItem('mobileButtonSettings', settings);
 }
 
-export function applySettings(settings: Record<string, ButtonSetting>) {
-    Object.entries(settings).forEach(([id, cfg]) => {
+export function applySettings(settings: Settings, inTeam = false) {
+    const set = inTeam ? settings.team : settings.solo;
+    Object.entries(set).forEach(([id, cfg]) => {
         const el = document.getElementById(id) as HTMLButtonElement | null;
         if (!el) return;
         el.textContent = cfg.label;
@@ -73,7 +88,7 @@ export function applySettings(settings: Record<string, ButtonSetting>) {
     });
     if ((window as any).clientExtension?.eventTarget) {
         (window as any).clientExtension.eventTarget.dispatchEvent(
-            new CustomEvent('mobileButtonsSettings', { detail: settings })
+            new CustomEvent('mobileButtonsSettings', { detail: set })
         );
     }
 }
@@ -108,7 +123,7 @@ export default async function initMobileButtonSettings() {
         }
     };
 
-    let current = await loadSettings();
+    let current = (await loadSettings()).solo;
     const applyLive = (id: string, labelVal: string, colorVal: string) => {
         const btn = realMap[id];
         if (btn) {
@@ -215,8 +230,9 @@ export default async function initMobileButtonSettings() {
 
     saveBtn.addEventListener('click', () => {
         current = read();
-        saveSettings(current);
-        applySettings(current);
+        const all = { solo: current, team: current } as Settings;
+        saveSettings(all);
+        applySettings(all);
         modal.hide();
     });
 
@@ -224,7 +240,7 @@ export default async function initMobileButtonSettings() {
         modal.show();
     });
 
-    applySettings(current);
+    applySettings({ solo: current, team: current });
 }
 
 

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -102,7 +102,9 @@ export default async function initMobileButtonSettings() {
     const saveBtn = modalEl.querySelector('#mobile-buttons-save') as HTMLButtonElement;
 
     const sections = Array.from(modalEl.querySelectorAll<HTMLElement>('.mobile-button-config'));
-    const previewButtons = Array.from(modalEl.querySelectorAll<HTMLButtonElement>('#mobile-buttons-preview button[data-button-id]'));
+    const previewButtons = Array.from(modalEl.querySelectorAll<HTMLButtonElement>(
+        '#mobile-buttons-preview-solo button[data-button-id], #mobile-buttons-preview-team button[data-button-id]'
+    ));
     const previewMap: Record<string, HTMLButtonElement> = {};
     const realMap: Record<string, HTMLButtonElement> = {};
     previewButtons.forEach(btn => {
@@ -207,7 +209,9 @@ export default async function initMobileButtonSettings() {
 
     modalEl.addEventListener('click', (ev) => {
         if (activeConfig && !activeConfig.contains(ev.target as Node)) {
-            const isButton = (ev.target as HTMLElement).closest('#mobile-buttons-preview button');
+            const isButton = (ev.target as HTMLElement).closest(
+                '#mobile-buttons-preview-solo button, #mobile-buttons-preview-team button'
+            );
             if (!isButton) hideConfig();
         }
     });

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -7,6 +7,7 @@ import {
     defaultSettings,
     ButtonSetting,
     MacroType,
+    Settings,
 } from "../mobileButtonSettings";
 
 const macroOptions: { value: MacroType; label: string }[] = [
@@ -25,10 +26,11 @@ const directionOptions = ["nw","n","ne","w","e","sw","s","se","u","d"] as const;
 type SettingsMap = Record<string, ButtonSetting>;
 
 function MobileButtons() {
-    const [settings, setSettings] = useState<SettingsMap>({});
-    const [active, setActive] = useState<string | null>(null);
+    const [settings, setSettings] = useState<Settings>({ solo: {}, team: {} });
+    const [active, setActive] = useState<{ set: 'solo' | 'team'; id: string } | null>(null);
     const [pos, setPos] = useState<{ left: number; top: number }>({ left: 0, top: 0 });
-    const previewRef = useRef<HTMLDivElement>(null);
+    const soloRef = useRef<HTMLDivElement>(null);
+    const teamRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         loadSettings().then(setSettings);
@@ -71,13 +73,13 @@ function MobileButtons() {
 
     const textDirButtons = ['u-button', 'c-button', 'd-button', 'special-exit-button'];
 
-    function openConfig(id: string, ev: React.MouseEvent<HTMLButtonElement>) {
+    function openConfig(setName: 'solo' | 'team', id: string, ev: React.MouseEvent<HTMLButtonElement>) {
         const rect = ev.currentTarget.getBoundingClientRect();
-        const parent = previewRef.current?.getBoundingClientRect();
+        const parent = (setName === 'solo' ? soloRef.current : teamRef.current)?.getBoundingClientRect();
         if (parent) {
             setPos({ left: rect.left - parent.left, top: rect.bottom - parent.top + 4 });
         }
-        setActive(id);
+        setActive({ set: setName, id });
         ev.stopPropagation();
     }
 
@@ -85,32 +87,34 @@ function MobileButtons() {
         setActive(null);
     }
 
-    function update(id: string, field: keyof ButtonSetting, value: any) {
-        setSettings(prev => ({ ...prev, [id]: { ...prev[id], [field]: value } }));
+    function update(setName: 'solo' | 'team', id: string, field: keyof ButtonSetting, value: any) {
+        setSettings(prev => ({ ...prev, [setName]: { ...prev[setName], [id]: { ...prev[setName][id], [field]: value } } }));
     }
 
-    function resetColor(id: string) {
-        update(id, "color", defaultSettings[id].color);
+    function resetColor(setName: 'solo' | 'team', id: string) {
+        update(setName, "color", defaultSettings[id].color);
     }
 
     function save() {
         saveSettings(settings);
-        applySettings(settings);
+        const teamActive = !!(window as any).clientExtension?.TeamManager?.getLeader?.();
+        applySettings(settings, teamActive);
         const modal = (window as any).bootstrap?.Modal.getInstance(document.getElementById('mobile-buttons-modal')!);
         modal?.hide();
     }
 
-    const activeCfg = active ? (settings[active] || defaultSettings[active]) : null;
+    const activeCfg = active ? (settings[active.set][active.id] || defaultSettings[active.id]) : null;
 
     return (
         <div onClick={close} className="w-100 position-relative">
+            <h6>Bez drużyny</h6>
             <div
-                ref={previewRef}
-                id="mobile-buttons-preview"
+                ref={soloRef}
+                id="mobile-buttons-preview-solo"
                 className="mobile-direction-buttons mb-2"
             >
                 {order.map(id => {
-                    const cfg = settings[id] || defaultSettings[id] || { label: '⇩', color: '#6EB4DC', macro: 'functional' };
+                    const cfg = settings.solo[id] || defaultSettings[id] || { label: '⇩', color: '#6EB4DC', macro: 'functional' };
                     let classes = 'mobile-button';
                     if (topButtons.includes(id)) {
                         classes += ' mobile-button-text top-button';
@@ -119,7 +123,37 @@ function MobileButtons() {
                     } else {
                         classes += ' direction-button';
                     }
-                    const handle = notEditable.includes(id) ? undefined : (ev: React.MouseEvent<HTMLButtonElement>) => openConfig(id, ev);
+                    const handle = notEditable.includes(id) ? undefined : (ev: React.MouseEvent<HTMLButtonElement>) => openConfig('solo', id, ev);
+                    return (
+                        <button
+                            key={id}
+                            data-button-id={id}
+                            className={classes}
+                            style={{ backgroundColor: cfg.color }}
+                            onClick={handle}
+                        >
+                            {cfg.label}
+                        </button>
+                    );
+                })}
+            </div>
+            <h6 className="mt-3">W drużynie</h6>
+            <div
+                ref={teamRef}
+                id="mobile-buttons-preview-team"
+                className="mobile-direction-buttons mb-2"
+            >
+                {order.map(id => {
+                    const cfg = settings.team[id] || defaultSettings[id] || { label: '⇩', color: '#6EB4DC', macro: 'functional' };
+                    let classes = 'mobile-button';
+                    if (topButtons.includes(id)) {
+                        classes += ' mobile-button-text top-button';
+                    } else if (textDirButtons.includes(id)) {
+                        classes += ' mobile-button-text direction-button';
+                    } else {
+                        classes += ' direction-button';
+                    }
+                    const handle = notEditable.includes(id) ? undefined : (ev: React.MouseEvent<HTMLButtonElement>) => openConfig('team', id, ev);
                     return (
                         <button
                             key={id}
@@ -150,7 +184,7 @@ function MobileButtons() {
                             size="sm"
                             className="mobile-button-macro"
                             value={activeCfg.macro}
-                            onChange={e => update(active, "macro", e.target.value as MacroType)}
+                            onChange={e => update(active!.set, active!.id, "macro", e.target.value as MacroType)}
                         >
                             {macroOptions.map(o => (
                                 <option key={o.value} value={o.value}>{o.label}</option>
@@ -164,7 +198,7 @@ function MobileButtons() {
                             className="mobile-button-label"
                             type="text"
                             value={activeCfg.label}
-                            onChange={e => update(active!, "label", e.target.value)}
+                            onChange={e => update(active!.set, active!.id, "label", e.target.value)}
                         />
                     </Form.Group>
                     <Form.Group className="form-label mb-2 d-flex align-items-center gap-1">
@@ -174,9 +208,9 @@ function MobileButtons() {
                             type="color"
                             className="mobile-button-color flex-grow-1"
                             value={activeCfg.color}
-                            onChange={e => update(active!, "color", e.target.value)}
+                            onChange={e => update(active!.set, active!.id, "color", e.target.value)}
                         />
-                        <Button size="sm" variant="secondary" onClick={() => resetColor(active!)}>↺</Button>
+                        <Button size="sm" variant="secondary" onClick={() => resetColor(active!.set, active!.id)}>↺</Button>
                     </Form.Group>
                     {activeCfg.macro === "kierunek" && (
                         <Form.Group className="form-label mb-2">
@@ -185,7 +219,7 @@ function MobileButtons() {
                                 size="sm"
                                 className="mobile-button-direction"
                                 value={activeCfg.direction || ""}
-                                onChange={e => update(active!, "direction", e.target.value)}
+                                onChange={e => update(active!.set, active!.id, "direction", e.target.value)}
                             >
                                 {directionOptions.map(d => (
                                     <option key={d} value={d}>{d}</option>
@@ -201,7 +235,7 @@ function MobileButtons() {
                                 size="sm"
                                 className="mobile-button-command"
                                 value={activeCfg.command || ""}
-                                onChange={e => update(active!, "command", e.target.value)}
+                                onChange={e => update(active!.set, active!.id, "command", e.target.value)}
                             />
                         </Form.Group>
                     )}

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -29,6 +29,7 @@ function MobileButtons() {
     const [settings, setSettings] = useState<Settings>({ solo: {}, team: {} });
     const [active, setActive] = useState<{ set: 'solo' | 'team'; id: string } | null>(null);
     const [pos, setPos] = useState<{ left: number; top: number }>({ left: 0, top: 0 });
+    const [view, setView] = useState<'solo' | 'team'>('solo');
     const soloRef = useRef<HTMLDivElement>(null);
     const teamRef = useRef<HTMLDivElement>(null);
 
@@ -83,6 +84,11 @@ function MobileButtons() {
         ev.stopPropagation();
     }
 
+    function changeView(v: 'solo' | 'team') {
+        setView(v);
+        setActive(null);
+    }
+
     function close() {
         setActive(null);
     }
@@ -107,11 +113,26 @@ function MobileButtons() {
 
     return (
         <div onClick={close} className="w-100 position-relative">
-            <h6>Bez drużyny</h6>
+            <div className="btn-group mb-2">
+                <Button
+                    size="sm"
+                    variant={view === 'solo' ? 'primary' : 'secondary'}
+                    onClick={() => changeView('solo')}
+                >
+                    Bez drużyny
+                </Button>
+                <Button
+                    size="sm"
+                    variant={view === 'team' ? 'primary' : 'secondary'}
+                    onClick={() => changeView('team')}
+                >
+                    W drużynie
+                </Button>
+            </div>
             <div
                 ref={soloRef}
                 id="mobile-buttons-preview-solo"
-                className="mobile-direction-buttons mb-2"
+                className={`mobile-direction-buttons mb-2 ${view === 'solo' ? '' : 'd-none'}`}
             >
                 {order.map(id => {
                     const cfg = settings.solo[id] || defaultSettings[id] || { label: '⇩', color: '#6EB4DC', macro: 'functional' };
@@ -137,11 +158,10 @@ function MobileButtons() {
                     );
                 })}
             </div>
-            <h6 className="mt-3">W drużynie</h6>
             <div
                 ref={teamRef}
                 id="mobile-buttons-preview-team"
-                className="mobile-direction-buttons mb-2"
+                className={`mobile-direction-buttons mb-2 ${view === 'team' ? '' : 'd-none'}`}
             >
                 {order.map(id => {
                     const cfg = settings.team[id] || defaultSettings[id] || { label: '⇩', color: '#6EB4DC', macro: 'functional' };

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -533,7 +533,7 @@ export default class MobileDirectionButtons {
     }
 
     private updateTeamMode() {
-        const team = !!this.client.TeamManager.getLeader?.();
+        const team = !!this.client.TeamManager.isInAnyTeam?.();
         if (team !== this.teamMode) {
             this.teamMode = team;
             this.applyActiveSettings();

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -137,7 +137,10 @@ export default class MobileDirectionButtons {
                 this.renderIdzList();
             }
         };
-        this.client.addEventListener('gmcp.objects.nums', updateLists);
+        this.client.addEventListener('gmcp.objects.nums', () => {
+            updateLists();
+            this.updateTeamMode();
+        });
         this.client.addEventListener('gmcp.objects.data', () => {
             updateLists();
             this.updateTeamMode();

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -145,6 +145,9 @@ export default class MobileDirectionButtons {
             updateLists();
             this.updateTeamMode();
         });
+        this.client.addEventListener('teamChange', () => {
+            this.updateTeamMode();
+        });
 
         // Listen for window resize to check if mobile view
         window.addEventListener('resize', () => {

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -1,6 +1,6 @@
 import Client from "@client/src/Client";
 import { formatLabel } from "@client/src/scripts/functionalBind";
-import { loadSettings as loadMobileButtonSettings, ButtonSetting } from "../mobileButtonSettings";
+import { loadSettings as loadMobileButtonSettings, ButtonSetting, Settings } from "../mobileButtonSettings";
 import { getItemSync, setItemSync } from "@client/src/storage";
 
 export default class MobileDirectionButtons {
@@ -36,7 +36,9 @@ export default class MobileDirectionButtons {
     private lastScrollTop = 0;
     private collapsed = false;
     private directionButtons: Record<string, HTMLButtonElement | null> = {};
+    private allSettings: Settings = { solo: {}, team: {} };
     private buttonSettings: Record<string, ButtonSetting> = {};
+    private teamMode = false;
 
     private readonly polishToEnglish: Record<string, string> = {
         "polnoc": "north",
@@ -106,12 +108,10 @@ export default class MobileDirectionButtons {
         });
 
         loadMobileButtonSettings().then(settings => {
-            this.buttonSettings = settings;
+            this.allSettings = settings;
+            this.updateTeamMode();
             this.setupEventHandlers();
-            Object.keys(this.buttonSettings).forEach(id => {
-                const btn = document.getElementById(id) as HTMLButtonElement | null;
-                if (btn) this.applyConfigToButton(id, btn);
-            });
+            this.applyActiveSettings();
         });
         this.updateBracketRightButton();
         this.updateToggleButton();
@@ -138,7 +138,10 @@ export default class MobileDirectionButtons {
             }
         };
         this.client.addEventListener('gmcp.objects.nums', updateLists);
-        this.client.addEventListener('gmcp.objects.data', updateLists);
+        this.client.addEventListener('gmcp.objects.data', () => {
+            updateLists();
+            this.updateTeamMode();
+        });
 
         // Listen for window resize to check if mobile view
         window.addEventListener('resize', () => {
@@ -166,6 +169,10 @@ export default class MobileDirectionButtons {
             Object.keys(this.buttonSettings).forEach(id => {
                 const b = document.getElementById(id) as HTMLButtonElement | null;
                 if (b) this.applyConfigToButton(id, b);
+            });
+            loadMobileButtonSettings().then(s => {
+                this.allSettings = s;
+                this.updateTeamMode();
             });
         });
 
@@ -516,6 +523,22 @@ export default class MobileDirectionButtons {
             b.textContent = c.label;
             b.addEventListener('click', () => this.client.sendCommand(c.cmd));
             this.idzList!.appendChild(b);
+        });
+    }
+
+    private updateTeamMode() {
+        const team = !!this.client.TeamManager.getLeader?.();
+        if (team !== this.teamMode) {
+            this.teamMode = team;
+            this.applyActiveSettings();
+        }
+    }
+
+    private applyActiveSettings() {
+        this.buttonSettings = this.teamMode ? this.allSettings.team : this.allSettings.solo;
+        Object.keys(this.buttonSettings).forEach(id => {
+            const btn = document.getElementById(id) as HTMLButtonElement | null;
+            if (btn) this.applyConfigToButton(id, btn);
         });
     }
 

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -518,7 +518,9 @@ button:focus-visible {
   grid-template-columns: repeat(4, auto);
 }
 
-#mobile-buttons-preview {
+#mobile-buttons-preview,
+#mobile-buttons-preview-solo,
+#mobile-buttons-preview-team {
   position: static;
   display: grid;
   grid-template-columns: repeat(4, auto);


### PR DESCRIPTION
## Summary
- manage two mobile button configurations (solo & team)
- render both sets in configuration popup
- apply appropriate button set depending on team status
- refresh buttons when team status changes

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688bfb5a1dfc832aa3465ce7af2e8b85