### PR TITLE
feat: improve log export formatting

### DIFF
--- a/web-client/src/logBrowser.ts
+++ b/web-client/src/logBrowser.ts
@@ -45,9 +45,39 @@ function initLogBrowser() {
     });
   }
 
+  async function removeEmptyStores(database: IDBDatabase): Promise<IDBDatabase> {
+    const empty: string[] = [];
+    for (let i = 0; i < database.objectStoreNames.length; i++) {
+      const name = database.objectStoreNames.item(i);
+      if (!name) continue;
+      const tx = database.transaction(name, "readonly");
+      const req = tx.objectStore(name).count();
+      const count = await new Promise<number>((resolve) => {
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => resolve(0);
+      });
+      if (count === 0) empty.push(name);
+    }
+    if (empty.length === 0) return database;
+    database.close();
+    return new Promise((resolve, reject) => {
+      const upgrade = indexedDB.open("ArkadiaMessagesDB", database.version + 1);
+      upgrade.onupgradeneeded = () => {
+        for (const n of empty) {
+          if (upgrade.result.objectStoreNames.contains(n)) {
+            upgrade.result.deleteObjectStore(n);
+          }
+        }
+      };
+      upgrade.onsuccess = () => resolve(upgrade.result);
+      upgrade.onerror = () => reject(upgrade.error);
+    });
+  }
+
   async function refreshSessions() {
     db?.close();
     db = await openDb();
+    db = await removeEmptyStores(db);
     select.innerHTML = "";
     const names: string[] = [];
     for (let i = 0; i < db.objectStoreNames.length; i++) {
@@ -91,7 +121,7 @@ function initLogBrowser() {
           msg.style.whiteSpace = "pre-wrap";
           const timeSpan = document.createElement("span");
           timeSpan.classList.add("log-time");
-          timeSpan.textContent = `[${time}]`;
+          timeSpan.textContent = time;
           const contentSpan = document.createElement("span");
           contentSpan.innerHTML = line;
           msg.appendChild(timeSpan);
@@ -128,7 +158,7 @@ function initLogBrowser() {
           if (l.type) {
             classes.push(l.type);
           }
-          const lineHtml = `<div class="${classes.join(" ")}"><div class="output_msg_text" style="white-space:pre-wrap"><span class="log-time">[${time}]</span><span>${part}</span></div></div>`;
+          const lineHtml = `<div class="${classes.join(" ")}"><div class="output_msg_text" style="white-space:pre-wrap"><span class="log-time">${time}</span><span>${part}</span></div></div>`;
           entries.push(lineHtml);
         }
       }

--- a/web-client/src/logBrowser.ts
+++ b/web-client/src/logBrowser.ts
@@ -83,6 +83,35 @@ function initLogBrowser(): boolean {
     }
   }
 
+  function splitLines(html: string): string[] {
+    const lines: string[] = [];
+    const stack: { open: string; close: string }[] = [];
+    let line = "";
+    const regex = /(<[^>]+>|\r?\n)/g;
+    let last = 0;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(html)) !== null) {
+      const token = match[0];
+      line += html.slice(last, match.index);
+      if (token === "\n" || token === "\r\n") {
+        lines.push(line + stack.map(s => s.close).reverse().join(""));
+        line = stack.map(s => s.open).join("");
+      } else {
+        line += token;
+        if (token.startsWith("<") && !token.startsWith("</") && !token.endsWith("/>") && !token.startsWith("<!")) {
+          const tag = token.match(/^<([a-zA-Z0-9:-]+)/);
+          if (tag) stack.push({ open: token, close: `</${tag[1]}>` });
+        } else if (token.startsWith("</")) {
+          stack.pop();
+        }
+      }
+      last = regex.lastIndex;
+    }
+    line += html.slice(last);
+    lines.push(line);
+    return lines;
+  }
+
   function loadPreview(storeName: string) {
     if (!db) return;
     preview.innerHTML = "";
@@ -91,7 +120,7 @@ function initLogBrowser(): boolean {
     req.onsuccess = () => {
       const logs = req.result as LogEntry[];
       for (const entry of logs) {
-        const lines = entry.text.split(/\r?\n/);
+        const lines = splitLines(entry.text);
         const time = formatTime(entry.timestamp);
         for (const line of lines) {
           const wrapper = document.createElement("div");
@@ -135,7 +164,7 @@ function initLogBrowser(): boolean {
       const entries: string[] = [];
       for (const l of logs) {
         const time = formatDateTime(l.timestamp);
-        const parts = l.text.split(/\r?\n/);
+        const parts = splitLines(l.text);
         for (const part of parts) {
           const classes = ["output_msg"];
           if (l.type) {

--- a/web-client/src/logBrowser.ts
+++ b/web-client/src/logBrowser.ts
@@ -195,4 +195,8 @@ function initLogBrowser() {
   });
 }
 
-document.addEventListener("DOMContentLoaded", initLogBrowser);
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initLogBrowser);
+} else {
+  initLogBrowser();
+}

--- a/web-client/src/logBrowser.ts
+++ b/web-client/src/logBrowser.ts
@@ -62,7 +62,12 @@ function initLogBrowser() {
       const logs = req.result as LogEntry[];
       for (const entry of logs) {
         const lines = entry.text.split(/\r?\n/);
-        const time = new Date(entry.timestamp).toLocaleTimeString();
+        const time = new Date(entry.timestamp).toLocaleTimeString([], {
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+          hour12: false,
+        });
         for (const line of lines) {
           const wrapper = document.createElement("div");
           wrapper.classList.add("output_msg");
@@ -73,7 +78,8 @@ function initLogBrowser() {
           msg.classList.add("output_msg_text");
           msg.style.whiteSpace = "pre-wrap";
           const timeSpan = document.createElement("span");
-          timeSpan.textContent = `[${time}] `;
+          timeSpan.classList.add("log-time");
+          timeSpan.textContent = `[${time}]`;
           const contentSpan = document.createElement("span");
           contentSpan.innerHTML = line;
           msg.appendChild(timeSpan);
@@ -103,33 +109,34 @@ function initLogBrowser() {
       const logs = req.result as LogEntry[];
       const entries: string[] = [];
       for (const l of logs) {
-        const time = new Date(l.timestamp).toLocaleString();
+        const time = new Date(l.timestamp).toLocaleString([], { hour12: false });
         const parts = l.text.split(/\r?\n/);
         for (const part of parts) {
           const classes = ["output_msg"];
           if (l.type) {
             classes.push(l.type);
           }
-            const lineHtml = `<div class="${classes.join(" ")}"><div class="output_msg_text" style="white-space:pre-wrap"><span>[${time}] </span><span>${part}</span></div></div>`;
+          const lineHtml = `<div class="${classes.join(" ")}"><div class="output_msg_text" style="white-space:pre-wrap"><span class="log-time">[${time}]</span><span>${part}</span></div></div>`;
           entries.push(lineHtml);
         }
       }
-        const inlineStyles: string[] = [];
-        const linkTags: string[] = [];
-        for (const sheet of Array.from(document.styleSheets)) {
-          try {
-            const rules = Array.from(sheet.cssRules);
-            inlineStyles.push(rules.map(r => r.cssText).join("\n"));
-          } catch {
-            const href = (sheet as CSSStyleSheet).href;
-            if (href) {
-              linkTags.push(`<link rel="stylesheet" href="${href}">`);
-            }
+      const inlineStyles: string[] = [];
+      const linkTags: string[] = [];
+      for (const sheet of Array.from(document.styleSheets)) {
+        try {
+          const rules = Array.from(sheet.cssRules);
+          inlineStyles.push(rules.map(r => r.cssText).join("\n"));
+        } catch {
+          const href = (sheet as CSSStyleSheet).href;
+          if (href) {
+            linkTags.push(`<link rel="stylesheet" href="${href}">`);
           }
         }
+      }
+      inlineStyles.push("html, body { overflow: auto; } #logs-preview { height: auto; }");
 
-        const head = `<meta charset="UTF-8">\n${linkTags.join("\n")}\n<style>${inlineStyles.join("\n")}</style>`;
-        const html = `<!doctype html><html lang="en"><head>${head}</head><body><div id="main_text_output_msg_wrapper">${entries.join("\n")}</div></body></html>`;
+      const head = `<meta charset=\"UTF-8\">\n${linkTags.join("\n")}\n<style>${inlineStyles.join("\n")}</style>`;
+      const html = `<!doctype html><html lang=\"en\"><head>${head}</head><body><div id=\"logs-preview\">${entries.join("\n")}</div></body></html>`;
         const blob = new Blob([html], { type: "text/html" });
         const url = URL.createObjectURL(blob);
         const a = document.createElement("a");

--- a/web-client/src/logBrowser.ts
+++ b/web-client/src/logBrowser.ts
@@ -48,44 +48,24 @@ function initLogBrowser(): boolean {
     });
   }
 
-  async function removeEmptyStores(database: IDBDatabase): Promise<IDBDatabase> {
-    const empty: string[] = [];
-    for (let i = 0; i < database.objectStoreNames.length; i++) {
-      const name = database.objectStoreNames.item(i);
+
+  async function refreshSessions() {
+    db?.close();
+    db = await openDb();
+    select.innerHTML = "";
+    const names: string[] = [];
+    for (let i = 0; i < db.objectStoreNames.length; i++) {
+      const name = db.objectStoreNames.item(i);
       if (!name) continue;
-      const tx = database.transaction(name, "readonly");
+      const tx = db.transaction(name, "readonly");
       const req = tx.objectStore(name).count();
       const count = await new Promise<number>((resolve) => {
         req.onsuccess = () => resolve(req.result);
         req.onerror = () => resolve(0);
       });
-      if (count === 0) empty.push(name);
-    }
-    if (empty.length === 0) return database;
-    database.close();
-    return new Promise((resolve, reject) => {
-      const upgrade = indexedDB.open("ArkadiaMessagesDB", database.version + 1);
-      upgrade.onupgradeneeded = () => {
-        for (const n of empty) {
-          if (upgrade.result.objectStoreNames.contains(n)) {
-            upgrade.result.deleteObjectStore(n);
-          }
-        }
-      };
-      upgrade.onsuccess = () => resolve(upgrade.result);
-      upgrade.onerror = () => reject(upgrade.error);
-    });
-  }
-
-  async function refreshSessions() {
-    db?.close();
-    db = await openDb();
-    db = await removeEmptyStores(db);
-    select.innerHTML = "";
-    const names: string[] = [];
-    for (let i = 0; i < db.objectStoreNames.length; i++) {
-      const name = db.objectStoreNames.item(i);
-      if (name) names.push(name);
+      if (count > 0) {
+        names.push(name);
+      }
     }
     names.sort();
     for (const name of names) {

--- a/web-client/src/logBrowser.ts
+++ b/web-client/src/logBrowser.ts
@@ -16,6 +16,23 @@ function initLogBrowser() {
 
   let db: IDBDatabase | null = null;
 
+  function formatTime(ts: number): string {
+    const d = new Date(ts);
+    const h = String(d.getHours()).padStart(2, "0");
+    const m = String(d.getMinutes()).padStart(2, "0");
+    const s = String(d.getSeconds()).padStart(2, "0");
+    const ms = String(d.getMilliseconds()).padStart(3, "0");
+    return `${h}:${m}:${s}.${ms}`;
+  }
+
+  function formatDateTime(ts: number): string {
+    const d = new Date(ts);
+    const y = d.getFullYear();
+    const mo = String(d.getMonth() + 1).padStart(2, "0");
+    const da = String(d.getDate()).padStart(2, "0");
+    return `${y}-${mo}-${da} ${formatTime(ts)}`;
+  }
+
   const modal = new Modal(modalEl);
 
   function openDb(): Promise<IDBDatabase> {
@@ -62,12 +79,7 @@ function initLogBrowser() {
       const logs = req.result as LogEntry[];
       for (const entry of logs) {
         const lines = entry.text.split(/\r?\n/);
-        const time = new Date(entry.timestamp).toLocaleTimeString([], {
-          hour: "2-digit",
-          minute: "2-digit",
-          second: "2-digit",
-          hour12: false,
-        });
+        const time = formatTime(entry.timestamp);
         for (const line of lines) {
           const wrapper = document.createElement("div");
           wrapper.classList.add("output_msg");
@@ -109,7 +121,7 @@ function initLogBrowser() {
       const logs = req.result as LogEntry[];
       const entries: string[] = [];
       for (const l of logs) {
-        const time = new Date(l.timestamp).toLocaleString([], { hour12: false });
+        const time = formatDateTime(l.timestamp);
         const parts = l.text.split(/\r?\n/);
         for (const part of parts) {
           const classes = ["output_msg"];

--- a/web-client/src/logBrowser.ts
+++ b/web-client/src/logBrowser.ts
@@ -6,13 +6,16 @@ interface LogEntry {
   timestamp: number;
 }
 
-function initLogBrowser() {
+let initialized = false;
+
+function initLogBrowser(): boolean {
+  if (initialized) return true;
   const button = document.getElementById("logs-button") as HTMLButtonElement | null;
   const modalEl = document.getElementById("logs-modal") as HTMLElement | null;
   const select = document.getElementById("logs-session-select") as HTMLSelectElement | null;
   const preview = document.getElementById("logs-preview") as HTMLElement | null;
   const download = document.getElementById("logs-download") as HTMLButtonElement | null;
-  if (!button || !modalEl || !select || !preview || !download) return;
+  if (!button || !modalEl || !select || !preview || !download) return false;
 
   let db: IDBDatabase | null = null;
 
@@ -193,10 +196,23 @@ function initLogBrowser() {
     await refreshSessions();
     modal.show();
   });
+
+  initialized = true;
+  return true;
+}
+
+function ensureLogBrowser() {
+  if (initLogBrowser()) return;
+  const observer = new MutationObserver(() => {
+    if (initLogBrowser()) {
+      observer.disconnect();
+    }
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
 }
 
 if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", initLogBrowser);
+  document.addEventListener("DOMContentLoaded", ensureLogBrowser);
 } else {
-  initLogBrowser();
+  ensureLogBrowser();
 }

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -76,6 +76,10 @@ h1 {
   background-color: var(--bs-body-bg);
 }
 
+.log-time {
+  margin-right: 0.25rem;
+}
+
 #split-bottom {
   position: sticky;
   bottom: 0px;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -76,8 +76,14 @@ h1 {
   background-color: var(--bs-body-bg);
 }
 
-.log-time {
-  margin-right: 0.25rem;
+#logs-preview .output_msg_text {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 0.25rem;
+}
+
+#logs-preview .log-time {
+  color: darkorange;
 }
 
 #split-bottom {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -79,11 +79,11 @@ h1 {
 #logs-preview .output_msg_text {
   display: grid;
   grid-template-columns: max-content 1fr;
-  column-gap: 0.25rem;
 }
 
 #logs-preview .log-time {
   color: darkorange;
+  padding-right: 0.5rem;
 }
 
 #split-bottom {


### PR DESCRIPTION
## Summary
- use 24-hour timestamps in log viewer and exports
- ensure exported log HTML scrolls independently and add spacing between timestamp and text

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6897881513ec832a836fa9ecee4724b1