### PR TITLE
Add trigger testing popup

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -218,9 +218,6 @@
                     <button class="w-100 p-1" id="docs-button">Dokumentacja</button>
                 </li>
                 <li>
-                    <button class="w-100 p-1" id="trigger-tester-button">Tester triggerów</button>
-                </li>
-                <li>
                     <button class="w-100 p-1" id="debug-button">Debugowanie</button>
                 </li>
                 <li>
@@ -352,7 +349,10 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Debug Log</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    <div class="d-flex gap-2 align-items-center">
+                        <button type="button" class="btn btn-secondary btn-sm" id="trigger-tester-button">Tester triggerów</button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
                 </div>
                 <div id="debug-content" class="debug-content modal-body overflow-auto"></div>
             </div>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -218,6 +218,9 @@
                     <button class="w-100 p-1" id="docs-button">Dokumentacja</button>
                 </li>
                 <li>
+                    <button class="w-100 p-1" id="trigger-tester-button">Tester triggerów</button>
+                </li>
+                <li>
                     <button class="w-100 p-1" id="debug-button">Debugowanie</button>
                 </li>
                 <li>
@@ -310,6 +313,32 @@
                 </div>
                 <div class="modal-body position-relative d-flex flex-column align-items-center gap-2">
                     <div id="mobile-buttons-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="trigger-tester-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Tester triggerów</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body d-flex flex-column gap-2">
+                    <div>
+                        <label for="trigger-tester-tag" class="form-label mb-1">Tag triggera</label>
+                        <input id="trigger-tester-tag" class="form-control" />
+                    </div>
+                    <div>
+                        <label for="trigger-tester-line" class="form-label mb-1">Linia</label>
+                        <input id="trigger-tester-line" class="form-control" />
+                    </div>
+                    <div>
+                        <label for="trigger-tester-type" class="form-label mb-1">Typ GMCP</label>
+                        <input id="trigger-tester-type" class="form-control" />
+                    </div>
+                    <button class="btn btn-primary" id="trigger-tester-run">Testuj</button>
+                    <pre id="trigger-tester-output" class="mb-0"></pre>
                 </div>
             </div>
         </div>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -326,7 +326,11 @@
                 </div>
                 <div class="modal-body d-flex flex-column gap-2">
                     <div>
-                        <label for="trigger-tester-tag" class="form-label mb-1">Tag triggera</label>
+                        <label class="form-label mb-1">Wybierz trigger</label>
+                        <div id="trigger-tester-tree" class="border p-1" style="max-height:15rem;overflow:auto;"></div>
+                    </div>
+                    <div>
+                        <label for="trigger-tester-tag" class="form-label mb-1">Tag triggera (opcjonalnie)</label>
                         <input id="trigger-tester-tag" class="form-control" />
                     </div>
                     <div>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -326,12 +326,12 @@
                 </div>
                 <div class="modal-body d-flex flex-column gap-2">
                     <div>
-                        <label class="form-label mb-1">Wybierz trigger</label>
-                        <div id="trigger-tester-tree" class="border p-1" style="max-height:15rem;overflow:auto;"></div>
+                        <label for="trigger-tester-filter" class="form-label mb-1">Filtr wzorca</label>
+                        <input id="trigger-tester-filter" class="form-control" />
                     </div>
                     <div>
-                        <label for="trigger-tester-tag" class="form-label mb-1">Tag triggera (opcjonalnie)</label>
-                        <input id="trigger-tester-tag" class="form-control" />
+                        <label class="form-label mb-1">Wybierz trigger</label>
+                        <div id="trigger-tester-tree" class="border p-1" style="max-height:15rem;overflow:auto;"></div>
                     </div>
                     <div>
                         <label for="trigger-tester-line" class="form-label mb-1">Linia</label>

--- a/web-client/src/debug.ts
+++ b/web-client/src/debug.ts
@@ -38,4 +38,4 @@ function initDebug() {
   });
 }
 
-//document.addEventListener("DOMContentLoaded", initDebug);
+document.addEventListener("DOMContentLoaded", initDebug);

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -32,6 +32,7 @@ import UserTriggers from "./options/UserTriggers.tsx"
 import Shortcuts from "./options/Shortcuts.tsx"
 import MobileButtons from "./options/MobileButtons.tsx"
 import { loadSettings as loadMobileButtonSettings, applySettings as applyMobileButtonSettings } from "./mobileButtonSettings"
