### PR TITLE
feat: adjust HP color thresholds

### DIFF
--- a/web-client/src/CharState.ts
+++ b/web-client/src/CharState.ts
@@ -197,7 +197,13 @@ export default class CharState {
         const ratio = value / maxValue;
         const reverse = def === 0 || this.config[key].flip === true;
         let colorClass = "bg-success";
-        if (reverse) {
+        if (key === "hp") {
+          if (value <= 3) {
+            colorClass = "bg-danger";
+          } else if (value <= 5) {
+            colorClass = "bg-warning";
+          }
+        } else if (reverse) {
           if (ratio >= 2 / 3) {
             colorClass = "bg-danger";
           } else if (ratio >= 1 / 3) {
@@ -258,7 +264,13 @@ export default class CharState {
           const ratio = value / maxValue;
           const reverse = def === 0 || this.config[key].flip === true;
           let color = "green";
-          if (reverse) {
+          if (key === "hp") {
+            if (value <= 3) {
+              color = "red";
+            } else if (value <= 5) {
+              color = "yellow";
+            }
+          } else if (reverse) {
             if (ratio >= 2 / 3) {
               color = "red";
             } else if (ratio >= 1 / 3) {

--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -149,10 +149,10 @@ export default class ObjectList {
             const desc = coloredDesc + " ".repeat(Math.max(0, descWidth - rawDesc.length));
             let bar = "";
             if (typeof obj.state === "number") {
-                const hp = Math.max(0, Math.min(6, obj.state));
-                const color = hp < 3 ? "tomato" : (hp < 4 ? "yellow" : "springgreen");
-                const filled = "#".repeat(hp + 1);
-                const empty = "-".repeat(6 - hp);
+                const hp = Math.max(0, Math.min(6, obj.state)) + 1;
+                const color = hp <= 3 ? "tomato" : (hp <= 5 ? "yellow" : "springgreen");
+                const filled = "#".repeat(hp);
+                const empty = "-".repeat(7 - hp);
                 bar = `[<span style="color:${color}">${filled}${empty}</span>]`;
             }
             const attackers = objects


### PR DESCRIPTION
## Summary
- update object list HP colors for 6-7 green, 4-5 yellow, 3- red
- adjust footer HP bar and text color logic to match new thresholds

## Testing
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6893f8ff9338832abe4bbf521f22f47b