### PR TITLE
feat: add char state hover tooltip

### DIFF
--- a/web-client/src/CharState.ts
+++ b/web-client/src/CharState.ts
@@ -216,6 +216,7 @@ export default class CharState {
 
         const group = document.createElement("div");
         group.className = "char-state-bar";
+        group.title = key;
         const labelEl = document.createElement("span");
         labelEl.textContent = label + ":";
         if (highlight) labelEl.style.color = "tomato";


### PR DESCRIPTION
## Summary
- add hover tooltip for char state bars to reveal corresponding key

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6893e11e49ac832a9fe56ffdebd107f1