### PR TITLE
feat: add import/export for user settings

### DIFF
--- a/web-client/src/options/Aliases.tsx
+++ b/web-client/src/options/Aliases.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, ChangeEvent } from "react";
+import { useEffect, useState, ChangeEvent, useRef } from "react";
 import { Button, Form } from "react-bootstrap";
 import { TiDelete, TiEdit } from "react-icons/ti";
 import storage from "@client/src/storage";
@@ -15,6 +15,7 @@ function Aliases() {
     const [editIndex, setEditIndex] = useState<number | null>(null);
     const [showCreateForm, setShowCreateForm] = useState(false);
     const [filter, setFilter] = useState("");
+    const fileInput = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         storage.getItem("aliases").then(res => {
@@ -75,6 +76,36 @@ function Aliases() {
         saveList(updated);
     }
 
+    function exportAliases() {
+        const json = JSON.stringify(aliases, null, 2);
+        const blob = new Blob([json], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'arkadia-aliases.json';
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+
+    function importAliases(ev: ChangeEvent<HTMLInputElement>) {
+        const file = ev.target.files?.[0];
+        if (!file) return;
+        file.text().then(text => {
+            try {
+                const data = JSON.parse(text);
+                if (Array.isArray(data) && data.every(d => typeof d.pattern === 'string' && typeof d.command === 'string')) {
+                    saveList(data);
+                } else {
+                    alert('Błędny plik');
+                }
+            } catch {
+                alert('Błędny plik');
+            } finally {
+                if (fileInput.current) fileInput.current.value = '';
+            }
+        });
+    }
+
     const filteredAliases = aliases.filter(a =>
         a.pattern.toLowerCase().includes(filter.toLowerCase()) ||
         a.command.toLowerCase().includes(filter.toLowerCase())
@@ -82,7 +113,7 @@ function Aliases() {
 
     return (
         <div className="m-2 d-flex flex-column gap-2">
-            <div className="d-flex gap-2 align-items-center">
+            <div className="d-flex gap-2 align-items-center flex-wrap">
                 <Form.Control
                     type="text"
                     size="sm"
@@ -92,6 +123,15 @@ function Aliases() {
                     style={{width: '100%', maxWidth: '12rem'}}
                 />
                 <Button size="sm" onClick={openNew}>Dodaj alias</Button>
+                <Button size="sm" variant="secondary" onClick={exportAliases}>Eksport</Button>
+                <Button size="sm" variant="secondary" onClick={() => fileInput.current?.click()}>Importuj</Button>
+                <input
+                    ref={fileInput}
+                    type="file"
+                    accept="application/json"
+                    style={{ display: 'none' }}
+                    onChange={importAliases}
+                />
             </div>
             
             {showCreateForm && (

--- a/web-client/src/options/Guilds.tsx
+++ b/web-client/src/options/Guilds.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, ChangeEvent, useRef } from "react";
 import { Button } from "react-bootstrap";
 import storage, { getCurrentCharacter } from "@client/src/storage";
 import GuildSection from "./GuildSection";
@@ -10,6 +10,7 @@ function Guilds() {
     const [enemySelected, setEnemySelected] = useState<string[]>([]);
     const [colors, setColors] = useState<Record<string, string | undefined>>({});
     const [locked, setLocked] = useState(!getCurrentCharacter());
+    const fileInput = useRef<HTMLInputElement>(null);
     const defaultColors = useMemo(() => {
         const map: Record<string, string> = {};
         guilds.forEach(g => {
@@ -105,6 +106,41 @@ function Guilds() {
         });
     }
 
+    function exportGuilds() {
+        const data = { guilds: selected, enemyGuilds: enemySelected, guildColors: colors };
+        const json = JSON.stringify(data, null, 2);
+        const blob = new Blob([json], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'arkadia-guilds.json';
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+
+    async function importGuilds(ev: ChangeEvent<HTMLInputElement>) {
+        const file = ev.target.files?.[0];
+        if (!file) return;
+        try {
+            const text = await file.text();
+            const data = JSON.parse(text);
+            if (!data || !Array.isArray(data.guilds) || !Array.isArray(data.enemyGuilds) || typeof data.guildColors !== 'object') {
+                throw new Error();
+            }
+            const res = await storage.getItem('settings');
+            const base = res && res.settings ? { ...defaultSettings, ...res.settings } : { ...defaultSettings };
+            const settings = { ...base, guilds: data.guilds, enemyGuilds: data.enemyGuilds, guildColors: data.guildColors };
+            await storage.setItem('settings', settings);
+            setSelected(data.guilds);
+            setEnemySelected(data.enemyGuilds);
+            setColors(data.guildColors || {});
+        } catch {
+            alert('Błędny plik');
+        } finally {
+            if (fileInput.current) fileInput.current.value = '';
+        }
+    }
+
     const char = getCurrentCharacter();
 
     return (
@@ -130,7 +166,24 @@ function Guilds() {
                     onChangeAll={onChangeAll}
                     onChangeAllEnemy={onChangeAllEnemy}
                 />
-                <Button onClick={save}>Zapisz</Button>
+                <div className="d-flex gap-2 mt-2 flex-wrap">
+                    <Button size="sm" variant="secondary" onClick={exportGuilds}>Eksport</Button>
+                    <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => fileInput.current?.click()}
+                    >
+                        Importuj
+                    </Button>
+                    <Button onClick={save}>Zapisz</Button>
+                    <input
+                        ref={fileInput}
+                        type="file"
+                        accept="application/json"
+                        style={{ display: 'none' }}
+                        onChange={importGuilds}
+                    />
+                </div>
             </fieldset>
         </div>
     );

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, ChangeEvent } from "react";
 import { Button, Form } from "react-bootstrap";
 import {
     loadSettings,
@@ -42,6 +42,7 @@ function MobileButtons() {
     const [view, setView] = useState<'solo' | 'team'>('solo');
     const soloRef = useRef<HTMLDivElement>(null);
     const teamRef = useRef<HTMLDivElement>(null);
+    const fileInput = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         loadSettings().then(setSettings);
@@ -131,6 +132,38 @@ function MobileButtons() {
             removed.forEach(id => { delete buttons[id]; });
             return { ...prev, [view]: { ...set, buttons, order, cols: set.cols - 1 } };
         });
+    }
+
+    async function exportButtons() {
+        const cfg = await loadSettings();
+        const json = JSON.stringify(cfg, null, 2);
+        const blob = new Blob([json], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'arkadia-mobile-buttons.json';
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+
+    async function importButtons(ev: ChangeEvent<HTMLInputElement>) {
+        const file = ev.target.files?.[0];
+        if (!file) return;
+        try {
+            const text = await file.text();
+            const data = JSON.parse(text);
+            if (data && typeof data === 'object' && data.solo && data.team) {
+                saveSettings(data);
+                setSettings(data);
+                applySettings(data);
+            } else {
+                alert('Błędny plik');
+            }
+        } catch {
+            alert('Błędny plik');
+        } finally {
+            if (fileInput.current) fileInput.current.value = '';
+        }
     }
 
     function openConfig(setName: 'solo' | 'team', id: string, ev: React.MouseEvent<HTMLButtonElement>) {
@@ -398,8 +431,23 @@ function MobileButtons() {
                     )}
                 </div>
             )}
-            <div className="d-flex justify-content-end mt-2">
+            <div className="d-flex justify-content-end gap-2 mt-2 flex-wrap">
+                <Button size="sm" variant="secondary" onClick={exportButtons}>Eksport</Button>
+                <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => fileInput.current?.click()}
+                >
+                    Importuj
+                </Button>
                 <Button id="mobile-buttons-save" onClick={save}>Zapisz</Button>
+                <input
+                    ref={fileInput}
+                    type="file"
+                    accept="application/json"
+                    style={{ display: 'none' }}
+                    onChange={importButtons}
+                />
             </div>
         </div>
     );

--- a/web-client/src/options/Scripts.tsx
+++ b/web-client/src/options/Scripts.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, ChangeEvent } from "react";
+import { useEffect, useState, ChangeEvent, useRef } from "react";
 import { Button, Form } from "react-bootstrap";
 import { TiDelete } from "react-icons/ti";
 import storage from "@client/src/storage";
@@ -6,6 +6,7 @@ import storage from "@client/src/storage";
 function Scripts() {
     const [scripts, setScripts] = useState<string[]>([]);
     const [input, setInput] = useState("");
+    const fileInput = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         storage.getItem("scripts").then(res => {
@@ -33,6 +34,36 @@ function Scripts() {
     function remove(url: string) {
         const updated = scripts.filter(u => u !== url);
         save(updated);
+    }
+
+    function exportScripts() {
+        const json = JSON.stringify(scripts, null, 2);
+        const blob = new Blob([json], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'arkadia-scripts.json';
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+
+    function importScripts(ev: ChangeEvent<HTMLInputElement>) {
+        const file = ev.target.files?.[0];
+        if (!file) return;
+        file.text().then(text => {
+            try {
+                const data = JSON.parse(text);
+                if (Array.isArray(data) && data.every(d => typeof d === 'string')) {
+                    save(data);
+                } else {
+                    alert('Błędny plik');
+                }
+            } catch {
+                alert('Błędny plik');
+            } finally {
+                if (fileInput.current) fileInput.current.value = '';
+            }
+        });
     }
 
     return (
@@ -64,6 +95,17 @@ function Scripts() {
                     </li>
                 ))}
             </ul>
+            <div className="d-flex gap-2">
+                <Button size="sm" variant="secondary" onClick={exportScripts}>Eksport</Button>
+                <Button size="sm" variant="secondary" onClick={() => fileInput.current?.click()}>Importuj</Button>
+                <input
+                    ref={fileInput}
+                    type="file"
+                    accept="application/json"
+                    style={{ display: 'none' }}
+                    onChange={importScripts}
+                />
+            </div>
         </div>
     );
 }

--- a/web-client/src/options/UserTriggers.tsx
+++ b/web-client/src/options/UserTriggers.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, ChangeEvent } from "react";
+import { useEffect, useState, ChangeEvent, useRef } from "react";
 import { Button, Form } from "react-bootstrap";
 import { TiDelete, TiEdit } from "react-icons/ti";
 import storage from "@client/src/storage";
@@ -58,6 +58,7 @@ function UserTriggers() {
     const [editIndex, setEditIndex] = useState<number | null>(null);
     const [showCreateForm, setShowCreateForm] = useState(false);
     const [filter, setFilter] = useState('');
+    const fileInput = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         storage.getItem('triggers').then(res => {
@@ -94,7 +95,37 @@ function UserTriggers() {
     function remove(idx: number) {
         if (!confirm('Delete trigger?')) return;
         const updated = triggers.filter((_, i) => i !== idx);
-        saveList(updated);
+       saveList(updated);
+    }
+
+    function exportTriggers() {
+        const json = JSON.stringify(triggers, null, 2);
+        const blob = new Blob([json], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'arkadia-triggers.json';
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+
+    function importTriggers(ev: ChangeEvent<HTMLInputElement>) {
+        const file = ev.target.files?.[0];
+        if (!file) return;
+        file.text().then(text => {
+            try {
+                const data = JSON.parse(text);
+                if (Array.isArray(data) && data.every(d => typeof d.pattern === 'string' && Array.isArray(d.macros))) {
+                    saveList(data);
+                } else {
+                    alert('Błędny plik');
+                }
+            } catch {
+                alert('Błędny plik');
+            } finally {
+                if (fileInput.current) fileInput.current.value = '';
+            }
+        });
     }
 
     function addMacro() {
@@ -130,7 +161,7 @@ function UserTriggers() {
 
     return (
         <div className="m-2 d-flex flex-column gap-2">
-            <div className="d-flex gap-2 align-items-center">
+            <div className="d-flex gap-2 align-items-center flex-wrap">
                 <Form.Control
                     type="text"
                     size="sm"
@@ -140,6 +171,15 @@ function UserTriggers() {
                     style={{ width: '100%', maxWidth: '12rem' }}
                 />
                 <Button size="sm" onClick={openNew}>Add trigger</Button>
+                <Button size="sm" variant="secondary" onClick={exportTriggers}>Export</Button>
+                <Button size="sm" variant="secondary" onClick={() => fileInput.current?.click()}>Import</Button>
+                <input
+                    ref={fileInput}
+                    type="file"
+                    accept="application/json"
+                    style={{ display: 'none' }}
+                    onChange={importTriggers}
+                />
             </div>
             
             {showCreateForm && (


### PR DESCRIPTION
## Summary
- allow aliases to be saved and loaded from JSON files
- add JSON import/export for user triggers
- support saving/restoring mobile button layouts
- allow exporting/importing guild preferences and script URLs

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_688ff8789028832aa1bef7b06d901323