### PR TITLE
feat: add leader mobile button mode

### DIFF
--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -201,6 +201,10 @@ export default class TeamManager {
         return this.leaderId;
     }
 
+    isLeader(): boolean {
+        return this.leaderId !== undefined && this.leaderId === this.playerNum;
+    }
+
     clearTeam() {
         const hadMembers = this.members.size > 0 || this.leader !== undefined;
         this.members.clear();

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -842,7 +842,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     loadMobileButtonSettings().then(s => {
         const inTeam = !!client.TeamManager.isInAnyTeam?.();
-        applyMobileButtonSettings(s, inTeam);
+        const isLeader = !!client.TeamManager.isLeader?.();
+        applyMobileButtonSettings(s, inTeam, isLeader);
     });
 
     initUiSettings();

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -83,6 +83,7 @@ export interface LayoutSettings {
 export interface Settings {
     solo: LayoutSettings;
     team: LayoutSettings;
+    leader: LayoutSettings;
 }
 
 export function createDefaultLayout(): LayoutSettings {
@@ -99,26 +100,27 @@ export async function loadSettings(): Promise<Settings> {
                 order: Array.isArray(set?.order) ? set.order : [...defaultOrder],
                 cols: typeof set?.cols === 'number' && set.cols > 0 ? set.cols : defaultCols,
             });
-            if (raw.solo && raw.team && (raw.solo.buttons || raw.team.buttons)) {
-                return { solo: parseSet(raw.solo), team: parseSet(raw.team) };
+            if (raw.solo && raw.team && raw.leader && (raw.solo.buttons || raw.team.buttons || raw.leader.buttons)) {
+                return { solo: parseSet(raw.solo), team: parseSet(raw.team), leader: parseSet(raw.leader) };
             }
             const order = Array.isArray(raw.order) ? raw.order : [...defaultOrder];
             const cols = typeof raw.cols === 'number' && raw.cols > 0 ? raw.cols : defaultCols;
             return {
                 solo: { buttons: { ...defaultSettings, ...(raw.solo || {}) }, order: [...order], cols },
                 team: { buttons: { ...defaultSettings, ...(raw.team || raw.solo || {}) }, order: [...order], cols },
+                leader: { buttons: { ...defaultSettings, ...(raw.leader || raw.team || raw.solo || {}) }, order: [...order], cols },
             };
         }
     } catch {}
-    return { solo: createDefaultLayout(), team: createDefaultLayout() };
+    return { solo: createDefaultLayout(), team: createDefaultLayout(), leader: createDefaultLayout() };
 }
 
 export function saveSettings(settings: Settings) {
     storage.setItem('mobileButtonSettings', settings);
 }
 
