### PR TITLE
feat: add configurable herb use hooks

### DIFF
--- a/client/src/scripts/herbCounter.ts
+++ b/client/src/scripts/herbCounter.ts
@@ -115,6 +115,18 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
     });
     client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
 
+    let preUseCommands: string[] = [];
+    let postUseCommands: string[] = [];
+    client.addEventListener('settings', (ev: CustomEvent) => {
+        const st = ev.detail || {};
+        preUseCommands = typeof st.herbPreUseCommand === 'string'
+            ? st.herbPreUseCommand.split(';').map((c: string) => c.trim()).filter(Boolean)
+            : [];
+        postUseCommands = typeof st.herbPostUseCommand === 'string'
+            ? st.herbPostUseCommand.split(';').map((c: string) => c.trim()).filter(Boolean)
+            : [];
+    });
+
     async function ensureData() {
         if (!herbs) {
             if (!loading) {
@@ -153,7 +165,11 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
         const items = actions.flatMap(a =>
             amounts.map(n => ({
                 label: `${a.action} ${n}`,
-                action: () => client.sendCommand(`/z ${a.action} ${id} ${n}`)
+                action: () => {
+                    preUseCommands.forEach(cmd => client.sendCommand(cmd));
+                    client.sendCommand(`/z ${a.action} ${id} ${n}`);
+                    postUseCommands.forEach(cmd => client.sendCommand(cmd));
+                }
             }))
         );
         client.OutputHandler.showContextMenu(items, ev.pageX, ev.pageY);
@@ -337,7 +353,9 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
                 const herb = m[2].toLowerCase();
                 await take(herb, 1);
                 const biernik = herbs?.herb_id_to_odmiana[herb]?.biernik || herb;
+                preUseCommands.forEach(cmd => client.sendCommand(cmd));
                 client.sendCommand(`${action} ${biernik}`);
+                postUseCommands.forEach(cmd => client.sendCommand(cmd));
             }
         });
     }

