### PR TITLE
chore: strip click markers from session logs

### DIFF
--- a/web-client/src/sessionLogger.ts
+++ b/web-client/src/sessionLogger.ts
@@ -1,5 +1,6 @@
 const sessionId = Date.now();
 const storeName = `session_${sessionId}`;
+const CLICK_TAG_REG = /\{clickOpen:\d+(?::[^}]+)?\}|\{clickClose\}/g;
 
 const dbPromise: Promise<IDBDatabase> = new Promise((resolve, reject) => {
   // First open the database to determine the current version
@@ -46,7 +47,7 @@ export default function initSessionLogger(client: any) {
       if (text === "\n") {
         text = "";
       }
-      save(text, type);
+      save(text.replace(CLICK_TAG_REG, ''), type);
     }
   });
 }


### PR DESCRIPTION
## Summary
- drop click markers from messages before saving log entries

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6897aa259b7c832a83799630ca145c74