### PR TITLE
feat: add map exploration mode

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -1,10 +1,6 @@
 import {MapReader} from "mudlet-map-renderer";
 import Client from "./Client";
-import { getItemSync, setItemSync } from "./storage";
 import Room = MapData.Room;
-
-const STORAGE_KEY = 'mapperRoomId';
-const VISITED_ROOMS_KEY = 'visitedRooms';
 
 export const polishToEnglish = {
     ["polnoc"]: "north",
@@ -75,29 +71,16 @@ export default class MapHelper {
     refreshPosition = true;
     hashes = {};
     gmcpPosition: Position;
-    savedRoomId: number | null = null;
-    visitedRooms = new Set<number>();
 
     constructor(clientExtension: Client) {
         this.client = clientExtension
-        const savedData = getItemSync(STORAGE_KEY);
-        const saved = savedData ? savedData[STORAGE_KEY] : null;
-        if (saved) {
-            this.savedRoomId = parseInt(saved);
-        }
-        const visitedData = getItemSync(VISITED_ROOMS_KEY);
-        const visited = visitedData ? visitedData[VISITED_ROOMS_KEY] : null;
-        if (visited && Array.isArray(visited)) {
-            this.visitedRooms = new Set<number>(visited);
-        }
         this.client.addEventListener('enterLocation', (event) => this.handleNewLocation(event.detail))
         window.addEventListener('map-ready', (event: CustomEvent) => {
             this.mapReader = new MapReader(event.detail.mapData, event.detail.colors)
             // @ts-ignore
             Object.values(this.mapReader.roomIndex).forEach(room => this.hashes[room.hash] = room);
-            const startId = this.savedRoomId ?? 1;
-            window.dispatchEvent(new CustomEvent('map-ready-with-data', {detail: {mapData: event.detail.mapData, colors: event.detail.colors, startId: startId}}))
-            this.renderRoomById(startId)
+            window.dispatchEvent(new CustomEvent('map-ready-with-data', {detail: {mapData: event.detail.mapData, colors: event.detail.colors}}))
+            this.renderRoomById(1)
         })
 
         this.client.addEventListener('gmcp.room.info', (event: CustomEvent) => {
@@ -110,19 +93,6 @@ export default class MapHelper {
 
         this.client.addEventListener('refreshPositionWhenAble', () => {
             this.refreshPosition = true;
-        });
-
-        this.client.addEventListener('gmcp.char.info', () => {
-            const listener = (event: CustomEvent) => {
-                if (event.detail.key === STORAGE_KEY) {
-                    const value = parseInt(event.detail.value);
-                    if (!isNaN(value)) {
-                        this.savedRoomId = value;
-                        this.setMapRoomById(this.savedRoomId);
-                    }
-                }
-            };
-            this.client.addEventListener('storage', listener);
         });
 
         this.client.sendEvent('refreshPositionWhenAble');
@@ -267,10 +237,6 @@ export default class MapHelper {
 
     renderRoomById(id: number, sendEvent = true) {
         this.currentRoom = this.mapReader.getRoomById(id)
-        this.visitedRooms.add(id);
-        setItemSync(STORAGE_KEY, id.toString())
-        setItemSync(VISITED_ROOMS_KEY, Array.from(this.visitedRooms));
-        this.client.sendEvent('visitedRooms', Array.from(this.visitedRooms));
         if (sendEvent) {
             this.client.sendEvent('enterLocation', {id: id, room: this.currentRoom});
         }

--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -4,6 +4,7 @@ import { getItemSync, setItemSync } from "./storage";
 import Room = MapData.Room;
 
 const STORAGE_KEY = 'mapperRoomId';
+const VISITED_ROOMS_KEY = 'visitedRooms';
 
 export const polishToEnglish = {
     ["polnoc"]: "north",
@@ -75,6 +76,7 @@ export default class MapHelper {
     hashes = {};
     gmcpPosition: Position;
     savedRoomId: number | null = null;
+    visitedRooms = new Set<number>();
 
     constructor(clientExtension: Client) {
         this.client = clientExtension
@@ -82,6 +84,11 @@ export default class MapHelper {
         const saved = savedData ? savedData[STORAGE_KEY] : null;
         if (saved) {
             this.savedRoomId = parseInt(saved);
+        }
+        const visitedData = getItemSync(VISITED_ROOMS_KEY);
+        const visited = visitedData ? visitedData[VISITED_ROOMS_KEY] : null;
+        if (visited && Array.isArray(visited)) {
+            this.visitedRooms = new Set<number>(visited);
         }
         this.client.addEventListener('enterLocation', (event) => this.handleNewLocation(event.detail))
         window.addEventListener('map-ready', (event: CustomEvent) => {
@@ -260,7 +267,10 @@ export default class MapHelper {
 
     renderRoomById(id: number, sendEvent = true) {
         this.currentRoom = this.mapReader.getRoomById(id)
+        this.visitedRooms.add(id);
         setItemSync(STORAGE_KEY, id.toString())
+        setItemSync(VISITED_ROOMS_KEY, Array.from(this.visitedRooms));
+        this.client.sendEvent('visitedRooms', Array.from(this.visitedRooms));
         if (sendEvent) {
             this.client.sendEvent('enterLocation', {id: id, room: this.currentRoom});
         }

--- a/client/src/storage.ts
+++ b/client/src/storage.ts
@@ -33,6 +33,7 @@ const characterScopedKeys = new Set([
     'herb_counts',
     'herbs_data',
     'mapperRoomId',
+    'visitedRooms',
 ]);
 
 let currentCharacter: string | null = localStorage.getItem('currentCharacter');

--- a/client/src/storage.ts
+++ b/client/src/storage.ts
@@ -33,7 +33,6 @@ const characterScopedKeys = new Set([
     'herb_counts',
     'herbs_data',
     'mapperRoomId',
-    'visitedRooms',
 ]);
 
 let currentCharacter: string | null = localStorage.getItem('currentCharacter');

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -293,9 +293,9 @@
                     <label class="form-label">Zasięg renderowania mapy
                         <input id="ui-map-limit" type="number" step="1" min="1" value="35" class="form-control" />
                     </label>
-                    <label class="form-label">
+                    <label class="form-label d-flex align-items-center">
                         <input id="ui-exploration-mode" type="checkbox" class="form-check-input me-2" />
-                        Tryb eksploracji mapy
+                        Tryb eksploracji mapy <span id="ui-exploration-stats" class="ms-1 text-muted"></span>
                     </label>
                 </div>
                 <div class="modal-footer">

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -293,6 +293,10 @@
                     <label class="form-label">Zasięg renderowania mapy
                         <input id="ui-map-limit" type="number" step="1" min="1" value="35" class="form-control" />
                     </label>
+                    <label class="form-label">
+                        <input id="ui-exploration-mode" type="checkbox" class="form-check-input me-2" />
+                        Tryb eksploracji mapy
+                    </label>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-primary" id="ui-settings-save">Zapisz</button>

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -1,10 +1,61 @@
 let limit = 35;
 
 import { MapReader, Renderer, Settings } from "mudlet-map-renderer";
-import { getItemSync, setItemSync } from "@client/src/storage";
+import { getCurrentCharacter, getItemSync, setItemSync } from "@client/src/storage";
 
 const STORAGE_KEY = 'mapperRoomId';
-const VISITED_ROOMS_KEY = 'visitedRooms';
+const VISITED_DB_NAME = 'ArkadiaVisitedRoomsDB';
+const VISITED_STORE_NAME = 'visitedRooms';
+
+function getVisitedKey() {
+    const char = getCurrentCharacter();
+    return char ? `${char}:${VISITED_STORE_NAME}` : VISITED_STORE_NAME;
+}
+
+async function openVisitedDB(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open(VISITED_DB_NAME, 1);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(VISITED_STORE_NAME)) {
+                db.createObjectStore(VISITED_STORE_NAME, { keyPath: 'id' });
+            }
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(new Error('Failed to open IndexedDB'));
+    });
+}
+
+async function loadVisitedRooms(): Promise<number[]> {
+    try {
+        const db = await openVisitedDB();
+        return await new Promise<number[]>((resolve) => {
+            const tx = db.transaction([VISITED_STORE_NAME], 'readonly');
+            const store = tx.objectStore(VISITED_STORE_NAME);
+            const req = store.get(getVisitedKey());
+            req.onsuccess = () => {
+                const rooms = req.result?.rooms;
+                resolve(Array.isArray(rooms) ? rooms : []);
+            };
+            req.onerror = () => resolve([]);
+        });
+    } catch {
+        return [];
+    }
+}
+
+async function saveVisitedRooms(rooms: number[]): Promise<void> {
+    try {
+        const db = await openVisitedDB();
+        await new Promise<void>((resolve, reject) => {
+            const tx = db.transaction([VISITED_STORE_NAME], 'readwrite');
+            const store = tx.objectStore(VISITED_STORE_NAME);
+            const req = store.put({ id: getVisitedKey(), rooms });
+            req.onsuccess = () => resolve();
+            req.onerror = () => reject(new Error('Failed to store visited rooms'));
+        });
+    } catch {}
+}
 
 export default class EmbeddedMap {
     private map: HTMLElement;
@@ -65,23 +116,17 @@ export default class EmbeddedMap {
             if (!isNaN(savedId)) {
                 initialRoom = savedId;
             }
-            const visitedData = getItemSync(VISITED_ROOMS_KEY);
-            const visited = visitedData ? visitedData[VISITED_ROOMS_KEY] : null;
-            if (visited && Array.isArray(visited)) {
-                this.visited = new Set<number>(visited);
-            }
         } catch {}
         this.zoom = zoom;
         this.limit = limit;
         this.explorationMode = explorationMode;
         this.renderer = new Renderer(this.map, this.reader, this.settings);
-        this.renderRoomById(initialRoom);
 
-        window.addEventListener('enterLocation', (ev: any) => {
+        window.addEventListener('enterLocation', async (ev: any) => {
             const id = ev.detail.id;
             this.visited.add(id);
             setItemSync(STORAGE_KEY, id.toString());
-            setItemSync(VISITED_ROOMS_KEY, Array.from(this.visited));
+            await saveVisitedRooms(Array.from(this.visited));
             this.renderRoomById(id);
         });
 
@@ -94,6 +139,13 @@ export default class EmbeddedMap {
             this.refresh();
         })
 
+        this.initVisitedRooms(initialRoom);
+    }
+
+    private async initVisitedRooms(initialRoom: number) {
+        const visited = await loadVisitedRooms();
+        visited.forEach(id => this.visited.add(id));
+        this.renderRoomById(initialRoom);
     }
 
     private _onTouchStart(ev: TouchEvent) {

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -70,6 +70,7 @@ export default class EmbeddedMap {
     private limit: number;
     private explorationMode = false;
     private visited = new Set<number>();
+    private totalRooms: number;
 
     constructor(mapData: any, colors: any, startId?: number) {
         this.map = document.querySelector<HTMLCanvasElement>("#map")!;
@@ -84,6 +85,7 @@ export default class EmbeddedMap {
         this.map.addEventListener('touchcancel', this._onTouchEnd);
         this.map.addEventListener('zoom', this._onZoom);
         this.reader = new MapReader(mapData, colors);
+        this.totalRooms = this.reader.getAreas().reduce((sum: number, area: any) => sum + area.rooms.length, 0);
         this.settings = new Settings();
         this.settings.areaName = false;
         this.settings.scale = 90;
@@ -262,6 +264,14 @@ export default class EmbeddedMap {
 
     refresh() {
         this.renderRoom(this.currentRoom);
+    }
+
+    getVisitedCount() {
+        return this.visited.size;
+    }
+
+    getRoomCount() {
+        return this.totalRooms;
     }
 
     setExplorationMode(on: boolean) {

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -14,6 +14,8 @@ export default class EmbeddedMap {
     private _touchStartDistance: number | null = null;
     private zoom: number;
     private limit: number;
+    private explorationMode = false;
+    private visited = new Set<number>();
 
     constructor(mapData: any, colors: any, startId: number) {
         this.map = document.querySelector<HTMLCanvasElement>("#map")!;
@@ -35,6 +37,7 @@ export default class EmbeddedMap {
         this.settings.transparentLabels = true;
         this.settings
         let zoom = 0.30;
+        let explorationMode = false;
         try {
             const data = getItemSync('uiSettings');
             const parsed = data?.uiSettings as any;
@@ -45,12 +48,16 @@ export default class EmbeddedMap {
                 if (typeof parsed.mapLimit === 'number' && parsed.mapLimit > 0) {
                     limit = parsed.mapLimit;
                 }
+                if (typeof parsed.explorationMode === 'boolean') {
+                    explorationMode = parsed.explorationMode;
+                }
             }
         } catch {
             // ignore malformed data
         }
         this.zoom = zoom;
         this.limit = limit;
+        this.explorationMode = explorationMode;
         this.renderer = new Renderer(this.map, this.reader, this.settings);
         this.renderRoomById(startId);
 
@@ -65,6 +72,13 @@ export default class EmbeddedMap {
         window.addEventListener('highlights', (ev: any) => {
             this.highlights = ev.detail;
             this.refresh();
+        })
+
+        window.addEventListener('visitedRooms', (ev: any) => {
+            this.visited = new Set(ev.detail || []);
+            if (this.explorationMode) {
+                this.refresh();
+            }
         })
     }
 
@@ -130,12 +144,21 @@ export default class EmbeddedMap {
                 yMin: room.y - this.limit,
                 yMax: room.y + this.limit
             });
+            if (this.explorationMode) {
+                const rooms: Record<number, any> = {};
+                Object.values(area.rooms).forEach((r: any) => {
+                    if (r && this.visited.has(r.id)) {
+                        rooms[r.id] = r;
+                    }
+                });
+                area.rooms = rooms;
+            }
             this.renderer?.clear();
             this.renderer.renderArea(area);
             this.renderer.controls.centerRoom(room.id);
             this.renderer.controls.setZoom(this.zoom);
             this.renderer.backgroundLayer.remove();
-
+            
             this.currentRoom = room;
             const label = document.getElementById('location-label');
             if (label && area) {
@@ -173,6 +196,11 @@ export default class EmbeddedMap {
 
     refresh() {
         this.renderRoom(this.currentRoom);
+    }
+
+    setExplorationMode(on: boolean) {
+        this.explorationMode = on;
+        this.refresh();
     }
 
     setZoom(zoom: number) {

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -3,6 +3,9 @@ let limit = 35;
 import { MapReader, Renderer, Settings } from "mudlet-map-renderer";
 import { getItemSync, setItemSync } from "@client/src/storage";
 
+const STORAGE_KEY = 'mapperRoomId';
+const VISITED_ROOMS_KEY = 'visitedRooms';
+
 export default class EmbeddedMap {
     private map: HTMLElement;
     private reader: any;
@@ -17,7 +20,7 @@ export default class EmbeddedMap {
     private explorationMode = false;
     private visited = new Set<number>();
 
-    constructor(mapData: any, colors: any, startId: number) {
+    constructor(mapData: any, colors: any, startId?: number) {
         this.map = document.querySelector<HTMLCanvasElement>("#map")!;
         this.map.style.touchAction = 'none';
         this._pinchZoom = this._pinchZoom.bind(this);
@@ -38,6 +41,7 @@ export default class EmbeddedMap {
         this.settings
         let zoom = 0.30;
         let explorationMode = false;
+        let initialRoom = startId ?? 1;
         try {
             const data = getItemSync('uiSettings');
             const parsed = data?.uiSettings as any;
@@ -55,14 +59,30 @@ export default class EmbeddedMap {
         } catch {
             // ignore malformed data
         }
+        try {
+            const saved = getItemSync(STORAGE_KEY);
+            const savedId = saved ? parseInt(saved[STORAGE_KEY]) : NaN;
+            if (!isNaN(savedId)) {
+                initialRoom = savedId;
+            }
+            const visitedData = getItemSync(VISITED_ROOMS_KEY);
+            const visited = visitedData ? visitedData[VISITED_ROOMS_KEY] : null;
+            if (visited && Array.isArray(visited)) {
+                this.visited = new Set<number>(visited);
+            }
+        } catch {}
         this.zoom = zoom;
         this.limit = limit;
         this.explorationMode = explorationMode;
         this.renderer = new Renderer(this.map, this.reader, this.settings);
-        this.renderRoomById(startId);
+        this.renderRoomById(initialRoom);
 
         window.addEventListener('enterLocation', (ev: any) => {
-            this.renderRoomById(ev.detail.id);
+            const id = ev.detail.id;
+            this.visited.add(id);
+            setItemSync(STORAGE_KEY, id.toString());
+            setItemSync(VISITED_ROOMS_KEY, Array.from(this.visited));
+            this.renderRoomById(id);
         });
 
         window.addEventListener('leadTo', (ev: any) => {
@@ -74,12 +94,6 @@ export default class EmbeddedMap {
             this.refresh();
         })
 
-        window.addEventListener('visitedRooms', (ev: any) => {
-            this.visited = new Set(ev.detail || []);
-            if (this.explorationMode) {
-                this.refresh();
-            }
-        })
     }
 
     private _onTouchStart(ev: TouchEvent) {
@@ -227,7 +241,7 @@ export default class EmbeddedMap {
 }
 
 export const createMap = (data: { mapData: any; colors: any; startId?: number }) => {
-    (window as any).embedded = new EmbeddedMap(data.mapData, data.colors, data.startId ?? 1);
+    (window as any).embedded = new EmbeddedMap(data.mapData, data.colors, data.startId);
 };
 
 window.addEventListener('map-ready-with-data', (e: Event) =>

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -145,8 +145,8 @@ export default class EmbeddedMap {
                 yMax: room.y + this.limit
             });
             if (this.explorationMode) {
-                const rooms: Record<number, any> = {};
-                Object.values(area.rooms).forEach((r: any) => {
+                const rooms: any[] = [];
+                area.rooms.forEach((r: any) => {
                     if (r && this.visited.has(r.id)) {
                         rooms[r.id] = r;
                     }

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -11,6 +11,7 @@ interface UiSettings {
     emojiLabels: boolean;
     xtermPalette: 'arkadia' | 'proper';
     footerMode: number;
+    explorationMode: boolean;
 }
 
 const defaultSettings: UiSettings = {
@@ -24,6 +25,7 @@ const defaultSettings: UiSettings = {
     emojiLabels: false,
     xtermPalette: 'arkadia',
     footerMode: 0,
+    explorationMode: false,
 };
 
 function apply(settings: UiSettings) {
@@ -69,6 +71,7 @@ function apply(settings: UiSettings) {
     if ((window as any).embedded?.renderer?.controls) {
         (window as any).embedded.setZoom?.(settings.mapScale);
         (window as any).embedded.setLimit?.(settings.mapLimit);
+        (window as any).embedded.setExplorationMode?.(settings.explorationMode);
         (window as any).embedded.refresh();
     }
     if ((window as any).clientExtension?.eventTarget) {
@@ -106,7 +109,8 @@ async function load(): Promise<UiSettings> {
             })();
             const xtermPalette = parsed.xtermPalette === 'proper' ? 'proper' : defaultSettings.xtermPalette;
             const footerMode = typeof parsed.footerMode === 'number' ? parsed.footerMode : defaultSettings.footerMode;
-            return { ...defaultSettings, ...parsed, mapScale, mapLimit, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode };
+            const explorationMode = !!parsed.explorationMode;
+            return { ...defaultSettings, ...parsed, mapScale, mapLimit, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode };
         }
     } catch {
         // ignore malformed data
@@ -130,6 +134,7 @@ export default async function initUiSettings() {
     const mapInput = modalEl.querySelector('#ui-map-scale') as HTMLInputElement;
     const mapHeightInput = modalEl.querySelector('#ui-map-height') as HTMLInputElement;
     const mapLimitInput = modalEl.querySelector('#ui-map-limit') as HTMLInputElement;
+    const explorationInput = modalEl.querySelector('#ui-exploration-mode') as HTMLInputElement;
     const showButtonsInput = modalEl.querySelector('#ui-show-buttons') as HTMLInputElement;
     const emojiLabelsInput = modalEl.querySelector('#ui-emoji-labels') as HTMLInputElement;
     const xtermPaletteInput = modalEl.querySelector('#ui-xterm-palette') as HTMLSelectElement;
@@ -143,6 +148,7 @@ export default async function initUiSettings() {
     mapInput.value = String(current.mapScale);
     mapHeightInput.value = String(current.mapHeight);
     mapLimitInput.value = String(current.mapLimit);
+    explorationInput.checked = current.explorationMode;
     showButtonsInput.checked = current.showButtons;
     emojiLabelsInput.checked = current.emojiLabels;
     xtermPaletteInput.value = current.xtermPalette;
@@ -174,7 +180,8 @@ export default async function initUiSettings() {
             showButtons: showButtonsInput.checked,
             emojiLabels: emojiLabelsInput.checked,
             xtermPalette: (xtermPaletteInput.value as 'arkadia' | 'proper') || defaultSettings.xtermPalette,
-            footerMode: parseInt(footerModeInput.value) || defaultSettings.footerMode
+            footerMode: parseInt(footerModeInput.value) || defaultSettings.footerMode,
+            explorationMode: explorationInput.checked,
         };
     }
 

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -135,6 +135,7 @@ export default async function initUiSettings() {
     const mapHeightInput = modalEl.querySelector('#ui-map-height') as HTMLInputElement;
     const mapLimitInput = modalEl.querySelector('#ui-map-limit') as HTMLInputElement;
     const explorationInput = modalEl.querySelector('#ui-exploration-mode') as HTMLInputElement;
+    const explorationStats = modalEl.querySelector('#ui-exploration-stats') as HTMLElement | null;
     const showButtonsInput = modalEl.querySelector('#ui-show-buttons') as HTMLInputElement;
     const emojiLabelsInput = modalEl.querySelector('#ui-emoji-labels') as HTMLInputElement;
     const xtermPaletteInput = modalEl.querySelector('#ui-xterm-palette') as HTMLSelectElement;
@@ -154,6 +155,15 @@ export default async function initUiSettings() {
     xtermPaletteInput.value = current.xtermPalette;
     footerModeInput.value = String(current.footerMode);
     apply(current);
+
+    function refreshExplorationStats() {
+        const map = (window as any).embedded;
+        if (map?.getVisitedCount && map?.getRoomCount && explorationStats) {
+            const visited = map.getVisitedCount();
+            const total = map.getRoomCount();
+            explorationStats.textContent = `(${visited}/${total})`;
+        }
+    }
 
     function read(): UiSettings {
         const mapScale = (() => {
@@ -193,6 +203,7 @@ export default async function initUiSettings() {
     });
 
     button.addEventListener('click', () => {
+        refreshExplorationStats();
         modal.show();
     });
 }


### PR DESCRIPTION
## Summary
- track visited rooms per character and emit visits to the map
- add exploration mode toggle and filter map to visited locations
- store exploration preference in UI settings

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6894fd7720ac832aa2a46046631eb0c4