### PR TITLE
feat: add /sprzet alias for self evaluation

### DIFF
--- a/client/src/scripts/selfEvaluation.ts
+++ b/client/src/scripts/selfEvaluation.ts
@@ -109,5 +109,6 @@ export default function initSelfEvaluation(
 
     if (aliases) {
         aliases.push({ pattern: /^\/ocen$/, callback: run });
+        aliases.push({ pattern: /^\/sprzet$/, callback: run });
     }
 }

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -85,4 +85,5 @@ Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorze
 - **/naprawa** - Alias do `/napraw`.
 - **/napraw_ubrania** - Naprawianie ubrania u krawca.
 - **/ocen** - ocenia swoje bronie i zbroje, wypisujac jedynie ich stan.
+- **/sprzet** - Alias do `/ocen`.
 - **/ocenkamienie** - oblicza łączną wartość kamieni.


### PR DESCRIPTION
## Summary
- allow `/sprzet` to trigger self evaluation same as `/ocen`
- document `/sprzet` alias

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_689631f1df1c832aba2aa9dd46af7561