### PR TITLE
Fix NPC list refresh after new additions

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -210,12 +210,12 @@ export default class Client {
         this.port = port
         port.onMessage.addListener((message) => {
             if (message && typeof message.type === 'string') {
-                this.eventTarget.dispatchEvent(new CustomEvent(message.type, {detail: message.data}))
+                this.sendEvent(message.type, message.data)
                 return
             }
             if (message && typeof message === 'object') {
                 Object.entries(message).forEach(([key, value]) => {
-                    this.eventTarget.dispatchEvent(new CustomEvent(key, {detail: value}))
+                    this.sendEvent(key, value)
                 })
             }
         })

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -69,6 +69,16 @@ beforeEach(() => {
   (global as any).clientAdapterMock = { send: jest.fn(), stop: jest.fn(), connect: jest.fn(), output: jest.fn(), sendGmcp: jest.fn() };
 });
 
+test('port messages trigger window events', () => {
+  new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const listener = (global as any).portMock.onMessage.addListener.mock.calls[0][0];
+  const detail = [{ name: 'Foo', loc: 1 }];
+  listener({ npc: detail });
+  expect((window as any).dispatchEvent).toHaveBeenCalledWith(
+    expect.objectContaining({ type: 'npc', detail })
+  );
+});
+
 test('createEvent returns object with type and data', () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   expect(client.createEvent('t', 123)).toEqual({ type: 't', data: 123 });


### PR DESCRIPTION
## Summary
- Dispatch background port messages using `sendEvent` so window listeners receive NPC updates
- Test that port messages trigger window events

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6891fb9f2e78832a93aa46e773a4f940