+import "./triggerTester"
 
 const client = new Client(arkadiaClient, new MockPort())
 window.clientExtension = client;

--- a/web-client/src/triggerTester.ts
+++ b/web-client/src/triggerTester.ts
@@ -7,13 +7,59 @@ function initTriggerTester() {
     const modalEl = document.getElementById('trigger-tester-modal') as HTMLElement | null;
     if (!button || !modalEl) return;
     const modal = new Modal(modalEl);
-    button.addEventListener('click', () => modal.show());
-
     const runBtn = modalEl.querySelector('#trigger-tester-run') as HTMLButtonElement;
     const tagInput = modalEl.querySelector('#trigger-tester-tag') as HTMLInputElement;
     const lineInput = modalEl.querySelector('#trigger-tester-line') as HTMLInputElement;
     const typeInput = modalEl.querySelector('#trigger-tester-type') as HTMLInputElement;
     const outputEl = modalEl.querySelector('#trigger-tester-output') as HTMLElement;
+    const treeEl = modalEl.querySelector('#trigger-tester-tree') as HTMLElement;
+
+    let selectedPath: Trigger[] | null = null;
+    let selectedEl: HTMLElement | null = null;
+
+    button.addEventListener('click', () => {
+        buildTree();
+        modal.show();
+    });
+
+    function buildTree() {
+        selectedPath = null;
+        selectedEl = null;
+        treeEl.innerHTML = '';
+        // @ts-ignore
+        const manager = (window as any).clientExtension?.Triggers;
+        if (!manager) return;
+        const roots: Trigger[] = [
+            ...Array.from(manager.triggers.values()),
+            ...manager.tokenTriggers?.map((t: any) => t.trigger) || [],
+            ...Array.from(manager.multilineTriggers.values()),
+        ];
+        const rootUl = document.createElement('ul');
+        roots.forEach(t => rootUl.appendChild(createNode(t, [])));
+        treeEl.appendChild(rootUl);
+    }
+
+    function createNode(trigger: Trigger, path: Trigger[]): HTMLLIElement {
+        const li = document.createElement('li');
+        li.textContent = trigger.tag ? `[${trigger.tag}] ${patternToString(trigger.pattern)}` : patternToString(trigger.pattern);
+        li.style.cursor = 'pointer';
+        li.addEventListener('click', ev => {
+            ev.stopPropagation();
+            selectedPath = [...path, trigger];
+            if (selectedEl) {
+                selectedEl.classList.remove('bg-primary', 'text-light');
+            }
+            selectedEl = li;
+            li.classList.add('bg-primary', 'text-light');
+        });
+        const children = Array.from(trigger.children.values());
+        if (children.length) {
+            const ul = document.createElement('ul');
+            children.forEach(ch => ul.appendChild(createNode(ch, [...path, trigger])));
+            li.appendChild(ul);
+        }
+        return li;
+    }
 
     runBtn.addEventListener('click', () => {
         const tag = tagInput.value.trim();
@@ -26,7 +72,10 @@ function initTriggerTester() {
             outputEl.textContent = 'No trigger manager.';
             return;
         }
-        const path = findTriggerPath(tag, triggers);
+        let path = selectedPath;
+        if (!path && tag) {
+            path = findTriggerPath(tag, triggers);
+        }
         if (!path) {
             outputEl.textContent = 'Trigger not found.';
             return;

--- a/web-client/src/triggerTester.ts
+++ b/web-client/src/triggerTester.ts
@@ -8,21 +8,26 @@ function initTriggerTester() {
     if (!button || !modalEl) return;
     const modal = new Modal(modalEl);
     const runBtn = modalEl.querySelector('#trigger-tester-run') as HTMLButtonElement;
-    const tagInput = modalEl.querySelector('#trigger-tester-tag') as HTMLInputElement;
     const lineInput = modalEl.querySelector('#trigger-tester-line') as HTMLInputElement;
     const typeInput = modalEl.querySelector('#trigger-tester-type') as HTMLInputElement;
     const outputEl = modalEl.querySelector('#trigger-tester-output') as HTMLElement;
     const treeEl = modalEl.querySelector('#trigger-tester-tree') as HTMLElement;
+    const filterInput = modalEl.querySelector('#trigger-tester-filter') as HTMLInputElement;
 
     let selectedPath: Trigger[] | null = null;
     let selectedEl: HTMLElement | null = null;
 
     button.addEventListener('click', () => {
-        buildTree();
+        filterInput.value = '';
+        buildTree('');
         modal.show();
     });
 
-    function buildTree() {
+    filterInput.addEventListener('input', () => {
+        buildTree(filterInput.value.trim().toLowerCase());
+    });
+
+    function buildTree(filter: string) {
         selectedPath = null;
         selectedEl = null;
         treeEl.innerHTML = '';
@@ -35,34 +40,40 @@ function initTriggerTester() {
             ...Array.from(manager.multilineTriggers.values()),
         ];
         const rootUl = document.createElement('ul');
-        roots.forEach(t => rootUl.appendChild(createNode(t, [])));
+        roots.forEach(t => {
+            const node = createNode(t, [], filter);
+            if (node) rootUl.appendChild(node);
+        });
         treeEl.appendChild(rootUl);
     }
 
-    function createNode(trigger: Trigger, path: Trigger[]): HTMLLIElement {
+    function createNode(trigger: Trigger, path: Trigger[], filter: string): HTMLLIElement | null {
+        const text = trigger.tag ? `[${trigger.tag}] ${patternToString(trigger.pattern)}` : patternToString(trigger.pattern);
+        const match = text.toLowerCase().includes(filter);
+        const childNodes = Array.from(trigger.children.values()).map(ch => createNode(ch, [...path, trigger], filter)).filter((n): n is HTMLLIElement => n !== null);
+        if (!match && childNodes.length === 0) return null;
         const li = document.createElement('li');
-        li.textContent = trigger.tag ? `[${trigger.tag}] ${patternToString(trigger.pattern)}` : patternToString(trigger.pattern);
+        li.textContent = text;
         li.style.cursor = 'pointer';
+        const currentPath = [...path, trigger];
         li.addEventListener('click', ev => {
             ev.stopPropagation();
-            selectedPath = [...path, trigger];
+            selectedPath = currentPath;
             if (selectedEl) {
                 selectedEl.classList.remove('bg-primary', 'text-light');
             }
             selectedEl = li;
             li.classList.add('bg-primary', 'text-light');
         });
-        const children = Array.from(trigger.children.values());
-        if (children.length) {
+        if (childNodes.length) {
             const ul = document.createElement('ul');
-            children.forEach(ch => ul.appendChild(createNode(ch, [...path, trigger])));
+            childNodes.forEach(ch => ul.appendChild(ch));
             li.appendChild(ul);
         }
         return li;
     }
 
     runBtn.addEventListener('click', () => {
-        const tag = tagInput.value.trim();
         const line = lineInput.value;
         const type = typeInput.value.trim();
         outputEl.textContent = '';
@@ -72,12 +83,9 @@ function initTriggerTester() {
             outputEl.textContent = 'No trigger manager.';
             return;
         }
-        let path = selectedPath;
-        if (!path && tag) {
-            path = findTriggerPath(tag, triggers);
-        }
+        const path = selectedPath;
         if (!path) {
-            outputEl.textContent = 'Trigger not found.';
+            outputEl.textContent = 'Trigger not selected.';
             return;
         }
         const results: string[] = [];
@@ -89,28 +97,6 @@ function initTriggerTester() {
         }
         outputEl.textContent = results.join('\n');
     });
-}
-
-function findTriggerPath(tag: string, manager: any): Trigger[] | null {
-    const collections: Trigger[] = [
-        ...Array.from(manager.triggers.values()),
-        ...manager.tokenTriggers?.map((t: any) => t.trigger) || [],
-        ...Array.from(manager.multilineTriggers.values()),
-    ];
-    for (const t of collections) {
-        const path = findInTree(t, tag);
-        if (path) return path;
-    }
-    return null;
-}
-
-function findInTree(trigger: Trigger, tag: string): Trigger[] | null {
-    if (trigger.tag === tag) return [trigger];
-    for (const child of trigger.children.values()) {
-        const path = findInTree(child, tag);
-        if (path) return [trigger, ...path];
-    }
-    return null;
 }
 
 function matchTrigger(trigger: Trigger, rawLine: string, type: string): boolean {

--- a/web-client/src/triggerTester.ts
+++ b/web-client/src/triggerTester.ts
@@ -1,0 +1,94 @@
+import Modal from "bootstrap/js/dist/modal";
+import { stripAnsiCodes } from "@client/src/stripAnsiCodes";
+import type { Trigger } from "@client/src/Triggers";
+
+function initTriggerTester() {
+    const button = document.getElementById('trigger-tester-button') as HTMLButtonElement | null;
+    const modalEl = document.getElementById('trigger-tester-modal') as HTMLElement | null;
+    if (!button || !modalEl) return;
+    const modal = new Modal(modalEl);
+    button.addEventListener('click', () => modal.show());
+
+    const runBtn = modalEl.querySelector('#trigger-tester-run') as HTMLButtonElement;
+    const tagInput = modalEl.querySelector('#trigger-tester-tag') as HTMLInputElement;
+    const lineInput = modalEl.querySelector('#trigger-tester-line') as HTMLInputElement;
+    const typeInput = modalEl.querySelector('#trigger-tester-type') as HTMLInputElement;
+    const outputEl = modalEl.querySelector('#trigger-tester-output') as HTMLElement;
+
+    runBtn.addEventListener('click', () => {
+        const tag = tagInput.value.trim();
+        const line = lineInput.value;
+        const type = typeInput.value.trim();
+        outputEl.textContent = '';
+        // @ts-ignore
+        const triggers = (window as any).clientExtension?.Triggers;
+        if (!triggers) {
+            outputEl.textContent = 'No trigger manager.';
+            return;
+        }
+        const path = findTriggerPath(tag, triggers);
+        if (!path) {
+            outputEl.textContent = 'Trigger not found.';
+            return;
+        }
+        const results: string[] = [];
+        for (let i = 0; i < path.length; i++) {
+            const t = path[i];
+            const matched = matchTrigger(t, line, type);
+            results.push(`${'  '.repeat(i)}${patternToString(t.pattern)}: ${matched ? 'matched' : 'no match'}`);
+            if (!matched) break;
+        }
+        outputEl.textContent = results.join('\n');
+    });
+}
+
+function findTriggerPath(tag: string, manager: any): Trigger[] | null {
+    const collections: Trigger[] = [
+        ...Array.from(manager.triggers.values()),
+        ...manager.tokenTriggers?.map((t: any) => t.trigger) || [],
+        ...Array.from(manager.multilineTriggers.values()),
+    ];
+    for (const t of collections) {
+        const path = findInTree(t, tag);
+        if (path) return path;
+    }
+    return null;
+}
+
+function findInTree(trigger: Trigger, tag: string): Trigger[] | null {
+    if (trigger.tag === tag) return [trigger];
+    for (const child of trigger.children.values()) {
+        const path = findInTree(child, tag);
+        if (path) return [trigger, ...path];
+    }
+    return null;
+}
+
+function matchTrigger(trigger: Trigger, rawLine: string, type: string): boolean {
+    const line = stripAnsiCodes(rawLine).replace(/\s$/g, '');
+    const patterns = Array.isArray(trigger.pattern) ? trigger.pattern : [trigger.pattern];
+    for (const pattern of patterns) {
+        if (pattern instanceof RegExp) {
+            if (line.match(pattern)) return true;
+        } else if (typeof pattern === 'string') {
+            const index = rawLine.toLowerCase().indexOf(pattern.toLowerCase());
+            if (index > -1) return true;
+        } else if (typeof pattern === 'function') {
+            const res = pattern(rawLine, line, undefined as any, type);
+            if (res) return true;
+        }
+    }
+    return false;
+}
+
+function patternToString(pattern: any): string {
+    if (Array.isArray(pattern)) {
+        return pattern.map(patternToString).join(' | ');
+    }
+    if (pattern instanceof RegExp) return pattern.toString();
+    if (typeof pattern === 'string') return pattern;
+    if (typeof pattern === 'function') return pattern.name ? `[fn ${pattern.name}]` : '[fn]';
+    return String(pattern);
+}
+
+document.addEventListener('DOMContentLoaded', initTriggerTester);


### PR DESCRIPTION
## Summary
- add "Tester triggerów" button and modal to open trigger testing UI
- implement trigger tester script to look up triggers by tag and show where matching fails for given line and GMCP type
- wire trigger tester into main client

## Testing
- `yarn --cwd web-client build`
- `yarn --cwd client test`
- `yarn --cwd web-client test`


------
https://chatgpt.com/codex/tasks/task_e_689131b34fb4832abfeb203fff1c2d9a