### PR TITLE
Fix typo in idz command list

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -96,7 +96,7 @@ export function registerScripts(client: Client) {
 
     client.Triggers.registerTrigger([
         /^Wykonuje komende 'idz /,
-        /^Ruszasz (?:niespiesznie|marszem|truchtem|biegiem|szbkim biegiem) w droge\./
+        /^Ruszasz (?:niespiesznie|marszem|truchtem|biegiem|szybkim biegiem) w droge\./
     ], (): undefined => {
         client.sendEvent('refreshPositionWhenAble')
     })

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -522,7 +522,7 @@ export default class MobileDirectionButtons {
             { label: 'idz marszem', cmd: 'idz marszem' },
             { label: 'idz truchtem', cmd: 'idz truchtem' },
             { label: 'idz biegiem', cmd: 'idz biegiem' },
-            { label: 'idz s. biegiem', cmd: 'idz szybkiem biegiem' },
+            { label: 'idz s. biegiem', cmd: 'idz szybkim biegiem' },
         ];
         cmds.forEach(c => {
             const b = document.createElement('button');


### PR DESCRIPTION
## Summary
- correct "idz szybkim biegiem" command in mobile direction buttons
- handle "szybkim biegiem" in movement trigger regex

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_688f552c8b6c832a8afe7241109576dc