### PR TITLE
feat: allow custom command binds

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -71,6 +71,7 @@ export default class Client {
         alt?: boolean;
         shift?: boolean;
     };
+    customBinds: { key: string; ctrl?: boolean; alt?: boolean; shift?: boolean; command: string }[] = [];
     inLineProcess = false; //TODO figure out something else
     defaultColor = 255;
     buffer: { out: string, type?: string }[] = [];
@@ -126,6 +127,17 @@ export default class Client {
                 this.support()
                 ev.preventDefault()
             }
+            this.customBinds.forEach(cb => {
+                if (
+                    (ev.code === cb.key || ev.key === cb.key) &&
+                    !!cb.ctrl === ev.ctrlKey &&
+                    !!cb.alt === ev.altKey &&
+                    !!cb.shift === ev.shiftKey
+                ) {
+                    this.sendCommand(cb.command)
+                    ev.preventDefault()
+                }
+            })
         })
 
         const applyBinds = (b: any) => {
@@ -150,6 +162,12 @@ export default class Client {
             const support = b?.support
             if (support) {
                 this.supportBind = { ...support }
+            }
+            const custom = b?.custom
+            if (custom) {
+                this.customBinds = [...custom]
+            } else {
+                this.customBinds = []
             }
         }
 

--- a/client/src/scripts/binds.ts
+++ b/client/src/scripts/binds.ts
@@ -13,6 +13,9 @@ export default function initBinds(client: Client, aliases?: { pattern: RegExp; c
             `Nape\u0142nij lamp\u0119: ${lamp}`,
             `Wesprzyj: ${support}`,
         ];
+        (client.customBinds || []).forEach(cb => {
+            lines.push(`${cb.command}: ${formatLabel(cb)}`);
+        });
         client.println(lines.join("\n"));
     }
 

--- a/docs/BINDS.md
+++ b/docs/BINDS.md
@@ -10,4 +10,5 @@ Rozszerzenie umożliwia ustawienie kilku skrótów klawiaturowych. Domyślne bin
   przywódcy z GMCP.
 
 Bindy można modyfikować w zakładce **Bindowanie** na stronie opcji rozszerzenia.
+Możesz także dodać własne skróty, które wyślą dowolną komendę.
 Aktualnie ustawione skróty możesz też wypisać w grze komendą `/binds`.

--- a/web-client/src/options/Binds.tsx
+++ b/web-client/src/options/Binds.tsx
@@ -9,6 +9,10 @@ interface Bind {
     shift?: boolean;
 }
 
+interface CustomBind extends Bind {
+    command: string;
+}
+
 interface DirectionBinds {
     n: Bind;
     s: Bind;
@@ -29,6 +33,7 @@ interface BindSettings {
     attack: Bind;
     support: Bind;
     directions: DirectionBinds;
+    custom: CustomBind[];
 }
 
 const defaultBinds: BindSettings = {
@@ -49,6 +54,7 @@ const defaultBinds: BindSettings = {
         d: { key: 'NumpadSubtract' },
         special: { key: 'Numpad0' },
     },
+    custom: [],
 };
 
 function label(bind: Bind) {
@@ -80,6 +86,7 @@ function Binds() {
                     ...defaultBinds.directions,
                     ...res?.binds?.directions,
                 },
+                custom: res?.binds?.custom || [],
             });
         });
     }, []);
@@ -96,6 +103,33 @@ function Binds() {
         setBinds(prev => ({
             ...prev,
             directions: { ...prev.directions, [dir]: { key: code, ctrl: ctrlKey, alt: altKey, shift: shiftKey } },
+        }));
+    }
+
+    function handleCaptureCustom(idx: number, ev: React.KeyboardEvent) {
+        ev.preventDefault();
+        const { code, ctrlKey, altKey, shiftKey } = ev;
+        setBinds(prev => ({
+            ...prev,
+            custom: prev.custom.map((b, i) => i === idx ? { ...b, key: code, ctrl: ctrlKey, alt: altKey, shift: shiftKey } : b),
+        }));
+    }
+
+    function handleCommandChange(idx: number, command: string) {
+        setBinds(prev => ({
+            ...prev,
+            custom: prev.custom.map((b, i) => i === idx ? { ...b, command } : b),
+        }));
+    }
+
+    function addCustomBind() {
+        setBinds(prev => ({ ...prev, custom: [...prev.custom, { key: '', command: '' }] }));
+    }
+
+    function removeCustomBind(idx: number) {
+        setBinds(prev => ({
+            ...prev,
+            custom: prev.custom.filter((_, i) => i !== idx),
         }));
     }
 
@@ -288,6 +322,35 @@ function Binds() {
                                     value={label(binds.directions.special)}
                                     onKeyDown={ev => handleCaptureDir('special', ev)}
                                 />
+                            </td>
+                        </tr>
+                        {binds.custom.map((b, idx) => (
+                            <tr key={idx}>
+                                <td>
+                                    <Form.Control
+                                        type="text"
+                                        size="sm"
+                                        value={b.command}
+                                        onChange={ev => handleCommandChange(idx, ev.target.value)}
+                                    />
+                                </td>
+                                <td>
+                                    <div className="d-flex gap-2">
+                                        <Form.Control
+                                            type="text"
+                                            readOnly
+                                            size="sm"
+                                            value={label(b)}
+                                            onKeyDown={ev => handleCaptureCustom(idx, ev)}
+                                        />
+                                        <Button variant="danger" size="sm" onClick={() => removeCustomBind(idx)}>Usuń</Button>
+                                    </div>
+                                </td>
+                            </tr>
+                        ))}
+                        <tr>
+                            <td colSpan={2}>
+                                <Button size="sm" onClick={addCustomBind}>Dodaj skrót</Button>
                             </td>
                         </tr>
                     </tbody>


### PR DESCRIPTION
## Summary
- allow defining custom command keybinds in options
- execute custom binds and list them via /binds
- document custom keybinds in user docs

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6891df105f2c832a946c7d44e6556e84