### PR TITLE
chore: remove xterm palette debug log

### DIFF
--- a/client/src/Colors.ts
+++ b/client/src/Colors.ts
@@ -32,7 +32,6 @@ const palette = (() => {
 colorCodes.xterm = palette === 'proper' ? colorCodes.xtermProper : colorCodes.xtermArkadia;
 
 export function setXtermPalette(p: 'arkadia' | 'proper') {
-    console.log('Setting xterm palette to', p);
     colorCodes.xterm = p === 'proper' ? colorCodes.xtermProper : colorCodes.xtermArkadia;
 }
 


### PR DESCRIPTION
## Summary
- remove stray xterm palette console log

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68954790f46c832a902c64bb88e0b6a5