### PR TITLE
feat: prioritize potoczna language in selectors

### DIFF
--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -20,6 +20,7 @@ const collectModeOptions = [
 const collectMoneyOptions = ["wszystkie", "srebrne", "zlote"]
 
 const languageOptions = [
+    "potoczna",
     "bretonski",
     "drukh-eltharin",
     "estalijski",
@@ -39,7 +40,6 @@ const languageOptions = [
     "tar-eltharin",
     "tileanski",
     "zerrikanski",
-    "potoczna",
     "ghassall",
 ]
 


### PR DESCRIPTION
## Summary
- Show "potoczna" at the top of language selectors

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68965b8a0194832aa0c22912500e9d00