### PR TITLE
Treat triggers and groups uniformly in gag extraction

### DIFF
--- a/client/src/People.ts
+++ b/client/src/People.ts
@@ -1,7 +1,7 @@
 import people from './people.json'
 import Client from "./Client";
-import { color, RESET, findClosestColor } from './Colors';
-import { stripAnsiCodes } from './Triggers';
+import {color, RESET, findClosestColor} from './Colors';
+import {stripAnsiCodes} from './Triggers';
 
 export default class People {
 
@@ -63,7 +63,7 @@ export default class People {
                 return prefix + highlighted + suffixText + suffix
             }
 
-            this.client.Triggers.registerTokenTrigger(replacement.description, descCallback, this.tag)
+            this.client.Triggers.registerTokenTrigger(replacement.description, descCallback, this.tag, {caseInsensitive: true})
 
             if (isEnemy || (inGuild && guildColor !== undefined)) {
                 const key = `${replacement.name}|${replacement.guild}`
@@ -77,7 +77,7 @@ export default class People {
                         const highlighted = color(chosenColor) + token + RESET
                         return prefix + highlighted + suffix
                     }
-                    this.client.Triggers.registerTokenTrigger(replacement.name, nameCallback, this.tag)
+                    this.client.Triggers.registerTokenTrigger(replacement.name, nameCallback, this.tag, {caseInsensitive: true})
                     addedNames.add(key)
                 }
             }

