### PR TITLE
feat: highlight mountain arrival and descent

### DIFF
--- a/client/src/scripts/mountain.ts
+++ b/client/src/scripts/mountain.ts
@@ -16,6 +16,16 @@ export default function initMountain(client: Client) {
         return colorString(line, YELLOW);
     }, tag);
 
+    client.Triggers.registerTrigger(/Docierasz na gore\./, (_r, line) => {
+        mountainMovingDir = undefined;
+        return colorString(line, YELLOW);
+    }, tag);
+
+    client.Triggers.registerTrigger(/Bezpiecznie schodzisz na dol\./, (_r, line) => {
+        mountainMovingDir = undefined;
+        return colorString(line, YELLOW);
+    }, tag);
+
     client.Triggers.registerTrigger(/Odpadasz od sciany i lecisz w dol/, (_r, line) => {
         if (mountainMovingDir === "up") {
             client.Map.moveBack();

--- a/client/test/mountain.test.ts
+++ b/client/test/mountain.test.ts
@@ -30,6 +30,16 @@ describe('mountain triggers', () => {
     expect(result).toBe(prefix + 'Zaczynasz wspinac sie' + suffix);
   });
 
+  test('colors reaching top line yellow', () => {
+    const result = parse('Docierasz na gore.');
+    expect(result).toBe(prefix + 'Docierasz na gore.' + suffix);
+  });
+
+  test('colors safe descent line yellow', () => {
+    const result = parse('Bezpiecznie schodzisz na dol.');
+    expect(result).toBe(prefix + 'Bezpiecznie schodzisz na dol.' + suffix);
+  });
+
   test('colors falling line yellow and moves back when climbing up', () => {
     parse('Zaczynasz wspinac sie');
     const result = parse('Odpadasz od sciany i lecisz w dol');


### PR DESCRIPTION
## Summary
- color mountain peak and safe descent messages yellow
- test yellow coloring for new mountain messages

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6895b1bff898832a98baa6463b42a3b5