### PR TITLE
Pause mapper movement when paralyzed

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -3,6 +3,7 @@ import { stripAnsiCodes } from "./stripAnsiCodes";
 import PackageHelper from "./PackageHelper";
 import MapHelper from "./MapHelper";
 import InlineCompassRose from "./scripts/inlineCompassRose";
+import Pausers from "./Pausers";
 import {Howl} from "howler";
 import {mudletColorLine, setXtermPalette} from "./Colors";
 import {
@@ -40,6 +41,7 @@ export default class Client {
     Triggers = new Triggers(this);
     packageHelper = new PackageHelper(this);
     Map = new MapHelper(this);
+    Pausers = new Pausers(this);
     OutputHandler = new OutputHandler(this);
     TeamManager = new TeamManager(this);
     ObjectManager = new ObjectManager(this);

--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -71,6 +71,7 @@ export default class MapHelper {
     refreshPosition = true;
     hashes = {};
     gmcpPosition: Position;
+    paused = false;
 
     constructor(clientExtension: Client) {
         this.client = clientExtension
@@ -98,6 +99,10 @@ export default class MapHelper {
         this.client.sendEvent('refreshPositionWhenAble');
     }
 
+    setPaused(paused: boolean) {
+        this.paused = paused;
+    }
+
     parseCommand(command) {
         if (command === "zerknij" || command === "spojrz" || command === "sp") {
             this.refreshPosition = true;
@@ -117,6 +122,9 @@ export default class MapHelper {
     }
 
     move(direction: string) {
+        if (this.paused) {
+            return {direction, moved: false}
+        }
         let actualDirection = direction
         if (this.currentRoom) {
             const allExits = Object.assign(

--- a/client/src/Pausers.ts
+++ b/client/src/Pausers.ts
@@ -1,0 +1,49 @@
+import Client from "./Client";
+
+interface OwnData {
+    paralyzed?: boolean;
+    editing?: boolean;
+}
+
+export default class Pausers {
+    private client: Client;
+    private playerId?: string;
+    private paralyzed = false;
+    private editing = false;
+    private active = false;
+
+    constructor(client: Client) {
+        this.client = client;
+        this.client.addEventListener('gmcp.char.info', (e: CustomEvent) => {
+            if (e.detail?.object_num !== undefined) {
+                this.playerId = String(e.detail.object_num);
+            }
+        });
+        this.client.addEventListener('gmcp.objects.data', (e: CustomEvent) => {
+            this.check(e.detail as Record<string, OwnData>);
+        });
+    }
+
+    private check(data: Record<string, OwnData>) {
+        if (!this.playerId) return;
+        const own = data[this.playerId];
+        if (!own) return;
+        let changed = false;
+        if (own.paralyzed !== undefined) {
+            this.paralyzed = !!own.paralyzed;
+            changed = true;
+        }
+        if (own.editing !== undefined) {
+            this.editing = !!own.editing;
+            changed = true;
+        }
+        if (changed) {
+            const shouldPause = this.paralyzed || this.editing;
+            this.client.Map.setPaused(shouldPause);
+            if (shouldPause !== this.active) {
+                this.active = shouldPause;
+                this.client.sendEvent(shouldPause ? 'pauserStart' : 'pauserEnd');
+            }
+        }
+    }
+}

--- a/client/src/scripts/idz.ts
+++ b/client/src/scripts/idz.ts
@@ -14,6 +14,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
     let timer: number | null = null;
     let paused = false;
     let target: number | null = null;
+    let pausedByPauser = false;
 
     const isWalking = () => !paused && path.length > 0;
 
@@ -120,6 +121,20 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
 
     client.addEventListener('stepBack', stopWalk);
     client.addEventListener('mapMove', stopWalk);
+    client.addEventListener('pauserStart', () => {
+        if (!paused && path.length > 0) {
+            paused = true;
+            pausedByPauser = true;
+            clearTimer();
+        }
+    });
+    client.addEventListener('pauserEnd', () => {
+        if (pausedByPauser) {
+            paused = false;
+            pausedByPauser = false;
+            scheduleStep();
+        }
+    });
 
     aliases.push({
         pattern: /\/idz$/,

--- a/client/test/Pausers.test.ts
+++ b/client/test/Pausers.test.ts
@@ -1,0 +1,58 @@
+import Pausers from '../src/Pausers';
+import { EventEmitter } from 'events';
+
+class FakeMap {
+  paused = false;
+  setPaused(p: boolean) {
+    this.paused = p;
+  }
+}
+
+class FakeClient {
+  private emitter = new EventEmitter();
+  Map = new FakeMap();
+  addEventListener(event: string, cb: any, _options?: any) {
+    this.emitter.on(event, cb);
+    return () => this.emitter.off(event, cb);
+  }
+  sendEvent(type: string, detail?: any) {
+    this.emitter.emit(type, { detail });
+  }
+}
+
+describe('Pausers', () => {
+  let client: FakeClient;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    new Pausers((client as unknown) as any);
+    client.sendEvent('gmcp.char.info', { object_num: '1' });
+  });
+
+  test('pauses and resumes based on paralyzed state', () => {
+    client.sendEvent('gmcp.objects.data', { '1': { paralyzed: true } });
+    expect(client.Map.paused).toBe(true);
+    client.sendEvent('gmcp.objects.data', { '1': { paralyzed: false } });
+    expect(client.Map.paused).toBe(false);
+  });
+
+  test('editing state keeps map paused independently', () => {
+    client.sendEvent('gmcp.objects.data', { '1': { paralyzed: true } });
+    client.sendEvent('gmcp.objects.data', { '1': { editing: true } });
+    client.sendEvent('gmcp.objects.data', { '1': { paralyzed: false } });
+    expect(client.Map.paused).toBe(true);
+    client.sendEvent('gmcp.objects.data', { '1': { editing: false } });
+    expect(client.Map.paused).toBe(false);
+  });
+
+  test('emits events when pause starts and ends', () => {
+    let started = false;
+    let ended = false;
+    client.addEventListener('pauserStart', () => { started = true; });
+    client.addEventListener('pauserEnd', () => { ended = true; });
+    client.sendEvent('gmcp.objects.data', { '1': { paralyzed: true } });
+    expect(started).toBe(true);
+    client.sendEvent('gmcp.objects.data', { '1': { paralyzed: false } });
+    expect(ended).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Track pauser start/end and emit events for listeners
- Pause and resume walker automatically in response to pauser events
- Test that pauser events are fired

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68952354ae6c832ab9d6339efaaf32bc