### PR TITLE
feat: add macro to toggle mobile buttons

### DIFF
--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -10,6 +10,7 @@ export type MacroType =
     | 'kierunek'
     | 'wesprzyj'
     | 'moveMode'
+    | 'toggleButtons'
     | 'empty';
 
 export interface ButtonSetting {
@@ -25,7 +26,7 @@ export const defaultSettings: Record<string, ButtonSetting> = {
     'z-list-toggle': { macro: 'zList', label: '/z', color: '#6EB4DC' },
     'zas-list-toggle': { macro: 'zaList', label: '/za', color: '#6EB4DC' },
     'go-button': { macro: 'command', label: '/go', color: '#6EB4DC', command: '/go' },
-    'buttons-toggle': { macro: 'functional', label: '⇩', color: '#6EB4DC' },
+    'buttons-toggle': { macro: 'toggleButtons', label: '⇩', color: '#6EB4DC' },
     'bracket-right-button': { macro: 'functional', label: ']', color: '#6EB4DC' },
     'button-1': { macro: 'wesprzyj', label: 'wesprzyj', color: '#6EB4DC' },
     'button-2': { macro: 'command', label: '/z cel', color: '#6EB4DC', command: '/z' },

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -23,6 +23,7 @@ const macroOptions: { value: MacroType; label: string }[] = [
     { value: "specialExit", label: "Wyjście specjalne" },
     { value: "wesprzyj", label: "Wesprzyj prowadzącego" },
     { value: "moveMode", label: "Tryb ruchu" },
+    { value: "toggleButtons", label: "Przełącz przyciski" },
     { value: "empty", label: "Puste" },
 ];
 

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -592,6 +592,10 @@ export default class MobileDirectionButtons {
         const newBtn = clone;
         this.applyButtonSize(newBtn);
         if (id === 'bracket-right-button') this.bracketRightButton = newBtn;
+        if (id === 'buttons-toggle') {
+            this.toggleButton = newBtn;
+            this.updateToggleButton();
+        }
         if (id === 'z-list-toggle') this.zToggle = newBtn;
         if (id === 'zas-list-toggle') this.zasToggle = newBtn;
         if (cfg.macro === 'idzList') {
@@ -657,6 +661,9 @@ export default class MobileDirectionButtons {
                         if (this.idzList) this.idzList.style.display = 'grid';
                         newBtn.classList.add('active');
                     }
+                    break;
+                case 'toggleButtons':
+                    this.toggleVisibility();
                     break;
                 case 'command':
                     if (cfg.command) this.client.sendCommand(cfg.command);


### PR DESCRIPTION
## Summary
- add `toggleButtons` macro type for mobile buttons
- default top-right button toggles visibility using new macro
- expose toggle macro in mobile button settings UI

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_68903ba39c9c832a8a05dff2e8eb5545