### PR TITLE
refactor: centralize color logic

### DIFF
--- a/web-client/src/CharState.ts
+++ b/web-client/src/CharState.ts
@@ -1,5 +1,6 @@
 import ArkadiaClient from "./ArkadiaClient.ts";
 import { gmcp } from "@client/src/gmcp";
+import { COLOR_BAR_CLASS, COLOR_TEXT, getColorLevel } from "./colors.ts";
 
 export interface CharStateData {
   hp: number;
@@ -196,26 +197,8 @@ export default class CharState {
         value = Math.max(0, Math.min(maxValue, value));
         const ratio = value / maxValue;
         const reverse = def === 0 || this.config[key].flip === true;
-        let colorClass = "bg-success";
-        if (key === "hp") {
-          if (value <= 3) {
-            colorClass = "bg-danger";
-          } else if (value <= 5) {
-            colorClass = "bg-warning";
-          }
-        } else if (reverse) {
-          if (ratio >= 2 / 3) {
-            colorClass = "bg-danger";
-          } else if (ratio >= 1 / 3) {
-            colorClass = "bg-warning";
-          }
-        } else {
-          if (ratio <= 1 / 3) {
-            colorClass = "bg-danger";
-          } else if (ratio <= 2 / 3) {
-            colorClass = "bg-warning";
-          }
-        }
+        const colorLevel = getColorLevel(value, maxValue, reverse, key === "hp");
+        const colorClass = COLOR_BAR_CLASS[colorLevel];
         const opposite =
           def !== undefined ? (def > 0 ? 0 : maxValue) : null;
         const highlight = opposite !== null && value === opposite;
@@ -263,26 +246,8 @@ export default class CharState {
           const bar = "#".repeat(filledLen) + "-".repeat(emptyLen);
           const ratio = value / maxValue;
           const reverse = def === 0 || this.config[key].flip === true;
-          let color = "green";
-          if (key === "hp") {
-            if (value <= 3) {
-              color = "red";
-            } else if (value <= 5) {
-              color = "yellow";
-            }
-          } else if (reverse) {
-            if (ratio >= 2 / 3) {
-              color = "red";
-            } else if (ratio >= 1 / 3) {
-              color = "yellow";
-            }
-          } else {
-            if (ratio <= 1 / 3) {
-              color = "red";
-            } else if (ratio <= 2 / 3) {
-              color = "yellow";
-            }
-          }
+          const colorLevel = getColorLevel(value, maxValue, reverse, key === "hp");
+          const color = COLOR_TEXT[colorLevel];
           text = `${label}: <span style="color:${color}">[${bar}]</span>`;
         } else {
           text = `${label}: [${value}/${maxValue}]`;

--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -1,5 +1,6 @@
 import Client from "@client/src/Client";
 import { getItemSync, setItemSync } from "@client/src/storage";
+import { COLOR_OBJECT, getColorLevel } from "./colors.ts";
 
 export default class ObjectList {
     private client: Client;
@@ -150,7 +151,8 @@ export default class ObjectList {
             let bar = "";
             if (typeof obj.state === "number") {
                 const hp = Math.max(0, Math.min(6, obj.state)) + 1;
-                const color = hp <= 3 ? "tomato" : (hp <= 5 ? "yellow" : "springgreen");
+                const colorLevel = getColorLevel(hp, 7, false, true);
+                const color = COLOR_OBJECT[colorLevel];
                 const filled = "#".repeat(hp);
                 const empty = "-".repeat(7 - hp);
                 bar = `[<span style="color:${color}">${filled}${empty}</span>]`;

--- a/web-client/src/colors.ts
+++ b/web-client/src/colors.ts
@@ -1,0 +1,36 @@
+export type ColorLevel = 'success' | 'warning' | 'danger';
+
+export function getColorLevel(value: number, max: number, reverse = false, isHp = false): ColorLevel {
+  if (isHp) {
+    if (value <= 3) return 'danger';
+    if (value <= 5) return 'warning';
+    return 'success';
+  }
+  const ratio = max === 0 ? 0 : value / max;
+  if (reverse) {
+    if (ratio >= 2 / 3) return 'danger';
+    if (ratio >= 1 / 3) return 'warning';
+    return 'success';
+  }
+  if (ratio <= 1 / 3) return 'danger';
+  if (ratio <= 2 / 3) return 'warning';
+  return 'success';
+}
+
+export const COLOR_BAR_CLASS: Record<ColorLevel, string> = {
+  success: 'bg-success',
+  warning: 'bg-warning',
+  danger: 'bg-danger',
+};
+
+export const COLOR_TEXT: Record<ColorLevel, string> = {
+  success: 'green',
+  warning: 'yellow',
+  danger: 'red',
+};
+
+export const COLOR_OBJECT: Record<ColorLevel, string> = {
+  success: 'springgreen',
+  warning: 'yellow',
+  danger: 'tomato',
+};


### PR DESCRIPTION
## Summary
- extract shared color helpers for hp and ratio coloring
- use new helper in char state bars and text
- reuse helper for object list hp bar colors

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`


------
https://chatgpt.com/codex/tasks/task_e_6893faf12140832ab4df1bb72fac7951