### PR TITLE
Allow configuring move mode button in mobile settings

### DIFF
--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -24,6 +24,7 @@ export const defaultSettings: Record<string, ButtonSetting> = {
     'z-list-toggle': { macro: 'zList', label: '/z', color: '#6EB4DC' },
     'zas-list-toggle': { macro: 'zaList', label: '/za', color: '#6EB4DC' },
     'go-button': { macro: 'command', label: '/go', color: '#6EB4DC', command: '/go' },
+    'buttons-toggle': { macro: 'functional', label: '⇩', color: '#6EB4DC' },
     'bracket-right-button': { macro: 'functional', label: ']', color: '#6EB4DC' },
     'button-1': { macro: 'wesprzyj', label: 'wesprzyj', color: '#6EB4DC' },
     'button-2': { macro: 'command', label: '/z cel', color: '#6EB4DC', command: '/z' },

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -37,7 +37,7 @@ function MobileButtons() {
         loadSettings().then(setSettings);
     }, []);
 
-    const notEditable = ['buttons-toggle'];
+    const notEditable: string[] = [];
     const order = [
         'z-list-toggle',
         'zas-list-toggle',

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -455,7 +455,12 @@ export default class MobileDirectionButtons {
 
     private updateToggleButton() {
         if (!this.toggleButton) return;
-        this.toggleButton.textContent = this.collapsed ? '⇧' : '⇩';
+        const cfg = this.buttonSettings['buttons-toggle'];
+        if (cfg && cfg.macro !== 'functional') {
+            this.toggleButton.textContent = cfg.label;
+        } else {
+            this.toggleButton.textContent = this.collapsed ? '⇧' : '⇩';
+        }
     }
 
     private toggleVisibility() {
@@ -560,6 +565,7 @@ export default class MobileDirectionButtons {
         if (id === 'bracket-right-button') this.bracketRightButton = newBtn;
         if (id === 'z-list-toggle') this.zToggle = newBtn;
         if (id === 'zas-list-toggle') this.zasToggle = newBtn;
+        if (id === 'buttons-toggle') this.toggleButton = newBtn;
         if (cfg.macro === 'idzList') {
             this.idzToggle = newBtn;
         } else if (this.idzToggle === newBtn) {
@@ -581,16 +587,20 @@ export default class MobileDirectionButtons {
         const handler = () => {
             switch (cfg.macro) {
                 case 'functional':
-                    const event = new KeyboardEvent('keydown', {
-                        code: this.boundKey,
-                        key: this.boundKey,
-                        ctrlKey: this.boundCtrl,
-                        altKey: this.boundAlt,
-                        shiftKey: this.boundShift,
-                        bubbles: true,
-                        cancelable: true
-                    });
-                    document.dispatchEvent(event);
+                    if (id === 'buttons-toggle') {
+                        this.toggleVisibility();
+                    } else {
+                        const event = new KeyboardEvent('keydown', {
+                            code: this.boundKey,
+                            key: this.boundKey,
+                            ctrlKey: this.boundCtrl,
+                            altKey: this.boundAlt,
+                            shiftKey: this.boundShift,
+                            bubbles: true,
+                            cancelable: true
+                        });
+                        document.dispatchEvent(event);
+                    }
                     break;
                 case 'zList':
                     if (this.zList && this.zList.style.display === 'grid') {


### PR DESCRIPTION
## Summary
- include move mode toggle in default mobile button settings
- enable editing of the move mode button
- preserve toggle behavior when button is customized

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_688f2288b060832aa9617fb1beb10c54