--- a/client/src/scripts/herbDescriptions.ts
+++ b/client/src/scripts/herbDescriptions.ts
@@ -7,6 +7,17 @@ export const HERB_NAME_COLOR = findClosestColor("#ffffff");
 
 export default async function initHerbDescriptions(client: Client) {
     const tag = "herbDescriptions";
+    let preUseCommands: string[] = [];
+    let postUseCommands: string[] = [];
+    client.addEventListener('settings', (ev: CustomEvent) => {
+        const st = ev.detail || {};
+        preUseCommands = typeof st.herbPreUseCommand === 'string'
+            ? st.herbPreUseCommand.split(';').map((c: string) => c.trim()).filter(Boolean)
+            : [];
+        postUseCommands = typeof st.herbPostUseCommand === 'string'
+            ? st.herbPostUseCommand.split(';').map((c: string) => c.trim()).filter(Boolean)
+            : [];
+    });
     try {
         const herbs = await loadHerbs();
         if (!herbs) return;
@@ -18,7 +29,11 @@ export default async function initHerbDescriptions(client: Client) {
             const items = actions.flatMap(a =>
                 amounts.map(n => ({
                     label: `${a.action} ${n}`,
-                    action: () => client.sendCommand(`/z ${a.action} ${herbId} ${n}`)
+                    action: () => {
+                        preUseCommands.forEach(cmd => client.sendCommand(cmd));
+                        client.sendCommand(`/z ${a.action} ${herbId} ${n}`);
+                        postUseCommands.forEach(cmd => client.sendCommand(cmd));
+                    }
                 }))
             );
             client.OutputHandler.showContextMenu(items, ev.pageX, ev.pageY);

--- a/client/test/herbDescriptions.test.ts
+++ b/client/test/herbDescriptions.test.ts
@@ -1,6 +1,7 @@
 import initHerbDescriptions, { HERB_NAME_COLOR } from '../src/scripts/herbDescriptions';
 import Triggers from '../src/Triggers';
 import { color, RESET } from '../src/Colors';
+import { EventEmitter } from 'events';
 
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
@@ -12,6 +13,11 @@ class FakeClient {
     }
   } as any;
   FunctionalBind = { set: jest.fn() } as any;
+  private emitter = new EventEmitter();
+  addEventListener(event: string, cb: any) { this.emitter.on(event, cb); }
+  removeEventListener(event: string, cb: any) { this.emitter.off(event, cb); }
+  dispatch(event: string, detail: any) { this.emitter.emit(event, { detail }); }
+  sendCommand = jest.fn();
 }
 
 describe('herb descriptions', () => {

--- a/docs/HERBS.md
+++ b/docs/HERBS.md
@@ -9,4 +9,6 @@ Moduł licznika ziół pozwala zliczyć zawartość wszystkich noszonych woreczk
 3. Za pomocą `/wezz nazwa [ilosc]` wyjmiesz wskazane zioło z woreczków. Jeśli ilość nie zostanie podana, domyślnie wyjmowana jest jedna sztuka.
 4. Polecenie `/zi akcja nazwa` wyjmuje zioło i wykonuje podaną akcję.
 
+W ustawieniach skryptów można zdefiniować komendy wykonywane przed i po użyciu ziół. Wiele komend należy oddzielić średnikiem (`;`).
+
 Informacje o zliczonych ziołach są przechowywane w pamięci przeglądarki osobno dla każdej postaci i wczytywane po ponownym uruchomieniu klienta.

--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -214,6 +214,33 @@ function SettingsForm() {
                     )}
                 </div>
             </div>
+            <div className="mb-4 border rounded p-3">
+                <h5 className="fw-bold mb-2">Zioła</h5>
+                <div className="d-flex flex-column gap-2">
+                    <Form.Group>
+                        <Form.Label className="me-1 mb-0">Komendy przed użyciem:</Form.Label>
+                        <Form.Control
+                            type="text"
+                            size="sm"
+                            value={settings.herbPreUseCommand}
+                            onChange={e => onChangeSetting(s => s.herbPreUseCommand = e.target.value)}
+                            style={{width: '100%', maxWidth: '20rem'}}
+                        />
+                        <Form.Text className="text-muted">Oddziel komendy średnikiem (;)</Form.Text>
+                    </Form.Group>
+                    <Form.Group>
+                        <Form.Label className="me-1 mb-0">Komendy po użyciu:</Form.Label>
+                        <Form.Control
+                            type="text"
+                            size="sm"
+                            value={settings.herbPostUseCommand}
+                            onChange={e => onChangeSetting(s => s.herbPostUseCommand = e.target.value)}
+                            style={{width: '100%', maxWidth: '20rem'}}
+                        />
+                        <Form.Text className="text-muted">Oddziel komendy średnikiem (;)</Form.Text>
+                    </Form.Group>
+                </div>
+            </div>
             <Button onClick={handleSubmission}>Zapisz</Button>
             </fieldset>
         </div>

--- a/web-client/src/options/defaultSettings.ts
+++ b/web-client/src/options/defaultSettings.ts
@@ -7,6 +7,8 @@ export interface Settings {
     collectMode: number;
     collectMoneyType: number;
     collectExtra: string[];
+    herbPreUseCommand: string;
+    herbPostUseCommand: string;
 }
 
 export const defaultSettings: Settings = {
@@ -18,4 +20,6 @@ export const defaultSettings: Settings = {
     collectMode: 3,
     collectMoneyType: 1,
     collectExtra: [],
+    herbPreUseCommand: '',
+    herbPostUseCommand: '',
 };


### PR DESCRIPTION
## Summary
- allow configuring commands to run before and after using herbs
- expose new herb use command fields in settings UI with guidance on separating multiple commands with `;`
- document configurable pre/post herb commands for the herb counter

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68951435bb1c832a9e6b65e4d2c7ea7f