### PR TITLE
fix: keep char state footer text white in graphical mode

### DIFF
--- a/web-client/src/CharState.ts
+++ b/web-client/src/CharState.ts
@@ -199,7 +199,6 @@ export default class CharState {
         const reverse = def === 0 || this.config[key].flip === true;
         const colorLevel = getColorLevel(value, maxValue, reverse, key === "hp");
         const colorClass = COLOR_BAR_CLASS[colorLevel];
-        const color = COLOR_TEXT[colorLevel];
         const opposite =
           def !== undefined ? (def > 0 ? 0 : maxValue) : null;
         const highlight = opposite !== null && value === opposite;
@@ -218,7 +217,7 @@ export default class CharState {
         const valueSpan = document.createElement("span");
         valueSpan.className = "progress-value";
         valueSpan.textContent = `${value}/${maxValue}`;
-        valueSpan.style.color = color;
+        valueSpan.style.color = "white";
         progress.appendChild(bar);
         progress.appendChild(valueSpan);
         group.appendChild(labelEl);

--- a/web-client/test/CharState.test.ts
+++ b/web-client/test/CharState.test.ts
@@ -1,0 +1,28 @@
+import CharState from '../src/CharState';
+
+class MockClient {
+  private events: Record<string, Function[]> = {};
+  on(event: string, listener: Function) {
+    (this.events[event] ||= []).push(listener);
+  }
+  emit(event: string, ...args: any[]) {
+    (this.events[event] || []).forEach(fn => fn(...args));
+  }
+}
+
+describe('CharState', () => {
+  let client: MockClient;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="char-state" data-footer-mode="3"><span id="char-state-text"></span><div id="char-state-bars"></div></div>';
+    client = new MockClient();
+    new CharState(client as any);
+  });
+
+  test('progress values stay white in graphical mode', () => {
+    client.emit('gmcp.char.state', { hp: 5 });
+    const valueSpan = document.querySelector('#char-state-bars .progress-value') as HTMLElement;
+    expect(valueSpan).not.toBeNull();
+    expect(valueSpan.style.color).toBe('white');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure character state footer values stay white in graphical mode
- add unit test for graphical mode color

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6895d6fb6f8c832a9b9f8a2cebd44d44