### PR TITLE
Fix shop split line width on narrow view

### DIFF
--- a/client/src/scripts/armorShop.ts
+++ b/client/src/scripts/armorShop.ts
@@ -8,7 +8,7 @@ export default function initArmorShop(client: Client) {
         splitReg: /^-{75}$/,
         headerReg: /^\|\s*Nazwa towaru\s*\|\s*Mithryl\s*\|\s*Zloto\s*\|\s*Srebro\s*\|\s*Miedz\s*\|$/,
         itemReg: /^\|\s*(.+?)\s*\|\s*(\d*)\s*\|\s*(\d*)\s*\|\s*(\d*)\s*\|\s*(\d*)\s*\|$/,
-        makeSplit: (width) => "-".repeat(Math.max(0, width - 2)),
+        makeSplit: (width) => "-".repeat(Math.max(0, width)),
         makeHeader: (width, pad) => {
             const nameLine = `| ${pad('Nazwa towaru', width - 3)}|`;
             return nameLine

--- a/client/src/scripts/herbShop.ts
+++ b/client/src/scripts/herbShop.ts
@@ -8,7 +8,7 @@ export default function initHerbShop(client: Client) {
         splitReg: /^\+-{58}\+-{4}\+-{4}\+-{4}\+-{4}\+-{7}\+$/,
         headerReg: /^\|\s*Nazwa towaru\s*\|\s*mt\s*\|\s*zl\s*\|\s*sr\s*\|\s*md\s*\|\s*Ilosc\s*\|$/,
         itemReg: /^\|\s*(.+?)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|$/,
-        makeSplit: (width) => `+${"-".repeat(Math.max(0, width - 4))}+`,
+        makeSplit: (width) => `+${"-".repeat(Math.max(0, width - 2))}+`,
         makeHeader: (width, pad) => {
             const nameLine = `| ${pad('Nazwa towaru', width - 3)}|`;
             const numbersLine = `| ${pad('mt/zl/sr/md Ilosc', width - 3)}|`;

--- a/client/test/armorShop.test.ts
+++ b/client/test/armorShop.test.ts
@@ -34,7 +34,7 @@ describe('armor shop width adjustments', () => {
 
   test('adjusts split line', () => {
     const result = parse(split);
-    expect(result).toBe('-'.repeat(client.contentWidth - 2));
+    expect(result).toBe('-'.repeat(client.contentWidth));
   });
 
   test('splits item line when narrow', () => {

--- a/client/test/herbShop.test.ts
+++ b/client/test/herbShop.test.ts
@@ -34,7 +34,7 @@ describe('herb shop width adjustments', () => {
 
   test('adjusts split line', () => {
     const result = parse(split);
-    expect(result).toBe('+'.padEnd(client.contentWidth - 3, '-') + '+');
+    expect(result).toBe('+'.padEnd(client.contentWidth - 1, '-') + '+');
   });
 
   test('splits header and item lines when narrow', () => {


### PR DESCRIPTION
## Summary
- ensure shop header/footer lines use full width in narrow view
- update tests for herb and armor shops

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_688f4e951ac0832a8dbc3e562ad95583