### PR TITLE
feat: request notifications on demand

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -85,9 +85,6 @@ export default class Client {
         this.clientAdapter = clientAdapter
         attachGmcpListener(this);
 
-        if (typeof Notification !== 'undefined' && Notification.permission === 'default') {
-            Notification.requestPermission();
-        }
         window.addEventListener('extension-message', (ev: Event) => {
             const data: any = (ev as CustomEvent).detail;
             if (data && data.data !== undefined) {
@@ -417,6 +414,15 @@ export default class Client {
         } else {
             sound.once('load', play)
             sound.load()
+        }
+    }
+
+    enableNotifications() {
+        if (typeof Notification === 'undefined') {
+            return
+        }
+        if (Notification.permission === 'default') {
+            Notification.requestPermission()
         }
     }
 

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -69,16 +69,18 @@ beforeEach(() => {
   (global as any).clientAdapterMock = { send: jest.fn(), stop: jest.fn(), connect: jest.fn(), output: jest.fn(), sendGmcp: jest.fn() };
 });
 
-test('requests notification permission on start', () => {
+test('requests notification permission on demand', () => {
   (global as any).Notification = { permission: 'default', requestPermission: jest.fn() };
-  new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  client.enableNotifications();
   expect((global as any).Notification.requestPermission).toHaveBeenCalledTimes(1);
   delete (global as any).Notification;
 });
 
 test('does not request notification permission when already decided', () => {
   (global as any).Notification = { permission: 'granted', requestPermission: jest.fn() };
-  new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  client.enableNotifications();
   expect((global as any).Notification.requestPermission).not.toHaveBeenCalled();
   delete (global as any).Notification;
 });

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -214,6 +214,9 @@
                 <li>
                     <button class="w-100 p-1" id="shortcuts-button">Skróty</button>
                 </li>
+                <li id="enable-notifications-item">
+                    <button class="w-100 p-1" id="enable-notifications">Włącz powiadomienia</button>
+                </li>
                 <li>
                     <button class="w-100 p-1" id="docs-button">Dokumentacja</button>
                 </li>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -232,6 +232,7 @@
 
     <div id="auth-overlay">
         <button id="auth-close" class="overlay-close">✖</button>
+        <button id="enable-notifications-connection" class="btn btn-secondary btn-sm">Włącz powiadomienia</button>
         <div id="auth-panel">
             <img src="logo.png" class="logo mb-3" />
             <div id="connecting-spinner" class="spinner-border text-light"></div>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -455,6 +455,21 @@ document.addEventListener('DOMContentLoaded', () => {
     const loginForm = document.getElementById('login-form') as HTMLFormElement | null;
     const authClose = document.getElementById('auth-close') as HTMLButtonElement | null;
     const notificationCenter = document.getElementById('notification-center') as HTMLElement | null;
+    const enableNotificationsButton = document.getElementById('enable-notifications') as HTMLButtonElement | null;
+    const enableNotificationsItem = document.getElementById('enable-notifications-item') as HTMLElement | null;
+
+    if (enableNotificationsButton && enableNotificationsItem) {
+        const updateVisibility = () => {
+            if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
+                enableNotificationsItem.style.display = 'none';
+            }
+        };
+        enableNotificationsButton.addEventListener('click', () => {
+            client.enableNotifications();
+            updateVisibility();
+        });
+        updateVisibility();
+    }
 
     if (notificationCenter) {
         client.eventTarget.addEventListener('notify', (ev: CustomEvent<{ text: string; time?: number }>) => {

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -457,17 +457,29 @@ document.addEventListener('DOMContentLoaded', () => {
     const notificationCenter = document.getElementById('notification-center') as HTMLElement | null;
     const enableNotificationsButton = document.getElementById('enable-notifications') as HTMLButtonElement | null;
     const enableNotificationsItem = document.getElementById('enable-notifications-item') as HTMLElement | null;
+    const enableNotificationsConnection = document.getElementById('enable-notifications-connection') as HTMLButtonElement | null;
 
-    if (enableNotificationsButton && enableNotificationsItem) {
+    if (enableNotificationsButton || enableNotificationsItem || enableNotificationsConnection) {
         const updateVisibility = () => {
             if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
-                enableNotificationsItem.style.display = 'none';
+                if (enableNotificationsItem) {
+                    enableNotificationsItem.style.display = 'none';
+                }
+                if (enableNotificationsConnection) {
+                    enableNotificationsConnection.style.display = 'none';
+                }
             }
         };
-        enableNotificationsButton.addEventListener('click', () => {
+        const handleClick = () => {
             client.enableNotifications();
             updateVisibility();
-        });
+        };
+        if (enableNotificationsButton) {
+            enableNotificationsButton.addEventListener('click', handleClick);
+        }
+        if (enableNotificationsConnection) {
+            enableNotificationsConnection.addEventListener('click', handleClick);
+        }
         updateVisibility();
     }
 

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -725,6 +725,12 @@ button:focus-visible {
   opacity: 1;
 }
 
+#enable-notifications-connection {
+  position: absolute;
+  bottom: 0.5rem;
+  left: 0.5rem;
+}
+
 #login-form {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add button to enable notifications from the interface
- request browser notification permission only when user clicks the button
- adjust tests for on-demand notification permission
- move notifications button into interface menu

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6894f7a413d8832ab0aae04fe8903fe3