### PR TITLE
feat: allow disabling session logging

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -380,6 +380,10 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body d-flex flex-column gap-2">
+                    <div class="form-check form-switch">
+                        <input id="logs-enabled" class="form-check-input" type="checkbox">
+                        <label class="form-check-label" for="logs-enabled">Zapisuj logi</label>
+                    </div>
                     <div class="d-flex gap-2">
                         <select id="logs-session-select" class="form-select"></select>
                         <button id="logs-download" class="btn btn-secondary">Pobierz</button>

--- a/web-client/src/logBrowser.ts
+++ b/web-client/src/logBrowser.ts
@@ -1,4 +1,5 @@
 import Modal from "bootstrap/js/dist/modal";
+import storage from "@client/src/storage";
 
 interface LogEntry {
   text: string;
@@ -15,7 +16,16 @@ function initLogBrowser(): boolean {
   const select = document.getElementById("logs-session-select") as HTMLSelectElement | null;
   const preview = document.getElementById("logs-preview") as HTMLElement | null;
   const download = document.getElementById("logs-download") as HTMLButtonElement | null;
-  if (!button || !modalEl || !select || !preview || !download) return false;
+  const enabled = document.getElementById("logs-enabled") as HTMLInputElement | null;
+  if (!button || !modalEl || !select || !preview || !download || !enabled) return false;
+
+  storage.getItem("loggingEnabled").then(res => {
+    enabled.checked = res?.loggingEnabled !== false;
+  });
+
+  enabled.addEventListener("change", () => {
+    storage.setItem("loggingEnabled", enabled.checked);
+  });
 
   let db: IDBDatabase | null = null;
 

--- a/web-client/src/sessionLogger.ts
+++ b/web-client/src/sessionLogger.ts
@@ -1,6 +1,20 @@
+import storage, { getItemSync } from "@client/src/storage";
+
 const sessionId = Date.now();
 const storeName = `session_${sessionId}`;
 const CLICK_TAG_REG = /\{clickOpen:\d+(?::[^}]+)?\}|\{clickClose\}/g;
+
+let loggingEnabled = true;
+const saved = getItemSync("loggingEnabled");
+if (saved && typeof saved.loggingEnabled === "boolean") {
+  loggingEnabled = saved.loggingEnabled;
+}
+
+storage.onChanged?.addListener(changes => {
+  if (changes.loggingEnabled) {
+    loggingEnabled = !!changes.loggingEnabled.newValue;
+  }
+});
 
 const dbPromise: Promise<IDBDatabase> = new Promise((resolve, reject) => {
   // First open the database to determine the current version
@@ -43,6 +57,7 @@ function save(text: string, type?: string) {
 
 export default function initSessionLogger(client: any) {
   client.on('message', (text?: string, type?: string) => {
+    if (!loggingEnabled) return;
     if (text) {
       if (text === "\n") {
         text = "";


### PR DESCRIPTION
## Summary
- add toggle in logs modal to enable or disable logging
- persist logging preference and respect it when capturing messages

## Testing
- `corepack yarn --cwd client test`
- `corepack yarn --cwd web-client test`
- `corepack yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6897ad6e20d0832aac62b0ad95bbe96c