### PR TITLE
Improve log export formatting

### DIFF
--- a/web-client/src/logBrowser.ts
+++ b/web-client/src/logBrowser.ts
@@ -42,7 +42,9 @@ function initLogBrowser() {
       const option = document.createElement("option");
       option.value = name;
       const ts = parseInt(name.replace("session_", ""), 10);
-      option.textContent = isNaN(ts) ? name : new Date(ts).toLocaleString();
+      option.textContent = isNaN(ts)
+        ? name
+        : new Date(ts).toLocaleString(undefined, { hour12: false });
       select.appendChild(option);
     }
     if (names.length > 0) {
@@ -62,7 +64,9 @@ function initLogBrowser() {
       const logs = req.result as LogEntry[];
       for (const entry of logs) {
         const lines = entry.text.split(/\r?\n/);
-        const time = new Date(entry.timestamp).toLocaleTimeString();
+        const time = new Date(entry.timestamp).toLocaleTimeString(undefined, {
+          hour12: false,
+        });
         for (const line of lines) {
           const wrapper = document.createElement("div");
           wrapper.classList.add("output_msg");
@@ -73,7 +77,8 @@ function initLogBrowser() {
           msg.classList.add("output_msg_text");
           msg.style.whiteSpace = "pre-wrap";
           const timeSpan = document.createElement("span");
-          timeSpan.textContent = `[${time}] `;
+          timeSpan.classList.add("log-time");
+          timeSpan.textContent = `[${time}]`;
           const contentSpan = document.createElement("span");
           contentSpan.innerHTML = line;
           msg.appendChild(timeSpan);
@@ -103,33 +108,22 @@ function initLogBrowser() {
       const logs = req.result as LogEntry[];
       const entries: string[] = [];
       for (const l of logs) {
-        const time = new Date(l.timestamp).toLocaleString();
+        const time = new Date(l.timestamp).toLocaleString(undefined, {
+          hour12: false,
+        });
         const parts = l.text.split(/\r?\n/);
         for (const part of parts) {
           const classes = ["output_msg"];
           if (l.type) {
             classes.push(l.type);
           }
-            const lineHtml = `<div class="${classes.join(" ")}"><div class="output_msg_text" style="white-space:pre-wrap"><span>[${time}] </span><span>${part}</span></div></div>`;
+          const lineHtml = `<div class="${classes.join(" ")}"><div class="output_msg_text" style="white-space:pre-wrap"><span class="log-time">[${time}]</span><span>${part}</span></div></div>`;
           entries.push(lineHtml);
         }
       }
-        const inlineStyles: string[] = [];
-        const linkTags: string[] = [];
-        for (const sheet of Array.from(document.styleSheets)) {
-          try {
-            const rules = Array.from(sheet.cssRules);
-            inlineStyles.push(rules.map(r => r.cssText).join("\n"));
-          } catch {
-            const href = (sheet as CSSStyleSheet).href;
-            if (href) {
-              linkTags.push(`<link rel="stylesheet" href="${href}">`);
-            }
-          }
-        }
-
-        const head = `<meta charset="UTF-8">\n${linkTags.join("\n")}\n<style>${inlineStyles.join("\n")}</style>`;
-        const html = `<!doctype html><html lang="en"><head>${head}</head><body><div id="main_text_output_msg_wrapper">${entries.join("\n")}</div></body></html>`;
+      const head =
+        '<meta charset="UTF-8"><style>html{overflow:auto;}body{font-family:monospace;font-size:0.775rem;} .log-time{margin-right:0.4em;}</style>';
+      const html = `<!doctype html><html lang="en"><head>${head}</head><body><div id="main_text_output_msg_wrapper">${entries.join("\n")}</div></body></html>`;
         const blob = new Blob([html], { type: "text/html" });
         const url = URL.createObjectURL(blob);
         const a = document.createElement("a");

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -791,6 +791,10 @@ button:focus-visible {
     padding: 0;
 }
 
+.log-time {
+  margin-right: 0.4em;
+}
+
 .logo {
   width: auto;
   height: auto;


### PR DESCRIPTION
## Summary
- show log timestamps in 24-hour format and add spacing
- simplify exported log HTML and enable overflow scrolling

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68979564aa14832a943460d6a5900c99