### PR TITLE
Add fight status indicator to page title

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -393,7 +393,7 @@
         </div>
     <div id="context-menu" class="context-menu"></div>
 </div>
-<script src="pako.min.js"></script>
+<script src="/pako.min.js"></script>
 <script type="module" src="/src/plugin.ts"></script>
 <script type="module" src="/src/main.ts"></script>
 <script type="module" src="/src/docs.ts"></script>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -271,6 +271,10 @@
                         <input id="ui-emoji-labels" type="checkbox" class="form-check-input me-2" />
                         Etykiety emoji w stanie postaci
                     </label>
+                    <label class="form-label">
+                        <input id="ui-fight-title-icon" type="checkbox" class="form-check-input me-2" />
+                        Ikona walki w tytule
+                    </label>
                     <label class="form-label">Paleta kolorów
                         <select id="ui-xterm-palette" class="form-select">
                             <option value="arkadia">Arkadia</option>

--- a/web-client/src/FightTitle.ts
+++ b/web-client/src/FightTitle.ts
@@ -5,12 +5,16 @@ export default class FightTitle {
   private client: typeof ArkadiaClient;
   private playerNum?: string;
   private isFighting = false;
+  private readonly fightPrefix = "⚔ ";
+  private readonly idlePrefix = "  ";
 
   constructor(client: typeof ArkadiaClient) {
     this.client = client;
     this.baseTitle = document.title;
+    this.updateTitle(false, true);
     client.on("gmcp.char.info", (info: any) => this.handleCharInfo(info));
     client.on("gmcp.objects.data", (data: Record<string, any>) => this.handleObjectsData(data));
+    client.on("client.disconnect", () => this.reset());
   }
 
   private handleCharInfo(info: any) {
@@ -28,10 +32,16 @@ export default class FightTitle {
     this.updateTitle(fighting);
   }
 
-  private updateTitle(fighting: boolean) {
-    if (this.isFighting === fighting) return;
+  private reset() {
+    this.playerNum = undefined;
+    this.updateTitle(false, true);
+  }
+
+  private updateTitle(fighting: boolean, force = false) {
+    if (!force && this.isFighting === fighting) return;
     this.isFighting = fighting;
-    document.title = this.isFighting ? `⚔ ${this.baseTitle}` : this.baseTitle;
+    const prefix = this.isFighting ? this.fightPrefix : this.idlePrefix;
+    document.title = `${prefix}${this.baseTitle}`;
   }
 }
 

--- a/web-client/src/FightTitle.ts
+++ b/web-client/src/FightTitle.ts
@@ -23,7 +23,8 @@ export default class FightTitle {
     if (!this.playerNum) return;
     const obj = data[this.playerNum];
     if (!obj) return;
-    const fighting = obj.attack_num !== false && obj.attack_num !== undefined;
+    if (obj.attack_num === undefined) return;
+    const fighting = obj.attack_num !== false;
     this.updateTitle(fighting);
   }
 

--- a/web-client/src/FightTitle.ts
+++ b/web-client/src/FightTitle.ts
@@ -1,0 +1,36 @@
+import ArkadiaClient from "./ArkadiaClient.ts";
+
+export default class FightTitle {
+  private baseTitle: string;
+  private client: typeof ArkadiaClient;
+  private playerNum?: string;
+  private isFighting = false;
+
+  constructor(client: typeof ArkadiaClient) {
+    this.client = client;
+    this.baseTitle = document.title;
+    client.on("gmcp.char.info", (info: any) => this.handleCharInfo(info));
+    client.on("gmcp.objects.data", (data: Record<string, any>) => this.handleObjectsData(data));
+  }
+
+  private handleCharInfo(info: any) {
+    if (info && typeof info.object_num !== "undefined") {
+      this.playerNum = String(info.object_num);
+    }
+  }
+
+  private handleObjectsData(data: Record<string, any>) {
+    if (!this.playerNum) return;
+    const obj = data[this.playerNum];
+    if (!obj) return;
+    const fighting = obj.attack_num !== false && obj.attack_num !== undefined;
+    this.updateTitle(fighting);
+  }
+
+  private updateTitle(fighting: boolean) {
+    if (this.isFighting === fighting) return;
+    this.isFighting = fighting;
+    document.title = this.isFighting ? `⚔ ${this.baseTitle}` : this.baseTitle;
+  }
+}
+

--- a/web-client/src/FightTitle.ts
+++ b/web-client/src/FightTitle.ts
@@ -6,7 +6,7 @@ export default class FightTitle {
   private playerNum?: string;
   private isFighting = false;
   private readonly fightPrefix = "⚔ ";
-  private readonly idlePrefix = "  ";
+  private readonly idlePrefix = "\u00A0\u00A0"; // two non-breaking spaces
   private enabled = true;
 
   constructor(client: typeof ArkadiaClient) {

--- a/web-client/src/FightTitle.ts
+++ b/web-client/src/FightTitle.ts
@@ -7,6 +7,7 @@ export default class FightTitle {
   private isFighting = false;
   private readonly fightPrefix = "⚔ ";
   private readonly idlePrefix = "  ";
+  private enabled = true;
 
   constructor(client: typeof ArkadiaClient) {
     this.client = client;
@@ -15,6 +16,12 @@ export default class FightTitle {
     client.on("gmcp.char.info", (info: any) => this.handleCharInfo(info));
     client.on("gmcp.objects.data", (data: Record<string, any>) => this.handleObjectsData(data));
     client.on("client.disconnect", () => this.reset());
+    (window as any).clientExtension?.eventTarget.addEventListener("uiSettings", (ev: CustomEvent) => {
+      if (typeof ev.detail?.fightTitleIcon === "boolean") {
+        this.enabled = ev.detail.fightTitleIcon;
+        this.updateTitle(this.isFighting, true);
+      }
+    });
   }
 
   private handleCharInfo(info: any) {
@@ -40,6 +47,10 @@ export default class FightTitle {
   private updateTitle(fighting: boolean, force = false) {
     if (!force && this.isFighting === fighting) return;
     this.isFighting = fighting;
+    if (!this.enabled) {
+      document.title = this.baseTitle;
+      return;
+    }
     const prefix = this.isFighting ? this.fightPrefix : this.idlePrefix;
     document.title = `${prefix}${this.baseTitle}`;
   }

--- a/web-client/src/FightTitle.ts
+++ b/web-client/src/FightTitle.ts
@@ -6,7 +6,7 @@ export default class FightTitle {
   private playerNum?: string;
   private isFighting = false;
   private readonly fightPrefix = "⚔ ";
-  private readonly idlePrefix = "\u00A0\u00A0"; // two non-breaking spaces
+  private readonly idlePrefix = "ㅤ ";
   private enabled = true;
 
   constructor(client: typeof ArkadiaClient) {

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -11,6 +11,7 @@ import BreakItemWarning from "./BreakItemWarning";
 import PackageStatus from "./PackageStatus";
 import CharStateInfo from "./CharStateInfo";
 import ReleaseGuard from "./ReleaseGuard";
+import FightTitle from "./FightTitle";
 
 import "@client/src/main.ts"
 import MockPort from "./MockPort.ts";
@@ -861,6 +862,7 @@ document.addEventListener('DOMContentLoaded', () => {
     new BreakItemWarning(arkadiaClient);
     new ReleaseGuard(arkadiaClient);
     new PackageStatus(arkadiaClient);
+    new FightTitle(arkadiaClient);
     new ObjectList(client);
 
     // Initialize mobile direction buttons

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -9,6 +9,7 @@ interface UiSettings {
     showButtons: boolean;
     mapHeight: number;
     emojiLabels: boolean;
+    fightTitleIcon: boolean;
     xtermPalette: 'arkadia' | 'proper';
     footerMode: number;
     explorationMode: boolean;
@@ -23,6 +24,7 @@ const defaultSettings: UiSettings = {
     showButtons: true,
     mapHeight: typeof window !== 'undefined' && window.innerWidth < 768 ? 25 : 30,
     emojiLabels: false,
+    fightTitleIcon: true,
     xtermPalette: 'arkadia',
     footerMode: 0,
     explorationMode: false,
@@ -82,6 +84,7 @@ function apply(settings: UiSettings) {
                     emojiLabels: settings.emojiLabels,
                     xtermPalette: settings.xtermPalette,
                     footerMode: settings.footerMode,
+                    fightTitleIcon: settings.fightTitleIcon,
                 },
             })
         );
@@ -110,7 +113,8 @@ async function load(): Promise<UiSettings> {
             const xtermPalette = parsed.xtermPalette === 'proper' ? 'proper' : defaultSettings.xtermPalette;
             const footerMode = typeof parsed.footerMode === 'number' ? parsed.footerMode : defaultSettings.footerMode;
             const explorationMode = !!parsed.explorationMode;
-            return { ...defaultSettings, ...parsed, mapScale, mapLimit, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode };
+            const fightTitleIcon = typeof parsed.fightTitleIcon === 'boolean' ? parsed.fightTitleIcon : defaultSettings.fightTitleIcon;
+            return { ...defaultSettings, ...parsed, mapScale, mapLimit, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode, fightTitleIcon };
         }
     } catch {
         // ignore malformed data
@@ -138,6 +142,7 @@ export default async function initUiSettings() {
     const explorationStats = modalEl.querySelector('#ui-exploration-stats') as HTMLElement | null;
     const showButtonsInput = modalEl.querySelector('#ui-show-buttons') as HTMLInputElement;
     const emojiLabelsInput = modalEl.querySelector('#ui-emoji-labels') as HTMLInputElement;
+    const fightTitleIconInput = modalEl.querySelector('#ui-fight-title-icon') as HTMLInputElement;
     const xtermPaletteInput = modalEl.querySelector('#ui-xterm-palette') as HTMLSelectElement;
     const footerModeInput = modalEl.querySelector('#ui-footer-mode') as HTMLSelectElement;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
@@ -152,6 +157,7 @@ export default async function initUiSettings() {
     explorationInput.checked = current.explorationMode;
     showButtonsInput.checked = current.showButtons;
     emojiLabelsInput.checked = current.emojiLabels;
+    fightTitleIconInput.checked = current.fightTitleIcon;
     xtermPaletteInput.value = current.xtermPalette;
     footerModeInput.value = String(current.footerMode);
     apply(current);
@@ -189,6 +195,7 @@ export default async function initUiSettings() {
             mapHeight: parseFloat(mapHeightInput.value) || defaultSettings.mapHeight,
             showButtons: showButtonsInput.checked,
             emojiLabels: emojiLabelsInput.checked,
+            fightTitleIcon: fightTitleIconInput.checked,
             xtermPalette: (xtermPaletteInput.value as 'arkadia' | 'proper') || defaultSettings.xtermPalette,
             footerMode: parseInt(footerModeInput.value) || defaultSettings.footerMode,
             explorationMode: explorationInput.checked,


### PR DESCRIPTION
## Summary
- track player fighting state from GMCP objects
- prepend ⚔ to page title while fighting

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6895401b0634832aa24b40bd605213f2