-export function applySettings(settings: Settings, inTeam = false) {
-    const set = inTeam ? settings.team : settings.solo;
+export function applySettings(settings: Settings, inTeam = false, isLeader = false) {
+    const set = isLeader ? settings.leader : inTeam ? settings.team : settings.solo;
     const container = document.getElementById('mobile-direction-buttons') as HTMLDivElement | null;
     if (container) {
         container.style.gridTemplateColumns = `repeat(${set.cols}, auto)`;

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -50,7 +50,6 @@ function MobileButtons() {
     const modes = ['solo', 'team', 'leader'] as const;
     type Mode = typeof modes[number];
     const [copyFrom, setCopyFrom] = useState<Mode>('solo');
-    const [copyTo, setCopyTo] = useState<Mode>('team');
 
     useEffect(() => {
         loadSettings().then(setSettings);
@@ -234,7 +233,8 @@ function MobileButtons() {
         setActive(null);
     }
 
-    function copyLayout(from: 'solo' | 'team' | 'leader', to: 'solo' | 'team' | 'leader') {
+    function copyLayout(from: Mode) {
+        const to = view;
         if (from === to) return;
         setSettings(prev => ({ ...prev, [to]: JSON.parse(JSON.stringify(prev[from])) }));
     }
@@ -278,21 +278,6 @@ function MobileButtons() {
                 </div>
                 <Button size="sm" variant="secondary" onClick={() => restoreDefaults(view)}>
                     Domyślne
-                </Button>
-            </div>
-            <div className="d-flex align-items-center gap-2 mb-2">
-                <Form.Select size="sm" value={copyFrom} onChange={e => setCopyFrom(e.target.value as Mode)}>
-                    <option value="solo">Bez drużyny</option>
-                    <option value="team">W drużynie</option>
-                    <option value="leader">Prowadzący</option>
-                </Form.Select>
-                <Form.Select size="sm" value={copyTo} onChange={e => setCopyTo(e.target.value as Mode)}>
-                    <option value="solo">Bez drużyny</option>
-                    <option value="team">W drużynie</option>
-                    <option value="leader">Prowadzący</option>
-                </Form.Select>
-                <Button size="sm" variant="secondary" onClick={() => copyLayout(copyFrom, copyTo)}>
-                    Kopiuj
                 </Button>
             </div>
             <div className="d-flex flex-column align-items-center mb-2">
@@ -529,7 +514,17 @@ function MobileButtons() {
                     )}
                 </div>
             )}
-            <div className="d-flex justify-content-end mt-2">
+            <div className="d-flex justify-content-between mt-2">
+                <div className="d-flex align-items-center gap-2">
+                    <Form.Select size="sm" value={copyFrom} onChange={e => setCopyFrom(e.target.value as Mode)}>
+                        <option value="solo">Bez drużyny</option>
+                        <option value="team">W drużynie</option>
+                        <option value="leader">Prowadzący</option>
+                    </Form.Select>
+                    <Button size="sm" variant="secondary" onClick={() => copyLayout(copyFrom)}>
+                        Kopiuj
+                    </Button>
+                </div>
                 <Button id="mobile-buttons-save" onClick={save}>Zapisz</Button>
             </div>
         </div>

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -38,13 +38,19 @@ function MobileButtons() {
     const [settings, setSettings] = useState<Settings>({
         solo: { buttons: {}, order: [...defaultOrder], cols: defaultCols },
         team: { buttons: {}, order: [...defaultOrder], cols: defaultCols },
+        leader: { buttons: {}, order: [...defaultOrder], cols: defaultCols },
     });
     const [syncDirs, setSyncDirs] = useState(true);
-    const [active, setActive] = useState<{ set: 'solo' | 'team'; id: string } | null>(null);
+    const [active, setActive] = useState<{ set: 'solo' | 'team' | 'leader'; id: string } | null>(null);
     const [pos, setPos] = useState<{ left: number; top: number }>({ left: 0, top: 0 });
-    const [view, setView] = useState<'solo' | 'team'>('solo');
+    const [view, setView] = useState<'solo' | 'team' | 'leader'>('solo');
     const soloRef = useRef<HTMLDivElement>(null);
     const teamRef = useRef<HTMLDivElement>(null);
+    const leaderRef = useRef<HTMLDivElement>(null);
+    const modes = ['solo', 'team', 'leader'] as const;
+    type Mode = typeof modes[number];
+    const [copyFrom, setCopyFrom] = useState<Mode>('solo');
+    const [copyTo, setCopyTo] = useState<Mode>('team');
 
     useEffect(() => {
         loadSettings().then(setSettings);
@@ -136,9 +142,9 @@ function MobileButtons() {
         });
     }
 
-    function openConfig(setName: 'solo' | 'team', id: string, ev: React.MouseEvent<HTMLButtonElement>) {
+    function openConfig(setName: 'solo' | 'team' | 'leader', id: string, ev: React.MouseEvent<HTMLButtonElement>) {
         const rect = ev.currentTarget.getBoundingClientRect();
-        const parent = (setName === 'solo' ? soloRef.current : teamRef.current)?.getBoundingClientRect();
+        const parent = (setName === 'solo' ? soloRef.current : setName === 'team' ? teamRef.current : leaderRef.current)?.getBoundingClientRect();
         if (parent) {
             setPos({ left: rect.left - parent.left, top: rect.bottom - parent.top + 4 });
         }
@@ -150,7 +156,7 @@ function MobileButtons() {
         ev.stopPropagation();
     }
 
-    function changeView(v: 'solo' | 'team') {
+    function changeView(v: 'solo' | 'team' | 'leader') {
         setView(v);
         setActive(null);
     }
@@ -159,7 +165,7 @@ function MobileButtons() {
         setActive(null);
     }
 
-    function update(setName: 'solo' | 'team', id: string, field: keyof ButtonSetting, value: any) {
+    function update(setName: 'solo' | 'team' | 'leader', id: string, field: keyof ButtonSetting, value: any) {
         setSettings(prev => ({
             ...prev,
             [setName]: {
@@ -187,11 +193,12 @@ function MobileButtons() {
             return {
                 solo: updateSet(prev.solo),
                 team: updateSet(prev.team),
+                leader: updateSet(prev.leader),
             };
         });
     }
 
-    function resetColor(setName: 'solo' | 'team', id: string) {
+    function resetColor(setName: 'solo' | 'team' | 'leader', id: string) {
         const def = defaultSettings[id]?.color || emptySetting.color;
         if (syncDirs && (settings[setName].buttons[id]?.macro === 'kierunek' || defaultSettings[id]?.macro === 'kierunek')) {
             updateAllDirections('color', def);
@@ -200,7 +207,7 @@ function MobileButtons() {
         }
     }
 
-    function resetActiveColor(setName: 'solo' | 'team', id: string) {
+    function resetActiveColor(setName: 'solo' | 'team' | 'leader', id: string) {
         const def = defaultSettings[id]?.activeColor || '#2fa7c5';
         if (syncDirs && (settings[setName].buttons[id]?.macro === 'kierunek' || defaultSettings[id]?.macro === 'kierunek')) {
             updateAllDirections('activeColor', def);
@@ -209,7 +216,7 @@ function MobileButtons() {
         }
     }
 
-    function makeBlank(setName: 'solo' | 'team', id: string) {
+    function makeBlank(setName: 'solo' | 'team' | 'leader', id: string) {
         setSettings(prev => ({
             ...prev,
             [setName]: {
@@ -219,7 +226,7 @@ function MobileButtons() {
         }));
     }
 
-    function restoreDefaults(setName: 'solo' | 'team') {
+    function restoreDefaults(setName: 'solo' | 'team' | 'leader') {
         setSettings(prev => ({
             ...prev,
             [setName]: createDefaultLayout(),
@@ -227,10 +234,16 @@ function MobileButtons() {
         setActive(null);
     }
 
+    function copyLayout(from: 'solo' | 'team' | 'leader', to: 'solo' | 'team' | 'leader') {
+        if (from === to) return;
+        setSettings(prev => ({ ...prev, [to]: JSON.parse(JSON.stringify(prev[from])) }));
+    }
+
     function save() {
         saveSettings(settings);
-        const teamActive = !!(window as any).clientExtension?.TeamManager?.getLeader?.();
-        applySettings(settings, teamActive);
+        const teamActive = !!(window as any).clientExtension?.TeamManager?.isInAnyTeam?.();
+        const leaderActive = !!(window as any).clientExtension?.TeamManager?.isLeader?.();
+        applySettings(settings, teamActive, leaderActive);
         const modal = (window as any).bootstrap?.Modal.getInstance(document.getElementById('mobile-buttons-modal')!);
         modal?.hide();
     }
@@ -255,9 +268,31 @@ function MobileButtons() {
                     >
                         W drużynie
                     </Button>
+                    <Button
+                        size="sm"
+                        variant={view === 'leader' ? 'primary' : 'secondary'}
+                        onClick={() => changeView('leader')}
+                    >
+                        Prowadzący
+                    </Button>
                 </div>
                 <Button size="sm" variant="secondary" onClick={() => restoreDefaults(view)}>
                     Domyślne
+                </Button>
+            </div>
+            <div className="d-flex align-items-center gap-2 mb-2">
+                <Form.Select size="sm" value={copyFrom} onChange={e => setCopyFrom(e.target.value as Mode)}>
+                    <option value="solo">Bez drużyny</option>
+                    <option value="team">W drużynie</option>
+                    <option value="leader">Prowadzący</option>
+                </Form.Select>
+                <Form.Select size="sm" value={copyTo} onChange={e => setCopyTo(e.target.value as Mode)}>
+                    <option value="solo">Bez drużyny</option>
+                    <option value="team">W drużynie</option>
+                    <option value="leader">Prowadzący</option>
+                </Form.Select>
+                <Button size="sm" variant="secondary" onClick={() => copyLayout(copyFrom, copyTo)}>
+                    Kopiuj
                 </Button>
             </div>
             <div className="d-flex flex-column align-items-center mb-2">
@@ -318,6 +353,36 @@ function MobileButtons() {
                                 const isEmpty = cfg.macro === 'empty' || !cfg.label;
                                 if (isEmpty) classes += ' empty';
                                 const handle = notEditable.includes(id) ? undefined : (ev: React.MouseEvent<HTMLButtonElement>) => openConfig('team', id, ev);
+                                return (
+                                    <button
+                                        key={id}
+                                        data-button-id={id}
+                                        className={classes}
+                                        style={{ backgroundColor: isEmpty ? 'transparent' : cfg.color }}
+                                        onClick={handle}
+                                    >
+                                        {isEmpty ? '' : cfg.label}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                        <div
+                            ref={leaderRef}
+                            id="mobile-buttons-preview-leader"
+                            className={`mobile-direction-buttons preview mb-2 ${view === 'leader' ? '' : 'd-none'}`}
+                            style={{ gridTemplateColumns: `repeat(${settings.leader.cols}, auto)` }}
+                        >
+                            {settings.leader.order.map(id => {
+                                const cfg = settings.leader.buttons[id] || defaultSettings[id] || emptySetting;
+                                let classes = 'mobile-button';
+                                if (cfg.macro === 'kierunek') {
+                                    classes += ' direction-button';
+                                } else {
+                                    classes += ' mobile-button-text';
+                                }
+                                const isEmpty = cfg.macro === 'empty' || !cfg.label;
+                                if (isEmpty) classes += ' empty';
+                                const handle = notEditable.includes(id) ? undefined : (ev: React.MouseEvent<HTMLButtonElement>) => openConfig('leader', id, ev);
                                 return (
                                     <button
                                         key={id}

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -44,9 +44,11 @@ export default class MobileDirectionButtons {
     private allSettings: Settings = {
         solo: { buttons: {}, order: [], cols: 0 },
         team: { buttons: {}, order: [], cols: 0 },
+        leader: { buttons: {}, order: [], cols: 0 },
     };
     private buttonSettings: Record<string, ButtonSetting> = {};
     private teamMode = false;
+    private leaderMode = false;
 
     private readonly polishToEnglish: Record<string, string> = {
         "polnoc": "north",
@@ -591,15 +593,18 @@ export default class MobileDirectionButtons {
     }
 
     private updateTeamMode() {
-        const team = !!this.client.TeamManager.isInAnyTeam?.();
-        if (team !== this.teamMode) {
+        const leader = !!this.client.TeamManager.isLeader?.();
+        const team = leader || !!this.client.TeamManager.isInAnyTeam?.();
+        if (team !== this.teamMode || leader !== this.leaderMode) {
             this.teamMode = team;
+            this.leaderMode = leader;
             this.applyActiveSettings();
         }
     }
 
     private applyActiveSettings() {
-        this.buttonSettings = (this.teamMode ? this.allSettings.team : this.allSettings.solo).buttons;
+        const set = this.leaderMode ? this.allSettings.leader : this.teamMode ? this.allSettings.team : this.allSettings.solo;
+        this.buttonSettings = set.buttons;
         Object.keys(this.buttonSettings).forEach(id => {
             const btn = document.getElementById(id) as HTMLButtonElement | null;
             if (btn) this.applyConfigToButton(id, btn);

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -520,7 +520,8 @@ button:focus-visible {
 
 #mobile-buttons-preview,
 #mobile-buttons-preview-solo,
-#mobile-buttons-preview-team {
+#mobile-buttons-preview-team,
+#mobile-buttons-preview-leader {
   position: static;
   display: grid;
   grid-template-columns: repeat(4, auto);


### PR DESCRIPTION
## Summary
- extend mobile button settings with new leader mode for team leaders
- allow copying button layout between modes
- apply leader-specific layout and detection in UI and scripts

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68950ee98914832aa52ef28b94f1b7eb