### PR TITLE
Expand /por header width

### DIFF
--- a/client/src/scripts/compareAll.ts
+++ b/client/src/scripts/compareAll.ts
@@ -41,13 +41,26 @@ function getTargets(client: Client): string[] {
 }
 
 export function formatComparisonTable(results: Record<string, ComparisonStats>): string {
-    const lines: string[] = [];
-    const header = `#   OSOBA                   SIL  ZRE  WYT  SUMA`;
-    const line = `--  ---------------------- ---- ---- ---- -----`;
-    lines.push(header);
-    lines.push(line);
-    let i = 1;
+    const NAME_WIDTH = 30;
     const pad = (str: string, len: number) => str + " ".repeat(Math.max(0, len - str.length));
+    const header = [
+        pad("#", 3),
+        pad("OSOBA", NAME_WIDTH),
+        pad("SIL", 4),
+        pad("ZRE", 4),
+        pad("WYT", 4),
+        pad("SUMA", 5)
+    ].join(" ");
+    const line = [
+        pad("--", 3),
+        "-".repeat(NAME_WIDTH),
+        "----",
+        "----",
+        "----",
+        "-----"
+    ].join(" ");
+    const lines: string[] = [header, line];
+    let i = 1;
     const formatVal = (n: number | undefined) => {
         if (n === undefined) return "0";
         return n > 0 ? `+${n}` : String(n);
@@ -55,7 +68,14 @@ export function formatComparisonTable(results: Record<string, ComparisonStats>):
     Object.entries(results).forEach(([name, stats]) => {
         const total = (stats.sil || 0) + (stats.zre || 0) + (stats.wyt || 0);
         lines.push(
-            `${pad(String(i),3)} ${pad(name,22)} ${pad(formatVal(stats.sil),4)} ${pad(formatVal(stats.zre),4)} ${pad(formatVal(stats.wyt),4)} ${pad(formatVal(total),5)}`
+            [
+                pad(String(i), 3),
+                pad(name, NAME_WIDTH),
+                pad(formatVal(stats.sil), 4),
+                pad(formatVal(stats.zre), 4),
+                pad(formatVal(stats.wyt), 4),
+                pad(formatVal(total), 5)
+            ].join(" ")
         );
         i++;
     });

--- a/client/test/comparison.test.ts
+++ b/client/test/comparison.test.ts
@@ -1,4 +1,4 @@
-import initCompareAll from '../src/scripts/compareAll';
+import initCompareAll, { formatComparisonTable } from '../src/scripts/compareAll';
 import Triggers, { stripAnsiCodes } from '../src/Triggers';
 
 class FakeClient {
@@ -63,5 +63,14 @@ describe('compare all alias', () => {
     expect(client.sendCommand).toHaveBeenCalledWith('porownaj sile z ob_6', false);
     expect(client.sendCommand).toHaveBeenCalledWith('porownaj zrecznosc z ob_6', false);
     expect(client.sendCommand).toHaveBeenCalledWith('porownaj wytrzymalosc z ob_6', false);
+  });
+
+  test('formats header wide enough for long descriptions', () => {
+    const longName = 'przygarbiony wyszczerzony ork';
+    const table = formatComparisonTable({ [longName]: { sil: -1, zre: -1, wyt: -2 } });
+    const [header, underline, row] = table.split('\n');
+    expect(row).toContain(longName);
+    expect(underline.length).toBe(header.length);
+    expect(row.length).toBe(header.length);
   });
 });


### PR DESCRIPTION
## Summary
- widen `/por` comparison table header to support longer descriptions
- test header layout for very long names

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_68922b674eb8832a9b799052d655b3ee