### PR TITLE
feat: allow triggers to send commands

### DIFF
--- a/client/src/scripts/userTriggers.ts
+++ b/client/src/scripts/userTriggers.ts
@@ -6,9 +6,10 @@ function toUpperSafe(text: string) {
 }
 
 export interface UserMacro {
-    type: 'uppercase' | 'color' | 'replace' | 'beep';
+    type: 'uppercase' | 'color' | 'replace' | 'beep' | 'command';
     color?: string;
     to?: string;
+    command?: string;
 }
 
 export interface UserTrigger {
@@ -53,6 +54,11 @@ export default function initUserTriggers(client: Client) {
                                 break;
                             case 'beep':
                                 client.playSound('beep');
+                                break;
+                            case 'command':
+                                if (m.command) {
+                                    client.sendCommand(m.command);
+                                }
                                 break;
                         }
                     });

--- a/client/test/userTriggers.test.ts
+++ b/client/test/userTriggers.test.ts
@@ -8,6 +8,7 @@ class FakeClient {
   removeEventListener = jest.fn();
   port = { postMessage: jest.fn() } as any;
   playSound = jest.fn();
+  sendCommand = jest.fn();
 }
 
 describe('userTriggers', () => {
@@ -51,6 +52,17 @@ describe('userTriggers', () => {
     const result = client.Triggers.parseLine('foo', '');
     expect(result).toBe('foo');
     expect(client.playSound).toHaveBeenCalledWith('beep');
+  });
+
+  test('command sends command', () => {
+    const client = new FakeClient();
+    initUserTriggers((client as unknown) as any);
+    const apply = client.addEventListener.mock.calls.find(c => c[0] === 'storage')[1];
+    const list: UserTrigger[] = [{ pattern: 'foo', macros: [{ type: 'command', command: 'bar' }] }];
+    apply({ detail: { key: 'triggers', value: list } } as any);
+    const result = client.Triggers.parseLine('foo', '');
+    expect(result).toBe('foo');
+    expect(client.sendCommand).toHaveBeenCalledWith('bar');
   });
 });
 

--- a/web-client/src/options/UserTriggers.tsx
+++ b/web-client/src/options/UserTriggers.tsx
@@ -4,9 +4,10 @@ import { TiDelete, TiEdit } from "react-icons/ti";
 import storage from "@client/src/storage";
 
 export interface UserMacro {
-    type: 'uppercase' | 'color' | 'replace' | 'beep';
+    type: 'uppercase' | 'color' | 'replace' | 'beep' | 'command';
     color?: string;
     to?: string;
+    command?: string;
 }
 
 export interface UserTrigger {
@@ -26,6 +27,7 @@ function MacroEditor({ macro, onChange, onRemove }: { macro: UserMacro; onChange
                 <option value="color">Koloruj</option>
                 <option value="replace">Zamień</option>
                 <option value="beep">Dźwięk</option>
+                <option value="command">Komenda</option>
             </Form.Select>
             {macro.type === 'color' && (
             <Form.Control
@@ -43,6 +45,16 @@ function MacroEditor({ macro, onChange, onRemove }: { macro: UserMacro; onChange
                     placeholder="Replacement"
                     value={macro.to || ''}
                     onChange={(e: ChangeEvent<HTMLInputElement>) => onChange({ ...macro, to: e.target.value })}
+                    style={{ width: '100%', maxWidth: '8rem' }}
+                />
+            )}
+            {macro.type === 'command' && (
+                <Form.Control
+                    type="text"
+                    size="sm"
+                    placeholder="Command"
+                    value={macro.command || ''}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => onChange({ ...macro, command: e.target.value })}
                     style={{ width: '100%', maxWidth: '8rem' }}
                 />
             )}
@@ -136,6 +148,8 @@ function UserTriggers() {
                         return m.to ? `replace ${m.to}` : 'replace';
                     case 'beep':
                         return 'beep';
+                    case 'command':
+                        return m.command ? `command ${m.command}` : 'command';
                     default:
                         return m.type;
                 }


### PR DESCRIPTION
## Summary
- add new `command` macro for user triggers to dispatch commands
- expose command macro in trigger options UI
- test trigger command macro behavior

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68951c3825ac832ab3e2e8cd35cf2a56