### PR TITLE
feat: add browser notifications for low hp

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -83,6 +83,10 @@ export default class Client {
     constructor(clientAdapter: ClientAdapter, port: any) {
         this.clientAdapter = clientAdapter
         attachGmcpListener(this);
+
+        if (typeof Notification !== 'undefined' && Notification.permission === 'default') {
+            Notification.requestPermission();
+        }
         window.addEventListener('extension-message', (ev: Event) => {
             const data: any = (ev as CustomEvent).detail;
             if (data && data.data !== undefined) {
@@ -412,6 +416,15 @@ export default class Client {
         } else {
             sound.once('load', play)
             sound.load()
+        }
+    }
+
+    notify(message: string) {
+        if (typeof Notification === 'undefined') {
+            return
+        }
+        if (Notification.permission === 'granted') {
+            new Notification(message)
         }
     }
 

--- a/client/src/scripts/hpAlert.ts
+++ b/client/src/scripts/hpAlert.ts
@@ -19,9 +19,11 @@ export default function initHpAlert(client: Client) {
         if (typeof hp !== 'number') return;
         hp++;
         if (hp < prev && hp < 3) {
-            const msg = colorString(`Jestes ${CONDITIONS[hp] ?? ''}`, ORANGE);
+            const plain = `Jestes ${CONDITIONS[hp] ?? ''}`;
+            const msg = colorString(plain, ORANGE);
             client.playSound('beep');
             client.println(`\n\n${msg}\n\n`);
+            client.notify(plain);
         }
         prev = hp;
     });

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -69,6 +69,20 @@ beforeEach(() => {
   (global as any).clientAdapterMock = { send: jest.fn(), stop: jest.fn(), connect: jest.fn(), output: jest.fn(), sendGmcp: jest.fn() };
 });
 
+test('requests notification permission on start', () => {
+  (global as any).Notification = { permission: 'default', requestPermission: jest.fn() };
+  new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  expect((global as any).Notification.requestPermission).toHaveBeenCalledTimes(1);
+  delete (global as any).Notification;
+});
+
+test('does not request notification permission when already decided', () => {
+  (global as any).Notification = { permission: 'granted', requestPermission: jest.fn() };
+  new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  expect((global as any).Notification.requestPermission).not.toHaveBeenCalled();
+  delete (global as any).Notification;
+});
+
 test('port messages trigger window events', () => {
   new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   const listener = (global as any).portMock.onMessage.addListener.mock.calls[0][0];

--- a/client/test/hpAlert.test.ts
+++ b/client/test/hpAlert.test.ts
@@ -6,6 +6,7 @@ class FakeClient {
   private emitter = new EventEmitter();
   println = jest.fn();
   playSound = jest.fn();
+  notify = jest.fn();
   addEventListener(event: string, cb: any) {
     this.emitter.on(event, cb);
   }
@@ -32,8 +33,10 @@ describe('hp alert', () => {
     send(3);
     send(1);
     expect(client.playSound).toHaveBeenCalledTimes(1);
-    const msg = colorString('Jestes ciezko ranny', color);
+    const plain = 'Jestes ciezko ranny';
+    const msg = colorString(plain, color);
     expect(client.println).toHaveBeenCalledWith(`\n\n${msg}\n\n`);
+    expect(client.notify).toHaveBeenCalledWith(plain);
   });
 
   test('prints again on further decrease', () => {
@@ -45,14 +48,18 @@ describe('hp alert', () => {
     const second = colorString('Jestes ledwo zywy', color);
     expect(client.println).toHaveBeenNthCalledWith(1, `\n\n${first}\n\n`);
     expect(client.println).toHaveBeenNthCalledWith(2, `\n\n${second}\n\n`);
+    expect(client.notify).toHaveBeenNthCalledWith(1, 'Jestes ciezko ranny');
+    expect(client.notify).toHaveBeenNthCalledWith(2, 'Jestes ledwo zywy');
   });
 
   test('does not trigger when hp rises', () => {
     send(2);
     client.println.mockClear();
     client.playSound.mockClear();
+    client.notify.mockClear();
     send(4);
     expect(client.playSound).not.toHaveBeenCalled();
     expect(client.println).not.toHaveBeenCalled();
+    expect(client.notify).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- allow `Client` to trigger browser notifications
- notify on low hp alerts
- request notification permission once during client startup

## Testing
- `CI=true yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6894a97e0450832a92f040cf4632605e