### PR TITLE
Persist last language across sessions

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -195,7 +195,7 @@ export default class Client {
             if (ev.detail?.name) {
                 setCurrentCharacter(ev.detail.name);
                 if (this.port) {
-                    ['settings', 'kill_counter', 'deposits', 'containers', 'herb_counts', 'mapperRoomId', 'binds'].forEach(k => {
+                    ['settings', 'kill_counter', 'deposits', 'containers', 'herb_counts', 'mapperRoomId', 'binds', 'lastLang'].forEach(k => {
                         this.port!.postMessage({ type: 'GET_STORAGE', key: k });
                     });
                 }

--- a/client/src/scripts/language.ts
+++ b/client/src/scripts/language.ts
@@ -7,10 +7,23 @@ function escapeRegExp(str: string) {
 export default function initLanguage(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
     if (!aliases) return;
 
+    const STORAGE_KEY = 'lastLang';
     let currentLang = 'potoczna';
     let adjective = '';
     let lastLang = '';
     let customAliases: { pattern: RegExp; callback: (m: RegExpMatchArray) => void }[] = [];
+
+    client.addEventListener('storage', (ev: CustomEvent) => {
+        if (ev.detail.key === STORAGE_KEY) {
+            lastLang = ev.detail.value || '';
+        }
+    });
+
+    client.addEventListener('port-connected', () => {
+        client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
+    });
+
+    client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
 
     function setLanguage(lang: string) {
         if (lang !== lastLang && lang !== 'potoczna') {
@@ -36,6 +49,7 @@ export default function initLanguage(client: Client, aliases?: { pattern: RegExp
         callback: (matches: RegExpMatchArray) => {
             client.send('justaw ' + matches[1]);
             lastLang = matches[1];
+            client.port?.postMessage({ type: 'SET_STORAGE', key: STORAGE_KEY, value: lastLang });
         }
     })
 

--- a/client/src/storage.ts
+++ b/client/src/storage.ts
@@ -33,6 +33,7 @@ const characterScopedKeys = new Set([
     'herb_counts',
     'herbs_data',
     'mapperRoomId',
+    'lastLang',
 ]);
 
 let currentCharacter: string | null = localStorage.getItem('currentCharacter');


### PR DESCRIPTION
## Summary
- Save selected language to character-scoped storage via `justaw` alias and load from storage on login
- Support character-specific storage for language by adding `lastLang` key

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_689649b8a494832ab40daf89f9a305c3