### PR TITLE
Clamp mobile buttons into view on startup

### DIFF
--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -317,6 +317,7 @@ export default class MobileDirectionButtons {
                 const { x, y } = savedPosition as any;
                 this.container.style.right = `${x}px`;
                 this.container.style.top = `${y}px`;
+                requestAnimationFrame(() => this.clampToView());
             } catch (e) {
                 console.error('Error parsing saved position:', e);
             }


### PR DESCRIPTION
## Summary
- clamp mobile direction buttons to viewport when enabled so they stay on screen

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6891f4c62a00832a8e3f3fdbb6b98858