### PR TITLE
feat: store processed output in indexeddb

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -382,7 +382,7 @@ export default class Client {
         }
         // @ts-ignore
         const text = Text.parse_patterns(printable)
-        this.buffer.push({out: text})
+        this.buffer.push({out: text, type: 'print'})
         if (!this.inLineProcess) {
             this.sendEvent('output-sent', 1)
         }

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -186,7 +186,7 @@ test('onLine sends printed messages after line and restores Output.send', () => 
   client.sendEvent('output-sent');
 
   expect(originalOutputSend).toHaveBeenNthCalledWith(1, expected);
-  expect((global as any).clientAdapterMock.output).toHaveBeenCalledWith('printed', undefined);
+  expect((global as any).clientAdapterMock.output).toHaveBeenCalledWith('printed', 'print');
 });
 
 test('onLine replaces reset sequences with preceding ANSI code', () => {

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -154,7 +154,7 @@
                 </div>
                 <div class="modal-body d-flex flex-column gap-2">
                     <select id="html-logs-select" class="form-select"></select>
-                    <div id="html-log-preview" class="border p-2" style="max-height:50vh;overflow:auto;"></div>
+                    <div id="html-log-preview" class="border p-2" style="max-height:50vh;overflow:auto;font-family:monospace;white-space:pre;"></div>
                     <button class="btn btn-primary" id="html-log-download" disabled>Pobierz</button>
                 </div>
             </div>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -145,6 +145,21 @@
             </div>
         </div>
     </div>
+    <div id="html-logs-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Logi HTML</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body d-flex flex-column gap-2">
+                    <select id="html-logs-select" class="form-select"></select>
+                    <div id="html-log-preview" class="border p-2" style="max-height:50vh;overflow:auto;"></div>
+                    <button class="btn btn-primary" id="html-log-download" disabled>Pobierz</button>
+                </div>
+            </div>
+        </div>
+    </div>
     <div id="shortcuts-modal" class="modal fade" tabindex="-1">
         <div class="modal-dialog modal-lg modal-dialog-scrollable">
             <div class="modal-content">
@@ -210,6 +225,9 @@
                 </li>
                 <li>
                     <button class="w-100 p-1" id="recordings-button">Nagrania</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="html-logs-button">Logi HTML</button>
                 </li>
                 <li>
                     <button class="w-100 p-1" id="shortcuts-button">Skróty</button>

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -4,6 +4,7 @@ import Recorder from './Recorder';
 import {ClientAdapter} from "@client/src/Client.ts";
 import eventBus, {ClientEvents} from "@client/src/eventBus.ts";
 import TelnetOptionNegotiation from "./TelnetOptionNegotiation.ts";
+import HtmlLogger from './HtmlLogger';
 
 
 type Params<T> = T extends void ? [] : T extends any[] ? T : [T];
@@ -83,6 +84,7 @@ class ArkadiaClient implements ClientAdapter {
                 this.emit('close', event);
                 this.emit('client.disconnect');
                 this.stopPing();
+                HtmlLogger.endSession();
 
                 // @ts-ignore
                 this.readInflator = new pako.Inflate()
@@ -90,6 +92,7 @@ class ArkadiaClient implements ClientAdapter {
 
             this.socket.onopen = (event: Event) => {
                 this.emit('open', event);
+                HtmlLogger.startSession();
                 this.emit('client.connect');
                 this.mccp = false;
                 this.startPing();
@@ -338,6 +341,7 @@ class ArkadiaClient implements ClientAdapter {
 
     private sendLine(text: string, type: string, i: number) {
         text = window.clientExtension.onLine(text, type)
+        HtmlLogger.logLine(text, type);
         eventBus.on('output-sent', () => this.emit(`gmcp_msg.${type}`, text), {once: true})
         Output.send(parseAnsiPatterns(text), type);
         this.emit('line-sent')

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -332,19 +332,25 @@ class ArkadiaClient implements ClientAdapter {
                 processed.push(message)
             }
         })
-        processed.forEach((message, i) => {
-            this.sendLine(message.text, message.type, i)
+        let lineCount = 0;
+        processed.forEach((message) => {
+            lineCount += this.sendLine(message.text, message.type);
         })
-        this.emit('output-sent', processed.length)
+        this.emit('output-sent', lineCount)
         this.messageBuffer = []
     }
 
-    private sendLine(text: string, type: string, i: number) {
+    private sendLine(text: string, type: string): number {
         text = window.clientExtension.onLine(text, type)
-        HtmlLogger.logLine(text, type);
-        eventBus.on('output-sent', () => this.emit(`gmcp_msg.${type}`, text), {once: true})
-        Output.send(parseAnsiPatterns(text), type);
-        this.emit('line-sent')
+        const timestamp = Date.now();
+        const lines = text.split(/\r?\n/);
+        lines.forEach(line => {
+            HtmlLogger.logLine(line, type, timestamp);
+            eventBus.on('output-sent', () => this.emit(`gmcp_msg.${type}`, line), {once: true})
+            Output.send(parseAnsiPatterns(line), type);
+            this.emit('line-sent')
+        })
+        return lines.length;
     }
 
     startRecording(name: string) {

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -248,6 +248,12 @@ class ArkadiaClient implements ClientAdapter {
     }
 
     output(text?: string, type?: string) {
+        if (typeof text === 'string') {
+            const timestamp = Date.now();
+            text.split(/\r?\n/).forEach(line => {
+                HtmlLogger.logLine(line, type, timestamp);
+            });
+        }
         this.emit('message', text, type)
     }
 

--- a/web-client/src/HtmlLogger.ts
+++ b/web-client/src/HtmlLogger.ts
@@ -1,0 +1,30 @@
+class HtmlLogger {
+    private db: IDBDatabase | null = null;
+    private storeName = 'lines';
+
+    startSession() {
+        const name = `html_logs_${Date.now()}`;
+        const request = indexedDB.open(name, 1);
+        request.onupgradeneeded = () => {
+            request.result.createObjectStore(this.storeName, { autoIncrement: true });
+        };
+        request.onsuccess = () => {
+            this.db = request.result;
+        };
+    }
+
+    endSession() {
+        if (this.db) {
+            this.db.close();
+            this.db = null;
+        }
+    }
+
+    logLine(text: string, type?: string) {
+        if (!this.db) return;
+        const tx = this.db.transaction(this.storeName, 'readwrite');
+        tx.objectStore(this.storeName).add({ timestamp: Date.now(), text, type });
+    }
+}
+
+export default new HtmlLogger();

--- a/web-client/src/HtmlLogger.ts
+++ b/web-client/src/HtmlLogger.ts
@@ -20,10 +20,10 @@ class HtmlLogger {
         }
     }
 
-    logLine(text: string, type?: string) {
+    logLine(text: string, type?: string, timestamp: number = Date.now()) {
         if (!this.db) return;
         const tx = this.db.transaction(this.storeName, 'readwrite');
-        tx.objectStore(this.storeName).add({ timestamp: Date.now(), text, type });
+        tx.objectStore(this.storeName).add({ timestamp, text, type });
     }
 }
 

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -34,6 +34,7 @@ import Shortcuts from "./options/Shortcuts.tsx"
 import MobileButtons from "./options/MobileButtons.tsx"
 import { loadSettings as loadMobileButtonSettings, applySettings as applyMobileButtonSettings } from "./mobileButtonSettings"
 import "./triggerTester"
+import {parseAnsiPatterns} from "./ansiParser"
 
 const client = new Client(arkadiaClient, new MockPort())
 window.clientExtension = client;
@@ -417,6 +418,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const aliasesButton = document.getElementById('aliases-button') as HTMLButtonElement | null;
     const triggersButton = document.getElementById('triggers-button') as HTMLButtonElement | null;
     const recordingsButton = document.getElementById('recordings-button') as HTMLButtonElement | null;
+    const htmlLogsButton = document.getElementById('html-logs-button') as HTMLButtonElement | null;
     const shortcutsButton = document.getElementById('shortcuts-button') as HTMLButtonElement | null;
     const mobileButtonsButton = document.getElementById('mobile-buttons-button') as HTMLButtonElement | null;
     const recordingButton = document.getElementById('recording-button') as HTMLButtonElement | null;
@@ -447,6 +449,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const triggersModal = triggersModalElement ? new Modal(triggersModalElement) : null;
     const recordingsModalElement = document.getElementById('recordings-modal');
     const recordingsModal = recordingsModalElement ? new Modal(recordingsModalElement) : null;
+    const htmlLogsModalElement = document.getElementById('html-logs-modal');
+    const htmlLogsModal = htmlLogsModalElement ? new Modal(htmlLogsModalElement) : null;
+    const htmlLogsSelect = document.getElementById('html-logs-select') as HTMLSelectElement | null;
+    const htmlLogPreview = document.getElementById('html-log-preview') as HTMLElement | null;
+    const htmlLogDownload = document.getElementById('html-log-download') as HTMLButtonElement | null;
     const shortcutsModalElement = document.getElementById('shortcuts-modal');
     const shortcutsModal = shortcutsModalElement ? new Modal(shortcutsModalElement) : null;
     const mobileButtonsModalElement = document.getElementById('mobile-buttons-modal');
@@ -524,6 +531,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (recordingsModal) {
             recordingsModal.hide();
         }
+        if (htmlLogsModal) {
+            htmlLogsModal.hide();
+        }
         if (shortcutsModal) {
             shortcutsModal.hide();
         }
@@ -575,6 +585,66 @@ document.addEventListener('DOMContentLoaded', () => {
     if (recordingsButton && recordingsModal) {
         recordingsButton.addEventListener('click', () => {
             recordingsModal.show();
+        });
+    }
+
+    if (htmlLogsButton && htmlLogsModal && htmlLogsSelect && htmlLogPreview && htmlLogDownload) {
+        const loadLog = (name: string) => {
+            const req = indexedDB.open(name);
+            req.onsuccess = () => {
+                const db = req.result;
+                const tx = db.transaction('lines', 'readonly');
+                const store = tx.objectStore('lines');
+                const getAll = store.getAll();
+                getAll.onsuccess = () => {
+                    const lines = getAll.result as {timestamp: number, text: string}[];
+                    const html = lines.map(line => {
+                        const time = new Date(line.timestamp).toLocaleTimeString();
+                        return `<div><span class="text-muted me-1">${time}</span>${parseAnsiPatterns(line.text)}</div>`;
+                    }).join('');
+                    htmlLogPreview.innerHTML = html;
+                    htmlLogDownload.disabled = false;
+                    htmlLogDownload.onclick = () => {
+                        const blob = new Blob([`<html><body>${html}</body></html>`], {type: 'text/html'});
+                        const url = URL.createObjectURL(blob);
+                        const a = document.createElement('a');
+                        a.href = url;
+                        a.download = `${name}.html`;
+                        a.click();
+                        URL.revokeObjectURL(url);
+                    };
+                    db.close();
+                };
+            };
+        };
+
+        const updateList = async () => {
+            htmlLogsSelect.innerHTML = '';
+            const dbs = await ((indexedDB as any).databases ? (indexedDB as any).databases() : []);
+            dbs.filter((d: any) => d.name && d.name.startsWith('html_logs_'))
+               .sort((a: any, b: any) => (b.name as string).localeCompare(a.name as string))
+               .forEach((d: any) => {
+                   const opt = document.createElement('option');
+                   const ts = Number((d.name as string).replace('html_logs_', ''));
+                   opt.value = d.name as string;
+                   opt.textContent = new Date(ts).toLocaleString();
+                   htmlLogsSelect.appendChild(opt);
+               });
+            if (htmlLogsSelect.value) {
+                loadLog(htmlLogsSelect.value);
+            } else {
+                htmlLogPreview.textContent = '';
+                htmlLogDownload.disabled = true;
+            }
+        };
+
+        htmlLogsButton.addEventListener('click', () => {
+            htmlLogsModal.show();
+            updateList();
+        });
+
+        htmlLogsSelect.addEventListener('change', () => {
+            loadLog(htmlLogsSelect.value);
         });
     }
 

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -600,12 +600,13 @@ document.addEventListener('DOMContentLoaded', () => {
                     const lines = getAll.result as {timestamp: number, text: string}[];
                     const html = lines.map(line => {
                         const time = new Date(line.timestamp).toLocaleTimeString();
-                        return `<div><span class="text-muted me-1">${time}</span>${parseAnsiPatterns(line.text)}</div>`;
+                        const parsed = parseAnsiPatterns(line.text);
+                        return `<div style="white-space:pre;font-family:monospace"><span style="color:#6c757d;margin-right:0.25rem">${time}</span>${parsed}</div>`;
                     }).join('');
                     htmlLogPreview.innerHTML = html;
                     htmlLogDownload.disabled = false;
                     htmlLogDownload.onclick = () => {
-                        const blob = new Blob([`<html><body>${html}</body></html>`], {type: 'text/html'});
+                        const blob = new Blob([`<html><head><meta charset=\"UTF-8\"/></head><body>${html}</body></html>`], {type: 'text/html'});
                         const url = URL.createObjectURL(blob);
                         const a = document.createElement('a');
                         a.href = url;


### PR DESCRIPTION
## Summary
- add HtmlLogger for capturing processed lines with timestamps in IndexedDB
- start and end a new log session on connect and disconnect
- record each processed line before HTML output
- add menu-accessible HTML log browser to preview and download saved sessions

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68966acfac3c832aa3c8f99d7dde3f49