### PR TITLE
feat: allow configuring mobile buttons grid

### DIFF
--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -82,7 +82,7 @@ export interface Settings {
     team: LayoutSettings;
 }
 
-function createDefaultLayout(): LayoutSettings {
+export function createDefaultLayout(): LayoutSettings {
     return { buttons: { ...defaultSettings }, order: [...defaultOrder], cols: defaultCols };
 }
 

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -45,9 +45,36 @@ export const defaultSettings: Record<string, ButtonSetting> = {
     'special-exit-button': { macro: 'specialExit', label: 'sp ex', color: '#6CA6CD' },
 };
 
+export const defaultOrder = [
+    'z-list-toggle',
+    'zas-list-toggle',
+    'go-button',
+    'buttons-toggle',
+    'bracket-right-button',
+    'button-1',
+    'button-2',
+    'button-3',
+    'nw-button',
+    'n-button',
+    'ne-button',
+    'u-button',
+    'w-button',
+    'c-button',
+    'e-button',
+    'd-button',
+    'sw-button',
+    's-button',
+    'se-button',
+    'special-exit-button',
+];
+
+export const defaultCols = 4;
+
 export interface Settings {
     solo: Record<string, ButtonSetting>;
     team: Record<string, ButtonSetting>;
+    order: string[];
+    cols: number;
 }
 
 export async function loadSettings(): Promise<Settings> {
@@ -55,19 +82,25 @@ export async function loadSettings(): Promise<Settings> {
         const data = await storage.getItem('mobileButtonSettings');
         const raw = data?.mobileButtonSettings;
         if (raw) {
+            const order = Array.isArray(raw.order) ? raw.order : defaultOrder;
+            const cols = typeof raw.cols === 'number' && raw.cols > 0 ? raw.cols : defaultCols;
             if (raw.solo || raw.team) {
                 return {
                     solo: { ...defaultSettings, ...(raw.solo || {}) },
                     team: { ...defaultSettings, ...(raw.team || raw.solo || {}) },
+                    order,
+                    cols,
                 };
             }
             return {
                 solo: { ...defaultSettings, ...(raw as any) },
                 team: { ...defaultSettings, ...(raw as any) },
+                order,
+                cols,
             };
         }
     } catch {}
-    return { solo: { ...defaultSettings }, team: { ...defaultSettings } };
+    return { solo: { ...defaultSettings }, team: { ...defaultSettings }, order: [...defaultOrder], cols: defaultCols };
 }
 
 export function saveSettings(settings: Settings) {
@@ -76,17 +109,34 @@ export function saveSettings(settings: Settings) {
 
 export function applySettings(settings: Settings, inTeam = false) {
     const set = inTeam ? settings.team : settings.solo;
-    Object.entries(set).forEach(([id, cfg]) => {
-        const el = document.getElementById(id) as HTMLButtonElement | null;
-        if (!el) return;
-        el.textContent = cfg.label;
-        el.style.backgroundColor = cfg.color;
-        if (cfg.direction) {
-            el.dataset.direction = cfg.direction;
-        } else {
-            el.removeAttribute('data-direction');
-        }
-    });
+    const container = document.getElementById('mobile-direction-buttons') as HTMLDivElement | null;
+    if (container) {
+        container.style.gridTemplateColumns = `repeat(${settings.cols}, auto)`;
+        const z = document.getElementById('z-buttons-list');
+        const zas = document.getElementById('zas-buttons-list');
+        const idz = document.getElementById('idz-buttons-list');
+        container.querySelectorAll('button').forEach(b => b.remove());
+        const empty: ButtonSetting = { macro: 'command', label: '', color: 'transparent' };
+        const insertBefore = z || zas || idz || null;
+        settings.order.forEach(id => {
+            const cfg = set[id] || defaultSettings[id] || empty;
+            const btn = document.createElement('button');
+            btn.id = id;
+            btn.className = 'mobile-button';
+            if (cfg.macro === 'kierunek') {
+                btn.classList.add('direction-button');
+            } else {
+                btn.classList.add('mobile-button-text');
+            }
+            if (cfg.label) {
+                btn.textContent = cfg.label;
+                btn.style.backgroundColor = cfg.color;
+            } else {
+                btn.classList.add('empty');
+            }
+            container.insertBefore(btn, insertBefore);
+        });
+    }
     if ((window as any).clientExtension?.eventTarget) {
         (window as any).clientExtension.eventTarget.dispatchEvent(
             new CustomEvent('mobileButtonsSettings', { detail: set })

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -1,4 +1,3 @@
-import Modal from "bootstrap/js/dist/modal";
 import storage from "@client/src/storage";
 
 export type MacroType =
@@ -10,7 +9,8 @@ export type MacroType =
     | 'specialExit'
     | 'kierunek'
     | 'wesprzyj'
-    | 'moveMode';
+    | 'moveMode'
+    | 'empty';
 
 export interface ButtonSetting {
     macro: MacroType;
@@ -71,11 +71,19 @@ export const defaultOrder = [
 
 export const defaultCols = 4;
 
-export interface Settings {
-    solo: Record<string, ButtonSetting>;
-    team: Record<string, ButtonSetting>;
+export interface LayoutSettings {
+    buttons: Record<string, ButtonSetting>;
     order: string[];
     cols: number;
+}
+
+export interface Settings {
+    solo: LayoutSettings;
+    team: LayoutSettings;
+}
+
+function createDefaultLayout(): LayoutSettings {
+    return { buttons: { ...defaultSettings }, order: [...defaultOrder], cols: defaultCols };
 }
 
 export async function loadSettings(): Promise<Settings> {
@@ -83,25 +91,23 @@ export async function loadSettings(): Promise<Settings> {
         const data = await storage.getItem('mobileButtonSettings');
         const raw = data?.mobileButtonSettings;
         if (raw) {
-            const order = Array.isArray(raw.order) ? raw.order : defaultOrder;
-            const cols = typeof raw.cols === 'number' && raw.cols > 0 ? raw.cols : defaultCols;
-            if (raw.solo || raw.team) {
-                return {
-                    solo: { ...defaultSettings, ...(raw.solo || {}) },
-                    team: { ...defaultSettings, ...(raw.team || raw.solo || {}) },
-                    order,
-                    cols,
-                };
+            const parseSet = (set: any): LayoutSettings => ({
+                buttons: { ...defaultSettings, ...(set?.buttons || set || {}) },
+                order: Array.isArray(set?.order) ? set.order : [...defaultOrder],
+                cols: typeof set?.cols === 'number' && set.cols > 0 ? set.cols : defaultCols,
+            });
+            if (raw.solo && raw.team && (raw.solo.buttons || raw.team.buttons)) {
+                return { solo: parseSet(raw.solo), team: parseSet(raw.team) };
             }
+            const order = Array.isArray(raw.order) ? raw.order : [...defaultOrder];
+            const cols = typeof raw.cols === 'number' && raw.cols > 0 ? raw.cols : defaultCols;
             return {
-                solo: { ...defaultSettings, ...(raw as any) },
-                team: { ...defaultSettings, ...(raw as any) },
-                order,
-                cols,
+                solo: { buttons: { ...defaultSettings, ...(raw.solo || {}) }, order: [...order], cols },
+                team: { buttons: { ...defaultSettings, ...(raw.team || raw.solo || {}) }, order: [...order], cols },
             };
         }
     } catch {}
-    return { solo: { ...defaultSettings }, team: { ...defaultSettings }, order: [...defaultOrder], cols: defaultCols };
+    return { solo: createDefaultLayout(), team: createDefaultLayout() };
 }
 
 export function saveSettings(settings: Settings) {
@@ -112,15 +118,15 @@ export function applySettings(settings: Settings, inTeam = false) {
     const set = inTeam ? settings.team : settings.solo;
     const container = document.getElementById('mobile-direction-buttons') as HTMLDivElement | null;
     if (container) {
-        container.style.gridTemplateColumns = `repeat(${settings.cols}, auto)`;
+        container.style.gridTemplateColumns = `repeat(${set.cols}, auto)`;
         const z = document.getElementById('z-buttons-list');
         const zas = document.getElementById('zas-buttons-list');
         const idz = document.getElementById('idz-buttons-list');
         container.querySelectorAll('button').forEach(b => b.remove());
-        const empty: ButtonSetting = { macro: 'command', label: '', color: 'transparent' };
+        const empty: ButtonSetting = { macro: 'empty', label: '', color: 'transparent' };
         const insertBefore = z || zas || idz || null;
-        settings.order.forEach(id => {
-            const cfg = set[id] || defaultSettings[id] || empty;
+        set.order.forEach(id => {
+            const cfg = set.buttons[id] || defaultSettings[id] || empty;
             const btn = document.createElement('button');
             btn.id = id;
             btn.className = 'mobile-button';
@@ -129,7 +135,8 @@ export function applySettings(settings: Settings, inTeam = false) {
             } else {
                 btn.classList.add('mobile-button-text');
             }
-            if (cfg.label) {
+            const isEmpty = cfg.macro === 'empty' || !cfg.label;
+            if (!isEmpty) {
                 btn.textContent = cfg.label;
                 btn.style.backgroundColor = cfg.color;
             } else {
@@ -140,163 +147,9 @@ export function applySettings(settings: Settings, inTeam = false) {
     }
     if ((window as any).clientExtension?.eventTarget) {
         (window as any).clientExtension.eventTarget.dispatchEvent(
-            new CustomEvent('mobileButtonsSettings', { detail: set })
+            new CustomEvent('mobileButtonsSettings', { detail: set.buttons })
         );
     }
-}
-
-export default async function initMobileButtonSettings() {
-    const button = document.getElementById('mobile-buttons-button') as HTMLButtonElement | null;
-    const modalEl = document.getElementById('mobile-buttons-modal');
-    if (!button || !modalEl) return;
-
-    const modal = new Modal(modalEl);
-    const saveBtn = modalEl.querySelector('#mobile-buttons-save') as HTMLButtonElement;
-
-    const sections = Array.from(modalEl.querySelectorAll<HTMLElement>('.mobile-button-config'));
-    const previewButtons = Array.from(modalEl.querySelectorAll<HTMLButtonElement>(
-        '#mobile-buttons-preview-solo button[data-button-id], #mobile-buttons-preview-team button[data-button-id]'
-    ));
-    const previewMap: Record<string, HTMLButtonElement> = {};
-    const realMap: Record<string, HTMLButtonElement> = {};
-    previewButtons.forEach(btn => {
-        const id = btn.dataset.buttonId!;
-        previewMap[id] = btn;
-    });
-    Object.keys(defaultSettings).forEach(id => {
-        const el = document.getElementById(id) as HTMLButtonElement | null;
-        if (el) realMap[id] = el;
-    });
-    const modalBody = modalEl.querySelector('.modal-body') as HTMLElement;
-    let activeConfig: HTMLElement | null = null;
-
-    const hideConfig = () => {
-        if (activeConfig) {
-            activeConfig.classList.add('d-none');
-            activeConfig = null;
-        }
-    };
-
-    let current = (await loadSettings()).solo;
-    const applyLive = (id: string, labelVal: string, colorVal: string) => {
-        const btn = realMap[id];
-        if (btn) {
-            btn.textContent = labelVal;
-            btn.style.backgroundColor = colorVal;
-        }
-    };
-    sections.forEach(section => {
-        const id = section.dataset.buttonId!;
-        const cfg = current[id] || defaultSettings[id];
-        const preview = previewMap[id];
-        const macro = section.querySelector('.mobile-button-macro') as HTMLSelectElement;
-        const label = section.querySelector('.mobile-button-label') as HTMLInputElement;
-        const color = section.querySelector('.mobile-button-color') as HTMLInputElement;
-        const command = section.querySelector('.mobile-button-command') as HTMLTextAreaElement;
-        const cmdLabel = section.querySelector('.mobile-button-command-label') as HTMLElement;
-        const direction = section.querySelector('.mobile-button-direction') as HTMLSelectElement;
-        const dirLabel = section.querySelector('.mobile-button-direction-label') as HTMLElement;
-        const reset = section.querySelector('.mobile-button-color-reset') as HTMLButtonElement | null;
-
-        macro.value = cfg.macro;
-        label.value = cfg.label;
-        color.value = cfg.color;
-        if (command) command.value = cfg.command || '';
-        if (direction) direction.value = cfg.direction || '';
-        if (preview) {
-            preview.textContent = label.value;
-            preview.style.backgroundColor = color.value;
-        }
-        applyLive(id, label.value, color.value);
-        const update = () => {
-            if (macro.value === 'command') {
-                cmdLabel.style.display = '';
-            } else {
-                cmdLabel.style.display = 'none';
-            }
-            if (macro.value === 'kierunek') {
-                dirLabel.style.display = '';
-            } else {
-                dirLabel.style.display = 'none';
-            }
-        };
-        macro.addEventListener('change', update);
-        if (reset) {
-            reset.addEventListener('click', () => {
-                color.value = defaultSettings[id].color;
-                if (preview) preview.style.backgroundColor = color.value;
-                applyLive(id, label.value, color.value);
-            });
-        }
-        label.addEventListener('input', () => {
-            if (preview) preview.textContent = label.value;
-            applyLive(id, label.value, color.value);
-        });
-        color.addEventListener('input', () => {
-            if (preview) preview.style.backgroundColor = color.value;
-            applyLive(id, label.value, color.value);
-        });
-        update();
-    });
-
-    previewButtons.forEach(btn => {
-        const id = btn.dataset.buttonId!;
-        const config = sections.find(s => s.dataset.buttonId === id);
-        if (!config) return;
-        btn.addEventListener('click', ev => {
-            ev.stopPropagation();
-            if (activeConfig === config) {
-                hideConfig();
-                return;
-            }
-            hideConfig();
-            const rect = btn.getBoundingClientRect();
-            const bodyRect = modalBody.getBoundingClientRect();
-            config.style.left = rect.left - bodyRect.left + 'px';
-            config.style.top = rect.bottom - bodyRect.top + 4 + 'px';
-            config.classList.remove('d-none');
-            activeConfig = config;
-        });
-    });
-
-    modalEl.addEventListener('click', (ev) => {
-        if (activeConfig && !activeConfig.contains(ev.target as Node)) {
-            const isButton = (ev.target as HTMLElement).closest(
-                '#mobile-buttons-preview-solo button, #mobile-buttons-preview-team button'
-            );
-            if (!isButton) hideConfig();
-        }
-    });
-
-    modalEl.addEventListener('hide.bs.modal', hideConfig);
-
-    const read = (): Record<string, ButtonSetting> => {
-        const result: Record<string, ButtonSetting> = {};
-        sections.forEach(section => {
-            const id = section.dataset.buttonId!;
-            const macro = (section.querySelector('.mobile-button-macro') as HTMLSelectElement).value as MacroType;
-            const label = (section.querySelector('.mobile-button-label') as HTMLInputElement).value;
-            const color = (section.querySelector('.mobile-button-color') as HTMLInputElement).value;
-            const command = (section.querySelector('.mobile-button-command') as HTMLTextAreaElement).value;
-            const direction = (section.querySelector('.mobile-button-direction') as HTMLSelectElement).value;
-            result[id] = { macro, label, color, command, direction };
-        });
-        return result;
-    };
-
-    saveBtn.addEventListener('click', () => {
-        current = read();
-        const all = { solo: current, team: current } as Settings;
-        saveSettings(all);
-        applySettings(all);
-        modal.hide();
-    });
-
-    button.addEventListener('click', () => {
-        modal.show();
-    });
-
-    applySettings({ solo: current, team: current });
 }
 
 

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -25,6 +25,7 @@ export const defaultSettings: Record<string, ButtonSetting> = {
     'z-list-toggle': { macro: 'zList', label: '/z', color: '#6EB4DC' },
     'zas-list-toggle': { macro: 'zaList', label: '/za', color: '#6EB4DC' },
     'go-button': { macro: 'command', label: '/go', color: '#6EB4DC', command: '/go' },
+    'buttons-toggle': { macro: 'functional', label: '⇩', color: '#6EB4DC' },
     'bracket-right-button': { macro: 'functional', label: ']', color: '#6EB4DC' },
     'button-1': { macro: 'wesprzyj', label: 'wesprzyj', color: '#6EB4DC' },
     'button-2': { macro: 'command', label: '/z cel', color: '#6EB4DC', command: '/z' },

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -187,77 +187,85 @@ function MobileButtons() {
                     W drużynie
                 </Button>
             </div>
-            <div className="d-flex justify-content-between mb-2 flex-wrap gap-2">
-                <div className="btn-group">
+            <div className="d-flex flex-column align-items-center mb-2">
+                <div className="d-flex gap-1 mb-2">
                     <Button size="sm" variant="secondary" onClick={() => addRow('top')}>+R↑</Button>
                     <Button size="sm" variant="secondary" onClick={() => removeRow('top')}>-R↑</Button>
+                </div>
+                <div className="d-flex align-items-center">
+                    <div className="d-flex flex-column gap-1 me-2">
+                        <Button size="sm" variant="secondary" onClick={() => addCol('left')}>+C←</Button>
+                        <Button size="sm" variant="secondary" onClick={() => removeCol('left')}>-C←</Button>
+                    </div>
+                    <div>
+                        <div
+                            ref={soloRef}
+                            id="mobile-buttons-preview-solo"
+                            className={`mobile-direction-buttons mb-2 ${view === 'solo' ? '' : 'd-none'}`}
+                            style={{ gridTemplateColumns: `repeat(${settings.cols}, auto)` }}
+                        >
+                            {settings.order.map(id => {
+                                const cfg = settings.solo[id] || defaultSettings[id] || emptySetting;
+                                let classes = 'mobile-button';
+                                if (cfg.macro === 'kierunek') {
+                                    classes += ' direction-button';
+                                } else {
+                                    classes += ' mobile-button-text';
+                                }
+                                if (!cfg.label) classes += ' empty';
+                                const handle = notEditable.includes(id) ? undefined : (ev: React.MouseEvent<HTMLButtonElement>) => openConfig('solo', id, ev);
+                                return (
+                                    <button
+                                        key={id}
+                                        data-button-id={id}
+                                        className={classes}
+                                        style={{ backgroundColor: cfg.color }}
+                                        onClick={handle}
+                                    >
+                                        {cfg.label}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                        <div
+                            ref={teamRef}
+                            id="mobile-buttons-preview-team"
+                            className={`mobile-direction-buttons mb-2 ${view === 'team' ? '' : 'd-none'}`}
+                            style={{ gridTemplateColumns: `repeat(${settings.cols}, auto)` }}
+                        >
+                            {settings.order.map(id => {
+                                const cfg = settings.team[id] || defaultSettings[id] || emptySetting;
+                                let classes = 'mobile-button';
+                                if (cfg.macro === 'kierunek') {
+                                    classes += ' direction-button';
+                                } else {
+                                    classes += ' mobile-button-text';
+                                }
+                                if (!cfg.label) classes += ' empty';
+                                const handle = notEditable.includes(id) ? undefined : (ev: React.MouseEvent<HTMLButtonElement>) => openConfig('team', id, ev);
+                                return (
+                                    <button
+                                        key={id}
+                                        data-button-id={id}
+                                        className={classes}
+                                        style={{ backgroundColor: cfg.color }}
+                                        onClick={handle}
+                                    >
+                                        {cfg.label}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </div>
+                    <div className="d-flex flex-column gap-1 ms-2">
+                        <Button size="sm" variant="secondary" onClick={() => addCol('right')}>+C→</Button>
+                        <Button size="sm" variant="secondary" onClick={() => removeCol('right')}>-C→</Button>
+                    </div>
+                </div>
+                <div className="d-flex gap-1 mt-2">
                     <Button size="sm" variant="secondary" onClick={() => addRow('bottom')}>+R↓</Button>
                     <Button size="sm" variant="secondary" onClick={() => removeRow('bottom')}>-R↓</Button>
                 </div>
-                <div className="btn-group">
-                    <Button size="sm" variant="secondary" onClick={() => addCol('left')}>+C←</Button>
-                    <Button size="sm" variant="secondary" onClick={() => removeCol('left')}>-C←</Button>
-                    <Button size="sm" variant="secondary" onClick={() => addCol('right')}>+C→</Button>
-                    <Button size="sm" variant="secondary" onClick={() => removeCol('right')}>-C→</Button>
-                </div>
-            </div>
-            <div
-                ref={soloRef}
-                id="mobile-buttons-preview-solo"
-                className={`mobile-direction-buttons mb-2 ${view === 'solo' ? '' : 'd-none'}`}
-                style={{ gridTemplateColumns: `repeat(${settings.cols}, auto)` }}
-            >
-                {settings.order.map(id => {
-                    const cfg = settings.solo[id] || defaultSettings[id] || emptySetting;
-                    let classes = 'mobile-button';
-                    if (cfg.macro === 'kierunek') {
-                        classes += ' direction-button';
-                    } else {
-                        classes += ' mobile-button-text';
-                    }
-                    if (!cfg.label) classes += ' empty';
-                    const handle = notEditable.includes(id) ? undefined : (ev: React.MouseEvent<HTMLButtonElement>) => openConfig('solo', id, ev);
-                    return (
-                        <button
-                            key={id}
-                            data-button-id={id}
-                            className={classes}
-                            style={{ backgroundColor: cfg.color }}
-                            onClick={handle}
-                        >
-                            {cfg.label}
-                        </button>
-                    );
-                })}
-            </div>
-            <div
-                ref={teamRef}
-                id="mobile-buttons-preview-team"
-                className={`mobile-direction-buttons mb-2 ${view === 'team' ? '' : 'd-none'}`}
-                style={{ gridTemplateColumns: `repeat(${settings.cols}, auto)` }}
-            >
-                {settings.order.map(id => {
-                    const cfg = settings.team[id] || defaultSettings[id] || emptySetting;
-                    let classes = 'mobile-button';
-                    if (cfg.macro === 'kierunek') {
-                        classes += ' direction-button';
-                    } else {
-                        classes += ' mobile-button-text';
-                    }
-                    if (!cfg.label) classes += ' empty';
-                    const handle = notEditable.includes(id) ? undefined : (ev: React.MouseEvent<HTMLButtonElement>) => openConfig('team', id, ev);
-                    return (
-                        <button
-                            key={id}
-                            data-button-id={id}
-                            className={classes}
-                            style={{ backgroundColor: cfg.color }}
-                            onClick={handle}
-                        >
-                            {cfg.label}
-                        </button>
-                    );
-                })}
             </div>
             {active && activeCfg && (
                 <div

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -26,7 +26,7 @@ const macroOptions: { value: MacroType; label: string }[] = [
 
 const directionOptions = ["nw","n","ne","w","e","sw","s","se","u","d"] as const;
 
-const emptySetting: ButtonSetting = { macro: 'command', label: '', color: 'transparent' };
+const emptySetting: ButtonSetting = { macro: 'command', label: '', color: '#6EB4DC' };
 
 type SettingsMap = Record<string, ButtonSetting>;
 
@@ -159,6 +159,13 @@ function MobileButtons() {
         update(setName, "color", def);
     }
 
+    function makeBlank(setName: 'solo' | 'team', id: string) {
+        setSettings(prev => ({
+            ...prev,
+            [setName]: { ...prev[setName], [id]: { ...emptySetting } },
+        }));
+    }
+
     function save() {
         saveSettings(settings);
         const teamActive = !!(window as any).clientExtension?.TeamManager?.getLeader?.();
@@ -201,7 +208,7 @@ function MobileButtons() {
                         <div
                             ref={soloRef}
                             id="mobile-buttons-preview-solo"
-                            className={`mobile-direction-buttons mb-2 ${view === 'solo' ? '' : 'd-none'}`}
+                            className={`mobile-direction-buttons preview mb-2 ${view === 'solo' ? '' : 'd-none'}`}
                             style={{ gridTemplateColumns: `repeat(${settings.cols}, auto)` }}
                         >
                             {settings.order.map(id => {
@@ -219,7 +226,7 @@ function MobileButtons() {
                                         key={id}
                                         data-button-id={id}
                                         className={classes}
-                                        style={{ backgroundColor: cfg.color }}
+                                        style={{ backgroundColor: cfg.label ? cfg.color : 'transparent' }}
                                         onClick={handle}
                                     >
                                         {cfg.label}
@@ -230,7 +237,7 @@ function MobileButtons() {
                         <div
                             ref={teamRef}
                             id="mobile-buttons-preview-team"
-                            className={`mobile-direction-buttons mb-2 ${view === 'team' ? '' : 'd-none'}`}
+                            className={`mobile-direction-buttons preview mb-2 ${view === 'team' ? '' : 'd-none'}`}
                             style={{ gridTemplateColumns: `repeat(${settings.cols}, auto)` }}
                         >
                             {settings.order.map(id => {
@@ -248,7 +255,7 @@ function MobileButtons() {
                                         key={id}
                                         data-button-id={id}
                                         className={classes}
-                                        style={{ backgroundColor: cfg.color }}
+                                        style={{ backgroundColor: cfg.label ? cfg.color : 'transparent' }}
                                         onClick={handle}
                                     >
                                         {cfg.label}
@@ -312,6 +319,14 @@ function MobileButtons() {
                         />
                         <Button size="sm" variant="secondary" onClick={() => resetColor(active!.set, active!.id)}>↺</Button>
                     </Form.Group>
+                    <Button
+                        size="sm"
+                        variant="secondary"
+                        className="mb-2"
+                        onClick={() => makeBlank(active!.set, active!.id)}
+                    >
+                        Pusty
+                    </Button>
                     {activeCfg.macro === "kierunek" && (
                         <Form.Group className="form-label mb-2">
                             <Form.Label>Kierunek</Form.Label>

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -22,16 +22,20 @@ const macroOptions: { value: MacroType; label: string }[] = [
     { value: "specialExit", label: "Wyjście specjalne" },
     { value: "wesprzyj", label: "Wesprzyj prowadzącego" },
     { value: "moveMode", label: "Tryb ruchu" },
+    { value: "empty", label: "Puste" },
 ];
 
 const directionOptions = ["nw","n","ne","w","e","sw","s","se","u","d"] as const;
 
-const emptySetting: ButtonSetting = { macro: 'command', label: '', color: '#6EB4DC' };
+const emptySetting: ButtonSetting = { macro: 'empty', label: '', color: 'transparent' };
 
 type SettingsMap = Record<string, ButtonSetting>;
 
 function MobileButtons() {
-    const [settings, setSettings] = useState<Settings>({ solo: {}, team: {}, order: [...defaultOrder], cols: defaultCols });
+    const [settings, setSettings] = useState<Settings>({
+        solo: { buttons: {}, order: [...defaultOrder], cols: defaultCols },
+        team: { buttons: {}, order: [...defaultOrder], cols: defaultCols },
+    });
     const [active, setActive] = useState<{ set: 'solo' | 'team'; id: string } | null>(null);
     const [pos, setPos] = useState<{ left: number; top: number }>({ left: 0, top: 0 });
     const [view, setView] = useState<'solo' | 'team'>('solo');
@@ -54,68 +58,66 @@ function MobileButtons() {
 
     function addRow(pos: 'top' | 'bottom') {
         setSettings(prev => {
-            const makeId = nextId(prev.order);
-            const ids = Array.from({ length: prev.cols }, () => makeId());
-            const solo: SettingsMap = { ...prev.solo };
-            const team: SettingsMap = { ...prev.team };
+            const set = prev[view];
+            const makeId = nextId(set.order);
+            const ids = Array.from({ length: set.cols }, () => makeId());
+            const buttons: SettingsMap = { ...set.buttons };
             ids.forEach(id => {
-                solo[id] = { ...emptySetting };
-                team[id] = { ...emptySetting };
+                buttons[id] = { ...emptySetting };
             });
-            const order = pos === 'top' ? [...ids, ...prev.order] : [...prev.order, ...ids];
-            return { ...prev, solo, team, order };
+            const order = pos === 'top' ? [...ids, ...set.order] : [...set.order, ...ids];
+            return { ...prev, [view]: { ...set, buttons, order } };
         });
     }
 
     function removeRow(pos: 'top' | 'bottom') {
         setSettings(prev => {
-            const rows = Math.floor(prev.order.length / prev.cols);
+            const set = prev[view];
+            const rows = Math.floor(set.order.length / set.cols);
             if (rows <= 1) return prev;
-            const start = pos === 'top' ? 0 : prev.order.length - prev.cols;
-            const removed = prev.order.slice(start, start + prev.cols);
-            const order = pos === 'top' ? prev.order.slice(prev.cols) : prev.order.slice(0, start);
-            const solo: SettingsMap = { ...prev.solo };
-            const team: SettingsMap = { ...prev.team };
-            removed.forEach(id => { delete solo[id]; delete team[id]; });
-            return { ...prev, solo, team, order };
+            const start = pos === 'top' ? 0 : set.order.length - set.cols;
+            const removed = set.order.slice(start, start + set.cols);
+            const order = pos === 'top' ? set.order.slice(set.cols) : set.order.slice(0, start);
+            const buttons: SettingsMap = { ...set.buttons };
+            removed.forEach(id => { delete buttons[id]; });
+            return { ...prev, [view]: { ...set, buttons, order } };
         });
     }
 
     function addCol(side: 'left' | 'right') {
         setSettings(prev => {
-            const makeId = nextId(prev.order);
-            const solo: SettingsMap = { ...prev.solo };
-            const team: SettingsMap = { ...prev.team };
+            const set = prev[view];
+            const makeId = nextId(set.order);
+            const buttons: SettingsMap = { ...set.buttons };
             const order: string[] = [];
-            const rows = Math.floor(prev.order.length / prev.cols);
+            const rows = Math.floor(set.order.length / set.cols);
             for (let r = 0; r < rows; r++) {
                 if (side === 'left') {
                     const id = makeId();
                     order.push(id);
-                    solo[id] = { ...emptySetting };
-                    team[id] = { ...emptySetting };
+                    buttons[id] = { ...emptySetting };
                 }
-                const row = prev.order.slice(r * prev.cols, (r + 1) * prev.cols);
+                const row = set.order.slice(r * set.cols, (r + 1) * set.cols);
                 order.push(...row);
                 if (side === 'right') {
                     const id = makeId();
                     order.push(id);
-                    solo[id] = { ...emptySetting };
-                    team[id] = { ...emptySetting };
+                    buttons[id] = { ...emptySetting };
                 }
             }
-            return { ...prev, solo, team, order, cols: prev.cols + 1 };
+            return { ...prev, [view]: { ...set, buttons, order, cols: set.cols + 1 } };
         });
     }
 
     function removeCol(side: 'left' | 'right') {
         setSettings(prev => {
-            if (prev.cols <= 1) return prev;
-            const rows = Math.floor(prev.order.length / prev.cols);
+            const set = prev[view];
+            if (set.cols <= 1) return prev;
+            const rows = Math.floor(set.order.length / set.cols);
             const order: string[] = [];
             const removed: string[] = [];
             for (let r = 0; r < rows; r++) {
-                const row = prev.order.slice(r * prev.cols, (r + 1) * prev.cols);
+                const row = set.order.slice(r * set.cols, (r + 1) * set.cols);
                 if (side === 'left') {
                     removed.push(row[0]);
                     order.push(...row.slice(1));
@@ -124,10 +126,9 @@ function MobileButtons() {
                     order.push(...row.slice(0, row.length - 1));
                 }
             }
-            const solo: SettingsMap = { ...prev.solo };
-            const team: SettingsMap = { ...prev.team };
-            removed.forEach(id => { delete solo[id]; delete team[id]; });
-            return { ...prev, solo, team, order, cols: prev.cols - 1 };
+            const buttons: SettingsMap = { ...set.buttons };
+            removed.forEach(id => { delete buttons[id]; });
+            return { ...prev, [view]: { ...set, buttons, order, cols: set.cols - 1 } };
         });
     }
 
@@ -151,18 +152,30 @@ function MobileButtons() {
     }
 
     function update(setName: 'solo' | 'team', id: string, field: keyof ButtonSetting, value: any) {
-        setSettings(prev => ({ ...prev, [setName]: { ...prev[setName], [id]: { ...prev[setName][id], [field]: value } } }));
+        setSettings(prev => ({
+            ...prev,
+            [setName]: {
+                ...prev[setName],
+                buttons: {
+                    ...prev[setName].buttons,
+                    [id]: { ...prev[setName].buttons[id], [field]: value },
+                },
+            },
+        }));
     }
 
     function resetColor(setName: 'solo' | 'team', id: string) {
         const def = defaultSettings[id]?.color || emptySetting.color;
-        update(setName, "color", def);
+        update(setName, id, 'color', def);
     }
 
     function makeBlank(setName: 'solo' | 'team', id: string) {
         setSettings(prev => ({
             ...prev,
-            [setName]: { ...prev[setName], [id]: { ...emptySetting } },
+            [setName]: {
+                ...prev[setName],
+                buttons: { ...prev[setName].buttons, [id]: { ...emptySetting } },
+            },
         }));
     }
 
@@ -174,7 +187,7 @@ function MobileButtons() {
         modal?.hide();
     }
 
-    const activeCfg = active ? (settings[active.set][active.id] || defaultSettings[active.id] || emptySetting) : null;
+    const activeCfg = active ? (settings[active.set].buttons[active.id] || defaultSettings[active.id] || emptySetting) : null;
 
     return (
         <div onClick={close} className="w-100 position-relative">
@@ -209,27 +222,28 @@ function MobileButtons() {
                             ref={soloRef}
                             id="mobile-buttons-preview-solo"
                             className={`mobile-direction-buttons preview mb-2 ${view === 'solo' ? '' : 'd-none'}`}
-                            style={{ gridTemplateColumns: `repeat(${settings.cols}, auto)` }}
+                            style={{ gridTemplateColumns: `repeat(${settings.solo.cols}, auto)` }}
                         >
-                            {settings.order.map(id => {
-                                const cfg = settings.solo[id] || defaultSettings[id] || emptySetting;
+                            {settings.solo.order.map(id => {
+                                const cfg = settings.solo.buttons[id] || defaultSettings[id] || emptySetting;
                                 let classes = 'mobile-button';
                                 if (cfg.macro === 'kierunek') {
                                     classes += ' direction-button';
                                 } else {
                                     classes += ' mobile-button-text';
                                 }
-                                if (!cfg.label) classes += ' empty';
+                                const isEmpty = cfg.macro === 'empty' || !cfg.label;
+                                if (isEmpty) classes += ' empty';
                                 const handle = notEditable.includes(id) ? undefined : (ev: React.MouseEvent<HTMLButtonElement>) => openConfig('solo', id, ev);
                                 return (
                                     <button
                                         key={id}
                                         data-button-id={id}
                                         className={classes}
-                                        style={{ backgroundColor: cfg.label ? cfg.color : 'transparent' }}
+                                        style={{ backgroundColor: isEmpty ? 'transparent' : cfg.color }}
                                         onClick={handle}
                                     >
-                                        {cfg.label}
+                                        {isEmpty ? '' : cfg.label}
                                     </button>
                                 );
                             })}
@@ -238,27 +252,28 @@ function MobileButtons() {
                             ref={teamRef}
                             id="mobile-buttons-preview-team"
                             className={`mobile-direction-buttons preview mb-2 ${view === 'team' ? '' : 'd-none'}`}
-                            style={{ gridTemplateColumns: `repeat(${settings.cols}, auto)` }}
+                            style={{ gridTemplateColumns: `repeat(${settings.team.cols}, auto)` }}
                         >
-                            {settings.order.map(id => {
-                                const cfg = settings.team[id] || defaultSettings[id] || emptySetting;
+                            {settings.team.order.map(id => {
+                                const cfg = settings.team.buttons[id] || defaultSettings[id] || emptySetting;
                                 let classes = 'mobile-button';
                                 if (cfg.macro === 'kierunek') {
                                     classes += ' direction-button';
                                 } else {
                                     classes += ' mobile-button-text';
                                 }
-                                if (!cfg.label) classes += ' empty';
+                                const isEmpty = cfg.macro === 'empty' || !cfg.label;
+                                if (isEmpty) classes += ' empty';
                                 const handle = notEditable.includes(id) ? undefined : (ev: React.MouseEvent<HTMLButtonElement>) => openConfig('team', id, ev);
                                 return (
                                     <button
                                         key={id}
                                         data-button-id={id}
                                         className={classes}
-                                        style={{ backgroundColor: cfg.label ? cfg.color : 'transparent' }}
+                                        style={{ backgroundColor: isEmpty ? 'transparent' : cfg.color }}
                                         onClick={handle}
                                     >
-                                        {cfg.label}
+                                        {isEmpty ? '' : cfg.label}
                                     </button>
                                 );
                             })}
@@ -291,42 +306,55 @@ function MobileButtons() {
                             size="sm"
                             className="mobile-button-macro"
                             value={activeCfg.macro}
-                            onChange={e => update(active!.set, active!.id, "macro", e.target.value as MacroType)}
+                            onChange={e => {
+                                const val = e.target.value as MacroType;
+                                if (val === 'empty') {
+                                    makeBlank(active!.set, active!.id);
+                                } else {
+                                    update(active!.set, active!.id, 'macro', val);
+                                }
+                            }}
                         >
                             {macroOptions.map(o => (
                                 <option key={o.value} value={o.value}>{o.label}</option>
                             ))}
                         </Form.Select>
                     </Form.Group>
-                    <Form.Group className="form-label mb-2">
-                        <Form.Label>Etykieta</Form.Label>
-                        <Form.Control
+                    {activeCfg.macro !== 'empty' && (
+                        <Form.Group className="form-label mb-2">
+                            <Form.Label>Etykieta</Form.Label>
+                            <Form.Control
+                                size="sm"
+                                className="mobile-button-label"
+                                type="text"
+                                value={activeCfg.label}
+                                onChange={e => update(active!.set, active!.id, 'label', e.target.value)}
+                            />
+                        </Form.Group>
+                    )}
+                    {activeCfg.macro !== 'empty' && (
+                        <Form.Group className="form-label mb-2 d-flex align-items-center gap-1">
+                            <Form.Label>Kolor</Form.Label>
+                            <Form.Control
+                                size="sm"
+                                type="color"
+                                className="mobile-button-color flex-grow-1"
+                                value={activeCfg.color}
+                                onChange={e => update(active!.set, active!.id, 'color', e.target.value)}
+                            />
+                            <Button size="sm" variant="secondary" onClick={() => resetColor(active!.set, active!.id)}>↺</Button>
+                        </Form.Group>
+                    )}
+                    {activeCfg.macro !== 'empty' && (
+                        <Button
                             size="sm"
-                            className="mobile-button-label"
-                            type="text"
-                            value={activeCfg.label}
-                            onChange={e => update(active!.set, active!.id, "label", e.target.value)}
-                        />
-                    </Form.Group>
-                    <Form.Group className="form-label mb-2 d-flex align-items-center gap-1">
-                        <Form.Label>Kolor</Form.Label>
-                        <Form.Control
-                            size="sm"
-                            type="color"
-                            className="mobile-button-color flex-grow-1"
-                            value={activeCfg.color}
-                            onChange={e => update(active!.set, active!.id, "color", e.target.value)}
-                        />
-                        <Button size="sm" variant="secondary" onClick={() => resetColor(active!.set, active!.id)}>↺</Button>
-                    </Form.Group>
-                    <Button
-                        size="sm"
-                        variant="secondary"
-                        className="mb-2"
-                        onClick={() => makeBlank(active!.set, active!.id)}
-                    >
-                        Pusty
-                    </Button>
+                            variant="secondary"
+                            className="mb-2"
+                            onClick={() => makeBlank(active!.set, active!.id)}
+                        >
+                            Pusty
+                        </Button>
+                    )}
                     {activeCfg.macro === "kierunek" && (
                         <Form.Group className="form-label mb-2">
                             <Form.Label>Kierunek</Form.Label>

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -10,6 +10,7 @@ import {
     Settings,
     defaultOrder,
     defaultCols,
+    createDefaultLayout,
 } from "../mobileButtonSettings";
 
 const macroOptions: { value: MacroType; label: string }[] = [
@@ -179,6 +180,14 @@ function MobileButtons() {
         }));
     }
 
+    function restoreDefaults(setName: 'solo' | 'team') {
+        setSettings(prev => ({
+            ...prev,
+            [setName]: createDefaultLayout(),
+        }));
+        setActive(null);
+    }
+
     function save() {
         saveSettings(settings);
         const teamActive = !!(window as any).clientExtension?.TeamManager?.getLeader?.();
@@ -191,20 +200,25 @@ function MobileButtons() {
 
     return (
         <div onClick={close} className="w-100 position-relative">
-            <div className="btn-group mb-2">
-                <Button
-                    size="sm"
-                    variant={view === 'solo' ? 'primary' : 'secondary'}
-                    onClick={() => changeView('solo')}
-                >
-                    Bez drużyny
-                </Button>
-                <Button
-                    size="sm"
-                    variant={view === 'team' ? 'primary' : 'secondary'}
-                    onClick={() => changeView('team')}
-                >
-                    W drużynie
+            <div className="d-flex align-items-center gap-2 mb-2">
+                <div className="btn-group">
+                    <Button
+                        size="sm"
+                        variant={view === 'solo' ? 'primary' : 'secondary'}
+                        onClick={() => changeView('solo')}
+                    >
+                        Bez drużyny
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant={view === 'team' ? 'primary' : 'secondary'}
+                        onClick={() => changeView('team')}
+                    >
+                        W drużynie
+                    </Button>
+                </div>
+                <Button size="sm" variant="secondary" onClick={() => restoreDefaults(view)}>
+                    Domyślne
                 </Button>
             </div>
             <div className="d-flex flex-column align-items-center mb-2">

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -8,6 +8,8 @@ import {
     ButtonSetting,
     MacroType,
     Settings,
+    defaultOrder,
+    defaultCols,
 } from "../mobileButtonSettings";
 
 const macroOptions: { value: MacroType; label: string }[] = [
@@ -24,10 +26,12 @@ const macroOptions: { value: MacroType; label: string }[] = [
 
 const directionOptions = ["nw","n","ne","w","e","sw","s","se","u","d"] as const;
 
+const emptySetting: ButtonSetting = { macro: 'command', label: '', color: 'transparent' };
+
 type SettingsMap = Record<string, ButtonSetting>;
 
 function MobileButtons() {
-    const [settings, setSettings] = useState<Settings>({ solo: {}, team: {} });
+    const [settings, setSettings] = useState<Settings>({ solo: {}, team: {}, order: [...defaultOrder], cols: defaultCols });
     const [active, setActive] = useState<{ set: 'solo' | 'team'; id: string } | null>(null);
     const [pos, setPos] = useState<{ left: number; top: number }>({ left: 0, top: 0 });
     const [view, setView] = useState<'solo' | 'team'>('solo');
@@ -37,43 +41,95 @@ function MobileButtons() {
     useEffect(() => {
         loadSettings().then(setSettings);
     }, []);
-
     const notEditable = ['buttons-toggle'];
-    const order = [
-        'z-list-toggle',
-        'zas-list-toggle',
-        'go-button',
-        'buttons-toggle',
-        'bracket-right-button',
-        'button-1',
-        'button-2',
-        'button-3',
-        'nw-button',
-        'n-button',
-        'ne-button',
-        'u-button',
-        'w-button',
-        'c-button',
-        'e-button',
-        'd-button',
-        'sw-button',
-        's-button',
-        'se-button',
-        'special-exit-button',
-    ];
 
-    const topButtons = [
-        'z-list-toggle',
-        'zas-list-toggle',
-        'go-button',
-        'buttons-toggle',
-        'bracket-right-button',
-        'button-1',
-        'button-2',
-        'button-3',
-    ];
+    function nextId(ids: string[]) {
+        const max = ids.reduce((m, id) => {
+            const match = /^button-(\d+)$/.exec(id);
+            return match ? Math.max(m, parseInt(match[1], 10)) : m;
+        }, 3);
+        let current = max;
+        return () => `button-${++current}`;
+    }
 
-    const textDirButtons = ['u-button', 'c-button', 'd-button', 'special-exit-button'];
+    function addRow(pos: 'top' | 'bottom') {
+        setSettings(prev => {
+            const makeId = nextId(prev.order);
+            const ids = Array.from({ length: prev.cols }, () => makeId());
+            const solo: SettingsMap = { ...prev.solo };
+            const team: SettingsMap = { ...prev.team };
+            ids.forEach(id => {
+                solo[id] = { ...emptySetting };
+                team[id] = { ...emptySetting };
+            });
+            const order = pos === 'top' ? [...ids, ...prev.order] : [...prev.order, ...ids];
+            return { ...prev, solo, team, order };
+        });
+    }
+
+    function removeRow(pos: 'top' | 'bottom') {
+        setSettings(prev => {
+            const rows = Math.floor(prev.order.length / prev.cols);
+            if (rows <= 1) return prev;
+            const start = pos === 'top' ? 0 : prev.order.length - prev.cols;
+            const removed = prev.order.slice(start, start + prev.cols);
+            const order = pos === 'top' ? prev.order.slice(prev.cols) : prev.order.slice(0, start);
+            const solo: SettingsMap = { ...prev.solo };
+            const team: SettingsMap = { ...prev.team };
+            removed.forEach(id => { delete solo[id]; delete team[id]; });
+            return { ...prev, solo, team, order };
+        });
+    }
+
+    function addCol(side: 'left' | 'right') {
+        setSettings(prev => {
+            const makeId = nextId(prev.order);
+            const solo: SettingsMap = { ...prev.solo };
+            const team: SettingsMap = { ...prev.team };
+            const order: string[] = [];
+            const rows = Math.floor(prev.order.length / prev.cols);
+            for (let r = 0; r < rows; r++) {
+                if (side === 'left') {
+                    const id = makeId();
+                    order.push(id);
+                    solo[id] = { ...emptySetting };
+                    team[id] = { ...emptySetting };
+                }
+                const row = prev.order.slice(r * prev.cols, (r + 1) * prev.cols);
+                order.push(...row);
+                if (side === 'right') {
+                    const id = makeId();
+                    order.push(id);
+                    solo[id] = { ...emptySetting };
+                    team[id] = { ...emptySetting };
+                }
+            }
+            return { ...prev, solo, team, order, cols: prev.cols + 1 };
+        });
+    }
+
+    function removeCol(side: 'left' | 'right') {
+        setSettings(prev => {
+            if (prev.cols <= 1) return prev;
+            const rows = Math.floor(prev.order.length / prev.cols);
+            const order: string[] = [];
+            const removed: string[] = [];
+            for (let r = 0; r < rows; r++) {
+                const row = prev.order.slice(r * prev.cols, (r + 1) * prev.cols);
+                if (side === 'left') {
+                    removed.push(row[0]);
+                    order.push(...row.slice(1));
+                } else {
+                    removed.push(row[row.length - 1]);
+                    order.push(...row.slice(0, row.length - 1));
+                }
+            }
+            const solo: SettingsMap = { ...prev.solo };
+            const team: SettingsMap = { ...prev.team };
+            removed.forEach(id => { delete solo[id]; delete team[id]; });
+            return { ...prev, solo, team, order, cols: prev.cols - 1 };
+        });
+    }
 
     function openConfig(setName: 'solo' | 'team', id: string, ev: React.MouseEvent<HTMLButtonElement>) {
         const rect = ev.currentTarget.getBoundingClientRect();
@@ -99,7 +155,8 @@ function MobileButtons() {
     }
 
     function resetColor(setName: 'solo' | 'team', id: string) {
-        update(setName, "color", defaultSettings[id].color);
+        const def = defaultSettings[id]?.color || emptySetting.color;
+        update(setName, "color", def);
     }
 
     function save() {
@@ -110,7 +167,7 @@ function MobileButtons() {
         modal?.hide();
     }
 
-    const activeCfg = active ? (settings[active.set][active.id] || defaultSettings[active.id]) : null;
+    const activeCfg = active ? (settings[active.set][active.id] || defaultSettings[active.id] || emptySetting) : null;
 
     return (
         <div onClick={close} className="w-100 position-relative">
@@ -130,21 +187,35 @@ function MobileButtons() {
                     W drużynie
                 </Button>
             </div>
+            <div className="d-flex justify-content-between mb-2 flex-wrap gap-2">
+                <div className="btn-group">
+                    <Button size="sm" variant="secondary" onClick={() => addRow('top')}>+R↑</Button>
+                    <Button size="sm" variant="secondary" onClick={() => removeRow('top')}>-R↑</Button>
+                    <Button size="sm" variant="secondary" onClick={() => addRow('bottom')}>+R↓</Button>
+                    <Button size="sm" variant="secondary" onClick={() => removeRow('bottom')}>-R↓</Button>
+                </div>
+                <div className="btn-group">
+                    <Button size="sm" variant="secondary" onClick={() => addCol('left')}>+C←</Button>
+                    <Button size="sm" variant="secondary" onClick={() => removeCol('left')}>-C←</Button>
+                    <Button size="sm" variant="secondary" onClick={() => addCol('right')}>+C→</Button>
+                    <Button size="sm" variant="secondary" onClick={() => removeCol('right')}>-C→</Button>
+                </div>
+            </div>
             <div
                 ref={soloRef}
                 id="mobile-buttons-preview-solo"
                 className={`mobile-direction-buttons mb-2 ${view === 'solo' ? '' : 'd-none'}`}
+                style={{ gridTemplateColumns: `repeat(${settings.cols}, auto)` }}
             >
-                {order.map(id => {
-                    const cfg = settings.solo[id] || defaultSettings[id] || { label: '⇩', color: '#6EB4DC', macro: 'functional' };
+                {settings.order.map(id => {
+                    const cfg = settings.solo[id] || defaultSettings[id] || emptySetting;
                     let classes = 'mobile-button';
-                    if (topButtons.includes(id)) {
-                        classes += ' mobile-button-text top-button';
-                    } else if (textDirButtons.includes(id)) {
-                        classes += ' mobile-button-text direction-button';
-                    } else {
+                    if (cfg.macro === 'kierunek') {
                         classes += ' direction-button';
+                    } else {
+                        classes += ' mobile-button-text';
                     }
+                    if (!cfg.label) classes += ' empty';
                     const handle = notEditable.includes(id) ? undefined : (ev: React.MouseEvent<HTMLButtonElement>) => openConfig('solo', id, ev);
                     return (
                         <button
@@ -163,17 +234,17 @@ function MobileButtons() {
                 ref={teamRef}
                 id="mobile-buttons-preview-team"
                 className={`mobile-direction-buttons mb-2 ${view === 'team' ? '' : 'd-none'}`}
+                style={{ gridTemplateColumns: `repeat(${settings.cols}, auto)` }}
             >
-                {order.map(id => {
-                    const cfg = settings.team[id] || defaultSettings[id] || { label: '⇩', color: '#6EB4DC', macro: 'functional' };
+                {settings.order.map(id => {
+                    const cfg = settings.team[id] || defaultSettings[id] || emptySetting;
                     let classes = 'mobile-button';
-                    if (topButtons.includes(id)) {
-                        classes += ' mobile-button-text top-button';
-                    } else if (textDirButtons.includes(id)) {
-                        classes += ' mobile-button-text direction-button';
-                    } else {
+                    if (cfg.macro === 'kierunek') {
                         classes += ' direction-button';
+                    } else {
+                        classes += ' mobile-button-text';
                     }
+                    if (!cfg.label) classes += ' empty';
                     const handle = notEditable.includes(id) ? undefined : (ev: React.MouseEvent<HTMLButtonElement>) => openConfig('team', id, ev);
                     return (
                         <button

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -39,7 +39,10 @@ export default class MobileDirectionButtons {
     private lastScrollTop = 0;
     private collapsed = false;
     private directionButtons: Record<string, HTMLButtonElement | null> = {};
-    private allSettings: Settings = { solo: {}, team: {} };
+    private allSettings: Settings = {
+        solo: { buttons: {}, order: [], cols: 0 },
+        team: { buttons: {}, order: [], cols: 0 },
+    };
     private buttonSettings: Record<string, ButtonSetting> = {};
     private teamMode = false;
 
@@ -563,7 +566,7 @@ export default class MobileDirectionButtons {
     }
 
     private applyActiveSettings() {
-        this.buttonSettings = this.teamMode ? this.allSettings.team : this.allSettings.solo;
+        this.buttonSettings = (this.teamMode ? this.allSettings.team : this.allSettings.solo).buttons;
         Object.keys(this.buttonSettings).forEach(id => {
             const btn = document.getElementById(id) as HTMLButtonElement | null;
             if (btn) this.applyConfigToButton(id, btn);
@@ -573,8 +576,9 @@ export default class MobileDirectionButtons {
     private applyConfigToButton(id: string, btn: HTMLButtonElement) {
         const cfg = this.buttonSettings[id];
         if (!cfg) return;
-        btn.textContent = cfg.label;
-        if (!cfg.label) {
+        const isEmpty = cfg.macro === 'empty' || !cfg.label;
+        btn.textContent = isEmpty ? '' : cfg.label;
+        if (isEmpty) {
             btn.classList.add('empty');
             btn.style.backgroundColor = 'transparent';
             btn.style.border = 'none';
@@ -610,6 +614,8 @@ export default class MobileDirectionButtons {
 
         const handler = () => {
             switch (cfg.macro) {
+                case 'empty':
+                    break;
                 case 'functional':
                     const event = new KeyboardEvent('keydown', {
                         code: this.boundKey,

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -175,6 +175,24 @@ export default class MobileDirectionButtons {
 
         this.client.addEventListener('mobileButtonsSettings', (ev: CustomEvent) => {
             this.buttonSettings = ev.detail || this.buttonSettings;
+            this.toggleButton = document.getElementById('buttons-toggle') as HTMLButtonElement | null;
+            this.bracketRightButton = document.getElementById('bracket-right-button') as HTMLButtonElement | null;
+            this.zToggle = document.getElementById('z-list-toggle') as HTMLButtonElement | null;
+            this.zasToggle = document.getElementById('zas-list-toggle') as HTMLButtonElement | null;
+            this.idzToggle = null;
+            this.directionButtons = {
+                nw: document.getElementById('nw-button') as HTMLButtonElement | null,
+                n: document.getElementById('n-button') as HTMLButtonElement | null,
+                ne: document.getElementById('ne-button') as HTMLButtonElement | null,
+                w: document.getElementById('w-button') as HTMLButtonElement | null,
+                e: document.getElementById('e-button') as HTMLButtonElement | null,
+                sw: document.getElementById('sw-button') as HTMLButtonElement | null,
+                s: document.getElementById('s-button') as HTMLButtonElement | null,
+                se: document.getElementById('se-button') as HTMLButtonElement | null,
+                u: document.getElementById('u-button') as HTMLButtonElement | null,
+                d: document.getElementById('d-button') as HTMLButtonElement | null,
+            };
+            this.setupEventHandlers();
             Object.keys(this.buttonSettings).forEach(id => {
                 const b = document.getElementById(id) as HTMLButtonElement | null;
                 if (b) this.applyConfigToButton(id, b);
@@ -217,9 +235,9 @@ export default class MobileDirectionButtons {
 
 
         if (this.toggleButton) {
-            this.toggleButton.addEventListener('click', () => {
+            this.toggleButton.onclick = () => {
                 this.toggleVisibility();
-            });
+            };
         }
 
         // Center and special exit buttons configured via settings
@@ -555,7 +573,15 @@ export default class MobileDirectionButtons {
         const cfg = this.buttonSettings[id];
         if (!cfg) return;
         btn.textContent = cfg.label;
-        btn.style.backgroundColor = cfg.color;
+        if (!cfg.label) {
+            btn.classList.add('empty');
+            btn.style.backgroundColor = 'transparent';
+            btn.style.border = 'none';
+        } else {
+            btn.classList.remove('empty');
+            btn.style.backgroundColor = cfg.color;
+            btn.style.border = '';
+        }
         const clone = btn.cloneNode(true) as HTMLButtonElement;
         btn.replaceWith(clone);
         const newBtn = clone;

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -192,6 +192,7 @@ export default class MobileDirectionButtons {
                 u: document.getElementById('u-button') as HTMLButtonElement | null,
                 d: document.getElementById('d-button') as HTMLButtonElement | null,
             };
+            this.updateToggleButton();
             this.setupEventHandlers();
             Object.keys(this.buttonSettings).forEach(id => {
                 const b = document.getElementById(id) as HTMLButtonElement | null;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -571,6 +571,10 @@ button:focus-visible {
   box-shadow: none;
 }
 
+.mobile-direction-buttons.preview .mobile-button.empty {
+  border: 1px dashed #888;
+}
+
 .mobile-button.active {
   filter: brightness(85%);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -565,6 +565,12 @@ button:focus-visible {
   touch-action: manipulation; /* Improve touch behavior */
 }
 
+.mobile-button.empty {
+  background-color: transparent;
+  border: none;
+  box-shadow: none;
+}
+
 .mobile-button.active {
   filter: brightness(85%);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
## Summary
- allow configuring mobile button grid dimensions
- support adding/removing rows and columns with empty placeholders
- refresh button handlers and styling when layout changes

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`


------
https://chatgpt.com/codex/tasks/task_e_688f64d5fc68832a975fdd11755e5bac