### PR TITLE
Color coin amounts listed without repeated 'monet'

### DIFF
--- a/client/src/scripts/coinColors.ts
+++ b/client/src/scripts/coinColors.ts
@@ -6,13 +6,12 @@ export default function initCoinColors(client: Client) {
     const tag = "coinColors";
     const patterns: { regex: RegExp; color: number }[] = [
         { regex: /(\w+\s+)?zlot(a|e|ych) monet(y|e|a|)/i, color: GOLD_COLOR },
-        { regex: /[Zz]lot(a|e|ych) monet(y|e|a|)/, color: GOLD_COLOR },
         { regex: /(\w+\s+)?mithrylow(a|e|ych) monet(y|e|a|)/i, color: MITHRIL_COLOR },
-        { regex: /[Mm]ithrylow(a|e|ych) monet(y|e|a|)/, color: MITHRIL_COLOR },
         { regex: /(\w+\s+)?srebrn(a|e|ych) monet(y|e|a|)/i, color: SILVER_COLOR },
-        { regex: /srebrn(a|e|ych) monet(y|e|a|)/i, color: SILVER_COLOR },
         { regex: /(\w+\s+)?miedzian(a|e|ych) monet(y|e|a|)/i, color: COPPER_COLOR },
-        { regex: /miedzian(a|e|ych) monet(y|e|a|)/i, color: COPPER_COLOR }
+        { regex: /(\w+\s+)?zlot(a|e|ych)(?!\s+monet)/i, color: GOLD_COLOR },
+        { regex: /(\w+\s+)?srebrn(a|e|ych)(?!\s+monet)/i, color: SILVER_COLOR },
+        { regex: /(\w+\s+)?miedzian(a|e|ych)(?!\s+monet)/i, color: COPPER_COLOR }
     ];
     patterns.forEach(({ regex, color }) => {
         client.Triggers.registerTrigger(regex, (raw, _line, m) => {

--- a/client/test/coinColors.test.ts
+++ b/client/test/coinColors.test.ts
@@ -1,0 +1,29 @@
+import initCoinColors from '../src/scripts/coinColors';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
+import { colorStringInLine } from '../src/Colors';
+import { GOLD_COLOR, SILVER_COLOR, COPPER_COLOR } from '../src/scripts/shop';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+}
+
+describe('coin colors trigger', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initCoinColors((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+  });
+
+  test('colors coins in receive sentence', () => {
+    const line = 'Otrzymujesz 11 zlotych, 15 srebrnych i 8 miedzianych monet.';
+    let expected = colorStringInLine(line, '11 zlotych', GOLD_COLOR);
+    expected = colorStringInLine(expected, '15 srebrnych', SILVER_COLOR);
+    expected = colorStringInLine(expected, '8 miedzianych monet', COPPER_COLOR);
+    const result = parse(line);
+    expect(stripAnsiCodes(result)).toBe(stripAnsiCodes(expected));
+    expect(result).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- highlight coin amounts like "11 zlotych" and "15 srebrnych" even when "monet" appears only once in the sentence
- streamline coin color trigger patterns and add regression test

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6891fa0dbfb0832ab629b7475cb12e6a