### PR TITLE
Preserve input focus during history navigation

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -710,6 +710,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!arkadiaClient.hasReceivedFirstGmcp()) return;
         if (commandHistory.length === 0) return;
 
+        const wasFocused = document.activeElement === messageInput;
+
         if (historyIndex === -1) {
             currentInput = messageInput.value;
             // Skip the just sent command if the input wasn't modified
@@ -720,7 +722,7 @@ document.addEventListener('DOMContentLoaded', () => {
             ) {
                 historyIndex = 1;
                 messageInput.value = commandHistory[commandHistory.length - 1 - historyIndex];
-                messageInput.select();
+                if (wasFocused) messageInput.select();
                 return;
             }
         }
@@ -729,17 +731,17 @@ document.addEventListener('DOMContentLoaded', () => {
             if (historyIndex < commandHistory.length - 1) {
                 historyIndex++;
                 messageInput.value = commandHistory[commandHistory.length - 1 - historyIndex];
-                messageInput.select();
+                if (wasFocused) messageInput.select();
             }
         } else {
             if (historyIndex > 0) {
                 historyIndex--;
                 messageInput.value = commandHistory[commandHistory.length - 1 - historyIndex];
-                messageInput.select();
+                if (wasFocused) messageInput.select();
             } else if (historyIndex === 0) {
                 historyIndex = -1;
                 messageInput.value = currentInput;
-                messageInput.select();
+                if (wasFocused) messageInput.select();
             }
         }
     }


### PR DESCRIPTION
## Summary
- avoid shifting focus when traversing command history unless input was already focused

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68954db32378832a835ba593d179edb0