### PR TITLE
feat: add map exploration mode

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -4,6 +4,7 @@ import { getItemSync, setItemSync } from "./storage";
 import Room = MapData.Room;
 
 const STORAGE_KEY = 'mapperRoomId';
+const VISITED_ROOMS_KEY = 'visitedRooms';
 
 export const polishToEnglish = {
     ["polnoc"]: "north",
@@ -75,6 +76,7 @@ export default class MapHelper {
     hashes = {};
     gmcpPosition: Position;
     savedRoomId: number | null = null;
+    visitedRooms = new Set<number>();
 
     constructor(clientExtension: Client) {
         this.client = clientExtension
@@ -82,6 +84,11 @@ export default class MapHelper {
         const saved = savedData ? savedData[STORAGE_KEY] : null;
         if (saved) {
             this.savedRoomId = parseInt(saved);
+        }
+        const visitedData = getItemSync(VISITED_ROOMS_KEY);
+        const visited = visitedData ? visitedData[VISITED_ROOMS_KEY] : null;
+        if (visited && Array.isArray(visited)) {
+            this.visitedRooms = new Set<number>(visited);
         }
         this.client.addEventListener('enterLocation', (event) => this.handleNewLocation(event.detail))
         window.addEventListener('map-ready', (event: CustomEvent) => {
@@ -260,7 +267,10 @@ export default class MapHelper {
 
     renderRoomById(id: number, sendEvent = true) {
         this.currentRoom = this.mapReader.getRoomById(id)
+        this.visitedRooms.add(id);
         setItemSync(STORAGE_KEY, id.toString())
+        setItemSync(VISITED_ROOMS_KEY, Array.from(this.visitedRooms));
+        this.client.sendEvent('visitedRooms', Array.from(this.visitedRooms));
         if (sendEvent) {
             this.client.sendEvent('enterLocation', {id: id, room: this.currentRoom});
         }

--- a/client/src/storage.ts
+++ b/client/src/storage.ts
@@ -33,6 +33,7 @@ const characterScopedKeys = new Set([
     'herb_counts',
     'herbs_data',
     'mapperRoomId',
+    'visitedRooms',
 ]);
 
 let currentCharacter: string | null = localStorage.getItem('currentCharacter');

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -293,6 +293,10 @@
                     <label class="form-label">Zasięg renderowania mapy
                         <input id="ui-map-limit" type="number" step="1" min="1" value="35" class="form-control" />
                     </label>
+                    <label class="form-label">
+                        <input id="ui-exploration-mode" type="checkbox" class="form-check-input me-2" />
+                        Tryb eksploracji mapy
+                    </label>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-primary" id="ui-settings-save">Zapisz</button>

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -14,6 +14,8 @@ export default class EmbeddedMap {
     private _touchStartDistance: number | null = null;
     private zoom: number;
     private limit: number;
+    private explorationMode = false;
+    private visited = new Set<number>();
 
     constructor(mapData: any, colors: any, startId: number) {
         this.map = document.querySelector<HTMLCanvasElement>("#map")!;
@@ -35,6 +37,7 @@ export default class EmbeddedMap {
         this.settings.transparentLabels = true;
         this.settings
         let zoom = 0.30;
+        let explorationMode = false;
         try {
             const data = getItemSync('uiSettings');
             const parsed = data?.uiSettings as any;
@@ -45,12 +48,16 @@ export default class EmbeddedMap {
                 if (typeof parsed.mapLimit === 'number' && parsed.mapLimit > 0) {
                     limit = parsed.mapLimit;
                 }
+                if (typeof parsed.explorationMode === 'boolean') {
+                    explorationMode = parsed.explorationMode;
+                }
             }
         } catch {
             // ignore malformed data
         }
         this.zoom = zoom;
         this.limit = limit;
+        this.explorationMode = explorationMode;
         this.renderer = new Renderer(this.map, this.reader, this.settings);
         this.renderRoomById(startId);
 
@@ -65,6 +72,13 @@ export default class EmbeddedMap {
         window.addEventListener('highlights', (ev: any) => {
             this.highlights = ev.detail;
             this.refresh();
+        })
+
+        window.addEventListener('visitedRooms', (ev: any) => {
+            this.visited = new Set(ev.detail || []);
+            if (this.explorationMode) {
+                this.refresh();
+            }
         })
     }
 
@@ -130,12 +144,15 @@ export default class EmbeddedMap {
                 yMin: room.y - this.limit,
                 yMax: room.y + this.limit
             });
+            if (this.explorationMode) {
+                area.rooms = area.rooms.filter((r: any) => r && this.visited.has(r.id));
+            }
             this.renderer?.clear();
             this.renderer.renderArea(area);
             this.renderer.controls.centerRoom(room.id);
             this.renderer.controls.setZoom(this.zoom);
             this.renderer.backgroundLayer.remove();
-
+            
             this.currentRoom = room;
             const label = document.getElementById('location-label');
             if (label && area) {
@@ -173,6 +190,11 @@ export default class EmbeddedMap {
 
     refresh() {
         this.renderRoom(this.currentRoom);
+    }
+
+    setExplorationMode(on: boolean) {
+        this.explorationMode = on;
+        this.refresh();
     }
 
     setZoom(zoom: number) {

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -11,6 +11,7 @@ interface UiSettings {
     emojiLabels: boolean;
     xtermPalette: 'arkadia' | 'proper';
     footerMode: number;
+    explorationMode: boolean;
 }
 
 const defaultSettings: UiSettings = {
@@ -24,6 +25,7 @@ const defaultSettings: UiSettings = {
     emojiLabels: false,
     xtermPalette: 'arkadia',
     footerMode: 0,
+    explorationMode: false,
 };
 
 function apply(settings: UiSettings) {
@@ -69,6 +71,7 @@ function apply(settings: UiSettings) {
     if ((window as any).embedded?.renderer?.controls) {
         (window as any).embedded.setZoom?.(settings.mapScale);
         (window as any).embedded.setLimit?.(settings.mapLimit);
+        (window as any).embedded.setExplorationMode?.(settings.explorationMode);
         (window as any).embedded.refresh();
     }
     if ((window as any).clientExtension?.eventTarget) {
@@ -106,7 +109,8 @@ async function load(): Promise<UiSettings> {
             })();
             const xtermPalette = parsed.xtermPalette === 'proper' ? 'proper' : defaultSettings.xtermPalette;
             const footerMode = typeof parsed.footerMode === 'number' ? parsed.footerMode : defaultSettings.footerMode;
-            return { ...defaultSettings, ...parsed, mapScale, mapLimit, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode };
+            const explorationMode = !!parsed.explorationMode;
+            return { ...defaultSettings, ...parsed, mapScale, mapLimit, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode };
         }
     } catch {
         // ignore malformed data
@@ -130,6 +134,7 @@ export default async function initUiSettings() {
     const mapInput = modalEl.querySelector('#ui-map-scale') as HTMLInputElement;
     const mapHeightInput = modalEl.querySelector('#ui-map-height') as HTMLInputElement;
     const mapLimitInput = modalEl.querySelector('#ui-map-limit') as HTMLInputElement;
+    const explorationInput = modalEl.querySelector('#ui-exploration-mode') as HTMLInputElement;
     const showButtonsInput = modalEl.querySelector('#ui-show-buttons') as HTMLInputElement;
     const emojiLabelsInput = modalEl.querySelector('#ui-emoji-labels') as HTMLInputElement;
     const xtermPaletteInput = modalEl.querySelector('#ui-xterm-palette') as HTMLSelectElement;
@@ -143,6 +148,7 @@ export default async function initUiSettings() {
     mapInput.value = String(current.mapScale);
     mapHeightInput.value = String(current.mapHeight);
     mapLimitInput.value = String(current.mapLimit);
+    explorationInput.checked = current.explorationMode;
     showButtonsInput.checked = current.showButtons;
     emojiLabelsInput.checked = current.emojiLabels;
     xtermPaletteInput.value = current.xtermPalette;
@@ -174,7 +180,8 @@ export default async function initUiSettings() {
             showButtons: showButtonsInput.checked,
             emojiLabels: emojiLabelsInput.checked,
             xtermPalette: (xtermPaletteInput.value as 'arkadia' | 'proper') || defaultSettings.xtermPalette,
-            footerMode: parseInt(footerModeInput.value) || defaultSettings.footerMode
+            footerMode: parseInt(footerModeInput.value) || defaultSettings.footerMode,
+            explorationMode: explorationInput.checked,
         };
     }
 


### PR DESCRIPTION
## Summary
- track visited rooms per character and emit visits to the map
- add exploration mode toggle and filter map to visited locations
- store exploration preference in UI settings

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`

------
https://chatgpt.com/codex/tasks/task_e_6894fd7720ac832aa2a46046631eb0c4