### PR TITLE
Highlight unexpected "daje ci" messages

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -40,6 +40,7 @@ import initHpAlert from './scripts/hpAlert'
 import initNoWeaponAlert from './scripts/noWeaponAlert'
 import initMagikZnika from './scripts/magikZnika'
 import initSeasonPrint from './scripts/seasonPrint'
+import initDajeCiHighlight from './scripts/dajeCiHighlight'
 import initPriceEvaluation from './scripts/priceEvaluation'
 import initStoneValue from './scripts/stoneValue'
 import initSelfEvaluation from './scripts/selfEvaluation'
@@ -167,6 +168,7 @@ export function registerScripts(client: Client) {
     initNewMail(client)
     initMagikZnika(client)
     initSeasonPrint(client)
+    initDajeCiHighlight(client)
     initGuildPostfix(client)
     initShortcuts(client, aliases)
     initShortExits(client)

--- a/client/src/scripts/dajeCiHighlight.ts
+++ b/client/src/scripts/dajeCiHighlight.ts
@@ -1,0 +1,14 @@
+import Client from "../Client";
+import { colorStringInLine, findClosestColor } from "../Colors";
+
+export default function initDajeCiHighlight(client: Client) {
+    const TURQUOISE = findClosestColor("#40e0d0");
+    const pattern = /^(?:[ >]*[A-Za-z !()]+ daje ci )(.*)$/;
+    client.Triggers.registerTrigger(pattern, (raw, _line, matches) => {
+        const group = matches[1];
+        if (group !== "nowy zapal do walki.") {
+            const start = matches.index ?? 0;
+            return colorStringInLine(raw, group, TURQUOISE, start);
+        }
+    }, "daje-ci-highlight");
+}


### PR DESCRIPTION
## Summary
- highlight gifts that don't give "nowy zapal do walki." in turquoise
- load new highlight trigger during client script initialization

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6895d9fda2b4832a9f5664d37f9777a8