--- a/client/src/Triggers.ts
+++ b/client/src/Triggers.ts
@@ -84,7 +84,7 @@ export class Trigger {
                 matches = line.match(pattern);
             } else if (typeof pattern === "string") {
                 const patternStr = pattern.toString();
-                const index = rawLine.toLowerCase().indexOf(patternStr.toLowerCase());
+                const index = rawLine.indexOf(patternStr);
                 if (index > -1) {
                     const end = index + patternStr.length;
                     matches = [rawLine.substring(index, end)];
@@ -97,7 +97,7 @@ export class Trigger {
                 break;
             }
         }
-        let matched = false;
+        let matched = patterns.length == 0;
         if (matches) {
             matched = true;
             if (this.options.stayOpenLines && this.options.stayOpenLines > 0) {

--- a/client/src/Triggers.ts
+++ b/client/src/Triggers.ts
@@ -21,6 +21,7 @@ type TriggerPattern = TriggerSubPattern | TriggerSubPattern[];
 
 export interface TriggerOptions {
     stayOpenLines?: number;
+    caseInsensitive?: boolean;
 }
 
 export function isType(type: string): TriggerMatchFunction {
@@ -84,7 +85,7 @@ export class Trigger {
                 matches = line.match(pattern);
             } else if (typeof pattern === "string") {
                 const patternStr = pattern.toString();
-                const index = rawLine.indexOf(patternStr);
+                const index = !this.options.caseInsensitive ? rawLine.indexOf(patternStr) : rawLine.toLowerCase().indexOf(patternStr.toLowerCase());
                 if (index > -1) {
                     const end = index + patternStr.length;
                     matches = [rawLine.substring(index, end)];

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -70,7 +70,7 @@ export function registerScripts(client: Client) {
     aliases.push({
         pattern: /\/fake (.*)/,
         callback: (matches: RegExpMatchArray) => {
-            client.clientAdapter.output(client.clientAdapter.parseAnsiPatterns(client.onLine(matches[1], 'other')))
+            client.clientAdapter.output(client.clientAdapter.parseAnsiPatterns(client.onLine(matches[1], 'combat.avatar')))
             // @ts-ignore
             client.clientAdapter.flushMessageBuffer() //TODO figure that one
         }

--- a/client/src/scripts/gags_lua.json
+++ b/client/src/scripts/gags_lua.json
@@ -2,13 +2,11 @@
   {
     "name": "gags",
     "patterns": [],
-    "triggers": [],
-    "groups": [
+    "triggers": [
       {
         "name": "color",
         "patterns": [],
-        "triggers": [],
-        "groups": [
+        "triggers": [
           {
             "name": "combat",
             "patterns": [
@@ -17,13 +15,11 @@
                 "type": 4
               }
             ],
-            "triggers": [],
-            "groups": [
+            "triggers": [
               {
                 "name": "bronie",
                 "patterns": [],
-                "triggers": [],
-                "groups": [
+                "triggers": [
                   {
                     "name": "srebrny_miecz",
                     "patterns": [
@@ -35,66 +31,65 @@
                     "triggers": [
                       {
                         "name": "srebrny_1",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_srebrny_miecz_srebrny_1()",
                         "patterns": [
                           {
                             "pattern": "Swobodnym ruchem swojego srebrnego kunsztownego miecza zacinasz lekko skore [a-zA-Z ]+ trafiajac [a-z ]+ w [a-z ]+\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_srebrny_miecz_srebrny_1()"
                       },
                       {
                         "name": "srebrny_2",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_srebrny_miecz_srebrny_2()",
                         "patterns": [
                           {
                             "pattern": "Ze zgrabnego wypadu tniesz miekko swoim srebrnym kunsztownym mieczem w [a-zA-Z ]+ pozostawiajac na [a-z ]+ ciele niewielka rane\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_srebrny_miecz_srebrny_2()"
                       },
                       {
                         "name": "srebrny_3",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_srebrny_miecz_srebrny_3()",
                         "patterns": [
                           {
                             "pattern": "Wprawnym ruchem ze swistem uderzasz swoim srebrnym kunsztownym mieczem w [a-zA-Z ]+ otwierajac bolesna, obficie krwawiaca rane\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_srebrny_miecz_srebrny_3()"
                       },
                       {
                         "name": "srebrny_4",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_srebrny_miecz_srebrny_4()",
                         "patterns": [
                           {
                             "pattern": "Mocnym cieciem uderzasz w [a-zA-Z ]+\\. Karby na ostrzu twojego srebrnego kunsztownego miecza natychmiast rozrywaja [a-z]+ skore, a krew splywa ze swiezo otwartych, szarpanych ran\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_srebrny_miecz_srebrny_4()"
                       },
                       {
                         "name": "srebrny_5",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_srebrny_miecz_srebrny_5()",
                         "patterns": [
                           {
                             "pattern": "Dopadasz [a-zA-Z ]+ i tniesz [a-z]+ z polobrotu w [a-z ]+ zalewajac ziemie i swoj srebrny kunsztowny miecz karmazynowa posoka\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_srebrny_miecz_srebrny_5()"
                       },
                       {
                         "name": "srebrny_fin",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_srebrny_miecz_srebrny_fin()",
                         "patterns": [
                           {
                             "pattern": "Podbiegasz do [a-zA-Z ]+ i spokojnym, precyzyjnym ruchem wyprowadzasz szerokie ciecie w [a-z ]+, a karby na twoim srebrnym kunsztownym mieczu rozrywaja cialo wroga\\. Widzisz, jak ostatkiem sil [a-zA-Z ]+ probuje wstac, lecz po chwili z cichym jekiem osuwa sie na ziemie\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_srebrny_miecz_srebrny_fin()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "jasniejace_bronie",
@@ -111,7 +106,6 @@
                     "triggers": [
                       {
                         "name": "jasniejacy_0",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(0)",
                         "patterns": [
                           {
                             "pattern": "Niecelny cios zdobion",
@@ -125,90 +119,90 @@
                             "pattern": " z trudem uskakuje przed morderczym ciosem ",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(0)"
                       },
                       {
                         "name": "jasniejacy_1",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(1)",
                         "patterns": [
                           {
                             "pattern": "Z szybkiego zamachu",
                             "type": 2
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(1)"
                       },
                       {
                         "name": "jasniejacy_2",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(2)",
                         "patterns": [
                           {
                             "pattern": "krwawy slad",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(2)"
                       },
                       {
                         "name": "jasniejacy_3",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(3)",
                         "patterns": [
                           {
                             "pattern": "jarzacym sie jasnym swiatlem orezem",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(3)"
                       },
                       {
                         "name": "jasniejacy_4",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(4)",
                         "patterns": [
                           {
                             "pattern": "W momencie, kiedy pelen sily cios",
                             "type": 2
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(4)"
                       },
                       {
                         "name": "jasniejacy_5",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(5)",
                         "patterns": [
                           {
                             "pattern": "Przy przykrym akompaniamencie kaleczonego ciala",
                             "type": 2
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(5)"
                       },
                       {
                         "name": "jasniejacy_6",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(6)",
                         "patterns": [
                           {
                             "pattern": "potwornie",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(6)"
                       },
                       {
                         "name": "jasniejacy_7",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(7)",
                         "patterns": [
                           {
                             "pattern": "Z zamaszystego zamachu",
                             "type": 2
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_jasniejace_bronie(7)"
                       },
                       {
                         "name": "jasniejacy_fin",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                         "patterns": [
                           {
                             "pattern": "jak gdyby bron nie mogla juz doczekac sie kolejnego",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "upiorne_bronie",
@@ -221,7 +215,6 @@
                     "triggers": [
                       {
                         "name": "upiorny_0",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_upiorne_bronie(0)",
                         "patterns": [
                           {
                             "pattern": "Wyrywajacy sie w strone",
@@ -231,11 +224,11 @@
                             "pattern": "Przy szyderczym chichocie glowy",
                             "type": 2
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_upiorne_bronie(0)"
                       },
                       {
                         "name": "upiorny_1",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_upiorne_bronie(1)",
                         "patterns": [
                           {
                             "pattern": "szybkim ciosem upiorn",
@@ -245,11 +238,11 @@
                             "pattern": "^(?<attacker>.+?) ledwo muska (?<target>.+?) upiornym ciemnym mlotem, trafiajac (?:go|ja) w (?<where>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_upiorne_bronie(1)"
                       },
                       {
                         "name": "upiorny_2",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_upiorne_bronie(2)",
                         "patterns": [
                           {
                             "pattern": "gwaltownym uderzeniem upiorn",
@@ -259,60 +252,60 @@
                             "pattern": "^Gwaltownym wymachem upiornego ciemnego mlota w (?<where>.+?) dosiegasz (?<target>.+?), lekko (?:go|ja) raniac\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_upiorne_bronie(2)"
                       },
                       {
                         "name": "upiorny_3",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_upiorne_bronie(3)",
                         "patterns": [
                           {
                             "pattern": "szakala rozjarzaja sie niklym blaskiem",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_upiorne_bronie(3)"
                       },
                       {
                         "name": "upiorny_4",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_upiorne_bronie(4)",
                         "patterns": [
                           {
                             "pattern": "Dajac poniesc sie drzemiacej",
                             "type": 2
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_upiorne_bronie(4)"
                       },
                       {
                         "name": "upiorny_5",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_upiorne_bronie(5)",
                         "patterns": [
                           {
                             "pattern": "Przy akompaniamencie ogluszajacego",
                             "type": 2
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_upiorne_bronie(5)"
                       },
                       {
                         "name": "upiorny_6",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_upiorne_bronie(6)",
                         "patterns": [
                           {
                             "pattern": "dobiegajacy z umieszczonej na broni glowy szakala",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_upiorne_bronie(6)"
                       },
                       {
                         "name": "upiorny_fin",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                         "patterns": [
                           {
                             "pattern": "Skupiajac cale swoje sily na okrutnym ataku",
                             "type": 2
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "bronie_z_kamieniami",
@@ -342,35 +335,33 @@
                         "type": 1
                       }
                     ],
-                    "triggers": [],
-                    "groups": [
+                    "triggers": [
                       {
                         "name": "ciosy",
                         "patterns": [],
                         "triggers": [
                           {
                             "name": "bron_kamienie_0",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bronie_z_kamieniami(0)",
                             "patterns": [
                               {
                                 "pattern": "dzga tylko powietrze",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bronie_z_kamieniami(0)"
                           },
                           {
                             "name": "bron_kamienie_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bronie_z_kamieniami(1)",
                             "patterns": [
                               {
                                 "pattern": "ledwie zahaczajac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bronie_z_kamieniami(1)"
                           },
                           {
                             "name": "bron_kamienie_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bronie_z_kamieniami(2)",
                             "patterns": [
                               {
                                 "pattern": "nieznacznie raniac",
@@ -380,11 +371,11 @@
                                 "pattern": "nieznacznie tlukac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bronie_z_kamieniami(2)"
                           },
                           {
                             "name": "bron_kamienie_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bronie_z_kamieniami(3)",
                             "patterns": [
                               {
                                 "pattern": "bolesnie raniac",
@@ -394,21 +385,21 @@
                                 "pattern": "bolesnie obijajac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bronie_z_kamieniami(3)"
                           },
                           {
                             "name": "bron_kamienie_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bronie_z_kamieniami(4)",
                             "patterns": [
                               {
                                 "pattern": "dotkliwie raniac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bronie_z_kamieniami(4)"
                           },
                           {
                             "name": "bron_kamienie_5",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bronie_z_kamieniami(5)",
                             "patterns": [
                               {
                                 "pattern": "bardzo ciezko raniac",
@@ -418,21 +409,21 @@
                                 "pattern": "bardzo ciezko lomoczac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bronie_z_kamieniami(5)"
                           },
                           {
                             "name": "bron_kamienie_6",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bronie_z_kamieniami(6)",
                             "patterns": [
                               {
                                 "pattern": ", masakrujac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bronie_z_kamieniami(6)"
                           },
                           {
                             "name": "bron_kamienie_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "miazdzac jej witalne organy.",
@@ -458,10 +449,10 @@
                                 "pattern": "i z wymachu wbijasz srebrzysty wulkaniczny kindzal w trzewia ofiary, momentalnie konczac walke.",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "kamienie",
@@ -482,56 +473,55 @@
                         "triggers": [
                           {
                             "name": "kamienie_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_wprawiane_kamienie(1)",
                             "patterns": [
                               {
                                 "pattern": "lekkie obrazenia",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_wprawiane_kamienie(1)"
                           },
                           {
                             "name": "kamienie_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_wprawiane_kamienie(2)",
                             "patterns": [
                               {
                                 "pattern": "znaczne obrazenia",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_wprawiane_kamienie(2)"
                           },
                           {
                             "name": "kamienie_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_wprawiane_kamienie(3)",
                             "patterns": [
                               {
                                 "pattern": "powazne obrazenia",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_wprawiane_kamienie(3)"
                           },
                           {
                             "name": "kamienie_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_wprawiane_kamienie(4)",
                             "patterns": [
                               {
                                 "pattern": "potworne obrazenia",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_wprawiane_kamienie(4)"
                           },
                           {
                             "name": "kamienie_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "potwornej agonii",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       }
                     ]
                   },
@@ -546,72 +536,70 @@
                     "triggers": [
                       {
                         "name": "drag-ktos-1",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_drag_ktos_drag_ktos_1()",
                         "patterns": [
                           {
                             "pattern": "nieznacznie",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_drag_ktos_drag_ktos_1()"
                       },
                       {
                         "name": "drag-ktos-2",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_drag_ktos_drag_ktos_2()",
                         "patterns": [
                           {
                             "pattern": "lekko",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_drag_ktos_drag_ktos_2()"
                       },
                       {
                         "name": "drag-ktos-3",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_drag_ktos_drag_ktos_3()",
                         "patterns": [
                           {
                             "pattern": "gleboko",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_drag_ktos_drag_ktos_3()"
                       },
                       {
                         "name": "drag-ktos-4",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_drag_ktos_drag_ktos_4()",
                         "patterns": [
                           {
                             "pattern": "powaznie",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_drag_ktos_drag_ktos_4()"
                       },
                       {
                         "name": "drag-ktos-5",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_drag_ktos_drag_ktos_5()",
                         "patterns": [
                           {
                             "pattern": "potwornie",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_drag_ktos_drag_ktos_5()"
                       },
                       {
                         "name": "drag-ktos-6",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_drag_ktos_drag_ktos_6()",
                         "patterns": [
                           {
                             "pattern": "bardzo ciezko",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_drag_ktos_drag_ktos_6()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "maczugi",
                     "patterns": [],
-                    "triggers": [],
-                    "groups": [
+                    "triggers": [
                       {
                         "name": "czarnoblekitny_pulsujacy_morgenstern",
                         "patterns": [
@@ -623,7 +611,6 @@
                         "triggers": [
                           {
                             "name": "pulsujacy_1",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_pulsujacy_morgenstern_1()",
                             "patterns": [
                               {
                                 "pattern": "^Jedynie lekko zahaczasz o (?<where_target>.+?) swym czarnoblekitnym pulsujacym morgensternem\\.$",
@@ -657,11 +644,11 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) lekko zahacza (?<taget>cie) o (?<where>.+?) swym czarnoblekitnym pulsujacym morgensternem\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_pulsujacy_morgenstern_1()"
                           },
                           {
                             "name": "pulsujacy_2",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_pulsujacy_morgenstern_2()",
                             "patterns": [
                               {
                                 "pattern": "^Trafiasz (?<target>.+?) w (?<where>.+?) swym czarnoblekitnym pulsujacym morgensternem, lekko (?:go|ja) raniac\\.$",
@@ -679,11 +666,11 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) lekko rani (?<target>.+?) uderzeniem swego czarnoblekitnego pulsujacego morgensterna\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_pulsujacy_morgenstern_2()"
                           },
                           {
                             "name": "pulsujacy_3",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_pulsujacy_morgenstern_3()",
                             "patterns": [
                               {
                                 "pattern": "^Ranisz (?<target>.+?) w (?<where>.+?) precyzyjnym ciosem swojego czarnoblekitnego pulsujacego morgensterna\\.$",
@@ -701,11 +688,11 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) poteznym ciosem czarnoblekitnego pulsujacego morgensterna trafia (?<target>.+?) w (?<where>.+?)\\. Metalowe kolce wnikaja w je(?:j|go) cialo, pozostawiajac krwawiaca rane\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_pulsujacy_morgenstern_3()"
                           },
                           {
                             "name": "pulsujacy_4",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_pulsujacy_morgenstern_4()",
                             "patterns": [
                               {
                                 "pattern": "^Nagle z czarnoblekitnego pulsujacego morgensterna wylatuje blekitny strumien energii, przeszywajacy (?<target>.+?)\\. Na je(?:go|j) twarzy pojawia sie grymas potwornego bolu\\.$",
@@ -715,11 +702,11 @@
                                 "pattern": "^Nagle z czarnoblekitnego pulsujacego morgensterna wylatuje  blekitny strumien energii przeszywajacy (?<where_target>.+?)\\. Widzisz jak na je(go|j) twarzy pojawia sie grymas potwornego bolu\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_pulsujacy_morgenstern_4()"
                           },
                           {
                             "name": "pulsujacy_5",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_pulsujacy_morgenstern_5()",
                             "patterns": [
                               {
                                 "pattern": "^Celnym uderzeniem trafiasz (?<target>.+?) w (?<where>.+?)\\. Czarnoblekitny pulsujacy morgenstern jarzac sie ostrym swiatlem bez trudu wnika w cialo, wypalajac olbrzymia rane\\. Slyszysz skwierczacy syk i czujesz niesamowicie paskudny swad\\.$",
@@ -737,11 +724,11 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) celnym uderzeniam trafia (?<target>.+?) w (?<where>.+?)\\. Czarnoblekitny pulsujacy morgenstern jarzac sie ostrym swiatlem bez trudu wnika w cialo, wypalajac olbrzymia rane\\. Slyszysz skwierczacy syk, a po chwili czujesz paskudny swad\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_pulsujacy_morgenstern_5()"
                           },
                           {
                             "name": "pulsujacy_6",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_pulsujacy_morgenstern_6()",
                             "patterns": [
                               {
                                 "pattern": "^Potezna kula niebieskiego ognia wylatuje z twego czarnoblekitnego pulsujacego morgensterna i trafia prosto w (?<target>.+?)\\. Sila uderzenia rzuca ni(?:a|m) do tylu i widzisz, jak magiczna energia niemal doszczetnie (?:go|ja) spala\\.$",
@@ -755,11 +742,11 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) uderzeniem swego czarnoblekitnego pulsujacego morgensterna straszliwie masakruje (?<target>.+?)\\. Widzisz jak ofiara slania sie, a krew z jej ran leje sie strumieniami\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_pulsujacy_morgenstern_6()"
                           },
                           {
                             "name": "pulsujacy_fin",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_pulsujacy_morgenstern_fin()",
                             "patterns": [
                               {
                                 "pattern": "^Z cala sila jaka dysponujesz wykonujesz potezny zamach swym czarnoblekitnym pulsujacym morgensternem\\. Od gory uderzasz (?<target>.+?) trafiajac (?:go|ja) prosto w (?<where>.+?), a bron z latwoscia miazdzy czaszke przeciwnika, ktory pada martwy na ziemie\\.$",
@@ -777,10 +764,10 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wykonuje potezne uderzenie swym czarnoblekitnym pulsujacym morgensternem i trafia centralnie w (?<where_target>.+?)\\. W momecie uderzenia nastepuje oslepiajaca eksplozja, a gdy po chwili spogladasz, widzisz jedynie zweglone cialo, ktore niemal natychmiast upada na ziemie\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_pulsujacy_morgenstern_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "dlugi_runiczny_korbacz",
@@ -793,7 +780,6 @@
                         "triggers": [
                           {
                             "name": "runiczny_korbacz",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_0()",
                             "patterns": [
                               {
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) usiluje cie trafic obszernym zamachem dlugiego runicznego korbacza, jednak zrecznym unikiem wymykasz sie spoza zasiegu jego broni\\.$",
@@ -807,11 +793,11 @@
                                 "pattern": "^Celnym uderzeniem dlugiego runicznego korbacza (?<attacker>.+) trafia cie w (?<where>.+?), lekko cie raniac\\.$jedna z ",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_0()"
                           },
                           {
                             "name": "runiczny_korbacz_0",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_0()",
                             "patterns": [
                               {
                                 "pattern": "^Wykonujesz silny zamach dlugim runicznym korbaczem, mierzac w (?<target>.+?), lecz (ta|ten) umiejetnie zbija twa bron .*\\.$",
@@ -849,41 +835,41 @@
                                 "pattern": "^Wykorzystujac chwile, w ktorej glowica twego dlugiego runicznego korbacza wybucha ognista poswiata, probujesz nia uderzyc (?<target>.+?), lecz robisz to tak nieumiejetnie, ze bronmija cel w bezpiecznej dlan odleglosci\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_0()"
                           },
                           {
                             "name": "runiczny_korbacz_1",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_1()",
                             "patterns": [
                               {
                                 "pattern": "^Z lekkiego zamachu dlugim runicznym korbaczem trafiasz (?<target>.+?) w (?<where>.+?), pozostawiajac drobne obrazenia\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_1()"
                           },
                           {
                             "name": "runiczny_korbacz_2",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_2()",
                             "patterns": [
                               {
                                 "pattern": "^Celnym uderzeniem dlugiego runicznego korbacza trafiasz (?<target>.+?) w (?<where>.+?), lekko (go|ja) raniac\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_2()"
                           },
                           {
                             "name": "runiczny_korbacz_3",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_3()",
                             "patterns": [
                               {
                                 "pattern": "^Wykonujac ukosny zamach dlugim runicznym korbaczem trafiasz (?<target>.+?) w (?<where>.+?), dotkliwie (go|ja) raniac\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_3()"
                           },
                           {
                             "name": "runiczny_korbacz_4",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_4()",
                             "patterns": [
                               {
                                 "pattern": "^Wykorzystujac slabosc w obronie (?<target>.+?), silnie uderzasz (?:go|ja) w (?<where>.+?) dlugim runicznym korbaczem, ciezko raniac\\.$",
@@ -893,31 +879,31 @@
                                 "pattern": "^Wykorzystujac slabosc w obronie (?<target>.+?), (?<attacker>.+?) silnie uderza (?:go|ja) w (?<where>.+?) dlugim runicznym korbaczem, ciezko raniac\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_4()"
                           },
                           {
                             "name": "runiczny_korbacz_5",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_5()",
                             "patterns": [
                               {
                                 "pattern": "^Z poteznego zamachu dlugiego runicznego korbacza uderzasz (?<target>.+?) w (?<where>.+?), masakrujac (go|ja) i niemalze konczac te walke\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_5()"
                           },
                           {
                             "name": "runiczny_korbacz_6",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_6()",
                             "patterns": [
                               {
                                 "pattern": "^Widzac oslabienie twego przeciwnika, z poteznego zamachu dlugiego runicznego korbacza uderzasz (?<target>.+?) w (?<where>.+?), pozostawiajac olbrzymie obrazenia\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_6()"
                           },
                           {
                             "name": "runiczny_korbacz_fin",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_fin()",
                             "patterns": [
                               {
                                 "pattern": "^Wkladajac w uderzenie wszystkie swe sily, wykonujesz olbrzymi zamach dlugim runicznym korbaczem, by z wielka predkoscia wbic go w cialo (?<target>.+?), miazdzac znajdujace sie wewnatrz organy oraz kosci i zabijajac (go|ja) na miejscu\\. Zadowolony z takiego zakonczenia walki ostentacyjnie przytrzymujesz truchlo swego martwego przeciwnika noga, aby gwaltownym ruchem wyrwac zen swa bron\\.$",
@@ -927,11 +913,11 @@
                                 "pattern": "^Wykorzystujac wyrazne widoczne oslabienie (?<target>.+?), z wysilkiem wykonujesz obszerny zamach swym dlugim runicznym korbaczem\\. Bron trafia w (?<where>.+?)ofiary, natychmiast wybuchajac magicznym, krwistoczerwonym plomieniem, ktory blyskawicznie ogarnia .+?, odbierajac resztki tlacego sie wen zycia\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_fin()"
                           },
                           {
                             "name": "runiczny_korbacz_spec",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_spec()",
                             "patterns": [
                               {
                                 "pattern": "^Gdy uderzasz (?<target>.+?) w .+? swym dlugim runicznym korbaczem, glowica broni wybucha krwistoczerwonym plomieniem, parzac tw(?:a|ego) przeciwni(?:czke|ka) magicznym ogniem\\.$",
@@ -949,10 +935,10 @@
                                 "pattern": "^W chwili gdy glowica twego dlugiego runicznego korbacza rozpala sie olbrzymim plomieniem, z wielka sila uderzasz (?<target>.+?) w (?<where>.+?), pozostawiajac potworne rany i poparzenia\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_runiczny_korbacz_spec()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "drag-ja",
@@ -969,66 +955,66 @@
                         "triggers": [
                           {
                             "name": "drag-ja-1",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_drag_ja_drag_ja_1()",
                             "patterns": [
                               {
                                 "pattern": "nieznacznie",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_drag_ja_drag_ja_1()"
                           },
                           {
                             "name": "drag-ja-2",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_drag_ja_drag_ja_2()",
                             "patterns": [
                               {
                                 "pattern": "lekko",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_drag_ja_drag_ja_2()"
                           },
                           {
                             "name": "drag-ja-3",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_drag_ja_drag_ja_3()",
                             "patterns": [
                               {
                                 "pattern": "gleboko",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_drag_ja_drag_ja_3()"
                           },
                           {
                             "name": "drag-ja-4",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_drag_ja_drag_ja_4()",
                             "patterns": [
                               {
                                 "pattern": "powaznie",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_drag_ja_drag_ja_4()"
                           },
                           {
                             "name": "drag-ja-5",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_drag_ja_drag_ja_5()",
                             "patterns": [
                               {
                                 "pattern": "potwornie",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_drag_ja_drag_ja_5()"
                           },
                           {
                             "name": "drag-ja-6",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_drag_ja_drag_ja_6()",
                             "patterns": [
                               {
                                 "pattern": "bardzo ciezko",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_drag_ja_drag_ja_6()"
                           }
                         ],
-                        "groups": []
+                        "multiline": true
                       },
                       {
                         "name": "dwusegmentowa_maczuga",
@@ -1041,7 +1027,6 @@
                         "triggers": [
                           {
                             "name": "dwusegmentowa",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_dwusegmentowa()",
                             "patterns": [
                               {
                                 "pattern": "^Z oszczednego zamachu uderzasz glowica szponiastej dwusegmentowej maczugi w (?<where>.+?), (?<damage>nie zadajac) jednak (?:powaznych ran|powazniejszych obrazen)\\.$",
@@ -1079,11 +1064,11 @@
                                 "pattern": "^Miazdzysz (?<target>.+?) swa szponiasta dwusegmentowa maczuga, a stalowe ostrza masywnej glowicy rozdzieraja straszliwa rane, niemalze doszczetnie (?<damage>masakrujac) (?:jego|jej) slaniajace sie cialo\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_dwusegmentowa()"
                           },
                           {
                             "name": "dwusegmentowa_0",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_dwusegmentowa()",
                             "patterns": [
                               {
                                 "pattern": "^Mordercze ostrza glowicy twej szponiastej dwusegmentowej maczugi ze swistem rozcinaja powietrze, (?<where_target>.+?) (?<damage>unik)a jednak tego ciosu\\.$",
@@ -1097,11 +1082,11 @@
                                 "pattern": "^Mordercze ostrza glowicy szponiastej dwusegmentowej maczugi (?<attacker>.+?) ze swistem rozcinaja powietrze, jednak (?<target>tobie) udaje sie (?<damage>unik)nac tego ciosu\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_dwusegmentowa()"
                           },
                           {
                             "name": "dwusegmentowa_inni",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_dwusegmentowa()",
                             "patterns": [
                               {
                                 "pattern": "^Z oszczednego zamachu (?<attacker>.+) uderza (?:cie glowica swej|glowica) szponiastej dwusegmentowej maczugi w (?<where_target>.+), (?<damage>nie zadajac) jednak powazniejszych ran\\.$",
@@ -1143,11 +1128,11 @@
                                 "pattern": "^W sama pore (?<target>\\w+(?: \\w+){0,4}) zakleszcza cios (?<attacker>\\w+(?: \\w+){0,4}) pomiedzy stalowe ogniwa swej szponiastej dwusegmentowej maczugi, (?<damage>powstrzymujac) ten niefortunny atak\\.",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_dwusegmentowa()"
                           },
                           {
                             "name": "dwusegmentowa_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "^Wkladajac w zamach cala swa sile(?<attacker>.*?) wyprowadza(?:sz|) potezny cios szponiasta dwusegmentowa maczuga, ktorej glowica grajac zlowrozebnie brzekiem stalowych ogniw zalobna melodie przecina z furkotem powietrze, z morderczym impetem dosiegajac (?<target>.+?)\\. Potwornie zmasakrowane cialo bezwladnie osuwa sie w ciagle rosnaca kaluze krwi\\.$",
@@ -1157,10 +1142,10 @@
                                 "pattern": "^Druzgoczacym zamachem szponiastej dwusegmentowej maczugi(?<attacker>.*?) powala(?:sz|) (?<target>.+?) na ziemie i z ponurym grymasem, bezlitosnie wymierza(?:sz|) smiertelny cios w je(?:go|j) (?<where>.+?), raz na zawsze konczac walke\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "krysztalowy_swietlisty_korbacz",
@@ -1173,7 +1158,6 @@
                         "triggers": [
                           {
                             "name": "swietlisty_0",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_krysztalowy_swietlisty_korbacz_0()",
                             "patterns": [
                               {
                                 "pattern": "^Bierzesz potezny zamach krysztalowym swietlistym korbaczem mierzac w (?<target>.+?), t(a|en) jednak cudem unika ciosu swiecacej glowicy\\.$",
@@ -1195,11 +1179,11 @@
                                 "pattern": "^Mlynkujac, wyprowadzasz mocne uderzenie krysztalowym swietlistym korbaczem mierzac w (?<target>.+?), jednak swiecaca glowica (nie dosiega celu|mija cel o wlos)\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_krysztalowy_swietlisty_korbacz_0()"
                           },
                           {
                             "name": "swietlisty",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_krysztalowy_swietlisty_korbacz()",
                             "patterns": [
                               {
                                 "pattern": "^Wyprowadzasz .+ uderzenie krysztalowym swietlistym korbaczem, (?<damage>ledwie zahaczajac|nieznacznie tlukac|bolesnie obijajac|dotkliwie raniac|bardzo ciezko lomoczac) (?<target>.+) w (?<where>.+)\\.$",
@@ -1213,11 +1197,11 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) (?:bierze zamach swiecaca glowica krysztalowego swietlistego korbacza|wyprowadza .+ uderzenie krysztalowym swietlistym korbaczem), (?<damage>ledwie zahaczajac|nieznacznie tlukac|bolesnie obijajac|dotkliwie raniac|bardzo ciezko lomoczac) (?<target>.+) w (?<where>.+)\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_krysztalowy_swietlisty_korbacz()"
                           },
                           {
                             "name": "swietlisty_6",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_krysztalowy_swietlisty_korbacz_6()",
                             "patterns": [
                               {
                                 "pattern": "^Z szerokiego mlynca bierzesz zamach krysztalowym swietlistym korbaczem i uderzasz (?<target>.+?) swiecaca glowica broni, na chwile pozbawiajac ofiare oddechu\\.$",
@@ -1227,11 +1211,11 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) z szerokiego mlynca bierze zamach krysztalowym swietlistym korbaczem i uderza (?<target>.+?) swiecaca glowica broni, na chwile pozbawiajac ofiare oddechu\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_krysztalowy_swietlisty_korbacz_6()"
                           },
                           {
                             "name": "swietlisty_fin",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_krysztalowy_swietlisty_korbacz_fin()",
                             "patterns": [
                               {
                                 "pattern": "^Zataczasz w powietrzu szerokie kolo glowica krysztalowego swietlistego korbacza i z calej sily uderzasz (?<target>.+?)\\.$",
@@ -1241,10 +1225,10 @@
                                 "pattern": "^(.+?) zatacza w powietrzu szerokie kolo glowica krysztalowego swietlistego korbacza i z calej sily uderza (?<target>.+?) i uderza z calej sily krysztalowym swietlistym korbaczem\\. Slychac trzask pekajacych kosci, gdy ofiara pada na ziemie\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_krysztalowy_swietlisty_korbacz_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "iskrzaca_zdobiona_bulawa",
@@ -1257,7 +1241,6 @@
                         "triggers": [
                           {
                             "name": "iskrzaca",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_iskrzaca_zdobiona_bulawa()",
                             "patterns": [
                               {
                                 "pattern": "^Gdy wykonujesz zamach swoja iskrzaca zdobiona bulawa, swist broni wydaje sie brzmiec jak wicher zwiastujacy nadejscie burzy\\. Mierzony cios trafia (?<target>.+?) w (?<where>.+?), (?<damage>powaznie) (go|ja) raniac\\.$",
@@ -1303,11 +1286,11 @@
                                 "pattern": "^Gdy (?<attacker>\\w+(?: \\w+){0,4}) wykonuje zamach swoja iskrzaca zdobiona bulawa, swist broni wydaje sie brzmiec jak wicher niosacy burze\\. Mierzony cios trafia (?<target>.+?) w (?<where>.+?) (?<damage>powaznie)  (?:go|ja) raniac\\.$",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_iskrzaca_zdobiona_bulawa()"
                           },
                           {
                             "name": "iskrzaca_inni",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_iskrzaca_zdobiona_bulawa()",
                             "patterns": [
                               {
                                 "pattern": "^Gdy (?<attacker>\\w+(?: \\w+){0,4}) wykonuje zamach swoja iskrzaca zdobiona bulawa, swist broni wydaje sie brzmiec jak wicher niosacy burze\\. Mierzony cios trafia (?<target>.+?) w(?<where>.+?) (?<damage>powaznie)  (?:go|ja) raniac\\.$",
@@ -1317,11 +1300,11 @@
                                 "pattern": "^Wsrod ogluszajacego huku gromow (?<attacker>\\w+(?: \\w+){0,4}) unosi swoja jasniejaca blekitna poswiata iskrzaca zdobiona bulawe i kieruje ja w strone (?<target>.+?)\\. Ze spowitej syczacymi iskrami glowicy strzela straszliwy, oslepiajacy piorun, (?<damage>razac) cel w (?<where>.*)\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_iskrzaca_zdobiona_bulawa()"
                           },
                           {
                             "name": "iskrza_fin",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_iskrzaca_zdobiona_bulawa_fin()",
                             "patterns": [
                               {
                                 "pattern": "^Cwieki na glowicy twojej iskrzacej zdobionej bulawy rozblyskuja bialym swiatlem, a wokol (?<target>.+?) zaczynaja tanczyc w powietrzu syczace iskry\\. Czujesz, jak magiczny sztorm zaklety w bulawie osiaga apogeum i unosisz bron do zadania ostatniego ciosu\\. W reakcji na ten ruch luk ze splecionych blyskawic przeskakuje miedzy glowica maczugi a ofiara, zabijajac ja na miejscu\\.$",
@@ -1331,10 +1314,10 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) unosi swoja bron, a po iskrzacej zdobionej bulawie zaczynaja pelzac biale blyskawice\\. Skierowawszy huczaca glowice ku (?<target>.+?), .+? pozwala szalejacej niej wewnatrz burzy znalezc ujscie\\. Wsrod ogluszajacego huku blyskawic, miedzy bronia a ofiara przeskakuje oslepiajaco bialy luk splecionych piorunow, ktory zabija cel na miejscu\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_iskrzaca_zdobiona_bulawa_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "starozytne_kosciane_berlo",
@@ -1347,7 +1330,6 @@
                         "triggers": [
                           {
                             "name": "kosciane_berlo",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_starozytne_kosciane_berlo()",
                             "patterns": [
                               {
                                 "pattern": "^(Bierzesz potezny zamach|Bierzesz mocarny zamach|Bierzesz straszliwy zamach|Wyprowadzasz z furia uderzenie|Wyprowadzasz z impetem uderzenie|Wyprowadzasz z calej sily uderzenie|Uderzasz) starozytnym koscianym berlem, (?<damage>ledwie zahaczajac|nieznacznie tlukac|dotkliwie raniac|bolesnie obijajac|bardzo ciezko lomoczac|masakrujac) (?<target>.+?) w (?<where>.+?)\\.$",
@@ -1357,11 +1339,11 @@
                                 "pattern": "^Wykorzystujesz (zrecznie|umiejetnie|straszliwy) ped starozytnego koscianego berla, (?<damage>ledwie zahaczajac|nieznacznie tlukac|dotkliwie raniac|bolesnie obijajac|bardzo ciezko lomoczac|masakrujac) (?<target>.+?) w (?<where>.+?)\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_starozytne_kosciane_berlo()"
                           },
                           {
                             "name": "kosciane_berlo_spec",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_starozytne_kosciane_berlo_spec()",
                             "patterns": [
                               {
                                 "pattern": "^Mocne uderzenie twojego starozytnego koscianego berla zahacza (?<target>.+?), a (.*) powoduje (?<damage>znaczne) obrazenia\\.$",
@@ -1379,11 +1361,11 @@
                                 "pattern": "^Uderzasz bezlitosnie (?<target>.+?) szybkim wypadem starozytnego koscianego berla, a (.+?) powoduje (?<damage>potworne)obrazenia\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_starozytne_kosciane_berlo_spec()"
                           },
                           {
                             "name": "kosciane_berlo_fin",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_starozytne_kosciane_berlo_fin()",
                             "patterns": [
                               {
                                 "pattern": "^Podchodzisz do .+? i z wymachu uderzasz starozytnym koscianym berlem, zamieniajac (?<where>.+?) ofiary w krwawa miazge\\.$",
@@ -1393,10 +1375,10 @@
                                 "pattern": "^Z calej sily uderzasz starozytnym koscianym berlem w (?<target>.+?), a (.+?) powoduje obrazenia tak rozlegle, ze przeciwnik pada na ziemie w potwornej agonii\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_starozytne_kosciane_berlo_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "lodowata_dluga_maczuga",
@@ -1409,7 +1391,6 @@
                         "triggers": [
                           {
                             "name": "lodowata_0",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_lodowata_dluga_maczuga()",
                             "patterns": [
                               {
                                 "pattern": "(?<attacker>.+?) wykonuje obszerny zamach lodowata dluga maczuga, usilujac trafic (?<target>.+?), jednak \\w+ w pore odkrywa zamiary przeciwnika i spokojnie (?<damage>odskakuje) na bok, unikajac tego ciosu\\.$",
@@ -1423,11 +1404,11 @@
                                 "pattern": "^Wykonujesz obszerny zamach lodowata dluga maczuga, usilujac trafic (?<target>.+?), jednak twoj(?:|a) przeciwni(?:czka|k) w pore (?<damage>paruje) ten cios .*\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_lodowata_dluga_maczuga()"
                           },
                           {
                             "name": "lodowata",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_lodowata_dluga_maczuga()",
                             "patterns": [
                               {
                                 "pattern": "^Dostrzegajac dogodna okazje do ataku, rzucasz sie do przodu i wykonujesz szybki zamach lodowata dluga maczuga\\. Twa bron trafia zaskoczon(?:ego|a) (?<target>.+?) w (?<where>.+?), (?<damage>.*)\\.$",
@@ -1437,11 +1418,11 @@
                                 "pattern": "^Dostrzegajac dogodna okazje do ataku, (?<attacker>.+?) rzuca sie do przodu i wykonuje szybki zamach lodowata dluga maczuga\\. (?:Twa|Jego|Jej) bron trafia zaskoczon(?:ego|a) (?<target>.+?) w (?<where>.+?), (?<damage>.*)\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_lodowata_dluga_maczuga()"
                           },
                           {
                             "name": "lodowata_fin",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_lodowata_dluga_maczuga()",
                             "patterns": [
                               {
                                 "pattern": "^Korzystajac z tego, ze (?<target>.+?) ledwo trzyma sie na nogach, unosisz lodowata dluga maczuge wysoko nad glowe, by zadac cios, ktory zakonczy te walke\\. Czujesz jak w reakcji na twe mysli bron zaczyna promieniowac odczuwalnym chlodem\\. Szybkim, ukosnym ruchem reki opuszczasz orez, uderzajac przeciwni(?:czke|ka) w .+\\. W chwili gdy bron dotyka ciala przeciwnika magiczne zimno otula twe serce, pozbawiajac cie litosci\\. Z (?<damage>mordercza) precyzja ponawiasz ciosy, wybierajac najbardziej wrazliwe czesci ciala ofiary i zaprzestajac natarcia dopiero wtedy, gdy twoj wrog zupelnie przestaje sie ruszac\\.$",
@@ -1451,10 +1432,10 @@
                                 "pattern": "^Korzystajac z tego, ze (?<target>.+?) ledwo trzyma sie na nogach, (?<attacker>.+?) unosi lodowata dluga maczug. wysoko nad glowe, by zadac cios, ktory zakonczy te walke\\. Po krotkiej chwili, szybkim, ukosnym ruchem reki opuszcza on(?:|a) orez, uderzajac przeciwni(?:ka|czke) w (?<where>.+?)\\. Nastepnie, bez cienia litosci z (?<damage>mordercza) precyzja ponawia ciosy, wybierajac najbardziej wrazliwe czesci ciala ofiary i zaprzestajac natarcia dopiero wtedy, gdy jego wrog zupelnie przestaje sie ruszac\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_lodowata_dluga_maczuga()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "ciezka_okretowa_kotwica",
@@ -1471,7 +1452,6 @@
                         "triggers": [
                           {
                             "name": "ciezka_okretowa_kotwica_moje",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_ciezka_okretowa_kotwica_moje()",
                             "patterns": [
                               {
                                 "pattern": "^((?<attacker>\\w+(?: \\w+){0,4}) bierze|Bierzesz) zamach ciezka okretowa kotwica na (?<target>.+?), (t(?:a|en) jednak cudem (?<damage>unik)a ciosu rozpedzonej broni|jednak w ostatniej chwili udaje ci sie zrobic unik)\\.$",
@@ -1497,10 +1477,10 @@
                                 "pattern": "^Uderzasz (?<target>.+?) wyrzucajac zza plecow ciezka okretowa kotwice, jednak caly impet zostaje (?<damage>wyparowany) przez .*\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_ciezka_okretowa_kotwica_moje()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "czarny_smukly_morgenstern",
@@ -1513,7 +1493,6 @@
                         "triggers": [
                           {
                             "name": "czarny_smukly_morg",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_morg()",
                             "patterns": [
                               {
                                 "pattern": "^Robisz (?<damage>krotki wypad) i udaje ci sie drasnac (?<target>.+?) swoim czarnym smuklym morgensternem\\.$",
@@ -1547,11 +1526,11 @@
                                 "pattern": "^Uderzasz poteznie swoim czarnym smuklym morgensternem z szerokiego zamachu trafiajac (?<target>.+?) prosto w (?<where>.+?)\\. Slyszysz paskudny chrzest, gdyciezka kula z kolcami (?<damage>masakruje) twojego przeciwnika\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_morg()"
                           },
                           {
                             "name": "czarny_smukly_morg_innych",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_morg()",
                             "patterns": [
                               {
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) robi (?<damage>krotki wypad) i udaje sie mu trafic (?:cie )?czarnym smuklym morgensternem (?:(?<target>.+?) )?w (?<where>.+?)\\.$",
@@ -1577,11 +1556,11 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) uderza poteznie swoim czarnym smuklym morgensternem z szerokiego zamachu trafiajac (?<target>.+?) prosto w twarz\\. Slyszysz dzwiek miazdzonych kosci, gdy ciezka kula z kolcami zamienia oblicze trafione(?:go|j) w (?<damage>krwawa miazge)\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_morg()"
                           },
                           {
                             "name": "czarne_smukly_morg_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "^Wykonujesz pelen obrot nadajac swojemu czarnemu smuklemu morgensternowi ogromny ped i zadajesz nim cios, ktory trafia (?<target>.+) w bok glowy\\. Slyszysz paskudne chrupniecie i wiesz juz, ze tego uderzenia nie mogl przezyc zaden smiertelnik\\. Po chwili martwe cialo .+ osuwa sie na ziemie\\.$",
@@ -1595,10 +1574,10 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wykonuje pelen obrot nadajac czarnemu smuklemu morgensternowi ogromny ped i zadaje nim cios, ktory trafia (?<target>.+?) w bok glowy\\. Slyszysz paskudne chrupniecie i wiesz juz, ze tego uderzenia nie mogl przezyc zaden smiertelnik\\. Po chwili martwe cialo .+ osuwa sie na ziemie\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       }
                     ]
                   },
@@ -1608,7 +1587,6 @@
                     "triggers": [
                       {
                         "name": "zielonkawy_bretonski_mlot",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_zielonkawy_bretonski_mlot()",
                         "patterns": [
                           {
                             "pattern": "^Glowica (?<weapon>zielonkawego bretonskiego mlota) (?<attacker>\\w+(?: \\w+){0,4}) zahacza (?<where_target>.+?) pozostawiajac na (je(?:go|j)|twoim) ciele (?<damage>niewielkie) zasinienie\\.$",
@@ -1638,10 +1616,9 @@
                             "pattern": "^Kolczasta glowica (?<weapon>zielonkawego bretonskiego mlota) (?<attacker>\\w+(?: \\w+){0,4}) z pelnego rozpedu trafia (?<target>\\w+(?: \\w+){0,4}) w (?<where>.+?)\\. Slyszysz nieprzyjemne chrupniecie gdy cios dosiega celu (?<damage>miazdzac) okoliczne kosci\\.$",
                             "type": 1
                           }
-                        ]
-                      }
-                    ],
-                    "groups": [
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_zielonkawy_bretonski_mlot()"
+                      },
                       {
                         "name": "adamantytowy_mlot",
                         "patterns": [
@@ -1653,7 +1630,6 @@
                         "triggers": [
                           {
                             "name": "adamantytowy_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_adamantytowy_mlot(1)",
                             "patterns": [
                               {
                                 "pattern": "Kaleczysz lekko",
@@ -1663,41 +1639,41 @@
                                 "pattern": "lekko kaleczy",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_adamantytowy_mlot(1)"
                           },
                           {
                             "name": "adamantytowy_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_adamantytowy_mlot(2)",
                             "patterns": [
                               {
                                 "pattern": "zamaszystym ciosem",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_adamantytowy_mlot(2)"
                           },
                           {
                             "name": "adamantytowy_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_adamantytowy_mlot(3)",
                             "patterns": [
                               {
                                 "pattern": "zamaszystym uderzeniem adamantytowego mlota bojowego.",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_adamantytowy_mlot(3)"
                           },
                           {
                             "name": "adamantytowy_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_adamantytowy_mlot(4)",
                             "patterns": [
                               {
                                 "pattern": "potezny cios adamantytowym mlotem bojowym, raniac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_adamantytowy_mlot(4)"
                           },
                           {
                             "name": "adamantytowy_5",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_adamantytowy_mlot(5)",
                             "patterns": [
                               {
                                 "pattern": "miazdzac czlonki",
@@ -1707,11 +1683,11 @@
                                 "pattern": "(?<attacker>.+?) wykonuje zamaszysty cios adamantytowym mlotem bojowym, miazdzac twe czlonki\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_adamantytowy_mlot(5)"
                           },
                           {
                             "name": "adamantytowy_6",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_adamantytowy_mlot(6)",
                             "patterns": [
                               {
                                 "pattern": "glebokie rany",
@@ -1721,20 +1697,20 @@
                                 "pattern": "masakruje",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_adamantytowy_mlot(6)"
                           },
                           {
                             "name": "adamantytowy_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "Martwe cialo pada",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "gryfi_mlot",
@@ -1747,76 +1723,75 @@
                         "triggers": [
                           {
                             "name": "gryfi_0",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_gryfi_mlot(0)",
                             "patterns": [
                               {
                                 "pattern": ", jednak zlakniony krwi dziob gryfa nie dosiega celu.",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_gryfi_mlot(0)"
                           },
                           {
                             "name": "gryfi_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_gryfi_mlot(1)",
                             "patterns": [
                               {
                                 "pattern": "ledwie zahaczajac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_gryfi_mlot(1)"
                           },
                           {
                             "name": "gryfi_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_gryfi_mlot(2)",
                             "patterns": [
                               {
                                 "pattern": "nieznacznie tlukac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_gryfi_mlot(2)"
                           },
                           {
                             "name": "gryfi_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_gryfi_mlot(3)",
                             "patterns": [
                               {
                                 "pattern": "bolesnie obijajac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_gryfi_mlot(3)"
                           },
                           {
                             "name": "gryfi_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_gryfi_mlot(4)",
                             "patterns": [
                               {
                                 "pattern": "dotkliwie raniac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_gryfi_mlot(4)"
                           },
                           {
                             "name": "gryfi_5",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_gryfi_mlot(5)",
                             "patterns": [
                               {
                                 "pattern": "Widzac zawahanie przeciwnika",
                                 "type": 2
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_gryfi_mlot(5)"
                           },
                           {
                             "name": "gryfi_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "Kiedy ofiara pada na ziemie",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "wielki_runiczny_mlot_wojenny",
@@ -1829,86 +1804,85 @@
                         "triggers": [
                           {
                             "name": "runiczny_0",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_runiczny_mlot(0)",
                             "patterns": [
                               {
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) bierze potezny zamach wielkim runicznym mlotem wojennym mierzac w (?<target>.+?), t(?:a|en) jednak cudem unika ciosu, .*\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_runiczny_mlot(0)"
                           },
                           {
                             "name": "runiczny_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_runiczny_mlot(1)",
                             "patterns": [
                               {
                                 "pattern": "ledwie zahaczajac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_runiczny_mlot(1)"
                           },
                           {
                             "name": "runiczny_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_runiczny_mlot(2)",
                             "patterns": [
                               {
                                 "pattern": "nieznacznie tlukac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_runiczny_mlot(2)"
                           },
                           {
                             "name": "runiczny_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_runiczny_mlot(3)",
                             "patterns": [
                               {
                                 "pattern": "bolesnie obijajac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_runiczny_mlot(3)"
                           },
                           {
                             "name": "runiczny_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_runiczny_mlot(4)",
                             "patterns": [
                               {
                                 "pattern": "dotkliwie raniac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_runiczny_mlot(4)"
                           },
                           {
                             "name": "runiczny_5",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_runiczny_mlot(5)",
                             "patterns": [
                               {
                                 "pattern": "bardzo ciezko lomoczac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_runiczny_mlot(5)"
                           },
                           {
                             "name": "runiczny_6",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_runiczny_mlot(6)",
                             "patterns": [
                               {
                                 "pattern": "niemal pada na ziemie",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_runiczny_mlot(6)"
                           },
                           {
                             "name": "runiczny_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "ofiary w krwawa miazge",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "foremny_mlot",
@@ -1921,76 +1895,75 @@
                         "triggers": [
                           {
                             "name": "foremny_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_foremny_mlot(1)",
                             "patterns": [
                               {
                                 "pattern": "ledwie osmalajac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_foremny_mlot(1)"
                           },
                           {
                             "name": "foremny_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_foremny_mlot(2)",
                             "patterns": [
                               {
                                 "pattern": "nieznacznie przypiekajac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_foremny_mlot(2)"
                           },
                           {
                             "name": "foremny_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_foremny_mlot(3)",
                             "patterns": [
                               {
                                 "pattern": "lekko przypiekajac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_foremny_mlot(3)"
                           },
                           {
                             "name": "foremny_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_foremny_mlot(4)",
                             "patterns": [
                               {
                                 "pattern": "dotkliwie przypiekajac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_foremny_mlot(4)"
                           },
                           {
                             "name": "foremny_5",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_foremny_mlot(5)",
                             "patterns": [
                               {
                                 "pattern": "mocno parzac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_foremny_mlot(5)"
                           },
                           {
                             "name": "foremny_6",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_foremny_mlot(6)",
                             "patterns": [
                               {
                                 "pattern": "powaznie parzac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_foremny_mlot(6)"
                           },
                           {
                             "name": "foremny_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "smiertelnie parzac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "rezonujacy_mlot",
@@ -2003,7 +1976,6 @@
                         "triggers": [
                           {
                             "name": "rezonujacy_ledwo",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot(1)",
                             "patterns": [
                               {
                                 "pattern": "^Posiadajace zbyt malo impetu uderzenie twojego rezonujacego krysztalowego mlota ledwie ociera sie o (?<target>.*)\\.$",
@@ -2013,11 +1985,11 @@
                                 "pattern": "^Posiadajace zbyt malo impetu uderzenie rezonujacego krysztalowego mlota dzierzonego przez (?<attacker>.+?) ledwie ociera sie o (?<target>.*)\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot(1)"
                           },
                           {
                             "name": "rezonujacy_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot(1)",
                             "patterns": [
                               {
                                 "pattern": "Tluczesz lekko",
@@ -2027,70 +1999,70 @@
                                 "pattern": "tlucze lekko",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot(1)"
                           },
                           {
                             "name": "rezonujacy_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot(2)",
                             "patterns": [
                               {
                                 "pattern": "bolesnie",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot(2)"
                           },
                           {
                             "name": "rezonujacy_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot(3)",
                             "patterns": [
                               {
                                 "pattern": "potwornie kaleczac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot(3)"
                           },
                           {
                             "name": "rezonujacy_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot(4)",
                             "patterns": [
                               {
                                 "pattern": "straszliwym ciosem",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot(4)"
                           },
                           {
                             "name": "rezonujacy_5",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot(4)",
                             "patterns": [
                               {
                                 "pattern": "Zawijac zamaszycie",
                                 "type": 2
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot(4)"
                           },
                           {
                             "name": "rezonujacy_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot(5)",
                             "patterns": [
                               {
                                 "pattern": "miazdzy witalne organy",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot(5)"
                           },
                           {
                             "name": "rezonujacy_spec",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot_spec()",
                             "patterns": [
                               {
                                 "pattern": "potezna, soniczna fala",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_rezonujacy_mlot_spec()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "czarny_smukly_mlot",
@@ -2103,7 +2075,6 @@
                         "triggers": [
                           {
                             "name": "czarny_mlot",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_mlot()",
                             "patterns": [
                               {
                                 "pattern": "^Udaje ci sie (?<damage>zahaczyc) kolcem czarnego smuklego mlota (?<target>.+?)\\.$",
@@ -2129,11 +2100,11 @@
                                 "pattern": "^Poteznie uderzasz (?<target>.+?) swoim czarnym smuklym mlotem w (?<where>.+?)\\. Pod wplywem sily tego ciosu .+ zwija sie z bolu\\. Krew, ktora zauwazasz na glowicy twojej broni swiadczy o zadanych przeciwni(?:czce|kowi) powaznych, (?<damage>wewnetrznych obrazeniach)\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_mlot()"
                           },
                           {
                             "name": "czarny_mlot_innych",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_mlot()",
                             "patterns": [
                               {
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) (?<damage>zahacza) (?<target>.+?) kolcem czarnego smuklego mlota trafiajac (?:go|ja|cie) w (?<where>.+?)\\.$",
@@ -2163,11 +2134,11 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) nadaje swojemu czarnemu smuklemu mlotowi ogromny impet i zadaje ci okrutny cios w (?<where>.+?) (?<damage>powaznie) (?<target>cie) raniac\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_mlot()"
                           },
                           {
                             "name": "czarny_mlot_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "^Z niesamowita precyzja zadajesz (?<target>.+?) morderczy cios swoim czarnym smuklym mlotem\\. Widzisz jak potworna sila uderzenia rozrywa (?:jego|jej) cialo, miazdzy zarowno kosci jak i organy wewnetrzne\\. .+ wydaje z siebie jedynie cichy jek a nastepnie bezsilnie pada na ziemie\\.$",
@@ -2177,10 +2148,10 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) z niesamowita precyzja zadaje morderczy cios (?<target>.+?) swoim czarnym smuklym mlotem\\. Widzisz jak potworna sila uderzenia rozrywa jego cialo, miazdzy zarowno kosci jak i organy wewnetrzne\\. .+ wydaje z siebie jedynie cichy jek a nastepnie bezsilnie pada na ziemie\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       }
                     ]
                   },
@@ -2189,8 +2160,44 @@
                     "patterns": [],
                     "triggers": [
                       {
+                        "name": "gorejacy_dlugi_talwar",
+                        "patterns": [
+                          {
+                            "pattern": "gorejac\\w+ dlug\\w+ talwar",
+                            "type": 1
+                          }
+                        ],
+                        "triggers": [
+                          {
+                            "name": "gorejacy_dlugi_talwar_innych",
+                            "patterns": [
+                              {
+                                "pattern": "^Dostrzegajac slabosc (?<target>\\w+(?: \\w+){0,4}), (?<attacker>\\w+(?: \\w+ \\w+|)) do nie(go|j), by wbic swoj gorejacy dlugi talwar w (?<where>.+)\\. Klinga je(go|j) mieczawybucha (?<damage>olbrzymim) plomieniem, ktory w mgnieniu oka ogarnia przeciwnika w calosci\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Gdy (?<attacker>\\w+(?: \\w+ \\w+|)) uderza (?<target>\\w+(?: \\w+){0,4}) gorejacym dlugim talwarem w (?<where>.+?), klinga je(?:go|j) miecza rozpala sie do czerwonosci, (?<damage>parzac) (?:cie|przeciwni(?:czke|ka)) nieznacznie\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Gdy z silnego zamachu (?<attacker>\\w+(?: \\w+ \\w+|)) tnie (?<target>\\w+(?: \\w+){0,4}) w (?<where>.+?), brzeszczot je(?:go|j) gorejacego dlugiego talwara (?<damage>wybucha) krwistoczerwonym jezorem ognia, mocno parzac (?:cie|przeciwni(?:czke|ka))\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Widzac, ze na ostrzu gorejacego dlugiego talwara zaczynaja pelzac ogniste plomyki, (?<attacker>\\w+(?: \\w+ \\w+|)) wykonuje szybki zamach, trafiajac (?<target>\\w+(?: \\w+){0,4}) w (?<where>.+?), pozostawiajac tam (?<damage>spore) oparzenie\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Brzeszczot gorejacego dlugiego talwara rozgrzewa sie nagle do czerwonosci, zas po jego powierzchni zaczynaja tanczyc krwistoczerwone plomienie\\. Wykorzystujac nadarzajaca sie okazje, (?<attacker>\\w+(?: \\w+ \\w+|)) z calych sil uderza nim (?<target>\\w+(?: \\w+){0,4}) w (?<where>.+?), pozostawiajac (?<damage>potworne) obrazenia\\.$",
+                                "type": 1
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_gorejacy_dlugi_talwar()"
+                          }
+                        ]
+                      },
+                      {
                         "name": "waski_kunsztowny_sihill",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_waski_kunsztowny_sihill()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) zgrabnym ruchem zwodzi (?<target>\\w+(?: \\w+){0,4}) i gwaltownie skracajac dystans wbija w (?:jego|jej|twoje) cialo smiertelne ostrze waskiego kunsztownego sihilla\\. Gwaltowny (?<damage>bryzg) krwi znaczy dlonie i twarz zabojcy purpurowymi cetkami\\.$",
@@ -2224,11 +2231,11 @@
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) blyskawicznie kontruje atak (?<target>\\w+(?: \\w+){0,4}), (?<damage>tnac) (?:go|ja) w (?<where>.+?) waskim kunsztownym sihillem\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_waski_kunsztowny_sihill()"
                       },
                       {
                         "name": "rapiery",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_rapier()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) omijajac zastawe (?<target>\\w+(?: \\w+){0,4}) uderza (?<weapon>\\w+ \\w+ rapierem) trafiajac (:?go|ja) w (?<where>.+?)\\. Gwaltownym szarpnieciem uwalnia ostrze pozostawiajac w ciele przeciwni(?:czki|ka) (?<damage>gleboka) rane\\.$",
@@ -2254,10 +2261,9 @@
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) myli (?<target>cie|.+?) (?:szybka parada|zawila finta) i zachodzac (?:go |ja |)od (?:lewej|prawej) strony tnie na odlew ?\\w+ \\w+ rapierem\\. Koncowka ostrza trafia (?:cie )?w .+? otwierajac plytka, choc dosyc (?<damage>dluga) rane\\.$",
                             "type": 1
                           }
-                        ]
-                      }
-                    ],
-                    "groups": [
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_rapier()"
+                      },
                       {
                         "name": "kruczoczarny_miecz",
                         "patterns": [
@@ -2269,7 +2275,6 @@
                         "triggers": [
                           {
                             "name": "kruczoczarny_0",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_kruczoczarny_miecz(0)",
                             "patterns": [
                               {
                                 "pattern": "glosnym swistem powietrze",
@@ -2279,21 +2284,21 @@
                                 "pattern": " dzga tylko powietrze.",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_kruczoczarny_miecz(0)"
                           },
                           {
                             "name": "kurczoczarny_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_kruczoczarny_miecz(1)",
                             "patterns": [
                               {
                                 "pattern": "waska struzka krwi",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_kruczoczarny_miecz(1)"
                           },
                           {
                             "name": "kruczoczarny_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_kruczoczarny_miecz(2)",
                             "patterns": [
                               {
                                 "pattern": "ciemna, gesta krew",
@@ -2303,50 +2308,50 @@
                                 "pattern": "pozostawia niewielkie zadrapanie",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_kruczoczarny_miecz(2)"
                           },
                           {
                             "name": "kruczoczarny_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_kruczoczarny_miecz(3)",
                             "patterns": [
                               {
                                 "pattern": "napotkane na swej drodze tkanki",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_kruczoczarny_miecz(3)"
                           },
                           {
                             "name": "kruczoczarny_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_kruczoczarny_miecz(4)",
                             "patterns": [
                               {
                                 "pattern": "tryskajaca krwia fontanne",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_kruczoczarny_miecz(4)"
                           },
                           {
                             "name": "kruczoczarny_5",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_kruczoczarny_miecz(5)",
                             "patterns": [
                               {
                                 "pattern": "wysilkiem utrzymuje sie na nogach",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_kruczoczarny_miecz(5)"
                           },
                           {
                             "name": "kruczoczarny_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "rozblyskuja oslepiajacym, czerwonym swiatlem",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "espadon",
@@ -2359,17 +2364,16 @@
                         "triggers": [
                           {
                             "name": "espadon_0",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(0)",
                             "patterns": [
                               {
                                 "pattern": "^Probujesz dosiegnac (?<target>\\w+(?: \\w+){0,4}) polyskliwym smuklym espadonem, jednak twoja bron nieznacznie chybia celu\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(0)"
                           },
                           {
                             "name": "espadon_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(1)",
                             "patterns": [
                               {
                                 "pattern": "Lekko muskasz",
@@ -2379,61 +2383,61 @@
                                 "pattern": "muska ",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(1)"
                           },
                           {
                             "name": "espadon_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(2)",
                             "patterns": [
                               {
                                 "pattern": "niezbyt mocno",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(2)"
                           },
                           {
                             "name": "espadon_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(3)",
                             "patterns": [
                               {
                                 "pattern": "uderzeniem swojego polyskliwego",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(3)"
                           },
                           {
                             "name": "espadon_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(4)",
                             "patterns": [
                               {
                                 "pattern": "mocny zamach i poteznym",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(4)"
                           },
                           {
                             "name": "espadon_5",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(5)",
                             "patterns": [
                               {
                                 "pattern": "mocne uderzenie",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(5)"
                           },
                           {
                             "name": "espadon_6",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(6)",
                             "patterns": [
                               {
                                 "pattern": "gleboka rane",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(6)"
                           },
                           {
                             "name": "espadon_7",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(7)",
                             "patterns": [
                               {
                                 "pattern": "potwornej rany",
@@ -2447,20 +2451,20 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) przerzuca swoj polyskliwy smukly espadon na wysokosc ramion i robiac gwaltowny wypad do przodu lewa stopa, piorunujacym uderzeniem tnie po skosie (?<target>.+?) w (?<where>.+?)\\. Mordercze ostrze przeleciawszy lukiem, pociaga za soba smuge ciemno-czerwonej krwi, ktora z powstalej rany momentalnie wyplywa szerokim strumieniem\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_espadon(7)"
                           },
                           {
                             "name": "espadon_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "pada na ziemie",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "arlekiny",
@@ -2473,7 +2477,6 @@
                         "triggers": [
                           {
                             "name": "smukly_miecz",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_smukly_miecz()",
                             "patterns": [
                               {
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) bez trudu unika uderzenia (?<target>.+?) i odskakuje od nie(?:go|j) ze smiechem\\. Obserwujac uwaznie jak przeciwni(?:czka|k) ponawia probe ataku, \\w+? z niezwykla zrecznoscia nurkuje pod ciosem, by wbic swoj smukly (?:demoniczny|zmiennoksztaltny) miecz w je(?:go|j) (?<where>.+?), pozostawiajac (?<damage>rozlegla) rane\\.$",
@@ -2511,11 +2514,11 @@
                                 "pattern": "^Z dzikim blyskiem w oku (?<attacker>.+?) nurkuje pod ciosem (?<target>.+?) i odpycha (?:go|ja) barkiem do tylu\\. Gdy przeciwni(?:czka|k) traci rownowage, \\w+? tnie (?:go|ja) smuklym (?:demonicznym|zmiennoksztaltnym) mieczem w (?<where>.+?), pozostawiajac (?<damage>krwawiaca) rane\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_smukly_miecz()"
                           },
                           {
                             "name": "smukly_miecz_moje",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_smukly_miecz()",
                             "patterns": [
                               {
                                 "pattern": "^W dzikim, nieokielznanym tancu ruszasz do ataku na (?<target>.+?), by szerokim cieciem smuklego (?:demonicznego|zmiennoksztaltnego) miecza (?<damage>ledwo musnac) (?:go|ja) w (?<where>.*)\\.$",
@@ -2557,10 +2560,10 @@
                                 "pattern": "^Bez zbednych gestow i krokow (?<probujesz>) ciac (?<target>.+?) od boku swym smuklym (?:demonicznym|zmiennoksztaltnym) mieczem, lecz twa bron nie dosiega celu\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_smukly_miecz()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "poszczerbiony_miecz",
@@ -2573,76 +2576,75 @@
                         "triggers": [
                           {
                             "name": "szczerba_0",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_szczerba(0)",
                             "patterns": [
                               {
                                 "pattern": " poszczerbiony obureczny miecz ze swistem przecina",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_szczerba(0)"
                           },
                           {
                             "name": "szczerba_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_szczerba(1)",
                             "patterns": [
                               {
                                 "pattern": "Koncowka swojego poszczerbionego oburecznego miecza",
                                 "type": 2
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_szczerba(1)"
                           },
                           {
                             "name": "szczerba_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_szczerba(2)",
                             "patterns": [
                               {
                                 "pattern": "Z lekkiego wymachu",
                                 "type": 2
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_szczerba(2)"
                           },
                           {
                             "name": "szczerba_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_szczerba(3)",
                             "patterns": [
                               {
                                 "pattern": "Mocnym wymachem z nad glowy",
                                 "type": 2
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_szczerba(3)"
                           },
                           {
                             "name": "szczerba_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_szczerba(4)",
                             "patterns": [
                               {
                                 "pattern": "Plynnym, zdecydowanym ruchem",
                                 "type": 2
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_szczerba(4)"
                           },
                           {
                             "name": "szczerba_5",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_szczerba(5)",
                             "patterns": [
                               {
                                 "pattern": "Ostrze poszczerbionego oburecznego miecza na moment rozblyska",
                                 "type": 2
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_szczerba(5)"
                           },
                           {
                             "name": "szczerba_spec",
-                            "script": "trigger_func_skrypty_ui_gags_spece_szczerba(matches[2])",
                             "patterns": [
                               {
                                 "pattern": "obureczny miecz zaczyna nagle jarzyc sie niesamowitym, czerwonym blaskiem, skierowanym w strone (.*)[,!]",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_spece_szczerba(matches[2])"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "jatagan",
@@ -2658,17 +2660,87 @@
                         ],
                         "triggers": [
                           {
+                            "name": "jasniejacy_zdobiony_jatagan_moje",
+                            "patterns": [
+                              {
+                                "pattern": "return scripts.gags:is_type(\"combat.avatar\")",
+                                "type": 4
+                              }
+                            ],
+                            "triggers": [
+                              {
+                                "name": "jatagan_1",
+                                "patterns": [
+                                  {
+                                    "pattern": "ledwo muskasz",
+                                    "type": 0
+                                  }
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_jatagan(1)"
+                              },
+                              {
+                                "name": "jatagan_2",
+                                "patterns": [
+                                  {
+                                    "pattern": "lekko ranisz",
+                                    "type": 0
+                                  }
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_jatagan(2)"
+                              },
+                              {
+                                "name": "jatagan_3",
+                                "patterns": [
+                                  {
+                                    "pattern": "jatagana ranisz",
+                                    "type": 0
+                                  }
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_jatagan(3)"
+                              },
+                              {
+                                "name": "jatagan_4",
+                                "patterns": [
+                                  {
+                                    "pattern": "powaznie ranisz",
+                                    "type": 0
+                                  }
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_jatagan(4)"
+                              },
+                              {
+                                "name": "jatagan_5",
+                                "patterns": [
+                                  {
+                                    "pattern": "bardzo ciezko ranisz",
+                                    "type": 0
+                                  }
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_jatagan(5)"
+                              },
+                              {
+                                "name": "jatagan_6",
+                                "patterns": [
+                                  {
+                                    "pattern": "masakrujesz",
+                                    "type": 0
+                                  }
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_jatagan(6)"
+                              }
+                            ]
+                          },
+                          {
                             "name": "jasniejacy_zdobiony_jatagan_inni",
-                            "script": "trigger_func_skrypty_ui_gags_jasniejacy_zdobiony_jatagan_inni()",
                             "patterns": [
                               {
                                 "pattern": "(?:Nagle cale otoczenie rozswietla sie|Nagly blysk rozswietla cale otoczenie|Jasniejaca luna znaczy powietrze|Swietlista smuga przecina powietrze), gdy (?:dlugim cieciem|szybkim pchnieciem) swym jasniejacym zdobionym jataganem (?<attacker>\\w+(?: \\w+){0,4}?) (?<damage>ledwo muska|bardzo ciezko rani|powaznie rani|rani|masakruje) (?<target>.+?), trafiajac (?:go|ja) w (?<where>.*)\\.",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_jasniejacy_zdobiony_jatagan_inni()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "szamszir",
@@ -2681,66 +2753,65 @@
                         "triggers": [
                           {
                             "name": "szamszir_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_szamszir(1)",
                             "patterns": [
                               {
                                 "pattern": "ledwie muskajac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_szamszir(1)"
                           },
                           {
                             "name": "szamszir_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_szamszir(2)",
                             "patterns": [
                               {
                                 "pattern": "lekko raniac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_szamszir(2)"
                           },
                           {
                             "name": "szamszir_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_szamszir(3)",
                             "patterns": [
                               {
                                 "pattern": ", raniac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_szamszir(3)"
                           },
                           {
                             "name": "szamszir_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_szamszir(4)",
                             "patterns": [
                               {
                                 "pattern": "powaznie raniac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_szamszir(4)"
                           },
                           {
                             "name": "szamszir_5",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_szamszir(5)",
                             "patterns": [
                               {
                                 "pattern": "bardzo ciezko raniac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_szamszir(5)"
                           },
                           {
                             "name": "szamszir_6",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_szamszir(6)",
                             "patterns": [
                               {
                                 "pattern": "masakrujac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_szamszir(6)"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "czarny_smukly_miecz",
@@ -2753,7 +2824,6 @@
                         "triggers": [
                           {
                             "name": "czarny_miecz",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_miecz()",
                             "patterns": [
                               {
                                 "pattern": "^Lekko (?<damage>kaleczysz) (?<target>.+?) w (?<where>.+?) koncem czarnego smuklego miecza\\.$",
@@ -2779,11 +2849,11 @@
                                 "pattern": "^Plaskim cieciem czarnego smuklego miecza udaje ci sie zbic zaslone (?<target>.+?) dzieki czemu bez przeszkod wykorzystujac impet broni zadajesz kolejny cios, ktory dosiega korpusu przeciwni(?:ka|czki)\\. Ostrze zaglebia sie w ciele prawie je (?<damage>rozplatujac) na dwie czesci\\. Gdy wyciagasz bron z rany widzisz na ze jej ostrze jest cale skapane we krwi ofiary\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_miecz()"
                           },
                           {
                             "name": "czarny_miecz_innych",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_miecz()",
                             "patterns": [
                               {
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) lekko (?<damage>kaleczy) (?<target>.+?) koncem czarnego smuklego miecza trafiajac (?:go|ja) w (?<where>.*)\\.$",
@@ -2813,28 +2883,112 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) lekko (?<target>cie) (?<damage>kaleczy) trafiajac koncem czarnego smuklego miecza w (?<where>.*)\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_miecz()"
                           },
                           {
                             "name": "czarny_miecz_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "^Z dzika furia nacierasz na (?<target>.+?) zmuszajac (?:go|ja) do cofania sie\\. W pewnym momencie dostrzegasz okazje do zadania smiertelnego ciosu\\. Wykonujesz zwod a nastepnie tniesz poteznie dokladnie przez korpus przeciwni(?:ka|czki)\\. Sila uderzenia jest tak ogromna, ze ostrze czarnego smuklego miecza rozcina cialo .+ na dwie polowy\\. Widzisz jak przez chwile ofiara chwiejnie utrzymuje sie w pionie, po czym, w dwoch kawalkach, zwala sie na ziemie\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "srebrny wiedzminski miecz dwureczny",
                         "patterns": [],
                         "triggers": [
                           {
+                            "name": "wiedzminski_ja",
+                            "patterns": [
+                              {
+                                "pattern": "return scripts.gags:is_type(\"combat.avatar\")",
+                                "type": 0
+                              }
+                            ],
+                            "triggers": [
+                              {
+                                "name": "ja_ledwo_muska",
+                                "patterns": [
+                                  {
+                                    "pattern": "^[ >]*Chwytasz \\w+ reka za podkrzyze swego srebrnego wiedzminskiego miecza dwurecznego, by wykonac nim blyskawiczne pchniecie, mierzac w (?<target>.+?)\\. Cios trafia zaskoczon(?:a|ego) przeciwni(?:czke|ka), zaledwie (?:ja|go) jednak muskajac\\.$",
+                                    "type": 1
+                                  }
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_wiedzminski_ja_ledwo_muska()"
+                              },
+                              {
+                                "name": "ja_lekko_rani",
+                                "patterns": [
+                                  {
+                                    "pattern": "^[ >]*Wykonujesz zwinny polobrot, ciagnac sztych swego srebrnego wiedzminskiego miecza dwurecznego tuz za soba by uderzyc nim.*",
+                                    "type": 1
+                                  },
+                                  {
+                                    "pattern": "^[ >]*Wykonujesz nagle pchniecie swym srebrnym wiedzminskim mieczem dwurecznym, lekko raniac .*\\.$",
+                                    "type": 1
+                                  }
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_wiedzminski_ja_lekko_rani()"
+                              },
+                              {
+                                "name": "ja_rani",
+                                "patterns": [
+                                  {
+                                    "pattern": "^[ >]*Klinga dzierzonego przez ciebie srebrnego wiedzminskiego miecza dwurecznego ze swistem przeszywa powietrze, gdy z wymachu .*",
+                                    "type": 1
+                                  }
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_wiedzminski_ja_rani()"
+                              },
+                              {
+                                "name": "ja_powaznie_rani",
+                                "patterns": [
+                                  {
+                                    "pattern": "^[ >]*Ze sporego wymachu zza glowy wyprowadzasz silny cios srebrnym wiedzminskim mieczem dwurecznym, mierzac w.*",
+                                    "type": 1
+                                  }
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_wiedzminski_ja_powaznie_rani()"
+                              },
+                              {
+                                "name": "ja_bardzo_ciezko_rani",
+                                "patterns": [
+                                  {
+                                    "pattern": "^[ >]*Gwaltownym ruchem wykonujesz precyzyjne .* swym srebrnym wiedzminskim mieczem dwurecznym, celujac w.*",
+                                    "type": 1
+                                  }
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_wiedzminski_ja_bardzo_ciezko_rani()"
+                              },
+                              {
+                                "name": "ja_masakruje1",
+                                "patterns": [
+                                  {
+                                    "pattern": "^[ >]*Dostrzegajac szanse na skuteczny atak na (?<target>.+?), chwytasz srebrny wiedzminski miecz dwureczny za podkrzyze i wykonujesz serie szybkich ciec i pchniec, z ktorych kazde rani i wyraznie meczy przeciwni",
+                                    "type": 1
+                                  }
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_wiedzminski_ja_masakruje1()"
+                              },
+                              {
+                                "name": "ja_masakruje",
+                                "patterns": [
+                                  {
+                                    "pattern": "^[ >]*Ukladasz wygodnie obie rece na rekojesci srebrnego wiedzminskiego miecza dwurecznego, poprawiajac w ten sposob uchwyt broni.*",
+                                    "type": 1
+                                  }
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_color_color_moje_ciosy_wiedzminski_ja_masakruje()"
+                              }
+                            ]
+                          },
+                          {
                             "name": "wiedzminski",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_srebrny_wiedzminski_miecz_dwureczny()",
                             "patterns": [
                               {
                                 "pattern": "^Widzisz jak (?<attacker>\\w+(?: \\w+){0,4}) chwyta (?:prawa|lewa) reka za podkrzyze swego srebrnego wiedzminskiego miecza dwurecznego, by wykonac nim blyskawiczne ciecie, mierzac w (?<where_target>.+?)\\. Cios trafia zaskoczonego przeciwnika, zaledwie go jednak muskajac\\.$",
@@ -2868,18 +3022,17 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wykonuje zwinny polobrot, ciagnac sztych swego srebrnego wiedzminskiego miecza dwurecznego tuz za soba by uderzyc nim w (?<target>\\w+(?: \\w+){0,4})\\. Precyzyjny cios tnie cel prosto w (?<where>.+?), pozostawiajac lekkie rany\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_srebrny_wiedzminski_miecz_dwureczny()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       }
                     ]
                   },
                   {
                     "name": "drzewce",
                     "patterns": [],
-                    "triggers": [],
-                    "groups": [
+                    "triggers": [
                       {
                         "name": "ognisty_trojzab",
                         "patterns": [
@@ -2891,17 +3044,16 @@
                         "triggers": [
                           {
                             "name": "trojzab_0",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_ognisty_trojzab(0)",
                             "patterns": [
                               {
                                 "pattern": "^(?<attacker>.+?) wykonuje straszliwy cios ogromnym ognistym trojzebem\\. Cios, ktory winien byl rozplatac (?<target>.+?) na miejscu ostatecznie rozstrzygajac konfrontacje, jednak caly impet zostal wyparowany przez .*\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_ognisty_trojzab(0)"
                           },
                           {
                             "name": "trojzab_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_ognisty_trojzab(1)",
                             "patterns": [
                               {
                                 "pattern": "rozognione plomieniem smugi",
@@ -2911,21 +3063,21 @@
                                 "pattern": "wykonujac zamach uderza",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_ognisty_trojzab(1)"
                           },
                           {
                             "name": "trojzab_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_ognisty_trojzab(2)",
                             "patterns": [
                               {
                                 "pattern": "rozpalone ogniem smugi",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_ognisty_trojzab(2)"
                           },
                           {
                             "name": "trojzab_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_ognisty_trojzab(3)",
                             "patterns": [
                               {
                                 "pattern": "krwi i swadu palonego ciala",
@@ -2935,21 +3087,21 @@
                                 "pattern": "plonaca stala ogromnego ognistego trojzebu przebija",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_ognisty_trojzab(3)"
                           },
                           {
                             "name": "trojzab_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_ognisty_trojzab(4)",
                             "patterns": [
                               {
                                 "pattern": "rany w skamienialy wegiel",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_ognisty_trojzab(4)"
                           },
                           {
                             "name": "trojzab_5",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_ognisty_trojzab(5)",
                             "patterns": [
                               {
                                 "pattern": "zweglaniu sie rozpalonej zelazem rany",
@@ -2959,20 +3111,20 @@
                                 "pattern": "przy tym bardzo ciezkie obrazenia.",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_ognisty_trojzab(5)"
                           },
                           {
                             "name": "trojzab_6",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_ognisty_trojzab(6)",
                             "patterns": [
                               {
                                 "pattern": "impetem pozostawiajacym jeno plomienny rozmazany",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_ognisty_trojzab(6)"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "srebrzysta_kosa",
@@ -2985,7 +3137,6 @@
                         "triggers": [
                           {
                             "name": "kosa_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_kosa(1)",
                             "patterns": [
                               {
                                 "pattern": "Kaleczysz lekko",
@@ -2995,80 +3146,80 @@
                                 "pattern": "lekko kaleczy",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_kosa(1)"
                           },
                           {
                             "name": "kosa_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_kosa(2)",
                             "patterns": [
                               {
                                 "pattern": "zamaszystym cieciem",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_kosa(2)"
                           },
                           {
                             "name": "kosa_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_kosa(3)",
                             "patterns": [
                               {
                                 "pattern": "finezyjnym cieciem",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_kosa(3)"
                           },
                           {
                             "name": "kosa_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_kosa(4)",
                             "patterns": [
                               {
                                 "pattern": "raniac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_kosa(4)"
                           },
                           {
                             "name": "kosa_5",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_kosa(5)",
                             "patterns": [
                               {
                                 "pattern": "tnac",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_kosa(5)"
                           },
                           {
                             "name": "kosa_6",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_kosa(6)",
                             "patterns": [
                               {
                                 "pattern": "Potezne uderzenie",
                                 "type": 2
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_kosa(6)"
                           },
                           {
                             "name": "kosa_7",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_kosa(7)",
                             "patterns": [
                               {
                                 "pattern": "Na ostrzu pozostaja",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_kosa(7)"
                           },
                           {
                             "name": "kosa_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "Slyszysz ohydny dzwiek rozdzieranej tkanki",
                                 "type": 2
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "adamantytowa_partyzana",
@@ -3081,27 +3232,26 @@
                         "triggers": [
                           {
                             "name": "partyzana_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_partyzana(1)",
                             "patterns": [
                               {
                                 "pattern": "laskim pchnieciem trafia",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_partyzana(1)"
                           },
                           {
                             "name": "partyzana_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_partyzana(2)",
                             "patterns": [
                               {
                                 "pattern": "krwawy slad",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_partyzana(2)"
                           },
                           {
                             "name": "partyzana_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_partyzana(3)",
                             "patterns": [
                               {
                                 "pattern": "krwawa rane",
@@ -3111,60 +3261,60 @@
                                 "pattern": "do krwi ostrzem",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_partyzana(3)"
                           },
                           {
                             "name": "partyzana_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_partyzana(4)",
                             "patterns": [
                               {
                                 "pattern": "broczaca krwia rane",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_partyzana(4)"
                           },
                           {
                             "name": "partyzana_5",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_partyzana(5)",
                             "patterns": [
                               {
                                 "pattern": "az z rany tryska krew.",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_partyzana(5)"
                           },
                           {
                             "name": "partyzana_6",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_partyzana(6)",
                             "patterns": [
                               {
                                 "pattern": "Finezyjnym pchnieciem",
                                 "type": 2
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_partyzana(6)"
                           },
                           {
                             "name": "partyzana_7",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_partyzana(7)",
                             "patterns": [
                               {
                                 "pattern": "powietrzu smuge kropelek krwi.",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_partyzana(7)"
                           },
                           {
                             "name": "partyzana_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "natychmiast konczac walke.",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "kobaltowa_halabarda",
@@ -3177,7 +3327,6 @@
                         "triggers": [
                           {
                             "name": "kobaltowa_fin",
-                            "script": "trigger_func_skrypty_ui_gags_moje_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "Czujesz ogarniajacy cie chlod, gdy z szerokiego",
@@ -3187,11 +3336,11 @@
                                 "pattern": "Ostrze twojej ciernistej kobaltowej halabardy niemal przepolawia",
                                 "type": 2
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_moje_ciosy_bron_fin()"
                           },
                           {
                             "name": "kobaltowa_innych_fin",
-                            "script": "trigger_func_skrypty_ui_gags_innych_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "z nienaturalnie chlodnym obliczem",
@@ -3201,86 +3350,84 @@
                                 "pattern": "ostrzem swojej ciernistej kobaltowej halabardy",
                                 "type": 0
                               }
-                            ]
-                          }
-                        ],
-                        "groups": [
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_innych_ciosy_bron_fin()"
+                          },
                           {
                             "name": "ciosy",
                             "patterns": [],
                             "triggers": [
                               {
                                 "name": "kobaltowa_0",
-                                "script": "trigger_func_skrypty_ui_gags_ciosy_kobaltowa(0)",
                                 "patterns": [
                                   {
                                     "pattern": "doslownie o wlos",
                                     "type": 0
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_ciosy_kobaltowa(0)"
                               },
                               {
                                 "name": "kobaltowa_1",
-                                "script": "trigger_func_skrypty_ui_gags_ciosy_kobaltowa(1)",
                                 "patterns": [
                                   {
                                     "pattern": "ledwie zahaczajac",
                                     "type": 0
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_ciosy_kobaltowa(1)"
                               },
                               {
                                 "name": "kobaltowa_2",
-                                "script": "trigger_func_skrypty_ui_gags_ciosy_kobaltowa(2)",
                                 "patterns": [
                                   {
                                     "pattern": ", kaleczac",
                                     "type": 0
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_ciosy_kobaltowa(2)"
                               },
                               {
                                 "name": "kobaltowa_3",
-                                "script": "trigger_func_skrypty_ui_gags_ciosy_kobaltowa(3)",
                                 "patterns": [
                                   {
                                     "pattern": "bolesnie kaleczac",
                                     "type": 0
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_ciosy_kobaltowa(3)"
                               },
                               {
                                 "name": "kobaltowa_4",
-                                "script": "trigger_func_skrypty_ui_gags_ciosy_kobaltowa(4)",
                                 "patterns": [
                                   {
                                     "pattern": ", gleboko raniac",
                                     "type": 0
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_ciosy_kobaltowa(4)"
                               },
                               {
                                 "name": "kobaltowa_5",
-                                "script": "trigger_func_skrypty_ui_gags_ciosy_kobaltowa(5)",
                                 "patterns": [
                                   {
                                     "pattern": "tniesz bolesnie",
                                     "type": 0
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_ciosy_kobaltowa(5)"
                               },
                               {
                                 "name": "kobaltowa_6",
-                                "script": "trigger_func_skrypty_ui_gags_ciosy_kobaltowa(6)",
                                 "patterns": [
                                   {
                                     "pattern": "bardzo gleboko raniac",
                                     "type": 0
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_ciosy_kobaltowa(6)"
                               }
-                            ],
-                            "groups": []
+                            ]
                           },
                           {
                             "name": "spec",
@@ -3288,36 +3435,35 @@
                             "triggers": [
                               {
                                 "name": "kobaltowa_spec_1",
-                                "script": "trigger_func_skrypty_ui_gags_kobaltowa_spec(1)",
                                 "patterns": [
                                   {
                                     "pattern": "ostrze ledwie",
                                     "type": 0
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_kobaltowa_spec(1)"
                               },
                               {
                                 "name": "kobaltowa_spec_2",
-                                "script": "trigger_func_skrypty_ui_gags_kobaltowa_spec(2)",
                                 "patterns": [
                                   {
                                     "pattern": "tnie cialo",
                                     "type": 0
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_kobaltowa_spec(2)"
                               },
                               {
                                 "name": "kobaltowa_spec_3",
-                                "script": "trigger_func_skrypty_ui_gags_kobaltowa_spec(3)",
                                 "patterns": [
                                   {
                                     "pattern": "gleboko w cialo",
                                     "type": 0
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_kobaltowa_spec(3)"
                               }
-                            ],
-                            "groups": []
+                            ]
                           }
                         ]
                       },
@@ -3332,7 +3478,6 @@
                         "triggers": [
                           {
                             "name": "czarna_glewia",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarna_smukla_glewia()",
                             "patterns": [
                               {
                                 "pattern": "^Samym koncem ostrza czarnej smuklej glewii trafiasz (?<target>.+?) w (?<where>.+?) (?<damage>nieznacznie) (?:go|ja) raniac\\.$",
@@ -3358,11 +3503,11 @@
                                 "pattern": "^Zdradzieckim cieciem wyprowadzonym od dolu trafiasz (?<target>.+?)\\. Widzisz jak ostrze czarnej smuklej glewii ze straszliwym impetem (?<damage>rozdziera cialo) przeciwni(?:ka|czki) docierajac niemal do polowy (?:jego|jej) korpusu\\. Twoja ofiara z trudem cofa sie uwalniajac tkwiaca w niej bron\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarna_smukla_glewia()"
                           },
                           {
                             "name": "czarna_glewia_innych",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarna_smukla_glewia()",
                             "patterns": [
                               {
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) trafia (?<target>.+?) samym koncem ostrza czarnej smuklej glewii w (?<where>.+?) (?<damage>nieznacznie) (?:cie|go|ja) raniac\\.$",
@@ -3396,11 +3541,11 @@
                                 "pattern": "^Ostrze czarnej smuklej glewii trzymanej przez (?<attacker>.+?) trafia (?<target>.+?) nie wyrzadzajac mu wiekszej krzywdy\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarna_smukla_glewia()"
                           },
                           {
                             "name": "czarna_glewia_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "^Cofasz sie o dwa kroki i opuszczajac poziomo zelezce czarnej smuklej glewii rzucasz sie do przodu\\. Widzisz jak czarne ostrze blyskawicznie wbija sie gleboko w cialo (?<target>.+)\\. Zmieniasz chwyt i bezlitosnie przekrecasz drzewce powiekszajac jeszcze rozmiary obrazen\\. Gdy konczysz ruch, zauwazasz jak .+ wypreza sie gwaltownie a potem calkowicie nieruchomieje\\. Cofasz bron i widzisz jak bezwladne cialo powoli osuwa sie na ziemie\\.$",
@@ -3410,10 +3555,10 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) cofa sie o dwa kroki i opuszczajac poziomo zelezce czarnej smuklej glewii rzuca sie do przodu\\. Widzisz jak czarne ostrze blyskawicznie wbija sie gleboko w cialo (?<target>.+)\\. Napastni(?:k|czka) zmienia chwyt i bezlitosnie przekreca drzewce powiekszajac jeszcze rozmiary obrazen\\. Gdy konczy ruch, zauwazasz jak .+ wypreza sie gwaltownie a potem calkowicie nieruchomieje\\. Uwolnione od broni cialo powoli osuwa sie na ziemie\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "laska_druchii",
@@ -3426,24 +3571,22 @@
                         "triggers": [
                           {
                             "name": "dluga_ciemna_laska",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_dluga_ciemna_laska()",
                             "patterns": [
                               {
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4})(?:[Ww]znosi(?:sz|)|[Zz]atacza(?:sz|) szeroki luk) dluga ciemna lask.(?: wysoko ponad glowe|), kierujac wienczaca ja czaszke w (?:twoja |)strone(?<target>.*?)\\. Czerep momentalnie rozwiera swe szczeki, uwalniajac .+?, ktor. ogarnia (?:wycelowana ofiare|przeciwni(?:ka|czke)|cie), powodujac (?<damage>nieznaczne|lekkie|znaczne|powazne|potworne|straszliwe) obrazenia.",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_dluga_ciemna_laska()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       }
                     ]
                   },
                   {
                     "name": "topory",
                     "patterns": [],
-                    "triggers": [],
-                    "groups": [
+                    "triggers": [
                       {
                         "name": "archaiczny_topor",
                         "patterns": [
@@ -3455,7 +3598,6 @@
                         "triggers": [
                           {
                             "name": "archaiczny_0",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_archaiczny_topor(0)",
                             "patterns": [
                               {
                                 "pattern": "Bierzesz plynny zamach swoim ",
@@ -3465,80 +3607,80 @@
                                 "pattern": "bierze plynny zamach swoim archaicznym zdobionym toporem",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_archaiczny_topor(0)"
                           },
                           {
                             "name": "archaiczny_1",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_archaiczny_topor(1)",
                             "patterns": [
                               {
                                 "pattern": "niewielka rane.",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_archaiczny_topor(1)"
                           },
                           {
                             "name": "archaiczny_2",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_archaiczny_topor(2)",
                             "patterns": [
                               {
                                 "pattern": "czerwona szrame.",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_archaiczny_topor(2)"
                           },
                           {
                             "name": "archaiczny_3",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_archaiczny_topor(3)",
                             "patterns": [
                               {
                                 "pattern": "znacznie.",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_archaiczny_topor(3)"
                           },
                           {
                             "name": "archaiczny_4",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_archaiczny_topor(4)",
                             "patterns": [
                               {
                                 "pattern": "krwawiaca szrame.",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_archaiczny_topor(4)"
                           },
                           {
                             "name": "archaiczny_5",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_archaiczny_topor(5)",
                             "patterns": [
                               {
                                 "pattern": "bezlitosnie rozrywajac tkanki",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_archaiczny_topor(5)"
                           },
                           {
                             "name": "archaiczny_6",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_archaiczny_topor(6)",
                             "patterns": [
                               {
                                 "pattern": "Nastepny taki cios",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_archaiczny_topor(6)"
                           },
                           {
                             "name": "archaiczny_fin",
-                            "script": "trigger_func_skrypty_ui_gags_innych_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "znieruchomiec na zawsze.",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_innych_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "kunsztowny_mithrylowy_topor_bojowy",
@@ -3546,7 +3688,6 @@
                         "triggers": [
                           {
                             "name": "mithrylowy",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_kunsztowny_mithrylowy_topor_bojowy()",
                             "patterns": [
                               {
                                 "pattern": "^Twoj kunsztowny mithrylowy topor bojowy (?<damage>dotyka) (?<target>.+?) w (?<where>.+?) robiac ladna, swieza rane\\.$",
@@ -3612,10 +3753,10 @@
                                 "pattern": "^Nagle (?<target>.+?) zachwial sie pod impetem (?<damage>druzgoczacego) ciosu twego kunsztownego mithrylowego topora bojowego\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_kunsztowny_mithrylowy_topor_bojowy()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "misterny_obosieczny_topor",
@@ -3625,8 +3766,7 @@
                             "type": 1
                           }
                         ],
-                        "triggers": [],
-                        "groups": [
+                        "triggers": [
                           {
                             "name": "moje",
                             "patterns": [
@@ -3638,7 +3778,6 @@
                             "triggers": [
                               {
                                 "name": "mister_1",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_misterny(1)",
                                 "patterns": [
                                   {
                                     "pattern": "^Z oszczednego zamachu uderzasz swym misternym obosiecznym toporem w (?<where>.+?) (?<target>.+?), znaczac ostrze broni kilkoma kroplami krwi\\.$",
@@ -3652,11 +3791,11 @@
                                     "pattern": "^Z oszczednego zamachu uderzasz swym misternym obosiecznym toporem w (?<target>.+?), nieznacznie raniac je(?:go|j) (?<where>.+?)\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_misterny(1)"
                               },
                               {
                                 "name": "mister_2",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_misterny(2)",
                                 "patterns": [
                                   {
                                     "pattern": "^Twoj misterny obosieczny topor zahacza o (?<where>.+?) (?<target>.+?), (?:pozostawiajac plytka, nierowna rane|zadajac nieduze obrazenia)\\.$",
@@ -3666,11 +3805,11 @@
                                     "pattern": "^Ostrym jak sztylet gornym szpikulcem sterczacym ze styliska misternego obosiecznego topora godzisz .*(, spuszczajac .* nieco krwi| w .+?, lekko (?:go|ja) raniac)\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_misterny(2)"
                               },
                               {
                                 "name": "mister_3",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_misterny(3)",
                                 "patterns": [
                                   {
                                     "pattern": "^Z szerokiego zamachu tniesz misternym obosiecznym toporem w (?<where>.+?) (?<target>.+?), (?:a tryskajaca z tej rany krew zrasza ziemie|raniac (?:go|ja))\\.$",
@@ -3680,11 +3819,11 @@
                                     "pattern": "^Korzystajac z nadarzajacej sie okazji, gwaltownym uderzeniem styliska misternego obosiecznego topora wbijasz sterczacy zen szpic w (?<where>.+?) (?<target>.+?), pozostawiajac gleboka rane\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_misterny(3)"
                               },
                               {
                                 "name": "mister_4",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_misterny(4)",
                                 "patterns": [
                                   {
                                     "pattern": "^Rozpedzone ostrze dzierzonego przez ciebie misternego obosiecznego topora bezlitosnie wbija sie w (?<where>.+?) (?<target>.+?), (?:zadajac (?:jej|mu) ciezka rane|ciezko (?:go|ja) raniac)\\.$",
@@ -3694,11 +3833,11 @@
                                     "pattern": "^Naglym pchnieciem wbijasz sterczacy z nasady zelezca misternego obosiecznego topora kolec w (?<where>.+?) (?<target>.+?), (?:powodujac paskudny krwotok|zadajac powazne obrazenia)\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_misterny(4)"
                               },
                               {
                                 "name": "mister_5",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_misterny(5)",
                                 "patterns": [
                                   {
                                     "pattern": "^Przy akompaniamencie oszalamiajacego syku przecinanego powietrza krwawe ostrze twego misternego obosiecznego topora (?:godzi|wrzyna sie) w (?<where>.+?) (?<target>.+?), (?:odrzucajac (?:go|ja) w tyl niczym szmaciana lalke\\.|zadajac ogromne obrazenia!)$",
@@ -3708,11 +3847,11 @@
                                     "pattern": "^Z impetem wyrzucasz przed siebie misterny obosieczny topor, idealnie wymierzajac cios gornego szpica w (?<where>.+?) (?<target>.+?), bardzo ciezko (?:go|ja) raniac\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_misterny(5)"
                               },
                               {
                                 "name": "mister_6",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_misterny(6)",
                                 "patterns": [
                                   {
                                     "pattern": "^Druzgoczacym atakiem misternego obosiecznego topora brutalnie rozcinasz (?<where>.+?) (?<target>.+?), zatrzymujac ped swej morderczej broni dopiero wtedy, kiedy zbrukane posoka ostrze grzeznie pomiedzy koscmi ofiary\\.$",
@@ -3726,11 +3865,11 @@
                                     "pattern": "^Zdradliwe pchniecie ozdobiona siedmiocalowym kolcem rekojescia twego misternego obosiecznego topora zupelnie zaskakuje (?<target>.+?), pozwalajac ci (tym ciosem praktycznie wygrac walke!|przebic je(?:go|j) (?<where>.+?) prawie na wylot!)$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_misterny(6)"
                               },
                               {
                                 "name": "mister_fin",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_misterny_fin()",
                                 "patterns": [
                                   {
                                     "pattern": "^Szybki niczym atak kobry cios gornego szpikulca sterczacego z twojego misternego obosiecznego topora z mordercza sila trafia (?<target>.+?)(?: w (?<where>.+?), momentalnie pozbawiajac (?:go|ja) zycia\\. Bezwladne cialo pada u twych stop, wciaz jeszcze broczac krwia ze smiertelnej rany|, momentalnie konczac walke)\\.$",
@@ -3744,10 +3883,10 @@
                                     "pattern": "^Rzucajac sie do ostatecznego ataku wyprowadzasz straszliwe, pelne sily ciecie swym misternym obosiecznym toporem, ktore z mordercza precyzja smiertelnie godzi (?<target>.+?) w (?<where>.+?), ostatecznie konczac boj\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_misterny_fin()"
                               }
-                            ],
-                            "groups": []
+                            ]
                           },
                           {
                             "name": "innych",
@@ -3755,17 +3894,16 @@
                             "triggers": [
                               {
                                 "name": "mister 0",
-                                "script": "trigger_func_skrypty_ui_gags_misterny_innych(0)",
                                 "patterns": [
                                   {
                                     "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) niezgrabnym ruchem probuje zaskoczyc (?<target>.+?), ale jego wyrzucony przed siebie misterny obosieczny topor dzga tylko powietrze\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_misterny_innych(0)"
                               },
                               {
                                 "name": "mister 1",
-                                "script": "trigger_func_skrypty_ui_gags_misterny_innych(1)",
                                 "patterns": [
                                   {
                                     "pattern": "^Z oszczednego zamachu .* uderza .* misternym obosiecznym toporem",
@@ -3775,11 +3913,11 @@
                                     "pattern": "^Szybkim ciosem jednego ze szpikulcow misternego obosiecznego topora .* uderza",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_misterny_innych(1)"
                               },
                               {
                                 "name": "mister 2",
-                                "script": "trigger_func_skrypty_ui_gags_misterny_innych(2)",
                                 "patterns": [
                                   {
                                     "pattern": "^.* zahacza misternym obosiecznym toporem",
@@ -3789,11 +3927,11 @@
                                     "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) godzi (?<target>.+) ostrym jak igla szpikulcem sterczacym ze styliska misternego obosiecznego topora w (?<where>.+?), upuszczajac (?:jej|mu) nieco krwi\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_misterny_innych(2)"
                               },
                               {
                                 "name": "mister 3",
-                                "script": "trigger_func_skrypty_ui_gags_misterny_innych(3)",
                                 "patterns": [
                                   {
                                     "pattern": "^.* z szerokiego zamachu tnie misternym obosiecznym toporem",
@@ -3803,11 +3941,11 @@
                                     "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wykorzystuje blad (?<target>.+?) i wbija (?:jej|mu) sterczacy z rekojesci misternego obosiecznego topora szpikulec w (?<where>.+?), pozostawiajac gleboka rane\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_misterny_innych(3)"
                               },
                               {
                                 "name": "mister 4",
-                                "script": "trigger_func_skrypty_ui_gags_misterny_innych(4)",
                                 "patterns": [
                                   {
                                     "pattern": "^Rozpedzone ostrze dzierzonego przez (?!ciebie)(?<attacker>.+?) misternego obosiecznego topora bezlitosnie wbija sie w (?<where_target>.+?), zadajac (?:jej|mu) ciezka rane\\.$",
@@ -3821,11 +3959,11 @@
                                     "pattern": "^Rozpedzone ostrze dzierzonego przez (?!ciebie)(?<attacker>.+?) misternego obosiecznego topora bezlitosnie wbija sie w (?<where_target>.+?), ciezko (?:go|je) raniac\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_misterny_innych(4)"
                               },
                               {
                                 "name": "mister 5",
-                                "script": "trigger_func_skrypty_ui_gags_misterny_innych(5)",
                                 "patterns": [
                                   {
                                     "pattern": "^Przy akompaniamencie oszalamiajacego syku przecinanego powietrza krwawe ostrze dzierzonego przez .* misternego obosiecznego topora",
@@ -3835,11 +3973,11 @@
                                     "pattern": ".* z impetem wyrzuca przed siebie misterny obosieczny topor",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_misterny_innych(5)\n\n"
                               },
                               {
                                 "name": "mister 6",
-                                "script": "trigger_func_skrypty_ui_gags_misterny_innych(6)",
                                 "patterns": [
                                   {
                                     "pattern": "^Druzgoczacym atakiem misternego obosiecznego topora (?<attacker>.+?) brutalnie rozcina (?<where_target>.+?), zatrzymujac ped swej morderczej broni dopiero wtedy, kiedy zbrukane posoka ostrze grzeznie pomiedzy koscmi ofiary\\.$",
@@ -3853,11 +3991,11 @@
                                     "pattern": "^Ostrze dzierzonego przez (?<attacker>.+?) misternego obosiecznego topora rozblyskuje w szalonym pedzie, straszliwie masakrujac (?<where_target>.+?)\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_misterny_innych(6)"
                               },
                               {
                                 "name": "mister fin",
-                                "script": "trigger_func_skrypty_ui_gags_innych_ciosy_bron_fin()",
                                 "patterns": [
                                   {
                                     "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) szybkim niczym atak kobry ciosem sterczacego z misternego obosiecznego topora gornego szpikulca z mordercza sila i precyzja trafia (?<target>.+?) w (?<where>.+?), momentalnie (konczac walke|pozbawiajac (?:go|ja) zycia\\. Bezwladne cialo wali sie na ziemie, wciaz broczac krwia ze smiertelnej rany)\\.$",
@@ -3875,10 +4013,10 @@
                                     "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) szybkim wypadem wymija (?<target>.+?), a jednoczesnie jego misterny obosieczny topor rozblyskuje dwukrotnie, zadajac mordercze ciecia\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_innych_ciosy_bron_fin()"
                               }
-                            ],
-                            "groups": []
+                            ]
                           }
                         ]
                       },
@@ -3893,16 +4031,15 @@
                         "triggers": [
                           {
                             "name": "gwiezdny",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_obosieczny_gwiezdny_topor()",
                             "patterns": [
                               {
                                 "pattern": "^(?:(?:Ostrze|Zelezce) twojego|Ostrza dzierzonego przez (?<attacker>.+?)) obosiecznego gwiezdnego topora (?:rozblyskuj[ae] nagle blaskiem tysiecy gwiazd, gdy ostrze broni )?(?<damage>niemal przecina w pol|tnie (?:lekko|plytko|gladko|gleboko|szeroko)) (?<target>.+?)(?:|, z sila i blaskiem spadajacej z nieba gwiazdy|, zostawiajac w powietrzu smuge mlecznobialego swiatla, blaknaca tak szybko, jak sie pojawila)\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_obosieczny_gwiezdny_topor()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "opalizujacy_runiczny_topor_obosieczny",
@@ -3912,135 +4049,133 @@
                             "type": 1
                           }
                         ],
-                        "triggers": [],
-                        "groups": [
+                        "triggers": [
                           {
                             "name": "moje",
                             "patterns": [],
                             "triggers": [
                               {
                                 "name": "opal spec 1",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal_spec(1)",
                                 "patterns": [
                                   {
                                     "pattern": "Wyprowadzasz potezny zamach opalizujacym runicznym toporem obosiecznym, jednak zle wymierzasz cios i bron zaledwie muska ",
                                     "type": 2
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal_spec(1)"
                               },
                               {
                                 "name": "opal spec 2",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal_spec(2)",
                                 "patterns": [
                                   {
                                     "pattern": "^Twoj opalizujacy runiczny topor obosieczny trafia (?<target>.+?), zaglebiajac sie lekko w je(?:go|j) (?<where>.+?)\\. Posoka powoli splywajaca po ostrzu zdaje sie gotowac\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal_spec(2)"
                               },
                               {
                                 "name": "opal spec 3",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal_spec(3)",
                                 "patterns": [
                                   {
                                     "pattern": "Zamaszystym cieciem opalizujacego runicznego topora obosiecznego trafiasz",
                                     "type": 2
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal_spec(3)"
                               },
                               {
                                 "name": "opal spec 4",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal_spec(4)",
                                 "patterns": [
                                   {
                                     "pattern": "Poteznym uderzeniem swojego opalizujacego runicznego topora obosiecznego",
                                     "type": 2
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal_spec(4)"
                               },
                               {
                                 "name": "opal spec 5",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal_spec(5)",
                                 "patterns": [
                                   {
                                     "pattern": "Ze swistem twoj opalizujacy runiczny topor obosieczny opada w kierunku ",
                                     "type": 2
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal_spec(5)"
                               },
                               {
                                 "name": "opal 1",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal(1)",
                                 "patterns": [
                                   {
                                     "pattern": "^Muskasz (?<target>.+?) w (?<where>.+?) swoim opalizujacym runicznym toporem obosiecznym\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal(1)"
                               },
                               {
                                 "name": "opal 2",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal(2)",
                                 "patterns": [
                                   {
                                     "pattern": "^Trafiasz (?<target>.+?) w (?<where>.+?) zamaszystym ciosem swojego opalizujacego runicznego topora obosiecznego, kaleczac (?:go|ja)\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal(2)"
                               },
                               {
                                 "name": "opal 3",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal(3)",
                                 "patterns": [
                                   {
                                     "pattern": "^Lekko ranisz (?<target>.+?), trafiajac (?:go|ja) w (?<where>.+?) zamaszystym cieciem swojego opalizujacego runicznego topora obosiecznego\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal(3)"
                               },
                               {
                                 "name": "opal 4",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal(4)",
                                 "patterns": [
                                   {
                                     "pattern": "^Wykonujesz potezny zamach opalizujacym runicznym toporem obosiecznym, raniac (?<target>.+?) w (?<where>.+?)$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal(4)"
                               },
                               {
                                 "name": "opal 5",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal(5)",
                                 "patterns": [
                                   {
                                     "pattern": "^Wykonujesz zamaszysty cios opalizujacym runicznym toporem obosiecznym, celujac w (?<target>.+?)\\. Ostrze wnika w cialo, pozostawiajac krwawa bruzde\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal(5)"
                               },
                               {
                                 "name": "opal 6",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal(6)",
                                 "patterns": [
                                   {
                                     "pattern": "^Potezne ciecie twojego opalizujacego runicznego topora obosiecznego trafia w (?<target>.+?), otwierajac krwawiaca rane na je(?:go|j) ciele\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal(6)"
                               },
                               {
                                 "name": "opal 7",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal(7)",
                                 "patterns": [
                                   {
                                     "pattern": "^Bezlitosnie masakrujesz (?<target>.+?) opalizujacym runicznym toporem obosiecznym, trafiajac (go|ja) w (?<where>.+?)\\. Wyglada na to, ze kolejne takie uderzenie bedzie juz ostatnim w tej walce\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal(7)"
                               },
                               {
                                 "name": "opal fin",
-                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal_fin()",
                                 "patterns": [
                                   {
                                     "pattern": "^Poteznym ciosem opalizujacego runicznego topora obosiecznego trafiasz (?<target>.+?) prosto w (?<where>.+?)\\. Krew zalewa (jej|mu) niewidzace juz nic oczy\\. Przeciwnik pada martwy\\.$",
@@ -4050,10 +4185,10 @@
                                     "pattern": "^Poteznym cieciem opalizujacego runicznego topora obosiecznego dosiegasz swego przeciwnika\\. Ostrze zaglebia sie w jego (?<where>.+?), przecinajac miesnie i gruchoczac kosci\\. Biale, oslepiajace swiatlo ktore bije od runow zdaje sie dodatkowo (?:go |ja |)ranic\\. (?<target>.+?) zamiera, .* na ziemie, dygoczac chwile, po czym nieruchomieje\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_moje_ciosy_opal_fin()"
                               }
-                            ],
-                            "groups": []
+                            ]
                           },
                           {
                             "name": "innych",
@@ -4061,7 +4196,6 @@
                             "triggers": [
                               {
                                 "name": "opal 1",
-                                "script": "trigger_func_skrypty_ui_gags_opal_innych(1)",
                                 "patterns": [
                                   {
                                     "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) (?<!ledwo )muska (?<target>.+) w (?<where>.+?) opalizujacym runicznym toporem obosiecznym\\.$",
@@ -4071,21 +4205,21 @@
                                     "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) ledwo muska cie w (?<where>.+?) swoim opalizujacym runicznym toporem obosiecznym\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_opal_innych(1)"
                               },
                               {
                                 "name": "opal 2",
-                                "script": "trigger_func_skrypty_ui_gags_opal_innych(2)",
                                 "patterns": [
                                   {
                                     "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) trafia (?<target>.+) w (?<where>.+?) zamaszystym ciosem opalizujacego runicznego topora obosiecznego, kaleczac (?:cie|go|ja)\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_opal_innych(2)"
                               },
                               {
                                 "name": "opal 3",
-                                "script": "trigger_func_skrypty_ui_gags_opal_innych(3)",
                                 "patterns": [
                                   {
                                     "pattern": "^.* lekko rani .* zamaszystym cieciem opalizujacego runicznego topora obosiecznego\\.$",
@@ -4095,100 +4229,100 @@
                                     "pattern": "^(.+?) lekko muska (?<target>.+?) zamaszystym cieciem opalizujacego runicznego topora obosiecznego.\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_opal_innych(3)"
                               },
                               {
                                 "name": "opal 4",
-                                "script": "trigger_func_skrypty_ui_gags_opal_innych(4)",
                                 "patterns": [
                                   {
                                     "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wykonuje potezny zamach opalizujacym runicznym toporem obosiecznym, raniac (?<target>.+?) w (?<where>.+?)\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_opal_innych(4)"
                               },
                               {
                                 "name": "opal 5",
-                                "script": "trigger_func_skrypty_ui_gags_opal_innych(5)\n\n",
                                 "patterns": [
                                   {
                                     "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wykonuje zamaszysty cios opalizujacym runicznym toporem obosiecznym, celujac w (?<target>.+?)\\. Ostrze wnika w cialo, pozostawiajac krwawa bruzde\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_opal_innych(5)\n\n"
                               },
                               {
                                 "name": "opal 6",
-                                "script": "trigger_func_skrypty_ui_gags_opal_innych(6)",
                                 "patterns": [
                                   {
                                     "pattern": "^Potezne ciecie opalizujacego runicznego topora (?<attacker>\\w+(?: \\w+){0,4}) dosiega",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_opal_innych(6)"
                               },
                               {
                                 "name": "opal 7",
-                                "script": "trigger_func_skrypty_ui_gags_opal_innych(7)",
                                 "patterns": [
                                   {
                                     "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) bezlitosnie masakruje (?<target>.+?) opalizujacym runicznym toporem obosiecznym\\. Wyglada na to, ze kolejne uderzenie (.+?) bedzie juz ostatnim w tej walce\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_opal_innych(7)"
                               },
                               {
                                 "name": "opal spec 1",
-                                "script": "trigger_func_skrypty_ui_gags_opal_spec_innych(1)",
                                 "patterns": [
                                   {
                                     "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wyprowadza potezny zamach opalizujacym runicznym toporem obosiecznym, jednak zle wymierza cios i bron zaledwie muska (?<target>.*)\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_opal_spec_innych(1)"
                               },
                               {
                                 "name": "opal spec 2",
-                                "script": "trigger_func_skrypty_ui_gags_opal_spec_innych(2)",
                                 "patterns": [
                                   {
                                     "pattern": "Opalizujacy runiczny topor obosieczny (?<attacker>.+?) trafia (?<target>.*), zaglebiajac sie lekko w je(?:go|j) (?<where>.+?)\\. Posoka powoli splywajaca po ostrzu zdaje sie gotowac\\.",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_opal_spec_innych(2)"
                               },
                               {
                                 "name": "opal spec 3",
-                                "script": "trigger_func_skrypty_ui_gags_opal_spec_innych(3)",
                                 "patterns": [
                                   {
                                     "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) zamaszystym cieciem opalizujacego runicznego topora obosiecznego trafia (?<target>.*)\\. Bron zaglebia sie w je(?:go|j) (?<where>.+?), a wyplywajaca z rany posoka zdaje sie odsuwac od otoczonego czerwona aura ostrza\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_opal_spec_innych(3)"
                               },
                               {
                                 "name": "opal spec 4",
-                                "script": "trigger_func_skrypty_ui_gags_opal_spec_innych(4)",
                                 "patterns": [
                                   {
                                     "pattern": "^.* poteznym uderzeniem swojego opalizujacego runicznego topora dosiega .*\\. Ostrze gruchocze",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_opal_spec_innych(4)"
                               },
                               {
                                 "name": "opal spec 5",
-                                "script": "trigger_func_skrypty_ui_gags_opal_spec_innych(5)",
                                 "patterns": [
                                   {
                                     "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) poteznym ciosem opalizujacego runicznego topora obosiecznego trafia (?<target>.+?) prosto w (?<where>.+?)\\. Krew zalewa (jej|mu) niewidzace juz nic oczy\\.$",
                                     "type": 1
                                   }
-                                ]
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_opal_spec_innych(5)"
                               }
-                            ],
-                            "groups": []
+                            ]
                           }
                         ]
                       },
@@ -4203,7 +4337,6 @@
                         "triggers": [
                           {
                             "name": "czarny_topor",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_topor()",
                             "patterns": [
                               {
                                 "pattern": "^(?<damage>Kaleczysz) (?<target>.+?) czarnym smuklym toporem trafiajac (?:go|ja) w (?<where>.+?)\\.$",
@@ -4229,11 +4362,11 @@
                                 "pattern": "^Potezne uderzenie trzymanego przez ciebie czarnego smuklego topora zaglebia jego ostrze w ciele (?<target>.+?)\\. Do twoich uszu dociera nieprzyjemny zgrzyt, jak gdyby twoja bron napotkala cos twardego i przeciela to\\. Widzisz jak przeciwni(?:k|czka) chwieje sie, o malo nie (?<damage>upadajac) na ziemie\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_topor()"
                           },
                           {
                             "name": "czarny_topor_innych",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_topor()",
                             "patterns": [
                               {
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) (?<damage>kaleczy) (?<target>.+?) trafiajac (?:go|ja) czarnym smuklym toporem w (?<where>.+?)\\.$",
@@ -4255,11 +4388,11 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wyprowadza potezne uderzenie czarnym smuklym toporem i zaglebia jego ostrze w ciele (?<target>.+?)\\. Do twoich uszu dociera nieprzyjemny zgrzyt, jak gdyby bron napotkala cos twardego i przeciela to\\. Widzisz jak trafion(?:y|a) chwieje sie, o malo nie (?<damage>upadajac) na ziemie\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_topor()"
                           },
                           {
                             "name": "czarny_topor_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "^Wykorzystujac chwile nieuwagi (?<target>.+?) bierzesz potezny zamach i uderzasz (?:go|ja) czarnym smuklym toporem\\. Ostrze twojej broni z gluchym odglosem wbija sie w cialo przeciwni(?:ka|czki) zaglebiajac sie w nim az po stylisko\\. Ostatnie, przedsmiertne, drgnienie ofiary niemal wyrywa ci bron z reki, wiec zdecydowanym ruchem uwalniasz ja i patrzysz beznamietnie jak .+ bezwladnie osuwa sie na ziemie\\.$",
@@ -4269,10 +4402,10 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wykorzystujac chwile nieuwagi (?<target>.+?) bierze potezny zamach i uderza (?:go|ja) czarnym smuklym toporem\\. Ostrze broni z gluchym odglosem wbija sie w cialo przeciwni(?:ka|czki) zaglebiajac sie w nim az po stylisko\\. Ostatnie, przedsmiertne, drgnienie ofiary niemal wyrywa .+ bron z reki, wiec zdecydowanym ruchem uwalnia ja i patrzy beznamietnie jak .+ bezwladnie osuwa sie na ziemie\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       }
                     ]
                   },
@@ -4282,7 +4415,6 @@
                     "triggers": [
                       {
                         "name": "snieznobialy_lsniacy_sztylet",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_nieznobialy_lsniacy_sztylet_moje()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) trafia snieznobialym lsniacym sztyletem w (?<where_target>.+?) pozostawiajac (?<damage>niewielka) rane\\.$",
@@ -4308,11 +4440,11 @@
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wyprowadza (?<damage>idealne) pchniecie snieznobialym lsniacym sztyletem trafiajac (?<target>.+?) w (?<where>.+?)\\. Krew szeroko tryska z rany\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_nieznobialy_lsniacy_sztylet_moje()"
                       },
                       {
                         "name": "lodowy_lsniacy_sztylet",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_lodowy_lsniacy_sztylet_moje()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) z sila snieznej lawiny wbija swoj lodowy lsniacy sztylet w (?<where_target>.+?)\\. Mrozne ostrze wnika gleboko, a rozchodzace sie z niego fale chlodu zadaja (?<damage>.*) obrazenia\\.$",
@@ -4334,11 +4466,11 @@
                             "pattern": "^Rozpedzony lodowy lsniacy sztylet (?<attacker>\\w+(?: \\w+){0,4}) wbija sie plytko w (?<where_target>.+?), pozostawiajac po sobie niewielka, lekko (?<damage>zmrozona) rane\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_lodowy_lsniacy_sztylet_moje()"
                       },
                       {
                         "name": "zabkowany_zakrzywiony_sztylet",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_zabkowany_zakrzywiony_sztylet()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wyprowadza szybkie pchniecie zabkowanym zakrzywionym sztyletem, jednak tym razem (?<target>.+?) okazuje sie od niego (?<damage>szybszy)\\.$",
@@ -4348,11 +4480,11 @@
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) trafia (?<target>.+?) w (?<where>.+?), (?<damage>delikatnie) znaczac koncem ostrza zabkowanego zakrzywionego sztyletu krwawa prege na je(?:go|j) skorze\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_zabkowany_zakrzywiony_sztylet()"
                       },
                       {
                         "name": "masywny_dlugi_sztylet",
-                        "script": "trigger_func_skrypty_ui_gags_ciosy_masywny_dlugi_sztylet_moje()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) blyskawicznym pchnieciem masywnego dlugiego sztyletu trafia (?<target>.+?) w (?<where>.+?)\\. W ostatniej chwili przeciwnik cofa sie gwaltownie o krok, przez co ostrze nie wchodzi w jego cialo dosc gleboko\\.$",
@@ -4370,10 +4502,324 @@
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) blyskawicznie prostuje reke wyrzucajac przed siebie masywny dlugi sztylet i trafia (?<target>.+?) w (?<where>.+?)\\. (?<damage>Krew) pokrywajaca ostrze swiadczy o celnosci tego uderzenia\\.$",
                             "type": 1
                           }
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_ciosy_masywny_dlugi_sztylet_moje()"
+                      },
+                      {
+                        "name": "sztylety_moje",
+                        "patterns": [
+                          {
+                            "pattern": "return scripts.gags:is_type(\"combat.avatar\")",
+                            "type": 4
+                          }
+                        ],
+                        "triggers": [
+                          {
+                            "name": "lodowy_lsniacy_sztylet_moje",
+                            "patterns": [
+                              {
+                                "pattern": "^Blyskawiczne pchniecie twoim lodowym lsniacym sztyletem w (?<where_target>.+?) pozostawia po sobie buchajaca krwia, (?<damage>powazna rane)\\. W powietrzu unosza sie smuzki bialej pary, powstajacej gdy ciepla posoka miesza sie z lodowatym ostrzem twej zabojczej broni\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Przed oczyma staje ci obraz snieznej burzy, gdy wbijasz swoj lodowy lsniacy sztylet gleboko w (?<where_target>.+?)\\. Na ciele przeciwni(?:czki|ka) krysztalki lodu mieszaja sie ze (?<damage>szkarlatna) krwia saczaca sie z rany\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Rozpedzony lodowy lsniacy sztylet wbija sie plytko w (?<where_target>.+?), pozostawiajac po sobie niewielka, lekko (?<damage>zmrozona) rane\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Skrzace sie ostrze twojego lodowego lsniacego sztyletu samym tylko czubkiem trafia w (?<where_target>.+?), pozostawiajac na je(?:go|j) skorze niewielka (?<damage>szrame)\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Twoj lodowy lsniacy sztylet ze swistem przeslizguje sie tuz obok (?<target>.+?) ciagnac za soba cieniutka (?<damage>smuge) bialych krysztalkow lodu\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wycie mroznego wichru dalekiej polnocy dzwieczy ci w uszach, gdy twoj lodowy lsniacy sztylet rozcina (?<where_target>.+?)\\. Twarz przeciwni(?:ka|czki) wykrzywia (?<damage>grymas) bolu, gdy fala obezwladniajacego chlodu przeplywa przez je(?:go|j) cialo\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wykorzystujac nieudolnosc i oslabienie swego przeciwnika, (?<damage>blyskawicznie) wyrzucasz reke dzierzaca lodowy lsniacy sztylet w jego kierunku i wbijasz smukle, mrozne ostrze az po sama garde\\. Z ust (?<target>.+?) wydobywa sie niemal bezglosny jek, gdy obezwladniajace zimno popycha go w ramiona smierci\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wzbierajaca w ostrzu twojego lodowego lsniacego sztyletu fala chlodu przenika na wskros cialo (?<target>.+?), gdy wbijasz (?:jej|mu) swa potezna bron prosto w (?<where>.+?)\\. Z otwartej w ten sposob rany wyplywa (?<damage>strumien) jaskrawoczerwonej krwi\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Z sila snieznej lawiny wbijasz swoj lodowy lsniacy sztylet w (?<where_target>.+?)\\. Mrozne ostrze wnika gleboko, a rozchodzace sie z niego fale chlodu zadaja (?<damage>.+?) obrazenia\\.$",
+                                "type": 1
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_lodowy_lsniacy_sztylet_moje()"
+                          },
+                          {
+                            "name": "polyskujacy_zdobiony_sztylet_moje",
+                            "patterns": [
+                              {
+                                "pattern": "^Trafiasz (?<target>.+?) w (?<where>.+?) trzymanym w rece sztyletem, (.+?) (?:go|ja) (?<damage>.*)\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Probujesz trafic (?<target>.+?) trzymanym w rece polyskujacym zdobionym sztyletem, ale twoj cios nieznacznie (?<damage>mija) cel\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Blyskawicznym ruchem wyrzucasz przed siebie trzymajaca zdobiony sztylet reke, (?<damage>raniac) (?<target>.+?) ta dziwna bronia w (?<where>.+?)\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wkladajac w pchniecie cala swoja sile blyskawicznym ruchem wbijasz sztylet w cialo (?<target>.+?)\\. Uswiadamiasz sobie, jak (?<damage>celne) bylo twoje uderzenie dopiero w chwili, gdy nieruchome juz cialo osuwa sie na ziemie\\. Jakby cieszac sie z wlasnie zadanej smierci klejnoty zdobiace bron rozblyskuja na chwile silniejszym swiatlem\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wykorzystujac luke w obronie przeciwnika przyskakujesz do (?<target>.+?) i z rozmachem (?<damage>trafiasz) (?:go|ja) w (?<where>.+?) trzymanym w rece sztyletem\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Szybkim zwodem dezorientujesz (?<target>.+?) po czym blyskawicznie uderzasz (?:go|ja) zdobionym sztyletem w (?<where>.+?), zadajac (?<damage>powazne) obrazenia\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wykonujesz szybki polobrot i wyprowadzasz cios, ktorego (?<target>.+?) nie jest w stanie ani uniknac, ani sparowac\\. Ostrze sztyletu trafia w (?<where>.+?) przeciwnika, (?<damage>zaglebiajac) sie w ciele\\.$",
+                                "type": 1
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_polyskujacy_zdobiony_sztylet_moje()"
+                          },
+                          {
+                            "name": "snieznobialy_lsniacy_sztylet_moje",
+                            "patterns": [
+                              {
+                                "pattern": "^Trafiasz snieznobialym lsniacym sztyletem w (?<where_target>.+?) pozostawiajac (?<damage>niewielka) rane\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wyprowadzasz szybkie pchniecie swoim snieznobialym lsniacym sztyletem mierzac w (?<where_target>.+?), jednak (?<damage>nie udaje) ci sie (?:go|jej) trafic\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Trafiasz (?<target>.+?) swoim snieznobialym lsniacym sztyletem w (?<where>.+?), jednak nie zadajesz (?:mu|jej) (?<damage>zadnych) obrazen\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Mocnym pchnieciem snieznobialym lsniacym sztyletem trafiasz (?<target>.+?) w (?<where>.+?) zadajac (?:jej|mu) (?<damage>powazna) rane\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wyprowadzasz szybkie pchniecie snieznobialym lsniacym sztyletem i trafiasz (?<target>.+?) w (?<where>.+?), (?<damage>wbijajac) (?:jej|mu) go az po rekojesc\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Twoje (?<damage>idealne) pchniecie snieznobialym lsniacym sztyletem trafia (?<target>.+?) w (?<where>.+?)\\. Krew szeroko tryska z rany\\.$",
+                                "type": 1
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_nieznobialy_lsniacy_sztylet_moje()"
+                          },
+                          {
+                            "name": "stalowe_smocze_pazury_moje",
+                            "patterns": [
+                              {
+                                "pattern": "^Doskakujesz do (?<target>.+?) i z grymasem na twarzy blyskawicznie (?<damage>tniesz) (?:go|ja) swymi stalowymi smoczymi pazurami w (?<where>.*)\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Nagle skrecasz swe cialo i wezowym ruchem omijasz zaslone (?<target>.+?)\\. Jedynie swist powietrza zdradza zadany z blyskawiczna szybkoscia cios, gdy stalowe smocze pazury rania (?<damage>gleboko) (.+?) w (?<where>.*)\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Odchylasz sie nieco w tyl i z zimnym usmiechem na ustach wyprowadzasz swymi stalowymi smoczymi pazurami zaskakujace ciecie od dolu, (?<damage>lekko) zahaczajac (?<target>.+?) w (?<where>.*)\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Ostrza stalowych smoczych pazurow z jazgotem zsuwaja sie po (.+?), gdy (?<target>.+?) (?<damage>wyparowuje) twoj cios\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wykonujesz blyskawiczny obrot wyrzucajac w przod swoja uzbrojona w stalowe smocze pazury dlon\\. Blysk zimnej stali przecina powietrze, gdy (?<damage>lekko) ranisz (?<target>.+?) w (?<where>.*)\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wykonujesz blyskawiczny obrot wyrzucajac w przod swoja uzbrojona w stalowe smocze pazury dlon\\. Blysk zimnej stali przecina powietrze, a ostrza wbijaja sie  w (?<where_target>.+?) pozostawiajac (?<damage>paskudna) szrame\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Poziomym cieciem swoich stalowych smoczych pazurow godzisz w (?<target>.+?), trafiajac w (?<where>.+?) i wywolujac (?<damage>bolesny) grymas na jego twarzy\\.$",
+                                "type": 1
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_stalowe_smocze_pazury_moje()"
+                          },
+                          {
+                            "name": "tileanskie_sprezynowe_stiletto_moje",
+                            "patterns": [
+                              {
+                                "pattern": "^Trafiasz (?<target>.+?) tileanskim sprezynowym stilettem w (?<where>.+?), raniac (?:go|ja)\\. Zwalniasz sprezyne, a potrojne .* (?<damage>.*)$",
+                                "type": 1
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_tileanskie_sprezynowe_stiletto_moje()"
+                          },
+                          {
+                            "name": "masywny_dlugi_sztylet_moje",
+                            "patterns": [
+                              {
+                                "pattern": "^Blyskawicznym pchnieciem masywnego dlugiego sztyletu trafiasz (?<target>.+?) w (?<where>.+?)\\. W ostatniej chwili przeciwnik (?<damage>cofa) sie gwaltownie o krok, przez co ostrze nie wchodzi w je(?:go|j) cialo dosc gleboko\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Raptownym ciosem masywnego dlugiego sztyletu trafiasz (?<target>.+?) w (?<where>.+?) zostawiajac na je(?:go|j) skorze (?<damage>plytka) rane\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Raptownym ciosem masywnego dlugiego sztyletu dosiegasz (?<target>.+?) trafiajac go w (?<where>.+?)\\. Ostrze bez trudu przecina skore pozostawiajac (?<damage>brzydka) rane\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wyprowadzasz gwaltowne pchniecie w (?<target>.+?), jednakze ostrze masywnego dlugiego sztyletu (?<damage>przecina) tylko powietrze\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Zbijasz cios (?<target>.+?) i doskakujesz do swojego przeciwnika jednoczesnie (?<damage>wbijajac) w niego swoj masywny dlugi sztylet az po sama rekojesc\\. Stojac tuz przy nim mozesz obserwowac, jak w jego oczach gasnie ostatnia iskra zycia\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Dostrzegajac blad w zastawie przeciwnika w mgnieniu oka skracasz dystans i wyprowadzasz serie pchniec masywnym dlugim sztyletem w (?<where>.+?) zadajac (?<target>.+?)(?<damage>dotkliwe) obrazenia\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Blyskawicznie prostujesz reke wyrzucajac przed siebie masywny dlugi sztylet i trafiasz (?<target>.+?) w (?<where>.+?)\\. (?<damage>Krew) pokrywajaca ostrze swiadczy o celnosci tego uderzenia\\.$",
+                                "type": 1
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_masywny_dlugi_sztylet_moje()"
+                          },
+                          {
+                            "name": "szylkretowy_falisty_sztylet_moje",
+                            "patterns": [
+                              {
+                                "pattern": "^Z (moca szkwalu|naporem spienionej fali|sila sztormu|szybkoscia zaglicy|potega wzburzonego morza|zajadloscia morskiego weza) wbijasz swoj szylkretowy falisty sztylet w (?<where_target>.+?), zostawiajac na ciele ofiary (?<damage>nieznaczne|nieduze|znaczne|bolesne|potworne|powazne|bardzo rozlegle) obrazenia\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Perla osadzona w glowicy szylkretowego falistego sztyletu wydaje sie na chwile blaknac, gdy jego ostrze (?<damage>mija) (?<target>.*)\\.$",
+                                "type": 1
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_szylkretowy_falisty_sztylet_moje()"
+                          },
+                          {
+                            "name": "tileanski_matowy_sztylet_moje",
+                            "patterns": [
+                              {
+                                "pattern": "^Doskakujesz do (?<target>.+?), plynnym ruchem unikajac je(?:go|j) ciosu, po czym wyprowadzasz zdradzieckie pchniecie tileanskim matowym sztyletem, celnie trafiajac (?:go|ja) w (?<where>.+?)\\. Matowe ostrze wchodzi bez oporu w cialo (.+?), zostawiajac po sobie (?<damage>gleboka) rane\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Ostrzem tileanskiego matowego sztyletu trafiasz (?<target>.+?) w (?<where>.+?), pozostawiajac na je(?:go|j) ciele (?<damage>lekka) rane\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Trafiasz (?<target>.+?) w (?<where>.+?) ostrzem swego tileanskiego matowego sztyletu, pozostawiajac na skorze (?<damage>plytka) rane\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wprowadzajac (?<target>.+?) w blad naglym skretem tulowia, wykorzystujesz je(?:go|j) dezorientacje zmniejszajac dzielacy was dystans paroma szybkimi krokami, by (?<damage>brutalnie) wbic tileanski matowy sztylet w je(?:go|j) (?<where>.+?)\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wykorzystujac oslabienie (?<target>.+?) skracasz szybko dzielacy was dystans\\. Z ogromna sila wbijasz raz za razem tileanski matowy sztylet w (?<where>.+?) ofiary, a z powstalej rany tryska (?<damage>fontanna) krwi\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Z kocia gracja zrywasz sie do przodu, a twoj tileanski matowy sztylet przecina powietrze wydajac nieprzyjemny dla uszu swist, by w koncu zaglebic sie w ciele (?<target>.+?), (?<damage>bardzo ciezko) (?:go|ja) raniac\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Widzac jak (?<target>.+?) slania sie na nogach, szybkim ruchem palcow zmieniasz uchwyt na tileanskim matowym sztylecie i z naglego zrywu dopadasz do nie(?:go|j) wbijajac (?:jej|mu) sztylet w (?<where>.+?)\\. (?<damage>Wyrwaniu) ostrza z ciala towarzyszy fontanna krwi buchajaca z je(?:go|j) zyl\\.$",
+                                "type": 1
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_tileanski_matowy_sztylet_moje()"
+                          },
+                          {
+                            "name": "zabkowany_zakrzywiony_sztylet_moje",
+                            "patterns": [
+                              {
+                                "pattern": "^Trafiasz (?<target>.+?) w (?<where>.+?), (?<damage>delikatnie) znaczac koncem ostrza zabkowanego zakrzywionego sztyletu krwawa (?:bruzde|prege) na jego (?:ciele|skorze)\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Trafiasz (?<target>.+?) zabkowanym zakrzywionym sztyletem w (?<where>.+?), znaczac ostrzem na je(?:go|j) ciele gleboka, (?<damage>krwawa) bruzde o poszarpanych brzegach\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Trafiasz (?<target>.+?) zabkowanym zakrzywionym sztyletem, (?<damage>raniac) (?:go|ja) dotkliwie w (?<where>.*)\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wbijasz zabkowany zakrzywiony sztylet (?<damage>gleboko) w (?<where_target>.+?) i ciagnac go lekko w gore czujesz, jak ostre stalowe zeby szarpia tkanki przeciwnika\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wbijasz zabkowany zakrzywiony sztylet w (?<where_target>.+?), zostawiajac brzydka, (?<damage>poszarpana) rane\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wyprowadzasz szybkie pchniecie zabkowanym zakrzywionym sztyletem, jednak tym razem (?<target>.+?) okazuje sie od ciebie (?<damage>szybsz)[ay]\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Plynnym ruchem obracasz zabkowany zakrzywiony sztylet, by zadac (?<target>.+?) (?<damage>mordercze) uderzenie od gory, nieomal (?:go|ja) rozplatujac\\.$",
+                                "type": 1
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_zabkowany_zakrzywiony_sztylet()"
+                          },
+                          {
+                            "name": "czarny_smukly_kordelas_moje",
+                            "patterns": [
+                              {
+                                "pattern": "^Naglym wypadem trafiasz (?<target>.+?) czarnym smuklym kordelasem w (?<where>.+?) lekko (?:go|ja) (?<damage>raniac)\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^(?<damage>Uderzasz) (?<target>.+?) czarnym smuklym kordelasem trafiajac (?:go|ja) w (?<where>.*)\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wykonujesz krotki zamach i (?<damage>ranisz) (?<target>.+?) ostrzem czarnego smuklego kordelasa trafiajac (?:go|ja) w (?<where>.*)\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Zwijasz sie w polpiruecie i uderzasz (?<target>.+?) ostrzem czarnego smuklego kordelasa\\. Widzisz, jak czubek sztyletu wbija sie w (?<where>.+?) przeciwni(czki|ka) otwierajac paskudna, (?<damage>poszarpana) rane\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Tniesz na odlew i trafiasz (?<target>.+?) czarnym smuklym kordelasem w (?<where>.+?) (?<damage>powaznie) (?:go|ja) raniac\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Przyskakujesz do (?<target>.+?) i (?<damage>poteznie) uderzasz od dolu\\. Cios, zbyt gwaltowny by ofiara mogla chociaz pomyslec o obronie, blyskawicznie dosiega ciala przeciwni(czki|ka)\\. Widzisz jak masywne ostrze czarnego smuklego kordelasa bez najmniejszych problemow otwiera dluga, poszarpana bruzde\\. Wykorzystujac szanse, z calej sily napierasz na bron, wbijajac ja coraz mocniej i glebiej\\.\\.\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Wzmacniajac cios gwaltownym zamachem trafiasz (?<target>.+?) ostrzem czarnego smuklego kordelasa w (?<where>.+?) bardzo (?<damage>ciezko) (?:go|ja) raniac\\.$",
+                                "type": 1
+                              },
+                              {
+                                "pattern": "^Ostrze twojego czarnego smuklego kordelasa trafia (?<target>.+?), jednak (?<damage>nie wyrzadza) (?:jej|mu) wiekszej krzywdy\\.$",
+                                "type": 1
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_kordelas_moje()"
+                          }
                         ]
-                      }
-                    ],
-                    "groups": [
+                      },
                       {
                         "name": "czarny_smukly_kordelas",
                         "patterns": [
@@ -4384,8 +4830,56 @@
                         ],
                         "triggers": [
                           {
+                            "name": "czarny_kordelas",
+                            "patterns": [
+                              {
+                                "pattern": "return scripts.gags:is_type(\"combat.avatar\")",
+                                "type": 4
+                              }
+                            ],
+                            "triggers": [
+                              {
+                                "name": "czarny_smukly_kordelas_moje",
+                                "patterns": [
+                                  {
+                                    "pattern": "^Naglym wypadem trafiasz (?<target>.+?) czarnym smuklym kordelasem w (?<where>.+?) lekko (?:go|ja) (?<damage>raniac)\\.$",
+                                    "type": 1
+                                  },
+                                  {
+                                    "pattern": "^(?<damage>Uderzasz) (?<target>.+?) czarnym smuklym kordelasem trafiajac (?:go|ja) w (?<where>.*)\\.$",
+                                    "type": 1
+                                  },
+                                  {
+                                    "pattern": "^Wykonujesz krotki zamach i (?<damage>ranisz) (?<target>.+?) ostrzem czarnego smuklego kordelasa trafiajac (?:go|ja) w (?<where>.*)\\.$",
+                                    "type": 1
+                                  },
+                                  {
+                                    "pattern": "^Zwijasz sie w polpiruecie i uderzasz (?<target>.+?) ostrzem czarnego smuklego kordelasa\\. Widzisz, jak czubek sztyletu wbija sie w (?<where>.+?) przeciwnika otwierajac paskudna, (?<damage>poszarpana) rane\\.$",
+                                    "type": 1
+                                  },
+                                  {
+                                    "pattern": "^Tniesz na odlew i trafiasz (?<target>.+?) czarnym smuklym kordelasem w (?<where>.+?) (?<damage>powaznie) (?:go|ja) raniac\\.$",
+                                    "type": 1
+                                  },
+                                  {
+                                    "pattern": "^Przyskakujesz do (?<target>.+?) i (?<damage>poteznie) uderzasz od dolu\\. Cios, zbyt gwaltowny by ofiara mogla chociaz pomyslec o obronie, blyskawicznie dosiega ciala przeciwnika\\. Widzisz jak masywne ostrze czarnego smuklego kordelasa bez najmniejszych problemow otwiera dluga, poszarpana bruzde\\. Wykorzystujac szanse, z calej sily napierasz na bron, wbijajac ja coraz mocniej i glebiej\\.\\.\\.$",
+                                    "type": 1
+                                  },
+                                  {
+                                    "pattern": "^Wzmacniajac cios gwaltownym zamachem trafiasz (?<target>.+?) ostrzem czarnego smuklego kordelasa w (?<where>.+?) bardzo (?<damage>ciezko) (?:go|ja) raniac\\.$",
+                                    "type": 1
+                                  },
+                                  {
+                                    "pattern": "^Ostrze twojego czarnego smuklego kordelasa trafia (?<target>.+?), jednak (?<damage>nie wyrzadza) (?:jej|mu) wiekszej krzywdy\\.$",
+                                    "type": 1
+                                  }
+                                ],
+                                "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_kordelas_moje()"
+                              }
+                            ]
+                          },
+                          {
                             "name": "czarny_kordelas_innych",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_kordelas()",
                             "patterns": [
                               {
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) uderza (?<target>.+?) czarnym smuklym kordelasem (?<damage>trafiajac) (?:go|ja) w (?<where>.*)\\.$",
@@ -4411,20 +4905,20 @@
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) uderza czarnym smuklym kordelasem (?<damage>trafiajac) (?<target>cie) w (?<where>.*)\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_czarny_smukly_kordelas()"
                           },
                           {
                             "name": "czarny_kordelas_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) przyskakuje do (?<target>.+?) i poteznie uderza od dolu\\. Cios, zbyt gwaltowny by ofiara mogla chociaz pomyslec o obronie, blyskawicznie dosiega ciala atakowane(?:go|j)\\. Widzisz jak masywne ostrze czarnego smuklego kordelasa bez najmniejszych problemow otwiera dluga, poszarpana bruzde\\. Wykorzystujac szanse, .+ z calej sily napiera na bron, wbijajac ja coraz mocniej i glebiej\\.\\.\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       },
                       {
                         "name": "antyczny_sztylet",
@@ -4437,7 +4931,6 @@
                         "triggers": [
                           {
                             "name": "antyczny_sztylet_moje",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_antyczny_sztylet()",
                             "patterns": [
                               {
                                 "pattern": "^(?:Jak gdyby kierowane wlasna wola, o|O)strze twojego antycznego zdobionego sztyletu trafia (?<target>.+?) w (?<where>.+?), pozostawiajac na je(?:go|j) ciele (?<damage>.+)\\.$",
@@ -4451,11 +4944,11 @@
                                 "pattern": "^Ostrze twojego antycznego zdobionego sztyletu trafia (?<target>.+?), nie czyniac (?:mu|jej) (?<damage>zadnej) krzywdy\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_antyczny_sztylet()"
                           },
                           {
                             "name": "antycznty_sztylet_fin",
-                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()",
                             "patterns": [
                               {
                                 "pattern": "^Trzymany przez (?<attacker>.+?) antyczny zdobiony sztylet jak gdyby z wlasnej woli wypryskuje do przodu w blyskawicznym, prawie nieuchwytnym dla oka uderzeniu, zaglebiajac sie az po rekojesc w ciele (?<target>.+?)\\. Ofiara nieruchomieje, bardzo powoli osuwajac sie na ziemie\\.$",
@@ -4465,10 +4958,10 @@
                                 "pattern": "[Bb]lyskawicznie skracajac dystans przyskakuje(?:sz|) do (?<target>.+?) i z calej sily tnie(?:sz|) swym antycznym zdobionym sztyletem\\. Potezne, smiertelne uderzenie powoduje, ze ostrze (?:twojej|jego|jej) broni rozblyskuje chciwym blaskiem\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_ciosy_bron_fin()"
                           }
-                        ],
-                        "groups": []
+                        ]
                       }
                     ]
                   }
@@ -4485,66 +4978,65 @@
                 "triggers": [
                   {
                     "name": "ja_ledwo_muska",
-                    "script": "trigger_func_skrypty_ui_gags_color_moje_ciosy(1)",
                     "patterns": [
                       {
                         "pattern": "Ledwo muskasz",
                         "type": 2
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_moje_ciosy(1)"
                   },
                   {
                     "name": "ja_lekko_rani",
-                    "script": "trigger_func_skrypty_ui_gags_color_moje_ciosy(2)",
                     "patterns": [
                       {
                         "pattern": "Lekko ranisz",
                         "type": 2
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_moje_ciosy(2)"
                   },
                   {
                     "name": "ja_rani",
-                    "script": "trigger_func_skrypty_ui_gags_color_moje_ciosy(3)",
                     "patterns": [
                       {
                         "pattern": "Ranisz",
                         "type": 2
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_moje_ciosy(3)"
                   },
                   {
                     "name": "ja_powaznie_rani",
-                    "script": "trigger_func_skrypty_ui_gags_color_moje_ciosy(4)",
                     "patterns": [
                       {
                         "pattern": "Powaznie ranisz",
                         "type": 2
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_moje_ciosy(4)"
                   },
                   {
                     "name": "ja_bardzo_ciezko_rani",
-                    "script": "trigger_func_skrypty_ui_gags_color_moje_ciosy(5)",
                     "patterns": [
                       {
                         "pattern": "Bardzo ciezko ranisz",
                         "type": 2
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_moje_ciosy(5)"
                   },
                   {
                     "name": "ja_masakruje",
-                    "script": "trigger_func_skrypty_ui_gags_color_moje_ciosy(6)",
                     "patterns": [
                       {
                         "pattern": "Masakrujesz",
                         "type": 2
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_moje_ciosy(6)"
                   }
-                ],
-                "groups": []
+                ]
               },
               {
                 "name": "color_moje_spece",
@@ -4554,25 +5046,23 @@
                     "type": 4
                   }
                 ],
-                "triggers": [],
-                "groups": [
+                "triggers": [
                   {
                     "name": "str",
                     "patterns": [],
                     "triggers": [
                       {
                         "name": "ja_wytracam",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_wytracam()",
                         "patterns": [
                           {
                             "pattern": "^Szybkim niczym mysl ruchem .+? wytracasz .+? z (?:reki|rak) (?<target>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_wytracam()"
                       },
                       {
                         "name": "ja_spec_0",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_spec_0()",
                         "patterns": [
                           {
                             "pattern": "(^[ >]*Wykorzystujac brak broni u przeciwnika, .* rownowage.*\\.$)",
@@ -4582,31 +5072,31 @@
                             "pattern": "(^[ >]*Slamazarnym wymachem .* probujesz wytracic .* z .*\\. Przeciwnik nie daje sie jednak zaskoczyc.*\\.$)",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_spec_0()"
                       },
                       {
                         "name": "ja_spec_1",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_spec_1()",
                         "patterns": [
                           {
                             "pattern": "(^[ >]*Wykorzystujac brak broni u przeciwnika, .* (ledwie zahaczajac|ledwie sinca).*\\.$)",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_spec_1()"
                       },
                       {
                         "name": "ja_spec_2",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_spec_2()",
                         "patterns": [
                           {
                             "pattern": "(^[ >]*Wykorzystujac brak broni u przeciwnika, .* (lekko raniac|krwawiace zadrapanie).*\\.$)",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_spec_2()"
                       },
                       {
                         "name": "ja_spec_3",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_spec_3()",
                         "patterns": [
                           {
                             "pattern": "(^[ >]*Wykorzystujac brak broni u przeciwnika, .* dluga, poszarpana rane.*\\.$)",
@@ -4616,65 +5106,465 @@
                             "pattern": "(^[ >]*Wykorzystujac brak broni u przeciwnika,.*, mocno raniac.*\\.$)",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_spec_3()"
                       },
                       {
                         "name": "ja_spec_4",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_spec_4()",
                         "patterns": [
                           {
                             "pattern": "(^[ >]*Wykorzystujac brak broni u przeciwnika, .* (bardzo mocno raniac|gleboka rane z wystajacymi).*\\.$)",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_spec_4()"
                       },
                       {
                         "name": "ja_spec_5",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_spec_5()",
                         "patterns": [
                           {
                             "pattern": "(^[ >]*Wykorzystujac brak broni u przeciwnika, .* smiertelne.*\\.$)",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_spec_5()"
                       },
                       {
                         "name": "ja_spec_end",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_spec_end()",
                         "patterns": [
                           {
                             "pattern": "(^[ >]*Momentalnie dostrzegajac stan wroga, decydujesz sie na ostateczny cios\\. .*\\.$)",
                             "type": 1
                           }
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_str_ja_spec_end()"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "leg",
+                    "patterns": [],
+                    "triggers": [
+                      {
+                        "name": "ja_spec",
+                        "patterns": [
+                          {
+                            "pattern": "(^[ >]*Napierasz zdecydowanie bokiem na.*)",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "(^[ >]*Nie tracac dystansu do .* cofasz.*)",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "(^[ >]*Przesuwasz sie nieznacznie w bok, obchodzac powoli.*)",
+                            "type": 1
+                          }
+                        ],
+                        "triggers": [
+                          {
+                            "name": "ja_spec_0",
+                            "patterns": [
+                              {
+                                "pattern": "przecinajac tylko powietrze",
+                                "type": 0
+                              },
+                              {
+                                "pattern": "nie czyniac najmniejszej krzywdy",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_leg_ja_spec_ja_spec_0()"
+                          },
+                          {
+                            "name": "ja_spec_1",
+                            "patterns": [
+                              {
+                                "pattern": "powodujac tylko ledwo zauwazalne obrazenia",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_leg_ja_spec_ja_spec_1()"
+                          },
+                          {
+                            "name": "ja_spec_2",
+                            "patterns": [
+                              {
+                                "pattern": "powodujac tylko nieznaczne obrazenia",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_leg_ja_spec_ja_spec_2()"
+                          },
+                          {
+                            "name": "ja_spec_3",
+                            "patterns": [
+                              {
+                                "pattern": "powodujac niemale obrazenia",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_leg_ja_spec_ja_spec_3()"
+                          },
+                          {
+                            "name": "ja_spec_4",
+                            "patterns": [
+                              {
+                                "pattern": "powodujac liczne i glebokie obrazenia",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_leg_ja_spec_ja_spec_4()"
+                          },
+                          {
+                            "name": "ja_spec_5",
+                            "patterns": [
+                              {
+                                "pattern": "powodujac rozlegle obrazenia",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_leg_ja_spec_ja_spec_5()"
+                          },
+                          {
+                            "name": "ja_spec_6",
+                            "patterns": [
+                              {
+                                "pattern": "powodujac prawie ze smiertelne obrazenia",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_leg_ja_spec_ja_spec_6()"
+                          },
+                          {
+                            "name": "ja_spec_7",
+                            "patterns": [
+                              {
+                                "pattern": "w jednym momencie konczac walke",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_leg_ja_spec_ja_spec_7()"
+                          }
                         ]
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "mie",
                     "patterns": [],
                     "triggers": [
                       {
+                        "name": "ja_spec_obszar",
+                        "patterns": [
+                          {
+                            "pattern": "Korzystajac z dogodnego ustawienia przeciagasz",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "Wykorzystujac dynamike ciosu przeciagasz",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "Przykleknawszy na jedno kolano prowadzisz",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "Odpowiednio przenoszac ciezar ciala ciagniesz",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "Wyrzucasz do przodu",
+                            "type": 0
+                          }
+                        ],
+                        "triggers": [
+                          {
+                            "name": "ja_spec_obszar_0",
+                            "patterns": [
+                              {
+                                "pattern": "zlobiac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_obszar_ja_spec_obszar_0()"
+                          },
+                          {
+                            "name": "ja_spec_obszar_1",
+                            "patterns": [
+                              {
+                                "pattern": "muskajac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_obszar_ja_spec_obszar_1()"
+                          },
+                          {
+                            "name": "ja_spec_obszar_2",
+                            "patterns": [
+                              {
+                                "pattern": "lekko raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_obszar_ja_spec_obszar_2()"
+                          },
+                          {
+                            "name": "ja_spec_obszar_3",
+                            "patterns": [
+                              {
+                                "pattern": ", raniac",
+                                "type": 1
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_obszar_ja_spec_obszar_3()"
+                          },
+                          {
+                            "name": "ja_spec_obszar_4",
+                            "patterns": [
+                              {
+                                "pattern": ", kaleczac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_obszar_ja_spec_obszar_4()"
+                          },
+                          {
+                            "name": "ja_spec_obszar_5",
+                            "patterns": [
+                              {
+                                "pattern": "paskudnie kaleczac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_obszar_ja_spec_obszar_5()"
+                          },
+                          {
+                            "name": "ja_spec_obszar_6",
+                            "patterns": [
+                              {
+                                "pattern": "ciezko raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_obszar_ja_spec_obszar_6()"
+                          },
+                          {
+                            "name": "ja_spec_obszar_fin",
+                            "patterns": [
+                              {
+                                "pattern": "w smiertelnym cieciu",
+                                "type": 0
+                              },
+                              {
+                                "pattern": "smiertelnie raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_obszar_ja_spec_obszar_fin()"
+                          }
+                        ]
+                      },
+                      {
                         "name": "ja_spec_end",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_end()",
                         "patterns": [
                           {
                             "pattern": "Wyczekujesz na dogodny moment i tniesz nagle",
                             "type": 2
                           }
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_end()"
+                      },
+                      {
+                        "name": "ja_spec",
+                        "patterns": [
+                          {
+                            "pattern": "Nie zwazajac na nic rozpoczynasz",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "Ruszasz do przodu, w pol kroku",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "Poprawiasz chwyt na",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "Niespodziewanie skrecasz",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "Wyrzucasz do przodu",
+                            "type": 0
+                          }
+                        ],
+                        "triggers": [
+                          {
+                            "name": "ja_spec_0",
+                            "patterns": [
+                              {
+                                "pattern": "cudem",
+                                "type": 0
+                              },
+                              {
+                                "pattern": "ktore jednak",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_ja_spec_0()"
+                          },
+                          {
+                            "name": "ja_spec_1",
+                            "patterns": [
+                              {
+                                "pattern": "ledwo zacina",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_ja_spec_1()"
+                          },
+                          {
+                            "name": "ja_spec_2",
+                            "patterns": [
+                              {
+                                "pattern": "bolesnie zacina",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_ja_spec_2()"
+                          },
+                          {
+                            "name": "ja_spec_3",
+                            "patterns": [
+                              {
+                                "pattern": "plytko tnie",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_ja_spec_3()"
+                          },
+                          {
+                            "name": "ja_spec_4",
+                            "patterns": [
+                              {
+                                "pattern": "ktore tnie",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_ja_spec_4()"
+                          },
+                          {
+                            "name": "ja_spec_5",
+                            "patterns": [
+                              {
+                                "pattern": "gleboko tnie",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_ja_spec_5()"
+                          },
+                          {
+                            "name": "ja_spec_6",
+                            "patterns": [
+                              {
+                                "pattern": "niemalze rozcina",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_ja_spec_6()"
+                          },
+                          {
+                            "name": "ja_spec_7",
+                            "patterns": [
+                              {
+                                "pattern": "z potworna moca tnie",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_mie_ja_spec_ja_spec_7()"
+                          }
                         ]
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "fan",
                     "patterns": [],
                     "triggers": [
                       {
+                        "name": "ja_spec",
+                        "patterns": [
+                          {
+                            "pattern": ".*ostrzegajac luke w obronie (przeciwnika|przeciwniczki) rzucasz sie do ataku.*trafiasz.*",
+                            "type": 1
+                          }
+                        ],
+                        "triggers": [
+                          {
+                            "name": "ja_spec_1",
+                            "patterns": [
+                              {
+                                "pattern": "ledwo muskajac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_fan_ja_spec_ja_spec_1()"
+                          },
+                          {
+                            "name": "ja_spec_2",
+                            "patterns": [
+                              {
+                                "pattern": "lekko raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_fan_ja_spec_ja_spec_2()"
+                          },
+                          {
+                            "name": "ja_spec_3",
+                            "patterns": [
+                              {
+                                "pattern": "([a-z]+) raniac",
+                                "type": 1
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_fan_ja_spec_ja_spec_3()"
+                          },
+                          {
+                            "name": "ja_spec_4",
+                            "patterns": [
+                              {
+                                "pattern": "powaznie raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_fan_ja_spec_ja_spec_4()"
+                          },
+                          {
+                            "name": "ja_spec_5",
+                            "patterns": [
+                              {
+                                "pattern": "bardzo ciezko raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_fan_ja_spec_ja_spec_5()"
+                          },
+                          {
+                            "name": "ja_spec_6",
+                            "patterns": [
+                              {
+                                "pattern": "masakrujac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_fan_ja_spec_ja_spec_6()"
+                          }
+                        ]
+                      },
+                      {
                         "name": "ja_spec_7",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_fan_ja_spec_7()",
                         "patterns": [
                           {
                             "pattern": "Stajesz pewnie na szeroko rozstawionych nogach i wyprowadzasz potezne uderzenie .* Bezlitosny, okrutny cios trafia .* zaglebiajac bron w.*",
@@ -4684,20 +5574,20 @@
                             "pattern": "Wykrzykujac glosno imie \\w+ stajesz pewnie na szeroko rozstawionych nogach i wyprowadzasz potezne uderzenie",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_fan_ja_spec_7()"
                       },
                       {
                         "name": "ja_spec_0",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_fan_ja_spec_0()",
                         "patterns": [
                           {
                             "pattern": "Bierzesz potezny zamach i wyprowadza.*ktory ma zmasakrowac.*Jednak [a-z]+ bro.*, nie czyniac",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_fan_ja_spec_0()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "kor",
@@ -4705,26 +5595,25 @@
                     "triggers": [
                       {
                         "name": "ja_spec_0",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_kor_ja_spec_0()",
                         "patterns": [
                           {
                             "pattern": "^Niezgrabnym (?:ruchem unikasz ciosu|wypadem do przodu probujesz zaskoczyc) (?<target>.+?), a(?:le|) twoj(?:|a) (?<bron>.+?), wyrzucon(?:a|y) (?:przed siebie, dzga|w bok,? bardziej dla utrzymania rownowagi niz zadania ciosu, przecina) tylko powietrze\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_kor_ja_spec_0()"
                       },
                       {
                         "name": "ja_spec",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_kor_ja_spec()",
                         "patterns": [
                           {
                             "pattern": "^(?<damage>Powol|Oszczed|Zgrab|Plyn|Blyskawicz)nym (?:(?:polobrotem|ruchem) unikasz ciosu|wypadem (?:w przod|do przodu) atakujesz) (?<target>.+?)(?:,| korzystajac| i | dzgajac)",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_kor_ja_spec()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "bar",
@@ -4732,7 +5621,6 @@
                     "triggers": [
                       {
                         "name": "ja_spec_0",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bar_ja_spec_ja_spec_0()\n",
                         "patterns": [
                           {
                             "pattern": "^Nie (?:zastanawiajac sie dlugo|przebierajac w srodkach|silac sie na wirtuozerie|tracac czasu na zbedne manewry) probujesz walnac (?<target>.+?) na odlew (?<weapon>.+?), jednak (bron jakims cudem nie siega celu|przeciwnik w pore wykonuje unik, uciekajac poza zasieg broni)\\.$",
@@ -4742,30 +5630,30 @@
                             "pattern": "^Nie (?:zastanawiajac sie dlugo|przebierajac w srodkach|silac sie na wirtuozerie|tracac czasu na zbedne manewry) z calej sily walisz (?<target>.+?) na odlew (?<weapon>.+?), jednak (bron traci caly impet|cios zatrzymuje sie) na .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bar_ja_spec_ja_spec_0()\n"
                       },
                       {
                         "name": "ja_spec",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bar_ja_spec()",
                         "patterns": [
                           {
                             "pattern": "^Nie (zastanawiajac sie dlugo|przebierajac w srodkach|silac sie na wirtuozerie|tracac czasu na zbedne manewry) z calej sily walisz (?<target>.+?) na odlew (?<weapon>.+?), (?<damage>.+?) (?:mu|jej) przy tym (?<where>.+?)(?<stun>\\. Nieprzyjemne chrzakniecie i metny wzrok przeciwnika swiadcza, ze dobrze wymierzony cios musial trafic w jakies wrazliwe miejsce)?\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bar_ja_spec()"
                       },
                       {
                         "name": "ja_fin",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bar_ja_fin()",
                         "patterns": [
                           {
                             "pattern": "^Wykonujesz potezny zamach (?<weapon>.+?) i wkladajac w cios cala swa sile, uderzasz na odlew (?<target>.+?)\\. Twa bron ze zlowrogim .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bar_ja_fin()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "gla",
@@ -4773,436 +5661,435 @@
                     "triggers": [
                       {
                         "name": "1",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_1()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Parujesz cios (.*) i uderzasz (go|ja|je) .* lecz nie trafiasz\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_1()"
                       },
                       {
                         "name": "2",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_2()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Parujesz cios (.*) i odpowiadasz nan szybkim ciosem .*, zadajac nieznaczne obrazenia\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_2()"
                       },
                       {
                         "name": "3",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_3()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Ciosem (.*) zadajesz (.*) (nieduze obrazenia|nieduza rane) i uderzeniem .* odpychasz w tyl\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_3()"
                       },
                       {
                         "name": "4",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_4()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Odpychasz (.*) i lekko kaleczysz (go|ja|je) ciosem .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_4()"
                       },
                       {
                         "name": "5",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_5()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Sprawnie parujesz atak (.*) i ranisz (go|ja|je) celna kontra ciosu .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_5()"
                       },
                       {
                         "name": "6",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_6()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Mocnym uderzeniem .* oszalamiasz (.*) i ciosem .* zadajesz (mu|jej|jemu) (znaczne obrazenia|krwista rane)(,|) .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_6()"
                       },
                       {
                         "name": "7",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_7()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Zatrzymujesz atak (.*) pewnym blokiem .*i poteznym ciosem .* powaznie ranisz (mu|jej|jemu) .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_7()"
                       },
                       {
                         "name": "8",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_8()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Nurkujac pod atakiem (.*) mocno ranisz (go|ja|je) ciosem .*i zaraz po tym kaleczysz uderzeniem .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_8()"
                       },
                       {
                         "name": "9",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_9()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Kilkakrotnie tluczesz w (.*) poteznymi ciosami .* i (krwawo|ciezko) ranisz (go|ja|je) .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_9()"
                       },
                       {
                         "name": "10",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_10()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Z wyrywajacym sie z twej piersi bojowym okrzykiem dopadasz do (.*) i blokujac .*, niemalze zakanczajac potyczke\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_10()"
                       },
                       {
                         "name": "11",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_11()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Blokujesz atak (.*) i zadanym z pelnego sily obrotu ciosem .* (bardzo |)ciezko ranisz (go|ja|je) .*(, rozpylajac deszcz krwi|)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_11()"
                       },
                       {
                         "name": "12",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_12()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Z pelnym wscieklosci rykiem blokujesz (.*) i zadanym z rozmachu uderzeniem .* masakrujesz .*, blyskawicznie konczac walke\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_12()"
                       },
                       {
                         "name": "13",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_13()",
                         "patterns": [
                           {
                             "pattern": "Twardym ciosem .* (zamieniasz|masakrujesz) (.*)(w krwawa miazge | )i druzgoczacym ciosem .* rzucasz (go|ja|je) na ziemie\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_13()"
                       },
                       {
                         "name": "14",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_14()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Zgrabnym unikiem omijasz desperacki atak (.*) i zadanym jednoczesnie ciosem .* i .* masakrujesz .*, konczac walke\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_14()"
                       },
                       {
                         "name": "15",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_15()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Starasz sie trafic (.*) poteznym uderzeniem .*, jednak nie udaje ci sie to\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_15()"
                       },
                       {
                         "name": "16",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_16()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Z szerokiego zamachu zamierzasz sie (.*), jednak zbyt wolny cios ledwie ociera sie o .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_16()"
                       },
                       {
                         "name": "17",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_17()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Zadanym z zamachu ciosem .* z trudem dosiegasz (.*), zadajac jednak (lekkie obrazenia|lekka rane)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_17()"
                       },
                       {
                         "name": "18",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_18()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Sprawnie blokujesz atak (.*) i celnym ciosem .* odrzucasz go w tyl, bolesnie raniac .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_18()"
                       },
                       {
                         "name": "19",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_19()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Uzyskujac inicjatywe, mocnym zamachem .* zbijasz .* i rabiesz (.*), zadajac spore obrazenia\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_19()"
                       },
                       {
                         "name": "20",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_20()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Gardzac ryzykiem, rzucasz sie na (.*) by z karkolomnej szarzy dosiegnac .* miazdzacym uderzeniem .* zadajac ciezka rane.*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_20()"
                       },
                       {
                         "name": "21",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_21()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Umiejetnym uderzeniem z calych sil trafiasz (.*) straszliwie (go|ja) masakrujac. Przymierzasz sie do decydujacego ciosu\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_21()"
                       },
                       {
                         "name": "22",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_22()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Poteznym ciosem .* rozbijasz resztki zaslony (.*), rzucajac (go|ja) na ziemie, po czym brutalnie ponawiajac atak konczysz walke\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_22()"
                       },
                       {
                         "name": "23",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_23()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Wykorzystujac mase .* bez trudu odbijasz ostatni cios (.*) i skupiajac sily na poteznym ataku morderczo nacierasz, doszczetnie (go|ja) masakrujac\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_23()"
                       },
                       {
                         "name": "24",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_24()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Szybkim zrywem rzucasz sie ku (.*), niemalze w jednej chwili uderzajac .*. Zmasakrowana ofiara osuwa sie na ziemie, zakanczajac walke\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_24()"
                       },
                       {
                         "name": "25",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_25()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Odrzucajac finezje na rzecz skutecznosci, szarzujesz na (.*) w szalonym pedzie odbijajac .*, by w koncu druzgoczacym uderzeniem poslac (go|ja) na ziemie, niemalze konczac walke\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_25()"
                       },
                       {
                         "name": "26",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_26()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Niezlomnie nacierajac, odbijasz (.*) szybkim uderzeniem .* i zadanym z calej sily ciosem ciezko ranisz .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_26()"
                       },
                       {
                         "name": "27",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_27()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Wykorzystujac jedna ze sztuczek areny, blyskawicznie unikasz (.*) i mordercza kontra .* powaznie ranisz .*\\.",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_27()"
                       },
                       {
                         "name": "28",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_28()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Wykorzystujac zasieg .* bez trudu dosiegasz (.*) mocnym uderzeniem .* i sprawnie szykujesz sie do ponowienia ataku\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_28()"
                       },
                       {
                         "name": "29",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_29()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Naglym ruchem podrywasz .*, zaskakujac (.*), zadajac (znaczne obrazenia|krwawiaca rane)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_29()"
                       },
                       {
                         "name": "30",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_30()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Blyskawicznym ciosem .* mijasz (.*) o wlos\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_30()"
                       },
                       {
                         "name": "31",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_31()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Wyprowadzonym z zaskoczenia ciosem .* starasz sie trafic (.*), lecz zadajesz ledwie nieznaczne obrazenia\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_31()"
                       },
                       {
                         "name": "32",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_32()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Wykorzystujac luke w obronie (.*) celnym ciosem .* uderzasz .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_32()"
                       },
                       {
                         "name": "33",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_33()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Umiejetnie unikasz ciosu (.*) i silnie uderzasz .* w .*, (zadajac spore obrazenia|kaleczac cialo)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_33()"
                       },
                       {
                         "name": "34",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_34()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Szalenczo nacierasz, zasypujac (.*) kilkoma ciosami .*, z ktorych kazdy (pozostawia na .* skorze krwawiacy slad, raniac .*|rani .*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_34()"
                       },
                       {
                         "name": "35",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_35()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Szybkim zwodem wprowadzasz (.*) w blad, po czym mocno ranisz .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_35()"
                       },
                       {
                         "name": "36",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_36()",
                         "patterns": [
                           {
                             "pattern": "Blyskawicznym uderzeniem .* kaleczysz (.*) i natychmiast atakujesz ponownie, .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_36()"
                       },
                       {
                         "name": "37",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_37()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Nie czekajac na kolejny ruch (.*) szybkim atakiem przebijasz sie przez .* obrone, raniac .* ciosem .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_37()"
                       },
                       {
                         "name": "38",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_38()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Z bojowym okrzykiem rzucasz sie do ostatecznego natarcia, by bezlitosnym ciosem .* zmasakrowac (.*), konczac walke\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_38()"
                       },
                       {
                         "name": "39",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_39()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Niemalze instynktownym ruchem odbijasz (.*) i z wsciekloscia masakrujesz .* ciosem .*, konczac boj\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_39()"
                       },
                       {
                         "name": "40",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_40()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Nie baczac na ryzyko, z szybkiego wypadu umiejetnie atakujesz (.*), dosiegajac (go|ja) pelnym sily uderzeniem .* w .*, ciezko (go|ja) raniac\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_40()"
                       },
                       {
                         "name": "41",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_41()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Z gladiatorska wprawa uchylasz sie przed ostatnim atakiem (.*) i morderczo kontrujac ciosem .* zakanczasz walke, masakrujac (mu|jej) .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_41()"
                       },
                       {
                         "name": "42",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_42()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Sprawnie nacierasz na (.*), w pedzie uderzajac .* ciosem .* w .*, zadajac (niewielka rane|niewielkie obrazenia)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_42()"
                       },
                       {
                         "name": "43",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_43()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Eleganckim wypadem omijasz obrone (.*) i wyprowadzonym z poteznego zamachu ciosem masakrujesz (jego|jej).*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gla_43()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "noz",
@@ -5210,7 +6097,6 @@
                     "triggers": [
                       {
                         "name": "noz_ja_spec",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_noz_ja_spec()",
                         "patterns": [
                           {
                             "pattern": "^Blyskawicznie wyrzucasz przed siebie reke dzierzaca (?<weapon>.+?), trafiajac (?<target>.+?) w (?<where>.+?)\\. Ofiara krzywi sie z bolu, a ty wyszarpujesz szybko swa bron, pozostawiajac (?<damage>krwawiaca) rane\\.$",
@@ -5324,10 +6210,10 @@
                             "pattern": "^Wykonujesz plynny polobrot dla zmylenia (?<target>.+?), zyskujac tym samym czas niezbedny do zadania bardziej precyzyjnego ciosu\\. Poziomym cieciem swo(?:ich|jego) (?<weapon>.+?) godzisz w ni(a|ego), (?<damage>celnie) trafiajac w (?<where>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_noz_ja_spec()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "par",
@@ -5335,36 +6221,297 @@
                     "triggers": [
                       {
                         "name": "ja_spec_0",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_par_ja_spec_0()",
                         "patterns": [
                           {
                             "pattern": "^[ >]Probujesz dosiegnac * jednak twoja bron nieznacznie chybia celu\\.$",
                             "type": 1
                           }
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_par_ja_spec_0()"
+                      },
+                      {
+                        "name": "ja_spec",
+                        "patterns": [
+                          {
+                            "pattern": "^[ >]*Zbierajac sie w sobie uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Z oszczednego zamachu .* uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*W zamieszaniu uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Z doskoku uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Z szybkiego doskoku uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Szybko skladajac sie do ciosu uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Pewnym ruchem uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Bez chwili namyslu uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Dziko hallakujac uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Z grymasem wysilku uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Zaciskajac z wysilku zeby uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Plynnym ruchem uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Blyskawicznie uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Wrzeszczac na cale gardlo uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Blyskawicznie skladajac sie do ciosu uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Bez zastanowienia uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Niezbyt celnie uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Oszczednym ruchem uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Bez wysilku uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Niezbyt dokladnie uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Robiac oszczedny zamach uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*W pospiechu uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Korzystajac z zamieszania uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Z lekkiego wymachu uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*Robiac szeroki zamach uderzasz .*\\.$",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*W szalenczym porywie uderzasz .*\\.$",
+                            "type": 1
+                          }
+                        ],
+                        "triggers": [
+                          {
+                            "name": "ja_spec_1",
+                            "patterns": [
+                              {
+                                "pattern": "nieznacznie raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_par_ja_spec_ja_spec_1()"
+                          },
+                          {
+                            "name": "ja_spec_2",
+                            "patterns": [
+                              {
+                                "pattern": "lekko raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_par_ja_spec_ja_spec_2()"
+                          },
+                          {
+                            "name": "ja_spec_3",
+                            "patterns": [
+                              {
+                                "pattern": "bolesnie raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_par_ja_spec_ja_spec_3()"
+                          },
+                          {
+                            "name": "ja_spec_4",
+                            "patterns": [
+                              {
+                                "pattern": "powaznie raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_par_ja_spec_ja_spec_4()"
+                          },
+                          {
+                            "name": "ja_spec_5",
+                            "patterns": [
+                              {
+                                "pattern": "bardzo ciezko raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_par_ja_spec_ja_spec_5()"
+                          },
+                          {
+                            "name": "ja_spec_6",
+                            "patterns": [
+                              {
+                                "pattern": "potwornie raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_par_ja_spec_ja_spec_6()"
+                          }
                         ]
                       },
                       {
                         "name": "ja_spec_fin",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_par_ja_spec_fin()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Blyskawicznie doskakujesz do .*, bezlitosnie masakrujac .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_par_ja_spec_fin()"
                       },
                       {
                         "name": "ja_spec_fin",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_par_ja_spec_fin()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Gwaltownym zrywem doskakujesz do .* mordercze uderzenie.*\\.$",
                             "type": 1
                           }
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_par_ja_spec_fin()"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "gp",
+                    "patterns": [],
+                    "triggers": [
+                      {
+                        "name": "ktos_spec",
+                        "patterns": [
+                          {
+                            "pattern": "Wykorzystujac dogodny moment wyprowadzasz",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "Wykorzystujac dogodny moment probujesz wyprowadzic",
+                            "type": 0
+                          }
+                        ],
+                        "triggers": [
+                          {
+                            "name": "ja_spec_0",
+                            "patterns": [
+                              {
+                                "pattern": "lecz",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gp_ktos_spec_ja_spec_0()"
+                          },
+                          {
+                            "name": "ja_spec_1",
+                            "patterns": [
+                              {
+                                "pattern": ", ledwo muskajac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gp_ktos_spec_ja_spec_1()"
+                          },
+                          {
+                            "name": "ja_spec_2",
+                            "patterns": [
+                              {
+                                "pattern": ", lekko raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gp_ktos_spec_ja_spec_2()"
+                          },
+                          {
+                            "name": "ja_spec_3",
+                            "patterns": [
+                              {
+                                "pattern": ", raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gp_ktos_spec_ja_spec_3()"
+                          },
+                          {
+                            "name": "ja_spec_4",
+                            "patterns": [
+                              {
+                                "pattern": ", powaznie raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gp_ktos_spec_ja_spec_4()"
+                          },
+                          {
+                            "name": "ja_spec_5",
+                            "patterns": [
+                              {
+                                "pattern": ", bardzo ciezko raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gp_ktos_spec_ja_spec_5()"
+                          },
+                          {
+                            "name": "ja_spec_6",
+                            "patterns": [
+                              {
+                                "pattern": ", masakrujac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_gp_ktos_spec_ja_spec_6()"
+                          }
                         ]
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "sprzet",
@@ -5372,86 +6519,85 @@
                     "triggers": [
                       {
                         "name": "blekitno-srebrna-trojkatna-tarcza",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_zbroje_blekitno_srebrna_trojkatna_tarcza()",
                         "patterns": [
                           {
                             "pattern": "^Blekitno-srebrna trojkatna tarcza rozblyskuje nagle bardzo ostrym blekitnym swiatlem, skierowanym w strone (.*)!",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_zbroje_blekitno_srebrna_trojkatna_tarcza()"
                       },
                       {
                         "name": "ciemnogranatowy-smukly-helm",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_zbroje_ciemnogranatowy_smukly_helm()",
                         "patterns": [
                           {
                             "pattern": "^(?<target>\\w+(?: \\w+){0,4}) zaczyna wpatrywac sie pustym wzrokiem w slepia weza wijacego sie u podstawy twojego ciemnogranatowego smuklego helmu\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_zbroje_ciemnogranatowy_smukly_helm()"
                       },
                       {
                         "name": "lsniaca-plomienista-tarcza",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_zbroje_lsniaca_plomienista_tarcza()",
                         "patterns": [
                           {
                             "pattern": "^Nagle lustrzana powierzchnia lsniacej plomienistej tarczy rozblyskuje jasnoczerwonym, palacym swiatlem\\.",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_zbroje_lsniaca_plomienista_tarcza()"
                       },
                       {
                         "name": "waski-zebaty-palasz",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bron_truje()",
                         "patterns": [
                           {
                             "pattern": "Masz wrazenie, ze trucizna dostala sie do krwi przeciwnika.",
                             "type": 3
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bron_truje()"
                       },
                       {
                         "name": "ja_gigantyczny_granitowy_mlot",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bar_ja_granit()",
                         "patterns": [
                           {
                             "pattern": "^Bierzesz ogromny zamach swoim gigantycznym granitowym mlotem i uderzasz nim w glowe (?<target>.+?)\\. Przeciwnik mruga oczami, nie bardzo wiedzac, co sie dzieje\\. Porzadnie (?:go|ja) zamroczylo\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bar_ja_granit()"
                       },
                       {
                         "name": "ja_jasniejacy_zdobiony_jatagan",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bronie_jasniejacy_zdobiony_jatagan()",
                         "patterns": [
                           {
                             "pattern": "^Rozblysk swiatla oslepia (?<target>.*)!$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bronie_jasniejacy_zdobiony_jatagan()"
                       },
                       {
                         "name": "ja_gigantyczny_granitowy_mlot",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bar_ja_granit()",
                         "patterns": [
                           {
                             "pattern": "^Bierzesz ogromny zamach swoim gigantycznym granitowym mlotem i uderzasz nim w glowe (?<target>.+?)\\. Przeciwnik mruga oczami, nie bardzo wiedzac, co sie dzieje\\. Porzadnie (?:go|ja) zamroczylo\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bar_ja_granit()"
                       },
                       {
                         "name": "ja_jasniejacy_zdobiony_jatagan",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bronie_jasniejacy_zdobiony_jatagan()",
                         "patterns": [
                           {
                             "pattern": "^Rozblysk swiatla oslepia (?<target>.*)!$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_moje_spece_bronie_jasniejacy_zdobiony_jatagan()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   }
                 ]
               },
@@ -5461,7 +6607,6 @@
                 "triggers": [
                   {
                     "name": "ktos",
-                    "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_ktos()",
                     "patterns": [
                       {
                         "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}?) (?<damage>ledwo muska|lekko rani|bardzo ciezko rani|powaznie rani|rani|masakruje|smiertelnie rani) (?<target>cie) (?<weapon>.+?), trafiajac cie w (?<where>.*)\\.$",
@@ -5471,10 +6616,9 @@
                         "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}?) (?<damage>ledwo muska|lekko rani|bardzo ciezko rani|powaznie rani|rani|masakruje|smiertelnie rani) (?<target_weapon>.+?), trafiajac (?:go|ja|je) w (?<where>.*)\\.$",
                         "type": 1
                       }
-                    ]
-                  }
-                ],
-                "groups": [
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_ktos()"
+                  },
                   {
                     "name": "pajeczaki",
                     "patterns": [
@@ -5498,7 +6642,6 @@
                     "triggers": [
                       {
                         "name": "pajeczaki_0",
-                        "script": "trigger_func_skrypty_ui_gags_innych_ciosy_pajeczaki(0)",
                         "patterns": [
                           {
                             "pattern": "wyskakuje do przodu, usilujac ugryzc ",
@@ -5512,11 +6655,11 @@
                             "pattern": "^(?<attacker>\\w+ \\w+ \\w+) wykonuje nagly zamach jednym z odnozy, usilujac trafic nim w (?<where_target>.+?), jednak (cios ten zsuwa sie po .+?, nie czyniac \\w zadnej szkody|zle wymierzony atak zupelnie pudluje|\\w+ udaje sie uniknac tego ciosu)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_innych_ciosy_pajeczaki(0)"
                       },
                       {
                         "name": "pajeczaki_1",
-                        "script": "trigger_func_skrypty_ui_gags_innych_ciosy_pajeczaki(1)",
                         "patterns": [
                           {
                             "pattern": "ledwo muskajac",
@@ -5526,11 +6669,11 @@
                             "pattern": "zaledwie muska",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_innych_ciosy_pajeczaki(1)"
                       },
                       {
                         "name": "pajeczaki_2",
-                        "script": "trigger_func_skrypty_ui_gags_innych_ciosy_pajeczaki(2)",
                         "patterns": [
                           {
                             "pattern": "niewielkie rany",
@@ -5540,11 +6683,11 @@
                             "pattern": "lekko zacina",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_innych_ciosy_pajeczaki(2)"
                       },
                       {
                         "name": "pajeczaki_3",
-                        "script": "trigger_func_skrypty_ui_gags_innych_ciosy_pajeczaki(3)",
                         "patterns": [
                           {
                             "pattern": "raniac",
@@ -5558,65 +6701,63 @@
                             "pattern": "tnie skore",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_innych_ciosy_pajeczaki(3)"
                       },
                       {
                         "name": "pajeczaki_4",
-                        "script": "trigger_func_skrypty_ui_gags_innych_ciosy_pajeczaki(4)",
                         "patterns": [
                           {
                             "pattern": "powaznie",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_innych_ciosy_pajeczaki(4)"
                       },
                       {
                         "name": "pajeczaki_5",
-                        "script": "trigger_func_skrypty_ui_gags_innych_ciosy_pajeczaki(5)",
                         "patterns": [
                           {
                             "pattern": "bardzo ciezko raniac",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_innych_ciosy_pajeczaki(5)"
                       },
                       {
                         "name": "pajeczaki_6",
-                        "script": "trigger_func_skrypty_ui_gags_innych_ciosy_pajeczaki(6)",
                         "patterns": [
                           {
                             "pattern": "masakrujac",
                             "type": 0
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_innych_ciosy_pajeczaki(6)"
                       }
-                    ],
-                    "groups": []
+                    ]
                   }
                 ]
               },
               {
                 "name": "color_innych_spece",
                 "patterns": [],
-                "triggers": [],
-                "groups": [
+                "triggers": [
                   {
                     "name": "str",
                     "patterns": [],
                     "triggers": [
                       {
                         "name": "ktos_wytraca",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_str_ktos_wytraca()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) szybkim niczym mysl ruchem (.+?) wytraca (?<weapon>.+?) z (?:reki|rak) (?<target>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_str_ktos_wytraca()"
                       },
                       {
                         "name": "ktos_spec_0",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_str_ktos_spec_0()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wykorzystujac brak broni u przeciwnika, wyprowadza cios .+? mierzac w (?<target>.+?) i prawie traci rownowage po je(?:go|j) zrecznym uniku\\.$",
@@ -5634,11 +6775,11 @@
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) slamazarnym wymachem (?<weapon>.+?) probuje wytracic tobie .+? z (?:rak|reki)\\. Nie dajesz sie jednak zaskoczyc swojemu przeciwnikowi, (?:zbijajac je(?:go|j) uderzenie na bok|cofajac sie w pore)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_str_ktos_spec_0()"
                       },
                       {
                         "name": "ktos_spec",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_str_ktos_spec()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wykorzystujac brak broni u przeciwnika, (?:blyskawicznie|w mgnieniu oka|z wyuczona wprawa) wyprowadza cios .+? mierzac w (?<target>.+?)\\. Wypracowanym uderzeniem trafia (?:go|ja) w .+?, (?<damage>.*)\\.$",
@@ -5648,20 +6789,20 @@
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wykorzystujac twoj brak broni, (?:blyskawicznie|w mgnieniu oka|z wyuczona wprawa) wyprowadza cios (?<weapon>.+?) mierzac w (?<target>ciebie)\\. Wypracowane uderzenie trafia cie w (?<where>.+?), (?<damage>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_str_ktos_spec()"
                       },
                       {
                         "name": "ktos_spec_end",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_str_ktos_spec_end()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) wykorzystujac oslabienie (?<target>.+?) dosiega (?:go|ja) chlodnym i precyzyjnym pchnieciem .+?\\. Widzisz, jak przeciwnik rozpaczliwie probuje sie cofnac, lecz znuzenie i rany bezlitosnie daja (?:mu|jej) o sobie znac\\. Na koncu je(?:go|j) oczy rozszerzaja sie ze zdumienia i zaraz potem zachodza mgla\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_str_ktos_spec_end()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "leg",
@@ -5669,7 +6810,6 @@
                     "triggers": [
                       {
                         "name": "leg_ktos_spec",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_leg_ktos_spec()",
                         "patterns": [
                           {
                             "pattern": "(?<attacker>\\w+(?: \\w+ \\w+)?) (?:przesuwa sie nieznacznie w bok, obchodzac powoli|zdecydowanie napiera bokiem na) (?<target>.+?)(?:, | i).*\\. (?<damage>\\w+).*\\.$",
@@ -5687,10 +6827,241 @@
                             "pattern": "^(?<attacker>\\w+(?: \\w+ \\w+)?) podbiega do (?<target>.+?) i wyprowadzajac potezny cios od dolu, tnie (?:go|ja) w (?<where_target>.+?) swoim .+?, nie szczedzac nawet kosci\\. Widzisz, jak zmasakrowane cialo pada na ziemie, by znieruchomiec na zawsze\\.$",
                             "type": 1
                           }
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_leg_ktos_spec()"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "mie",
+                    "patterns": [],
+                    "triggers": [
+                      {
+                        "name": "ktos_spec_obszar",
+                        "patterns": [
+                          {
+                            "pattern": "Korzystajac z dogodnego ustawienia przeciaga ",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "Wykorzystujac dynamike ciosu przeciaga ",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "Przykleknawszy na jedno kolano prowadzi ",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "Odpowiednio przenoszac ciezar ciala ciagnie ",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "wyczekuje na dogodny moment i ",
+                            "type": 0
+                          }
+                        ],
+                        "triggers": [
+                          {
+                            "name": "ktos_spec_obszar_0",
+                            "patterns": [
+                              {
+                                "pattern": "zlobiac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_obszar_ktos_spec_obszar_0()"
+                          },
+                          {
+                            "name": "ktos_spec_obszar_1",
+                            "patterns": [
+                              {
+                                "pattern": "muskajac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_obszar_ktos_spec_obszar_1()"
+                          },
+                          {
+                            "name": "ktos_spec_obszar_2",
+                            "patterns": [
+                              {
+                                "pattern": "lekko raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_obszar_ktos_spec_obszar_2()"
+                          },
+                          {
+                            "name": "ktos_spec_obszar_3",
+                            "patterns": [
+                              {
+                                "pattern": ", raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_obszar_ktos_spec_obszar_3()"
+                          },
+                          {
+                            "name": "ktos_spec_obszar_4",
+                            "patterns": [
+                              {
+                                "pattern": ", kaleczac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_obszar_ktos_spec_obszar_4()"
+                          },
+                          {
+                            "name": "ktos_spec_obszar_5",
+                            "patterns": [
+                              {
+                                "pattern": "paskudnie kaleczac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_obszar_ktos_spec_obszar_5()"
+                          },
+                          {
+                            "name": "ktos_spec_obszar_6",
+                            "patterns": [
+                              {
+                                "pattern": "ciezko raniac",
+                                "type": 0
+                              },
+                              {
+                                "pattern": "^(?<attacker>\\w+(?: \\w+ \\w+)?) wyczekuje na dogodny moment i (?<damage>tnie) nagle plasko przez (?<target>.+?) i (?<target2>.+?)\\. Ostrze (?<weapon>.+?) z nieprzyjemnym chrzestem przechodzi przez miesnie i kosci,a gdy w koncu zatrzymuje sie, oba ciala bez ducha osuwaja sie na podloze\\.$",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_obszar_ktos_spec_obszar_6()"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "ktos_spec",
+                        "patterns": [
+                          {
+                            "pattern": "^[ >]*Nie zwazajac na nic [a-zA-Z (),!]+ rozpoczyna",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*[a-zA-Z (),!]+ rusza do przodu, w pol kroku",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*[a-zA-Z (),!]+ poprawia chwyt na",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*[a-zA-Z (),!]+ niespodziewanie skreca",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "^[ >]*[a-zA-Z (),!]+ wyrzuca do przodu",
+                            "type": 1
+                          }
+                        ],
+                        "triggers": [
+                          {
+                            "name": "ktos_spec_0",
+                            "patterns": [
+                              {
+                                "pattern": "cudem",
+                                "type": 0
+                              },
+                              {
+                                "pattern": "ktore jednak",
+                                "type": 0
+                              },
+                              {
+                                "pattern": "ktore szczesliwie",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_ktos_spec_0()"
+                          },
+                          {
+                            "name": "ktos_spec_1",
+                            "patterns": [
+                              {
+                                "pattern": "ledwo zacina",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_ktos_spec_1()"
+                          },
+                          {
+                            "name": "ktos_spec_2",
+                            "patterns": [
+                              {
+                                "pattern": "bolesnie zacina",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_ktos_spec_2()"
+                          },
+                          {
+                            "name": "ktos_spec_3",
+                            "patterns": [
+                              {
+                                "pattern": "plytko tnie",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_ktos_spec_3()"
+                          },
+                          {
+                            "name": "ktos_spec_4",
+                            "patterns": [
+                              {
+                                "pattern": "ktore tnie",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_ktos_spec_4()"
+                          },
+                          {
+                            "name": "ktos_spec_5",
+                            "patterns": [
+                              {
+                                "pattern": "gleboko tnie",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_ktos_spec_5()"
+                          },
+                          {
+                            "name": "ktos_spec_6",
+                            "patterns": [
+                              {
+                                "pattern": "niemalze rozcina",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_ktos_spec_6()"
+                          },
+                          {
+                            "name": "ktos_spec_7",
+                            "patterns": [
+                              {
+                                "pattern": "z potworna moca tnie",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_mie_ktos_spec_ktos_spec_7()"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "ktos_spec_fin",
+                        "patterns": [
+                          {
+                            "pattern": "^(?<attacker>\\w+(?: \\w+ \\w+)?) wyczekuje na dogodny moment i (?<damage>tnie) nagle plasko przez (?<target>.+?) i (?<target2>.+?)\\. Ostrze (?<weapon>.+?) z nieprzyjemnym chrzestem przechodzi przez miesnie i kosci,a gdy w koncu zatrzymuje sie, oba ciala bez ducha osuwaja sie na podloze\\.$",
+                            "type": 1
+                          }
                         ]
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "fan",
@@ -5698,27 +7069,26 @@
                     "triggers": [
                       {
                         "name": "ktos_spec",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_fan_ktos_spec_ktos_spec()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) (?:(?:usmiecha sie przebiegle wyczuwajac zblizajace sie zwyciestwo|usmiecha sie czujac rozkosz zblizajacego sie zwyciestwa|wykonuje szybki, szalony piruet|wykrzywia twarz w grymasie nienawisci|zaciska mocniej palce na rekojesci broni|krzywi wargi w pelnym satysfakcji usmiechu) i )?dostrzegajac luke w (?:twojej )?obronie(?:| przeciwni(?:ka|czki)) rzuca sie do ataku\\. .* trafia (?<target>.+?) w (?<where>.+?) (?<damage>bardzo ciezko raniac|ledwo muskajac|lekko raniac|masakrujac|powaznie raniac|raniac) (?:go |)(?<weapon>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_fan_ktos_spec_ktos_spec()"
                       },
                       {
                         "name": "ktos_spec_fin",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_fan_ktos_spec_fin()",
                         "patterns": [
                           {
                             "pattern": "staje pewnie .* uderzenie .*. Bezlitosny, okrutny cios trafia .* zaglebiajac bron",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_fan_ktos_spec_fin()"
                       },
                       {
                         "name": "ktos_spec_0",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_fan_ktos_spec_0()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) bierze potezny zamach i wyprowadza .+? cios, ktory ma cie zmasakrowac\\. Ku twojej uldze je(go|j) bron mija cie nawet przez chwile ci nie zagrazajac\\. Uswiadamiasz sobie jednak, ze nastepnym razem mozesz nie miec tyle szczescia!$",
@@ -5728,10 +7098,10 @@
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) bierze potezny zamach i wyprowadza .+? cios, ktory ma zmasakrowac (?<target>.+?)\\. Jednak je(?:go|j) bron (?:malo nie wypadajac (?:jej|mu) z reki, mija cel o dobre pol metra|nieznacznie mija cel|mija cel(?: nawet nie trafiajac w jego poblize)?|jakims cudem mija cel|mija cel w sporej odleglosci), nie czyniac przeciwni(?:czce|kowi) najmniejszej krzywdy\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_fan_ktos_spec_0()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "kor",
@@ -5739,17 +7109,16 @@
                     "triggers": [
                       {
                         "name": "ktos_spec_0",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_kor_ktos_spec_0()",
                         "patterns": [
                           {
                             "pattern": "^Niezgrabnym ruchem (?<attacker>\\w+(?: \\w+ \\w+|)) unika (?:twego ciosu|ciosu (?<target>.+?)), a je(?:go|j) (?:wyrzucon(?:y|a) w bok .+?,|.+?, wyrzucony w bok) bardziej dla utrzymania rownowagi niz zadania ciosu, przecina tylko powietrze\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_kor_ktos_spec_0()"
                       },
                       {
                         "name": "ktos_spec_1",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_kor_ktos_spec()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+ \\w+|)) (?<damage>powol|oszczed|zgrab|plyn|blyskawicz)nym (?:wypadem do przodu atakuje|(?:polobrotem|ruchem) unika ciosu) (?<target>\\w+(?: \\w+){0,4})(?:,| korzystajac| i | dzgajac)",
@@ -5759,10 +7128,10 @@
                             "pattern": "^(?<attacker>\\w+(?: \\w+ \\w+|)) (?<damage>powol|oszczed|zgrab|plyn|blyskawicz)nym (?:polobrotem|ruchem) unika (?<target>twego) ciosu(?:,| korzystajac| i | dzgajac)",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_kor_ktos_spec()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "bar",
@@ -5770,7 +7139,6 @@
                     "triggers": [
                       {
                         "name": "ktos_spec_0",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_bar_ktos_spec_ktos_spec_0()",
                         "patterns": [
                           {
                             "pattern": "^Nie (?:zastanawiajac sie dlugo|przebierajac w srodkach|silac sie na wirtuozerie|tracac czasu na zbedne manewry) .+? probuje walnac (?<target>.+?) na odlew (?<weapon>.+), jednak przeciwnik w pore wykonuje unik, uciekajac poza zasieg broni\\.$",
@@ -5780,40 +7148,40 @@
                             "pattern": "^Nie (?:zastanawiajac sie dlugo|przebierajac w srodkach|silac sie na wirtuozerie|tracac czasu na zbedne manewry) .+? z calej sily wali (?<target>.+?) na odlew (?<weapon>.+), jednak bron traci caly impet na .+\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_bar_ktos_spec_ktos_spec_0()"
                       },
                       {
                         "name": "ktos_spec",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_bar_ktos_spec_ktos_spec()",
                         "patterns": [
                           {
                             "pattern": "^Nie (zastanawiajac sie dlugo|przebierajac w srodkach|silac sie na wirtuozerie|tracac czasu na zbedne manewry) (.+?) z calej sily wali (?<target>.+?) na odlew (?<weapon>.+?), (?<damage>.+?) (?:mu|jej) przy tym (?<where>.+?)(?<stun>\\. Nieprzyjemne chrzakniecie i metny wzrok przeciwnika swiadcza, ze dobrze wymierzony cios musial trafic w jakies wrazliwe miejsce)?\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_bar_ktos_spec_ktos_spec()"
                       },
                       {
                         "name": "ktos_spec_mnie",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_bar_ktos_spec_mnie_spec()",
                         "patterns": [
                           {
                             "pattern": "^Nie (zastanawiajac sie dlugo|przebierajac w srodkach|silac sie na wirtuozerie|tracac czasu na zbedne manewry) (.+?) z calej sily wali cie na odlew (?<weapon>.+?), (?<damage>\\w+) ci przy tym (?<where>.+?)(?<stun>\\. Dobrze wymierzony cios sprawia, ze chwiejesz sie na nogach i robi ci sie ciemno przed oczami\\.\\.)?\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_bar_ktos_spec_mnie_spec()"
                       },
                       {
                         "name": "ktos_fin",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_bar_ktos_fin()",
                         "patterns": [
                           {
                             "pattern": "^Twarz (.+?) wykrzywia grymas wysilku, gdy wykonuje potezny zamach (?<weapon>.+?) i z ogromna sila uderza na odlew (?<target>.+?)\\. Bron ze zlowrogim .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_bar_ktos_fin()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "gla",
@@ -5821,47 +7189,46 @@
                     "triggers": [
                       {
                         "name": "gl_3_mnie_1",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_1()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+ \\w+|)) paruje twoj cios (?<shield>.+?) i odpowiada nan szybkim ciosem (?<weapon>.+?) w (?<where>.+?), zadajac nieznaczne obrazenia\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_1()"
                       },
                       {
                         "name": "gl_3_mnie_2",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_2()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* paruje twoj cios .* i uderza .* lecz nie trafia cie\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_2()"
                       },
                       {
                         "name": "gl_3_mnie_3",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_3()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Ciosem .* w (nogi|glowe|lewe ramie|prawe ramie|korpus) (.*) zadaje ci nieduza rane i uderzeniem .* odpycha w tyl\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_3()"
                       },
                       {
                         "name": "gl_3_mnie_5",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_5()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+ \\w+|)) sprawnie paruje twoj atak (?<shield>.+?) i rani cie celna kontra ciosu (?<weapon>.+?) w (?<where>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_5()"
                       },
                       {
                         "name": "gl_3_mnie_6",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_6()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* oszlamia cie mocnym uderzeniem .* i ciosem .* zadaje ci krwista rane, raniac .*\\.$",
@@ -5871,501 +7238,501 @@
                             "pattern": "^(?<attacker>\\w+(?: \\w+ \\w+|)) oszlamia cie mocnym uderzeniem (?<shield>.+?) i ciosem (?<weapon>.+?) zadaje ci krwista rane w (?<where>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_6()"
                       },
                       {
                         "name": "gl_3_mnie_7",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_7()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* zatrzymuje twoj atak pewnym blokiem .* i poteznym ciosem .* powaznie rani ci .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_7()"
                       },
                       {
                         "name": "gl_3_mnie_8",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_8()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* kilkakrotnie tlucze cie w .* poteznymi ciosami .* i krwawo rani cie .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_8()"
                       },
                       {
                         "name": "gl_3_mnie_9",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_9()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Nurkujac pod twym atakiem (.*) mocno rani cie ciosem .* i zaraz po tym kaleczy uderzeniem .* w .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_9()"
                       },
                       {
                         "name": "gl_3_mnie_4",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_4()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* odpycha cie .* i lekko kaleczy ciosem .* w .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_mnie_4()"
                       },
                       {
                         "name": "gl_3_kogos_1",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_1()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*(?<attacker>\\w+(?: \\w+ \\w+|)) paruje cios (?<target_czym>.+?) i uderza (go|ja) (?<weapon>.+?) lecz nie trafia\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_1()"
                       },
                       {
                         "name": "gl_3_kogos_2",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_2()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*(?<attacker>\\w+(?: \\w+ \\w+|)) paruje cios (?<target_czym>.+?) i odpowiada nan szybkim ciosem (?<weapon>.+?) w (?<where>.+?), zadajac nieznaczne obrazenia\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_2()"
                       },
                       {
                         "name": "gl_3_kogos_3",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_3()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*(?<attacker>\\w+(?: \\w+ \\w+|)) odpycha (?<target_shield>.+?) i lekko kaleczy (go|ja) ciosem (?<weapon>.+?) w (?<where>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_3()"
                       },
                       {
                         "name": "gl_3_kogos_4",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_4()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*(?<attacker>\\w+(?: \\w+ \\w+|)) sprawnie paruje atak (?<target_czym>.+?) i rani (go|ja) celna kontra ciosu (?<weapon>.+?) w (?<where>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_4()"
                       },
                       {
                         "name": "gl_3_kogos_5",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_5()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*(?<attacker>\\w+(?: \\w+ \\w+|)) nurkujac pod atakiem (?<target>.+?) mocno rani (go|ja) ciosem (?<czym>.+?) i zaraz po tym kaleczy uderzeniem (?<weapon>.+?) w (?<where>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_5()"
                       },
                       {
                         "name": "gl_3_kogos_6",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_6()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Mocnym uderzeniem (?<shield_target>.+?) oszalamia (?<target>.+?) i ciosem (?<weapon>.+?) zadaje (jej|mu) (krwista rane, raniac|znaczne obrazenia|krwista rane) w (?<where>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_6()"
                       },
                       {
                         "name": "gl_3_kogos_7",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_7()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*(?<attacker>\\w+(?: \\w+ \\w+|)) zatrzymuje atak (?<target>.+?) pewnym blokiem (?<shield>.+?) i poteznym ciosem (?<weapon>.+?) powaznie rani (jej|mu) (?<where>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_7()"
                       },
                       {
                         "name": "gl_3_kogos_8",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_8()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*(?<attacker>\\w+(?: \\w+ \\w+|)) kilkakrotnie tlucze w (?<where_target>.+?) poteznymi ciosami (?<shield>.+?) i (ciezko rani|krwawo rani) (go|ja) (?<weapon>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_8()"
                       },
                       {
                         "name": "gl_3_kogos_9",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_9()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*(?<attacker>\\w+(?: \\w+ \\w+|)) blokuje atak (?<target_shield>.+?) i zadanym z pelnego sily obrotu ciosem (?<weapon>.+?) (|bardzo )ciezko rani (go|ja) w (?<where>.+?)(?:, rozpylajac deszcz krwi)?\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_9()"
                       },
                       {
                         "name": "gl_3_kogos_10",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_10()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Z wyrywajacym sie z je(?:go|j) piersi bojowym okrzykiem (?<attacker>\\w+(?: \\w+ \\w+|)) dopada do (?<target>.+?) i blokujac pole je(?:go|j) manewru (?<shield>.+?) kilkakrotnie, paskudnie masakruje (?:jej|mu) (?<where>.+?) ciosami (?<weapon>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_10()"
                       },
                       {
                         "name": "gl_3_kogos_11",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_11()",
                         "patterns": [
                           {
                             "pattern": "^Z pelnym wscieklosci rykiem (?<attacker>.+?) blokuje (?:zaslone )?(?<bron_target>.+) i zadanym z rozmachu uderzeniem (?<bron>.+?) masakruje (?:jej|mu) (?<where>.+?), blyskawicznie konczac walke\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_11()"
                       },
                       {
                         "name": "gl_3_kogos_12",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_12()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Zgrabnym unikiem (?<attacker>\\w+(?: \\w+ \\w+|)) omija desperacki atak (?<target>.+?) i zadanym jednoczesnie ciosem (?<weapon>.+?) i (?<shield>.+?) masakruje je(go|j) (?<where>.+?), konczac walke\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_12()"
                       },
                       {
                         "name": "gl_3_kogos_13",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_13()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Twardym ciosem (?<shield_attacker>.+?) zamienia twarz (?<target>.+?) w krwawa miazge i druzgoczacym ciosem (?<weapon>.+?) rzuca .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_13()"
                       },
                       {
                         "name": "gl_3_kogos_14",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_14()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Twardym ciosem .* ([a-zA-Z]+) masakruje (.*) i druzgoczacym ciosem .* rzuca .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_14()"
                       },
                       {
                         "name": "gl_3_kogos_15",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_15()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Oslaniajac sie .* ([a-zA-Z]+) stara sie trafic (.*) ciosem .*, jednak pudluje.*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_15()"
                       },
                       {
                         "name": "gl_3_kogos_16",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_16()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Rownoczesnym uderzeniem .* i .* ([a-zA-Z]+) bez skutku probuje trafic (.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_16()"
                       },
                       {
                         "name": "gl_3_kogos_17",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_17()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* paruje atak (.*) i ripostuje ciosem .* w je.* zadajac niewielkie obrazenia\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_17()"
                       },
                       {
                         "name": "gl_3_kogos_18",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_18()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* szybko zaslania .* uderza .* w (.*) ledwie jednak .* draskajac\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_18()"
                       },
                       {
                         "name": "gl_3_kogos_19",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_19()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* zbija cios (.*) i kontruje .* lekko kaleczac .* ciosem .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_19()"
                       },
                       {
                         "name": "gl_3_kogos_20",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_20()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* blokuje (zaslone|) (.*) i celnie rani (go|ja) .* w .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_20()"
                       },
                       {
                         "name": "gl_3_kogos_21",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_21()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* silnie napiera .* na (.*) i wyprowadzonym .* ciosem .* rani .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_21()"
                       },
                       {
                         "name": "gl_3_kogos_22",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_22()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* zrecznie unika ataku (.*) i .* doglebnie kaleczac .* silnym ciosem .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_22()"
                       },
                       {
                         "name": "gl_3_kogos_23",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_23()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* morderczo atakuje, blyskawicznie raniac (.*) ciosem .* w .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_23()"
                       },
                       {
                         "name": "gl_3_kogos_24",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_24()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* krwawo rani (.*) w .* ciosem .* i zaslania .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_24()"
                       },
                       {
                         "name": "gl_3_kogos_25",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_25()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* zbija .* (zaslone |)(.*) i uderza (go|ja) na odlew .* mierzac .* rozdzierajac bolesna rane\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_25()"
                       },
                       {
                         "name": "gl_3_kogos_26",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_26()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* odpycha (.*) i poteznie uderza (go|ja) .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_26()"
                       },
                       {
                         "name": "gl_3_kogos_27",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_27()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* oszalamia (.*) ciosem (.*) paskudnie rani .* uderzeniem .* w .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_27()"
                       },
                       {
                         "name": "gl_3_kogos_28",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_28()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Oslaniajac sie (.*) rzuca sie na (.*) wyprowadzajac w pedzie straszliwe ciecia .*, a .* krwisty slad, ciezko raniac .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_28()"
                       },
                       {
                         "name": "gl_3_kogos_29",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_29()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* ciosem .* przewraca (.*) na ziemie .* ciosow .*\\. To juz koniec walki.*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_29()"
                       },
                       {
                         "name": "gl_3_kogos_30",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_30()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* naglym wypadem omija (.*) i oslaniajac .* wbija ostrze .* miedzy je.* chlustajac krwia z rany powoli osuwa sie na kolana, a potem pada twarza na ziemie\\. To juz koniec walki.*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_30()"
                       },
                       {
                         "name": "gl_3_kogos_31",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_31()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* stara sie trafic (.*) poteznym uderzeniem .*, jednak nie udaje .* sie to\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_31()"
                       },
                       {
                         "name": "gl_3_kogos_32",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_32()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Szybkim zrywem (.*) rzuca sie ku (.*), niemalze w jednej chwili uderzajac .*\\. Zmasakrowana ofiara osuwa sie na ziemie, zakanczajac walke\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_32()"
                       },
                       {
                         "name": "gl_3_kogos_33",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_33()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Zadanym z zamachu ciosem .* ([a-zA-Z]+) z trudem dosiega (.*) trafiajac w .*, zadajac jednak lekka rane\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_33()"
                       },
                       {
                         "name": "gl_3_kogos_34",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_34()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* sprawnie blokuje atak (.*) i celnym ciosem .* odrzuca .* w tyl, bolesnie raniac w .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_34()"
                       },
                       {
                         "name": "gl_3_kogos_35",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_35()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* zyskujac inicjatywe, mocnym zamachem .* ([a-zA-Z]+) zbija .* i rabie (.*), zadajac spore obrazenia\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_35()"
                       },
                       {
                         "name": "gl_3_kogos_36",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_36()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Niezlomnie nacierajac, (.*) odbija .* szybkim .* i zadanym z calej sily ciosem ciezko rani (.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_36()"
                       },
                       {
                         "name": "gl_3_kogos_37",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_37()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Poteznym ciosem .* ([a-zA-Z]+) rozbija resztki zaslony (.*), rzucajac .* na ziemie, po czym brutalnie ponawiajac atak konczy walke\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_37()"
                       },
                       {
                         "name": "gl_3_kogos_38",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_38()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Wykorzystujac mase .* ([a-zA-Z]+) bez trudu odbija ostatni cios (.*) i skupiajac sily na poteznym ataku morderczo naciera, doszczetnie .* masakrujac\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_38()"
                       },
                       {
                         "name": "gl_3_kogos_39",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_39()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Gardzac ryzykiem, (.*) rzuca sie na .*, by z karkolomnej szarzy dosiegnac (.*) miazdzacym uderzeniem .*, zadajac ciezka rane\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_39()"
                       },
                       {
                         "name": "gl_3_kogos_40",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_40()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Wykorzystujac jedna ze sztuczek areny, (.*) blyskawicznie unika ciosu .* i mordercza kontra .* powaznie rani .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_40()"
                       },
                       {
                         "name": "gl_3_kogos_41",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_41()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Wykorzystujac zasieg .* ([a-zA-Z]+) bez trudu dosiega (.*) mocnym uderzeniem w .* i sprawnie szykuje sie do ponowienia ataku\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_41()"
                       },
                       {
                         "name": "gl_3_kogos_42",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_42()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Naglym ruchem (.*) podrywa .*, zaskakujac (.*) ciosem w .*, zadajac krwawiaca rane\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_42()"
                       },
                       {
                         "name": "gl_3_kogos_43",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_43()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Ciosem .* w .* zadaje (.*) (nieduza rane|nieduze obrazenia) i uderzeniem .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_43()"
                       },
                       {
                         "name": "gl_3_kogos_44",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_44()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* oglusza (.*) kilkoma szybkimi uderzeniami .*, po czym poteznym ciosem .* miazdzy jego bok, lamiac zebra i kregoslup\\. Zmasakrowana ofiara osuwa sie na ziemie\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_44()"
                       },
                       {
                         "name": "gl_3_kogos_45",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_45()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*(?<attacker>\\w+(?: \\w+ \\w+|)) szalenczo naciera, zasypujac (.*) kilkoma ciosami .*, z ktorych kazdy pozostawia na je(go|j) skorze krwawiacy slad, raniac .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_45()"
                       },
                       {
                         "name": "gl_3_kogos_46",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_46()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Niemalze instynktownym ruchem (.*) odbija zaslone (.*) i z wsciekloscia masakruje je.* ciosem .*, konczac boj\\.$",
@@ -6375,20 +7742,20 @@
                             "pattern": "^Niemalze instynktownym ruchem (?<attacker>.+?) odbija (?<weapon_target>.+?) i z wsciekloscia masakruje je(go|j) (?<where>.+?) ciosem (?<weapon>.+?), konczac boj\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_46()"
                       },
                       {
                         "name": "gl_3_kogos_47",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_47()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Odrzucajac finezje na rzecz skutecznosci, (.*) szarzuje na (.*) w szalonym pedzie odbijajac .*, by w koncu druzgoczacym uderzeniem poslac .* na ziemie, niemalze konczac walke\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gla_gl_3_kogos_47()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "noz",
@@ -6396,256 +7763,255 @@
                     "triggers": [
                       {
                         "name": "ktos_spec_0",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_0()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* spreza sie do skoku probujac ugodzic .* swym .* lecz traci koncentracje i .* niecelny cios.*$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_0()"
                       },
                       {
                         "name": "ktos_spec_1",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_1()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Wykorzystujac dogodna sytuacje, .* rzuca sie na .*, jednak .* nie jest w stanie nikogo zaskoczyc\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_1()"
                       },
                       {
                         "name": "ktos_spec_2",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_2()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* zamierza sie na .*, jednak .* z latwoscia unika ciosu\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_2()"
                       },
                       {
                         "name": "ktos_spec_3",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_3()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* wykonuje szybki wypad by trafic .* i pozostawic na .* ciele nieznaczne drasniecie\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_3()"
                       },
                       {
                         "name": "ktos_spec_4",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_4()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* odskakuje do tylu, a .*, ktory trzyma w rece, zatacza szeroki luk by trafic .*, zadajac jednak tylko nieznaczne obrazenia\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_4()"
                       },
                       {
                         "name": "ktos_spec_5",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_5()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* obracajac w reku swym .* wykonuje nagly zwod i trafia .* pozostawiajac tylko nieznaczne obrazenia\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_5()"
                       },
                       {
                         "name": "ktos_spec_6",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_6()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* wykorzystujac chwilowa dekoncentracje .*, wbija .* w .* cialo pozostawiajac tylko lekkie drasniecie\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_6()"
                       },
                       {
                         "name": "ktos_spec_7",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_7()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Wykorzystujac dogodna chwile .* doskakuje do .*, lecz .* udaje sie w pore zorientowac i .* pozostawia po sobie tylko lekkie drasniecie\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_7()"
                       },
                       {
                         "name": "ktos_spec_8",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_8()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* korzystajac z nieuwagi .* kluje .* cialo .* zostawiajac tylko lekkie drasniecie\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_8()"
                       },
                       {
                         "name": "ktos_spec_9",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_9()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* wykonuje pare oszczednych unikow starajac sie zmeczyc .* i gdy .* przystaje by zlapac oddech, wbija .* w .* cialo\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_9()"
                       },
                       {
                         "name": "ktos_spec_10",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_10()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* poziomym cieciem swojego .* godzi w .*, trafiajac w glowe i wywolujac bolesny grymas na .*$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_10()"
                       },
                       {
                         "name": "ktos_spec_11",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_11()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* uwaznie sledzi ruchy .* by trafiajac w .* swym.* pozostawic bolesna rane\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_11()"
                       },
                       {
                         "name": "ktos_spec_12",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_12()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* blyskawicznie skraca dystans dzielacy ja od .* znaczac .* krwawa bruzda\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_12()"
                       },
                       {
                         "name": "ktos_spec_13",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_13()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* blyskawicznie wyrzuca przed siebie reke dzierzaca .* i trafiajac .* pozostawia krwawiaca rane\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_13()"
                       },
                       {
                         "name": "ktos_spec_14",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_14()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* zaciska mocniej palce na .* i paskudnie rani .*, trafiajac .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_14()"
                       },
                       {
                         "name": "ktos_spec_15",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_15()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* mruzac oczy uwaznie obserwuje ruchy .*, a gdy .*, blyskawicznie wyrzuca .* rozlegle obrazenia\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_15()"
                       },
                       {
                         "name": "ktos_spec_16",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_16()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* uwaznie sledzi ruchy .*, aby w chwili, .*zadajac znaczne obrazenia\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_16()"
                       },
                       {
                         "name": "ktos_spec_17",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_17()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* wyprowadza swym .* pchniecie, .* az po rekojesc, a gdy .*, dostrzegasz, ze cala jest czerwona od krwi\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_17()"
                       },
                       {
                         "name": "ktos_spec_18",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_18()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* zaciska mocniej palce na .* i z naglego doskoku dopada do .* zadajac celowi powazne obrazenia\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_18()"
                       },
                       {
                         "name": "ktos_spec_19",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_19()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* zwinnym, kocim ruchem przypada do ziemi, .* blyskawicznie .*a z potwornej rany natychmiast zaczyna plynac krew\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_19()"
                       },
                       {
                         "name": "ktos_spec_20",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_20()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* zwinnie uchyla sie przed ciosem .* i wykorzystujac .* i zadajac bardzo powazne obrazenia\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_20()"
                       },
                       {
                         "name": "ktos_spec_21",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_21()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* zrecznym ruchem paruje cios .* rozszerzaja sie z bolu.* to juz koniec walki\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_21()"
                       },
                       {
                         "name": "ktos_spec_22",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_22()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Unikajac uderzenia .* blyskawicznie doskakuje .*ofiary uchodzi zycie.*jekiem osuwa sie na ziemie, a zabojca wyszarpuje swa bron z ciala i noga odsuwa zwloki na bok.*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_22()"
                       },
                       {
                         "name": "ktos_spec_23",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_23()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Wykorzystujac dekoncentracje i oslabienie (?<target>.+?), (?<attacker>.+?) silnym kopniakiem podcina.*odbierajac mu ostatnie sily\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_23()"
                       },
                       {
                         "name": "ktos_spec_24",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_24()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*Unikajac uderzenia .* blyskawicznie doskakuje .*Zauwazasz .* usmiech satysfakcji.* zakonczenia zywota.*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_noz_ktos_spec_24()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   },
                   {
                     "name": "par",
@@ -6653,122 +8019,381 @@
                     "triggers": [
                       {
                         "name": "ktos_spec_0",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_ktos_spec_0()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* probuje dosiegnac .*bron nieznacznie chybia celu\\.$",
                             "type": 1
                           }
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_ktos_spec_0()"
+                      },
+                      {
+                        "name": "ktos_spec_g1",
+                        "patterns": [
+                          {
+                            "pattern": "bez chwili namyslu uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "bez wysilku uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "bez zastanowienia uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "blyskawicznie skladajac sie do ciosu uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "blyskawicznie uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "dziko hallakujac uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "korzystajac z zamieszania uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "niezbyt celnie uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "niezbyt dokladnie uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "oszczednym ruchem uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "pewnym ruchem uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "plynnym ruchem uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "robiac szeroki zamach uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "robiac oszczedny zamach uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "szybko skladajac sie do ciosu uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "w pospiechu uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "w szalenczym porywie uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "w zamieszaniu uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "wrzeszczac na cale gardlo uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "z doskoku uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "z grymasem wysilku uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "z lekkiego wymachu uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "z szybkiego doskoku uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "zaciskajac z wysilku zeby uderza",
+                            "type": 0
+                          },
+                          {
+                            "pattern": "zbierajac sie w sobie uderza",
+                            "type": 0
+                          }
+                        ],
+                        "triggers": [
+                          {
+                            "name": "ktos_spec_0",
+                            "patterns": [
+                              {
+                                "pattern": "nieznacznie raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_ktos_spec_g1_ktos_spec_0()"
+                          },
+                          {
+                            "name": "ktos_spec_1",
+                            "patterns": [
+                              {
+                                "pattern": "lekko raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_ktos_spec_g1_ktos_spec_1()"
+                          },
+                          {
+                            "name": "ktos_spec_2",
+                            "patterns": [
+                              {
+                                "pattern": ", bolesnie raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_ktos_spec_g1_ktos_spec_2()"
+                          },
+                          {
+                            "name": "ktos_spec_3",
+                            "patterns": [
+                              {
+                                "pattern": "powaznie raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_ktos_spec_g1_ktos_spec_3()"
+                          },
+                          {
+                            "name": "ktos_spec_4",
+                            "patterns": [
+                              {
+                                "pattern": "bardzo ciezko raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_ktos_spec_g1_ktos_spec_4()"
+                          },
+                          {
+                            "name": "ktos_spec_5",
+                            "patterns": [
+                              {
+                                "pattern": "potwornie raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_ktos_spec_g1_ktos_spec_5()"
+                          }
                         ]
                       },
                       {
                         "name": "ktos_spec_1",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_ktos_spec_1()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* blyskawicznie doskakuje do .*, bezlitosnie masakrujac .*\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_ktos_spec_1()"
                       },
                       {
                         "name": "ktos_spec_2",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_ktos_spec_2()",
                         "patterns": [
                           {
                             "pattern": "^[ >]*.* doskakuje.* do .* mordercze uderzenie.*\\.$",
                             "type": 1
                           }
-                        ]
-                      }
-                    ],
-                    "groups": [
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_ktos_spec_2()"
+                      },
                       {
                         "name": "scatak",
                         "patterns": [],
                         "triggers": [
                           {
                             "name": "ktos_spec_0",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_0()",
                             "patterns": [
                               {
                                 "pattern": "^[ >]*.* ubiegajac reakcje .* zaskoczyc go blyskawicznym atakiem\\. Nieprecyzyjny cios .* chybia jednak celu\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_0()"
                           },
                           {
                             "name": "ktos_spec_1",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_1()",
                             "patterns": [
                               {
                                 "pattern": "^[ >]*.* blyskawicznym susem dopada .*, ledwie zahaczajac .*\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_1()"
                           },
                           {
                             "name": "ktos_spec_2",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_2()",
                             "patterns": [
                               {
                                 "pattern": "^[ >]*.* momentalnie doskakuje do .* w biegu skladajac sie co ciosu\\. Zawija z furkotem .*\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_2()"
                           },
                           {
                             "name": "ktos_spec_3",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_3()",
                             "patterns": [
                               {
                                 "pattern": "^[ >]*.* dziko hallakujac uderza .*, bardzo ciezko raniac.*\\.$",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_3()"
                           },
                           {
                             "name": "ktos_spec_4",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_4()",
                             "patterns": [
                               {
                                 "pattern": "z furia drapieznika rusza do ataku na",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_4()"
                           },
                           {
                             "name": "ktos_spec_5",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_5()",
                             "patterns": [
                               {
                                 "pattern": "wyprzedzajac nieudolny atak natychmiast rzuca sie w kierunku",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_5()"
                           },
                           {
                             "name": "ktos_spec_6",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_6()",
                             "patterns": [
                               {
                                 "pattern": "z dzikim krzykiem wpada na",
                                 "type": 0
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_6()"
                           },
                           {
                             "name": "ktos_spec_7",
-                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_7()",
                             "patterns": [
                               {
                                 "pattern": ".*uprzedzajac reakcje .* (blyskawicznym ciosem|z wielkim pospiechem stara sie|bez namyslu uderza).*",
                                 "type": 1
                               }
-                            ]
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_par_scatak_ktos_spec_7()"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "gp",
+                    "patterns": [],
+                    "triggers": [
+                      {
+                        "name": "ktos_spec",
+                        "patterns": [
+                          {
+                            "pattern": "^Wykorzystujac dogodny moment.* (?:wyprowadza|probuje wyprowadzic)\\s",
+                            "type": 1
+                          },
+                          {
+                            "pattern": "wykorzystujac dogodny moment wyprowadza szybki cios",
+                            "type": 0
                           }
                         ],
-                        "groups": []
+                        "triggers": [
+                          {
+                            "name": "ktos_spec_0",
+                            "patterns": [
+                              {
+                                "pattern": " lecz",
+                                "type": 0
+                              },
+                              {
+                                "pattern": "unik",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gp_ktos_spec_ktos_spec_0()"
+                          },
+                          {
+                            "name": "ktos_spec_1",
+                            "patterns": [
+                              {
+                                "pattern": ", ledwo muskajac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gp_ktos_spec_ktos_spec_1()"
+                          },
+                          {
+                            "name": "ktos_spec_2",
+                            "patterns": [
+                              {
+                                "pattern": ", lekko raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gp_ktos_spec_ktos_spec_2()"
+                          },
+                          {
+                            "name": "ktos_spec_3",
+                            "patterns": [
+                              {
+                                "pattern": ", raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gp_ktos_spec_ktos_spec_3()"
+                          },
+                          {
+                            "name": "ktos_spec_4",
+                            "patterns": [
+                              {
+                                "pattern": ", powaznie raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gp_ktos_spec_ktos_spec_4()"
+                          },
+                          {
+                            "name": "ktos_spec_5",
+                            "patterns": [
+                              {
+                                "pattern": ", bardzo ciezko raniac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gp_ktos_spec_ktos_spec_5()"
+                          },
+                          {
+                            "name": "ktos_spec_6",
+                            "patterns": [
+                              {
+                                "pattern": ", masakrujac",
+                                "type": 0
+                              }
+                            ],
+                            "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_gp_ktos_spec_ktos_spec_6()"
+                          }
+                        ]
                       }
                     ]
                   },
@@ -6778,56 +8403,55 @@
                     "triggers": [
                       {
                         "name": "blekitno-srebrna-trojkatna-tarcza",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_zbroje_blekitno_srebrna_trojkatna_tarcza()",
                         "patterns": [
                           {
                             "pattern": "^Trzymana przez (?<attacker>.+?) blekitno-srebrna trojkatna tarcza rozblyskuje nagle niesamowicie ostrym blekitnym swiatlem, skierowanym w strone (?<target>.+?), lecz rozblysk jest tak silny, ze na chwile rowniez ty odruchowo mruzysz oczy przed oslepiajaca jasnoscia!$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_zbroje_blekitno_srebrna_trojkatna_tarcza()"
                       },
                       {
                         "name": "ciemnogranatowy-smukly-helm",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_zbroje_ciemnogranatowy_smukly_helm()",
                         "patterns": [
                           {
                             "pattern": "^(?<target>\\w+(?: \\w+){0,4}) zaczyna wpatrywac sie pustym wzrokiem w slepia weza wijacego sie u podstawy ciemnogranatowego smuklego helmu na glowie (?<attacker>.*)\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_zbroje_ciemnogranatowy_smukly_helm()"
                       },
                       {
                         "name": "lsniaca-plomienista-tarcza",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_zbroje_lsniaca_plomienista_tarcza()",
                         "patterns": [
                           {
                             "pattern": "^Nagle lustrzana powierzchnia lsniacej plomienistej tarczy (?<attacker>.+?) rozblyskuje jasnoczerwonym, palacym swiatlem\\.",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_zbroje_lsniaca_plomienista_tarcza()"
                       },
                       {
                         "name": "jasniejacy-zdobiony-jatagan",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_bronie_jasniejacy_zdobiony_jatagan()",
                         "patterns": [
                           {
                             "pattern": "^(?<target>\\w+(?: \\w+){0,4}) wydaje sie byc oslepion[ay] rozblyskiem swiatla\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_bronie_jasniejacy_zdobiony_jatagan()"
                       },
                       {
                         "name": "gigantyczny-granitowy-mlot",
-                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_bronie_gigantyczny_granitowy_mlot()",
                         "patterns": [
                           {
                             "pattern": "^(?<attacker>\\w+(?: \\w+){0,4}) bierze ogromny zamach swoim gigantycznym granitowym mlotem i wyprowadza potworny cios w glowe (?<target>.+?)\\. Przeciwnik mruga oczami, nie bardzo wiedzac, co sie dzieje\\. Porzadnie (?:go|ja) zamroczylo\\.$",
                             "type": 1
                           }
-                        ]
+                        ],
+                        "script": "trigger_func_skrypty_ui_gags_color_color_innych_spece_bronie_gigantyczny_granitowy_mlot()"
                       }
-                    ],
-                    "groups": []
+                    ]
                   }
                 ]
               },
@@ -6842,7 +8466,6 @@
                 "triggers": [
                   {
                     "name": "ja_unikasz_ciosu",
-                    "script": "trigger_func_skrypty_ui_gags_color_color_moje_uniki_ja_unikasz_ciosu()",
                     "patterns": [
                       {
                         "pattern": "lecz tobie udaje sie uniknac tego ciosu.",
@@ -6864,11 +8487,11 @@
                         "pattern": "zrecznie unikasz ciosu.",
                         "type": 0
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_color_moje_uniki_ja_unikasz_ciosu()"
                   },
                   {
                     "name": "ja_ktos_nie_trafia",
-                    "script": "trigger_func_skrypty_ui_gags_color_color_moje_uniki_ja_ktos_nie_trafia()",
                     "patterns": [
                       {
                         "pattern": "nie udaje sie trafic ciebie",
@@ -6890,10 +8513,10 @@
                         "pattern": "na ciebie, lecz udaje ci sie uniknac",
                         "type": 0
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_color_moje_uniki_ja_ktos_nie_trafia()"
                   }
-                ],
-                "groups": []
+                ]
               },
               {
                 "name": "color_innych_uniki",
@@ -6901,7 +8524,6 @@
                 "triggers": [
                   {
                     "name": "ktos_unika_ciosu",
-                    "script": "trigger_func_skrypty_ui_gags_color_color_innych_uniki_ktos_unika_ciosu()",
                     "patterns": [
                       {
                         "pattern": "(^[ >]*Probujesz trafic [a-zA-Z (),!]+, lecz [a-z ]+ unika [a-z ]+ ciosu\\.$)",
@@ -6927,11 +8549,11 @@
                         "pattern": "zbaczajac z toru i chybiajac celu.",
                         "type": 0
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_color_innych_uniki_ktos_unika_ciosu()"
                   },
                   {
                     "name": "ktos_ktos_unika",
-                    "script": "trigger_func_skrypty_ui_gags_color_color_innych_uniki_ktos_ktos_unika()",
                     "patterns": [
                       {
                         "pattern": "^[ >]*[a-zA-Z (),!]+ probuje trafic .*, lecz .* uskakuje przed tym ciosem\\.$",
@@ -6949,10 +8571,10 @@
                         "pattern": "lecz (?:temu|tej) udaje sie uniknac (?:ataku|ciosu)\\.",
                         "type": 1
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_color_innych_uniki_ktos_ktos_unika()"
                   }
-                ],
-                "groups": []
+                ]
               },
               {
                 "name": "color_moje_parowanie",
@@ -6965,7 +8587,6 @@
                 "triggers": [
                   {
                     "name": "ja_paruje",
-                    "script": "trigger_func_skrypty_ui_gags_color_color_moje_parowanie_ja_paruje()",
                     "patterns": [
                       {
                         "pattern": "w ciebie, lecz tobie udaje sie (?:go sparowac|je zbic z linii ataku|zbic je z linii ataku)",
@@ -6991,11 +8612,11 @@
                         "pattern": "ty jednak bez trudu parujesz cios",
                         "type": 0
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_color_moje_parowanie_ja_paruje()"
                   },
                   {
                     "name": "ja_zbroja_paruje",
-                    "script": "trigger_func_skrypty_ui_gags_color_color_moje_parowanie_ja_zbroja_paruje()",
                     "patterns": [
                       {
                         "pattern": "trafia cie .+? caly impet uderzenia zostaje wyparowan. przez",
@@ -7029,11 +8650,11 @@
                         "pattern": "nie czyniac ci zadnej szkody.",
                         "type": 0
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_color_moje_parowanie_ja_zbroja_paruje()"
                   },
                   {
                     "name": "ja_tarcza_paruje",
-                    "script": "trigger_func_skrypty_ui_gags_color_color_moje_parowanie_ja_tarcza_paruje()",
                     "patterns": [
                       {
                         "pattern": "w ciebie, lecz .+? sie oslonic",
@@ -7063,21 +8684,21 @@
                         "pattern": "jednak udaje ci sie (?:sparowac ten cios|zablokowac ten atak)",
                         "type": 1
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_color_moje_parowanie_ja_tarcza_paruje()"
                   },
                   {
                     "name": "baron-tarcza2",
-                    "script": "trigger_func_skrypty_ui_gags_color_color_moje_parowanie_baron_tarcza2()",
                     "patterns": [
                       {
                         "pattern": "^[ >]*Blekitno-srebrna herbowa tarcza rozblyskuje nagle bardzo ostrym blekitnym swiatlem, skierowanym w strone.*",
                         "type": 1
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_color_moje_parowanie_baron_tarcza2()"
                   },
                   {
                     "name": "ja_paruje_lewak",
-                    "script": "trigger_func_skrypty_ui_gags_color_color_moje_parowanie_ja_paruje_lewak()",
                     "patterns": [
                       {
                         "pattern": "Szlachetna stal dzierzonego przez ciebie zdobionego dlugiego lewaka spiewa dzwiecznie, gdy udaje ci sie sparowac nadchodzacy cios",
@@ -7095,10 +8716,10 @@
                         "pattern": "Skladasz wprawnie zastawe, by sparowac cios",
                         "type": 2
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_color_moje_parowanie_ja_paruje_lewak()"
                   }
-                ],
-                "groups": []
+                ]
               },
               {
                 "name": "color_innych_parowanie",
@@ -7106,7 +8727,6 @@
                 "triggers": [
                   {
                     "name": "ktos_paruje",
-                    "script": "trigger_func_skrypty_ui_gags_color_color_innych_parowanie_ktos_paruje()",
                     "patterns": [
                       {
                         "pattern": "zbija je z linii ataku",
@@ -7140,11 +8760,11 @@
                         "pattern": "jednak bez trudu paruje cios",
                         "type": 0
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_color_innych_parowanie_ktos_paruje()"
                   },
                   {
                     "name": "ktos_zbroja",
-                    "script": "trigger_func_skrypty_ui_gags_color_color_innych_parowanie_ktos_zbroja_paruje()",
                     "patterns": [
                       {
                         "pattern": "[tT]rafia(?:sz|) (?!cie ).+? caly impet uderzenia zostaje wyparowany przez",
@@ -7174,11 +8794,11 @@
                         "pattern": "lecz uderzenie zatrzymuje sie na (?:jego|jej)",
                         "type": 1
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_color_innych_parowanie_ktos_zbroja_paruje()"
                   },
                   {
                     "name": "ktos_tarcza",
-                    "script": "trigger_func_skrypty_ui_gags_color_color_innych_parowanie_ktos_tarcza_paruje()",
                     "patterns": [
                       {
                         "pattern": "lecz (?:ten|ta) oslania sie",
@@ -7204,10 +8824,10 @@
                         "pattern": "naciera na (?!ciebie).+?, lecz jego .+? z hukiem trafia w",
                         "type": 1
                       }
-                    ]
+                    ],
+                    "script": "trigger_func_skrypty_ui_gags_color_color_innych_parowanie_ktos_tarcza_paruje()"
                   }
-                ],
-                "groups": []
+                ]
               }
             ]
           },
@@ -7217,7 +8837,6 @@
             "triggers": [
               {
                 "name": "cel_obrony_ktos",
-                "script": "trigger_func_skrypty_ui_gags_color_color_cele_cel_obrony_ktos()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*.* wskazuje )(.*) jako cel obrony\\.$",
@@ -7227,11 +8846,11 @@
                     "pattern": "(^[ >]*Wskazujesz )(.*) jako cel obrony\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_cele_cel_obrony_ktos()"
               },
               {
                 "name": "cel_ataku_ktos",
-                "script": "trigger_func_skrypty_ui_gags_color_color_cele_cel_ataku_ktos()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*.* wskazuje .* jako) cel ataku\\.$",
@@ -7249,10 +8868,10 @@
                     "pattern": "(^[ >]*Ledwo widocznym skinieniem glowy dajesz znak kompanom, ze .* ma jutro plywac z rybkami i stanowi teraz) cel ataku\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_cele_cel_ataku_ktos()"
               }
-            ],
-            "groups": []
+            ]
           },
           {
             "name": "color_rozkazy",
@@ -7260,7 +8879,6 @@
             "triggers": [
               {
                 "name": "rozkaz_kogos_zaslony",
-                "script": "trigger_func_skrypty_ui_gags_color_color_rozkazy_rozkaz_kogos_zaslony()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*.* wydaje ci rozkaz zasloniecia )(.*)\\.$",
@@ -7270,31 +8888,31 @@
                     "pattern": "(^[ >]*Wydajesz rozkaz zasloniecia )(.*)\\.$",
                     "type": 0
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_rozkazy_rozkaz_kogos_zaslony()"
               },
               {
                 "name": "rozkaz_kogos_zaatakowac",
-                "script": "trigger_func_skrypty_ui_gags_color_color_rozkazy_rozkaz_kogos_zaatakowac()",
                 "patterns": [
                   {
                     "pattern": "^(?:> )*((?:.+? wydaje ci|Wydajesz) rozkaz ataku na )(.*)\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_rozkazy_rozkaz_kogos_zaatakowac()"
               },
               {
                 "name": "rozkaz-zaslona-wykonanie",
-                "script": "trigger_func_skrypty_ui_gags_color_color_rozkazy_rozkaz_zaslona_wykonanie()",
                 "patterns": [
                   {
                     "pattern": "^Na rozkaz .+? zaslania(?:sz)? (.+?) przed ciosami .*\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_rozkazy_rozkaz_zaslona_wykonanie()"
               },
               {
                 "name": "rozkaz-atak-wykonanie",
-                "script": "trigger_func_skrypty_ui_gags_color_color_rozkazy_rozkaz_atak_wykonanie()",
                 "patterns": [
                   {
                     "pattern": "^[ >]*Na twoj rozkaz .* rzuca sie do ataku na .*$",
@@ -7304,20 +8922,20 @@
                     "pattern": "^[ >]*Na rozkaz .* rzucasz sie do ataku na .*$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_rozkazy_rozkaz_atak_wykonanie()"
               },
               {
                 "name": "rozkaz_kogos_zablokowac",
-                "script": "trigger_func_skrypty_ui_gags_color_color_rozkazy_rozkaz_kogos_zablokowac()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*.* wydaje ci rozkaz zablokowania )(.*)\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_rozkazy_rozkaz_kogos_zablokowac()"
               }
-            ],
-            "groups": []
+            ]
           },
           {
             "name": "color_bloki",
@@ -7325,67 +8943,66 @@
             "triggers": [
               {
                 "name": "blokowanie_proba_ciebie",
-                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_blokowanie_proba_ciebie()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*([a-zA-Z (),!]+) przymierza sie do odciecia ci drogi ucieczki\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_blokowanie_proba_ciebie()"
               },
               {
                 "name": "blokuje_cie",
-                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_blokuje_cie()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*([a-zA-Z(),! ]+) zajmuje pozycje umozliwiajaca odciecie ci drogi ucieczki\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_blokuje_cie()"
               },
               {
                 "name": "zajmujesz_pozycje",
-                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_zajmujesz_pozycje()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*Zajmujesz pozycje umozliwiajaca odciecie [a-zA-Z (),!]+ drogi ucieczki\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_zajmujesz_pozycje()"
               },
               {
                 "name": "zajmuje_pozycje",
-                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_zajmuje_pozycje()",
                 "patterns": [
                   {
                     "pattern": ".* zajmuje pozycje umozliwiajaca odciecie ([a-zA-Z (),!]+) drogi ucieczki\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_zajmuje_pozycje()"
               },
               {
                 "name": "blokujesz_droge",
-                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_blokujesz_droge()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*Blokujesz [a-zA-Z (),!]+ droge na .*\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_blokujesz_droge()"
               },
               {
                 "name": "blokuje_droge",
-                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_blokuje_droge()",
                 "patterns": [
                   {
                     "pattern": ".*blokuje ([a-zA-Z (),!]+) droge na .*\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_blokuje_droge()"
               },
               {
                 "name": "blokuje_ci_droge",
-                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_blokuje_ci_droge()",
                 "patterns": [
                   {
                     "pattern": "^Nie mozesz tego zrobic, gdyz .* blokuje ci droge\\.$",
@@ -7395,41 +9012,41 @@
                     "pattern": "^Nie mozesz sie tam udac, gdyz .* blokuje ci droge na .*\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_blokuje_ci_droge()"
               },
               {
                 "name": "omija_nieskuteczny_blok",
-                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_omija_nieskuteczny_blok()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*[a-zA-Z (),!]+ omija twoj nieskuteczny blok\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_omija_nieskuteczny_blok()"
               },
               {
                 "name": "przestajesz_odcinac",
-                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_przestajesz_odcinac()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*Przestajesz odcinac droge ucieczki [a-zA-Z (),!]+\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_przestajesz_odcinac()"
               },
               {
                 "name": "blokowanie_proba_kogos",
-                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_blokowanie_proba_kogos()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*([a-zA-Z (),!]+) przymierza sie do odciecia ([a-zA-Z ]+) drogi ucieczki\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_blokowanie_proba_kogos()"
               },
               {
                 "name": "blokowanie_proba_ty",
-                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_blokowanie_proba_ty()",
                 "patterns": [
                   {
                     "pattern": "^Na rozkaz [a-zA-Z ]+ przymierzasz sie do odciecia [a-zA-Z ]+ drogi ucieczki\\.$",
@@ -7439,10 +9056,10 @@
                     "pattern": "^Przymierzasz sie do odciecia [a-zA-Z ]+ drogi ucieczki\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_bloki_blokowanie_proba_ty()"
               }
-            ],
-            "groups": []
+            ]
           },
           {
             "name": "color_ogluchy",
@@ -7450,7 +9067,6 @@
             "triggers": [
               {
                 "name": "ogluch",
-                "script": "trigger_func_skrypty_ui_gags_color_color_ogluchy_ogluch()",
                 "patterns": [
                   {
                     "pattern": "Powoli osuwasz sie na ziemie",
@@ -7508,11 +9124,11 @@
                     "pattern": " poteznym ciosem ogona oglusza cie.",
                     "type": 0
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_ogluchy_ogluch()"
               },
               {
                 "name": "powrot-z-oglucha",
-                "script": "trigger_func_skrypty_ui_gags_color_color_ogluchy_powrot_z_oglucha()",
                 "patterns": [
                   {
                     "pattern": "Powoli dochodzisz do siebie",
@@ -7530,11 +9146,11 @@
                     "pattern": "Powoli odzyskujesz swobode ruchow",
                     "type": 0
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_ogluchy_powrot_z_oglucha()"
               },
               {
                 "name": "ogluch-golem-ktos",
-                "script": "trigger_func_skrypty_ui_gags_color_color_ogluchy_ogluch_golem_ktos()",
                 "patterns": [
                   {
                     "pattern": "golem w mgnieniu oka uderza w [A-Za-z]+, a on.? wyrwan. z oslupienia, probuje ratowac sie krokiem w tyl\\. Jednak wiele to nie pomaga i sila uderzenia odrzuca",
@@ -7544,10 +9160,10 @@
                     "pattern": "^Niespodziewanie kamienny golem wyciaga reke i uderza w glowe .*",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_ogluchy_ogluch_golem_ktos()"
               }
-            ],
-            "groups": []
+            ]
           },
           {
             "name": "color_bron",
@@ -7555,17 +9171,16 @@
             "triggers": [
               {
                 "name": "ktos_opuszcza_bron",
-                "script": "trigger_func_skrypty_ui_gags_color_color_bron_ktos_opuszcza_bron()",
                 "patterns": [
                   {
                     "pattern": "^[ >]*Uderzenie jest tak silne, ze (?<target>.+?) bezwiednie opuszcza [a-z ]+\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_bron_ktos_opuszcza_bron()"
               },
               {
                 "name": "walczysz_bez_broni",
-                "script": "trigger_func_skrypty_ui_gags_color_color_bron_walczysz_bez_broni()",
                 "patterns": [
                   {
                     "pattern": "^(Nie udaje ci sie trafic|Probujesz trafic|Ledwo muskasz|Lekko ranisz) (?<target>.+?) (lew\\w+|praw\\w+) (piescia|kolanem|stopa|lokciem|rekawica|butem)",
@@ -7575,20 +9190,20 @@
                     "pattern": "^Wykonujesz zamach ((lewym|prawym) butem) mierzac w (?<target>.+?), lecz t(a|en) paruje go .*\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_bron_walczysz_bez_broni()"
               },
               {
                 "name": "ktos_dobywa_broni",
-                "script": "trigger_func_skrypty_ui_gags_color_color_bron_ktos_dobywa_broni()",
                 "patterns": [
                   {
                     "pattern": "^(?<target>.+?) dobywa [a-z ]+\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_bron_ktos_dobywa_broni()"
               }
-            ],
-            "groups": []
+            ]
           },
           {
             "name": "color_npc",
@@ -7596,7 +9211,6 @@
             "triggers": [
               {
                 "name": "ogluch",
-                "script": "trigger_func_skrypty_ui_gags_color_color_npc_ogluch()",
                 "patterns": [
                   {
                     "pattern": ".* silnym ciosem .* oglusza (?!cie)([ a-zA-Z]+)\\.$",
@@ -7618,40 +9232,40 @@
                     "pattern": "^(?:Saurgl|Posepny okrutny rycerz chaosu) pochyla glowe i szarzuje, by uderzyc ([ a-zA-Z]+) dlugimi, ostro zakonczonymi rogami wyrastajacymi mu spod czarnego helmu\\. Potezny cios odrzuca ofiare i wyrywa jej oddech z piersi\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_npc_ogluch()"
               },
               {
                 "name": "koniec-oglucha",
-                "script": "trigger_func_skrypty_ui_gags_color_color_npc_koniec_oglucha()",
                 "patterns": [
                   {
                     "pattern": "([a-zA-Z ]+) powoli dochodzi do siebie\\.",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_npc_koniec_oglucha()"
               },
               {
                 "name": "goblin",
-                "script": "trigger_func_skrypty_ui_gags_color_color_npc_goblin()",
                 "patterns": [
                   {
                     "pattern": "^W slepiach [a-z ]+ pojawia sie nienawistny blysk.*? (?<damage>kaleczy|rozkrwawia|(?:gleboko )?rani|prawieze rozrabuje|wprost rozrabuje) ci.*\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_npc_goblin()"
               },
               {
                 "name": "npc_spec",
-                "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_ktos()",
                 "patterns": [
                   {
                     "pattern": "^Nagle (?<attacker>\\w+(?: \\w+){0,4}) wykonuje zamaszysty cios (?<weapon>.+?), ktory (?<damage>ledwo muska|lekko rani|bardzo ciezko rani|powaznie rani|rani|masakruje|niemal smiertelnie rani|smiertelnie rani) (?<target>.+?) w (?<where>.*)\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_innych_ciosy_ktos()"
               }
-            ],
-            "groups": []
+            ]
           },
           {
             "name": "color_other",
@@ -7659,27 +9273,26 @@
             "triggers": [
               {
                 "name": "zabiles_color",
-                "script": "trigger_func_skrypty_ui_gags_color_color_other_zabiles_color()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*(Zabil(?:es|as|)) (?<target>[a-zA-Z (),!]+)\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_other_zabiles_color()"
               },
               {
                 "name": "zabil_color",
-                "script": "trigger_func_skrypty_ui_gags_color_color_other_zabil_color()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*([a-zA-Z (),!]+) (zabil(?:|a)) ([a-zA-Z (),!]+)\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_other_zabil_color()"
               },
               {
                 "name": "mozesz_dobywac",
-                "script": "trigger_func_skrypty_ui_gags_color_color_other_mozesz_dobywac()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*Bol w (prawej|lewej) dloni staje sie mniej odczuwalny\\.$)",
@@ -7689,11 +9302,11 @@
                     "pattern": "Nagle czujesz,  jak dziwna sila opanowuje twe czlonki.  Nie jestes w stanie kontrolowac swojego zachowania!",
                     "type": 0
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_other_mozesz_dobywac()"
               },
               {
                 "name": "wytracenie_tobie",
-                "script": "trigger_func_skrypty_ui_gags_color_color_other_wytracenie_tobie()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*.*ruchem.*wytraca ci .*\\.)",
@@ -7703,70 +9316,70 @@
                     "pattern": "(^[ >]*Uderzenie jest tak silne, ze bezwiednie puszczasz (.*)\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_other_wytracenie_tobie()"
               },
               {
                 "name": "przelamanie",
-                "script": "trigger_func_skrypty_ui_gags_color_color_other_przelamanie()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*(.*) rzuca sie na (.*) przebijajac sie przez [a-z]+ ochrone\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_other_przelamanie()"
               },
               {
                 "name": "przelamanie-ty",
-                "script": "trigger_func_skrypty_ui_gags_color_color_other_przelamanie_ty()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*Rzucasz sie na (.*) przebijajac sie przez [a-z]+ ochrone\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_other_przelamanie_ty()"
               },
               {
                 "name": "nie-przelamanie-ty",
-                "script": "trigger_func_skrypty_ui_gags_color_color_other_nie_przelamanie_ty()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*Bezskutecznie rzucasz sie na .*, probujac przebic sie przez .* ochrone\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_other_nie_przelamanie_ty()"
               },
               {
                 "name": "nie-przelamanie",
-                "script": "trigger_func_skrypty_ui_gags_color_color_other_nie_przelamanie()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*.* rzuca sie na .*, bezskutecznie probujac przebic sie przez .* ochrone\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_other_nie_przelamanie()"
               },
               {
                 "name": "nekro-tilea",
-                "script": "trigger_func_skrypty_ui_gags_color_color_other_nekro_tilea()",
                 "patterns": [
                   {
                     "pattern": "Twoj.* (.*), lecac lagodnym lukiem, laduje na ziemi obok ciebie.",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_other_nekro_tilea()"
               },
               {
                 "name": "przekazanie",
-                "script": "trigger_func_team_leadership()",
                 "patterns": [
                   {
                     "pattern": ".* przekazuje ci prowadzenie druzyny\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_team_leadership()"
               }
-            ],
-            "groups": []
+            ]
           },
           {
             "name": "color_zaslony_udane",
@@ -7774,7 +9387,6 @@
             "triggers": [
               {
                 "name": "zaslaniasz_ty",
-                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_udane_zaslaniasz_ty()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*Zrecznie zaslaniasz ([\\[a-zA-Z (),!\\]]+) przed ciosami ([a-zA-Z (),!\\]]+)\\.$)",
@@ -7792,11 +9404,11 @@
                     "pattern": "(^[ >]*Zdecydowanym krokiem wysuwasz sie przed [\\[a-zA-Z (),!\\]]+, zimnym spojrzeniem dajac wszystkim do zrozumienia, ze moga sie do (niego|niej) zblizyc jedynie po twoim trupie\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_udane_zaslaniasz_ty()"
               },
               {
                 "name": "zaslania_kogos",
-                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_udane_zaslania_kogos()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*(?!Na rozkaz)([a-zA-Z (),!]+)(?: zrecznie)? zaslania ([a-zA-Z (),!]+) przed ciosami ([a-zA-Z (),!]+)\\.$)",
@@ -7822,40 +9434,40 @@
                     "pattern": "(^[ >]*[\\[a-zA-Z (),!\\]]+ z mrozacym krew w zylach spojrzeniem zdecydowanym krokiem wysuwa sie przed [\\[a-zA-Z (),!\\]]+ i opierajac dlon na trzonku [a-z ]+, daje do zrozumienia, ze kazdy kto zechce sie do (niej|niego) zblizyc, uczyni to jedynie po (jego|jej) trupie\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_udane_zaslania_kogos()"
               },
               {
                 "name": "wycofanie-za-ciebie",
-                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_udane_wycofanie_za_ciebie()",
                 "patterns": [
                   {
                     "pattern": "^[ >]*.* unosi swoja .* i szybko przesuwa sie za ciebie, kryjac.*",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_udane_wycofanie_za_ciebie()"
               },
               {
                 "name": "wycofanie_sie_ty",
-                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_udane_wycofanie_sie_ty()",
                 "patterns": [
                   {
                     "pattern": "[ >]*Unosisz swoja .* i szybko przesuwasz sie za .*, kryjac sie przed atakami",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_udane_wycofanie_sie_ty()"
               },
               {
                 "name": "wycofanie-kogos",
-                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_udane_wycofanie_kogos()",
                 "patterns": [
                   {
                     "pattern": "(?:unosi swoja .+? i |)szybko przesuwa sie za (?!ciebie).+?, (?:kryjac sie przed atakami .+?|uciekajac przed twoimi ciosami)\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_udane_wycofanie_kogos()"
               }
-            ],
-            "groups": []
+            ]
           },
           {
             "name": "color_zaslony_nieudane",
@@ -7863,7 +9475,6 @@
             "triggers": [
               {
                 "name": "nie_zaslaniasz_ty",
-                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_nieudane_nie_zaslaniasz_ty()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*Probujesz zaslonic ([a-zA-Z (),!]+) przed ciosami ([a-zA-Z (),!]+), jednak nie jestes w stanie tego uczynic\\.$)",
@@ -7873,11 +9484,11 @@
                     "pattern": "(^Na rozkaz .* probujesz zaslonic (.*) przed ciosami (.*), jednak nie jestes w stanie tego uczynic\\.$)",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_nieudane_nie_zaslaniasz_ty()"
               },
               {
                 "name": "nie_zaslania_kogos",
-                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_nieudane_nie_zaslania_kogos()",
                 "patterns": [
                   {
                     "pattern": "(^[ >]*([a-zA-Z (),!]+) probuje zaslonic ([a-zA-Z (),!]+) przed ciosami ([a-zA-Z (),!]+), jednak nie jest w stanie tego uczynic\\.$)",
@@ -7891,11 +9502,11 @@
                     "pattern": "(\\w+(?: \\w+){0,4}?) unosi swoja .+? i szybko przesuwa sie w (twoja strone|strone .+?), bezskutecznie probujac skryc sie za toba przed atakami .*\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_nieudane_nie_zaslania_kogos()"
               },
               {
                 "name": "nie_wycofanie_ty",
-                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_nieudane_nie_wycofanie_ty()",
                 "patterns": [
                   {
                     "pattern": "[ >]*Unosisz swoja .+? i przesuwasz sie w strone .+?, bezskutecznie probujac",
@@ -7905,10 +9516,10 @@
                     "pattern": "(\\w+(?: \\w+){0,4}?) unosi swoja .+? i szybko przesuwa sie w (twoja strone|strone .+?), bezskutecznie probujac skryc sie za (nia|nim|toba) przed atakami .*\\.$",
                     "type": 1
                   }
-                ]
+                ],
+                "script": "trigger_func_skrypty_ui_gags_color_color_zaslony_nieudane_nie_wycofanie_ty()"
               }
-            ],
-            "groups": []
+            ]
           }
         ]
       }

--- a/client/src/scripts/herbDescriptions.ts
+++ b/client/src/scripts/herbDescriptions.ts
@@ -1,7 +1,7 @@
 import Client from "../Client";
 import loadHerbs from "./herbsLoader";
-import { color, RESET, findClosestColor } from "../Colors";
-import { stripAnsiCodes } from "../Triggers";
+import {color, RESET, findClosestColor} from "../Colors";
+import {stripAnsiCodes} from "../Triggers";
 
 export const HERB_NAME_COLOR = findClosestColor("#ffffff");
 
@@ -36,7 +36,7 @@ export default async function initHerbDescriptions(client: Client) {
                     }
                     const clickable = client.OutputHandler.makeStringRightClickable(id, (ev) => showHerbActions(id, ev));
                     return prefix + token + ` (${color(HERB_NAME_COLOR)}${clickable}${RESET})` + suffix;
-                }, tag);
+                }, tag, {caseInsensitive: true});
             });
         });
     } catch (e) {

--- a/client/src/scripts/luaGags.ts
+++ b/client/src/scripts/luaGags.ts
@@ -66,8 +66,15 @@ type GagNode = {
     calls?: { func: string; args: string[] }[];
     script?: string;
     triggers?: GagNode[];
+    multiline?: boolean;
 };
 
+
+function registerTrigger(container: Triggers | Trigger, triggerPatterns: (RegExp | ((raw: string, line: string, matches: any, type: string) => RegExpMatchArray) | string)[], callback: (rawLine: string, line: string, matches: RegExpMatchArray) => string, node: GagNode, parent: Triggers | Trigger) {
+    return container instanceof Trigger
+        ? container.registerChild(triggerPatterns, callback, node.name)
+        : (parent as Triggers).registerTrigger(triggerPatterns, callback, node.name);
+}
 
 export default function registerLuaGagTriggers(client: Client) {
 
@@ -98,37 +105,45 @@ export default function registerLuaGagTriggers(client: Client) {
 
         if (patterns.length === 0 && children.length === 0) return;
 
-        let container: Triggers | Trigger = parent;
-        patterns.forEach((pat) => {
-            const pattern = toPattern(pat);
-            const callback = (rawLine: string, line: string, matches: RegExpMatchArray) => {
-                if (node.script != undefined) {
-                    global.line = rawLine
-                    global.matches = matches
-                    luaEnv.parse(`line = "${rawLine}"`).exec()
-                    luaEnv.parse(createMatches(matches)).exec()
-                    try {
-                        luaEnv.parse(node.script).exec()
-                    } catch (e) {
-                        const warn = `Zglos blad w powyzszej lini: ${e.message}`
-                        const clickable = client.OutputHandler.makeClickable(
-                            warn,
-                            warn,
-                            () => navigator.clipboard.writeText(line),
-                            'Kopiuj linie'
-                        )
-                        global.line = global.line + "\n" + colorString(clickable, ERROR_COLOR)
+        const container: Triggers | Trigger = parent;
+        const callback = (rawLine: string, line: string, matches: RegExpMatchArray) => {
+            if (node.script != undefined) {
+                global.line = rawLine
+                global.matches = matches
+                luaEnv.parse(`line = "${rawLine}"`).exec()
+                luaEnv.parse(createMatches(matches)).exec()
+                try {
+                    luaEnv.parse(node.script).exec()
+                } catch (e) {
+                    const warn = `Zglos blad w powyzszej lini: ${e.message}`
+                    const clickable = client.OutputHandler.makeClickable(
+                        warn,
+                        warn,
+                        () => navigator.clipboard.writeText(line),
+                        'Kopiuj linie'
+                    )
+                    global.line = global.line + "\n" + colorString(clickable, ERROR_COLOR)
 
-                    }
-                    rawLine = global.line
                 }
-                return rawLine;
+                rawLine = global.line
             }
-            container = container instanceof Trigger
-                ? container.registerChild(pattern, callback, node.name)
-                : (parent as Triggers).registerTrigger(pattern, callback, node.name);
-        });
-        children.forEach(ch => registerNode(container, ch));
+            return rawLine;
+        }
+
+        const triggers: Trigger[] = []
+        const triggerPatterns = patterns.map(pat => toPattern(pat));
+        if (!node.multiline) {
+            triggers.push(registerTrigger(container, triggerPatterns, callback, node, parent))
+        } else {
+            let prev = container;
+            triggerPatterns.forEach(pattern => {
+                registerTrigger(prev, [pattern], callback, node, parent)
+            })
+        }
+        triggers.forEach(trigger => {
+            children.forEach(ch => registerNode(trigger, ch));
+        })
+
     }
 
 

--- a/client/src/scripts/luaGags.ts
+++ b/client/src/scripts/luaGags.ts
@@ -60,18 +60,12 @@ function gagsIsType(
 
 type PatternObj = { pattern: string; type?: number | null };
 
-type GagTrigger = {
+type GagNode = {
     name: string;
     patterns: PatternObj[];
     calls?: { func: string; args: string[] }[];
     script?: string;
-};
-
-type GagGroup = {
-    name: string;
-    patterns: PatternObj[];
-    triggers: GagTrigger[];
-    groups: GagGroup[];
+    triggers?: GagNode[];
 };
 
 
@@ -98,40 +92,23 @@ export default function registerLuaGagTriggers(client: Client) {
         return p.pattern;
     }
 
-    function registerGroup(parent: Triggers | Trigger, group: GagGroup) {
-        const patterns = Array.isArray(group.patterns) ? group.patterns : [];
-        const triggers = Array.isArray(group.triggers) ? group.triggers : [];
-        const groups = Array.isArray(group.groups) ? group.groups : [];
+    function registerNode(parent: Triggers | Trigger, node: GagNode) {
+        const patterns = Array.isArray(node.patterns) ? node.patterns : [];
+        const children = Array.isArray(node.triggers) ? node.triggers : [];
 
-        if (patterns.length === 0 && triggers.length === 0) {
-            groups.forEach(gr => registerGroup(parent, gr));
-            return;
-        }
+        if (patterns.length === 0 && children.length === 0) return;
 
         let container: Triggers | Trigger = parent;
-        patterns.forEach(pat => {
-            const pattern = toPattern(pat);
-            container = container instanceof Trigger
-                ? container.registerChild(pattern, undefined, group.name)
-                : (parent as Triggers).registerTrigger(pattern, undefined, group.name);
-        });
-        triggers.forEach(tr => registerTrigger(container, tr));
-        groups.forEach(gr => registerGroup(container, gr));
-    }
-
-    function registerTrigger(parent: Triggers | Trigger, tr: GagTrigger) {
-        if (!tr.patterns || tr.patterns.length === 0) return;
-        let container: Triggers | Trigger = parent;
-        tr.patterns.forEach((pat) => {
+        patterns.forEach((pat) => {
             const pattern = toPattern(pat);
             const callback = (rawLine: string, line: string, matches: RegExpMatchArray) => {
-                if (tr.script != undefined) {
+                if (node.script != undefined) {
                     global.line = rawLine
                     global.matches = matches
                     luaEnv.parse(`line = "${rawLine}"`).exec()
                     luaEnv.parse(createMatches(matches)).exec()
                     try {
-                        luaEnv.parse(tr.script).exec()
+                        luaEnv.parse(node.script).exec()
                     } catch (e) {
                         const warn = `Zglos blad w powyzszej lini: ${e.message}`
                         const clickable = client.OutputHandler.makeClickable(
@@ -147,8 +124,11 @@ export default function registerLuaGagTriggers(client: Client) {
                 }
                 return rawLine;
             }
-            container instanceof Trigger ? container.registerChild(pattern, callback, tr.name) : (parent as Triggers).registerTrigger(pattern, callback, tr.name);
+            container = container instanceof Trigger
+                ? container.registerChild(pattern, callback, node.name)
+                : (parent as Triggers).registerTrigger(pattern, callback, node.name);
         });
+        children.forEach(ch => registerNode(container, ch));
     }
 
 
@@ -365,7 +345,7 @@ export default function registerLuaGagTriggers(client: Client) {
     }
 
 
-    (gagsData as GagGroup[]).forEach(group => registerGroup(client.Triggers, group));
+    (gagsData as GagNode[]).forEach(group => registerNode(client.Triggers, group));
     client.addEventListener("playBeep", () => {
         client.playSound("beep")
     })

--- a/client/src/scripts/magicKeys.ts
+++ b/client/src/scripts/magicKeys.ts
@@ -10,7 +10,7 @@ export default async function initMagicKeys(client: Client) {
         keys.forEach((pattern: string) => {
             client.Triggers.registerTokenTrigger(pattern, (raw) => {
                 return colorStringInLine(raw, pattern, KEYS_COLOR);
-            }, tag);
+            }, tag, { caseInsensitive: true});
         });
     } catch (e) {
         console.error("Failed to load magic keys", e);

--- a/client/src/scripts/magics.ts
+++ b/client/src/scripts/magics.ts
@@ -1,5 +1,5 @@
 import Client from "../Client";
-import { colorStringInLine, findClosestColor } from "../Colors";
+import {colorStringInLine, findClosestColor} from "../Colors";
 import loadMagics from "./magicsLoader";
 
 export const MAGICS_COLOR = findClosestColor('#cc3c3c');
@@ -11,7 +11,7 @@ export default async function initMagics(client: Client) {
             client.Triggers.registerTokenTrigger(pattern, (raw) => {
                 return colorStringInLine(raw, pattern, MAGICS_COLOR);
             }, tag);
-        });
+        }, {caseInsensitive: true});
     } catch (e) {
         console.error("Failed to load magics", e);
     }

--- a/scripts/extract-gags.js
+++ b/scripts/extract-gags.js
@@ -87,34 +87,25 @@ function getCalls(script) {
     return [];
 }
 
-function processTrigger(tr) {
-    const scriptNode = tr.script;
-    if (!scriptNode) return null;
-    const script = String(scriptNode).trim();
-    if (!script ||script.length === 0) return null;
-    return {
-        name: tr.name || '',
-        script: scriptNode,
-        patterns: extractPatterns(tr),
-    };
-}
-
-function processGroup(gr) {
-    const group = {
-        name: gr.name || '',
-        patterns: extractPatterns(gr),
-        triggers: [],
-        groups: [],
-    };
-    toArray(gr.Trigger).forEach(t => {
-        const res = processTrigger(t);
-        if (res) group.triggers.push(res);
+function processNode(node) {
+    const name = node.name || '';
+    const patterns = extractPatterns(node);
+    const scriptNode = node.script;
+    const script = scriptNode ? String(scriptNode).trim() : '';
+    const children = [];
+    toArray(node.Trigger).forEach(t => {
+        const res = processNode(t);
+        if (res) children.push(res);
     });
-    toArray(gr.TriggerGroup).forEach(g => {
-        const sub = processGroup(g);
-        if (sub.triggers.length || sub.groups.length) group.groups.push(sub);
+    toArray(node.TriggerGroup).forEach(g => {
+        const res = processNode(g);
+        if (res) children.push(res);
     });
-    return group;
+    if (!patterns.length && !children.length && !script) return null;
+    const out = { name, patterns };
+    if (script) out.script = scriptNode;
+    if (children.length) out.triggers = children;
+    return out;
 }
 
 const xmlData = fs.readFileSync(xmlPath, 'utf8');
@@ -122,6 +113,6 @@ xml2js.parseString(xmlData, {explicitArray: false}, (err, result) => {
     if (err) throw err;
     const root = xpath.find(result, "//MudletPackage/TriggerPackage/TriggerGroup[name='skrypty']/TriggerGroup[name='ui']/TriggerGroup[name='gags']")
     if (!root) return;
-    const groups = toArray(root).map(processGroup).filter(Boolean);
+    const groups = toArray(root).map(processNode).filter(Boolean);
     fs.writeFileSync("../client/src/scripts/gags_lua.json", JSON.stringify(groups));
 });

--- a/scripts/extract-gags.js
+++ b/scripts/extract-gags.js
@@ -105,6 +105,9 @@ function processNode(node) {
     const out = { name, patterns };
     if (script) out.script = scriptNode;
     if (children.length) out.triggers = children;
+    if (node.$.isMultiline === "yes") {
+        out.multiline = true;
+    }
     return out;
 }
 
@@ -114,5 +117,5 @@ xml2js.parseString(xmlData, {explicitArray: false}, (err, result) => {
     const root = xpath.find(result, "//MudletPackage/TriggerPackage/TriggerGroup[name='skrypty']/TriggerGroup[name='ui']/TriggerGroup[name='gags']")
     if (!root) return;
     const groups = toArray(root).map(processNode).filter(Boolean);
-    fs.writeFileSync("../client/src/scripts/gags_lua.json", JSON.stringify(groups));
+    fs.writeFileSync("./client/src/scripts/gags_lua.json", JSON.stringify(groups, null, 2));
 });


### PR DESCRIPTION
## Summary
- Unify trigger and trigger group parsing so both share fields and may contain nested triggers
- Simplify Lua gag registration with recursive `registerNode` to support nested structures

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_68912507dfd8832abbfb6c6657894aaa