### PR TITLE
Allow specifying container for /przejrzyj alias

### DIFF
--- a/client/src/scripts/prettyContainers.ts
+++ b/client/src/scripts/prettyContainers.ts
@@ -460,10 +460,11 @@ export default function initContainers(client: Client) {
     });
 
     client.aliases.push({
-        pattern: /\/przejrzyj/, callback: () => {
-            filter = magicAndKeysFilter
-            plugLinks = true
-            client.send("ob skrzynie");
-        }
-    })
+        pattern: /^\/przejrzyj(?: (\w+))?$/,
+        callback: (m?: RegExpMatchArray) => {
+            filter = magicAndKeysFilter;
+            plugLinks = true;
+            client.send(`przejrzyj ${m?.[1] ?? 'skrzynie'}`);
+        },
+    });
 }

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -10,7 +10,7 @@ Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorze
 - **/zabici2** - wyświetla podsumowanie liczby zabitych istot.
 - **/cechy** - uruchamia licznik poziomowania i wyświetla postępy.
 - **/postepy** - wyświetla postępy ulepszeń.
-- **/przejrzyj** - pokazuje zawartość skrzyń z kluczami i magicznymi przedmiotami.
+- **/przejrzyj [_co_]** - pokazuje zawartość skrzyń z kluczami i magicznymi przedmiotami lub podanego pojemnika.
 - **/por [_skrot_]** - porównuje siłę, zręczność i wytrzymałość z podanym obiektem lub wszystkimi w pomieszczeniu.
 
 ## Menedżer pojemników


### PR DESCRIPTION
## Summary
- allow `/przejrzyj` alias to accept an optional container name and send the appropriate command
- document optional argument for `/przejrzyj`

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6894e48243c4832aaaabd030649a0c57