### PR TITLE
Fix coin coloring requiring monety after adjective

### DIFF
--- a/client/src/scripts/coinColors.ts
+++ b/client/src/scripts/coinColors.ts
@@ -5,13 +5,10 @@ import { MITHRIL_COLOR, GOLD_COLOR, SILVER_COLOR, COPPER_COLOR } from "./shop";
 export default function initCoinColors(client: Client) {
     const tag = "coinColors";
     const patterns: { regex: RegExp; color: number }[] = [
-        { regex: /(\w+\s+)?zlot(a|e|ych) monet(y|e|a|)/i, color: GOLD_COLOR },
-        { regex: /(\w+\s+)?mithrylow(a|e|ych) monet(y|e|a|)/i, color: MITHRIL_COLOR },
-        { regex: /(\w+\s+)?srebrn(a|e|ych) monet(y|e|a|)/i, color: SILVER_COLOR },
-        { regex: /(\w+\s+)?miedzian(a|e|ych) monet(y|e|a|)/i, color: COPPER_COLOR },
-        { regex: /(\w+\s+)?zlot(a|e|ych)(?!\s+monet)/i, color: GOLD_COLOR },
-        { regex: /(\w+\s+)?srebrn(a|e|ych)(?!\s+monet)/i, color: SILVER_COLOR },
-        { regex: /(\w+\s+)?miedzian(a|e|ych)(?!\s+monet)/i, color: COPPER_COLOR }
+        { regex: /(\w+\s+)?mithrylow(a|e|ych)(?=.*\bmonet)/i, color: MITHRIL_COLOR },
+        { regex: /(\w+\s+)?zlot(a|e|ych)(?=.*\bmonet)/i, color: GOLD_COLOR },
+        { regex: /(\w+\s+)?srebrn(a|e|ych)(?=.*\bmonet)/i, color: SILVER_COLOR },
+        { regex: /(\w+\s+)?miedzian(a|e|ych)(?=.*\bmonet)/i, color: COPPER_COLOR }
     ];
     patterns.forEach(({ regex, color }) => {
         client.Triggers.registerTrigger(regex, (raw, _line, m) => {

--- a/client/test/coinColors.test.ts
+++ b/client/test/coinColors.test.ts
@@ -19,11 +19,24 @@ describe('coin colors trigger', () => {
 
   test('colors coins in receive sentence', () => {
     const line = 'Otrzymujesz 11 zlotych, 15 srebrnych i 8 miedzianych monet.';
-    let expected = colorStringInLine(line, '11 zlotych', GOLD_COLOR);
-    expected = colorStringInLine(expected, '15 srebrnych', SILVER_COLOR);
-    expected = colorStringInLine(expected, '8 miedzianych monet', COPPER_COLOR);
     const result = parse(line);
-    expect(stripAnsiCodes(result)).toBe(stripAnsiCodes(expected));
-    expect(result).toBe(expected);
+    const gold = colorStringInLine('11 zlotych', '11 zlotych', GOLD_COLOR);
+    const silver = colorStringInLine('15 srebrnych', '15 srebrnych', SILVER_COLOR);
+    const copper = colorStringInLine('8 miedzianych', '8 miedzianych', COPPER_COLOR);
+    expect(result).toContain(gold);
+    expect(result).toContain(silver);
+    expect(result).toContain(copper);
+    expect(stripAnsiCodes(result)).toBe(line);
+  });
+
+  test('does not color words without following monety', () => {
+    const line = 'Masz 10 srebrnych monet i zlote.';
+    const result = parse(line);
+    const silver = colorStringInLine('10 srebrnych', '10 srebrnych', SILVER_COLOR);
+    const gold = colorStringInLine('zlote', 'zlote', GOLD_COLOR);
+    expect(result).toContain(silver);
+    expect(result).toContain(' i zlote.');
+    expect(result).not.toContain(gold);
+    expect(stripAnsiCodes(result)).toBe(line);
   });
 });


### PR DESCRIPTION
## Summary
- restrict coin coloring to cases where the line contains "monet" after the coin adjective
- add regression test to ensure standalone "zlote" remains uncolored

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_6893e570f6f0832aa3a201c8f626aa13