### PR TITLE
refactor: modularize web client internals

### DIFF
--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -3,406 +3,85 @@ import {RecordedEvent} from './recordingStorage';
 import Recorder from './Recorder';
 import {ClientAdapter} from "@client/src/Client.ts";
 import eventBus, {ClientEvents} from "@client/src/eventBus.ts";
-import TelnetOptionNegotiation from "./TelnetOptionNegotiation.ts";
-
+import ProtocolHandler from './ProtocolHandler';
+import ConnectionManager from './ConnectionManager';
 
 type Params<T> = T extends void ? [] : T extends any[] ? T : [T];
 type EventListener<K extends keyof ClientEvents> = (...args: Params<ClientEvents[K]>) => void;
 
-// WebSocket configuration
-const WEBSOCKET_URL = 'wss://arkadia.rpg.pl/wss';
-const GMCP_COMMAND_CODE = 201;
-const MCCP_COMMAND_CODE = 86;
-const TELNET_OPTION_REGEX = /\u00FF\u00FA.*?\u00FF\u00F0|\u00FF.[^\u00FF]/g;
-
-
 class ArkadiaClient implements ClientAdapter {
-    private socket!: WebSocket;
-    private telnetNegotiator = new TelnetOptionNegotiation(this)
-    private mccp = false;
-    // @ts-ignore
-    private readInflator = new pako.Inflate()
-    private receivedFirstGmcp: boolean = false;
-    private userCommand: string | null = null;
-    private passwordCommand: string | null = null;
-    private lastConnectManual = true;
-    private pingTimer: number | null = null;
-    private messageBuffer: { text: string, type: string }[] = []
-    private recorder = new Recorder({
-        processIncomingData: (d) => this.processIncomingData(d),
-        sendCommand: (cmd) => this.sendCommand(cmd),
-        emit: (ev, ...args) => this.emit(ev, ...args)
-    });
+    private connection: ConnectionManager;
+    private protocol: ProtocolHandler;
+    private recorder: Recorder;
 
+    constructor(recorder: Recorder) {
+        this.recorder = recorder;
+        this.protocol = new ProtocolHandler(
+            () => {},
+            (ev, ...args) => this.emit(ev as any, ...args),
+            () => this.connection.enableMccp()
+        );
+        this.connection = new ConnectionManager(this.protocol, this.recorder, (ev, ...args) => this.emit(ev as any, ...args));
+        this.protocol.setSendRaw(this.connection.sendRaw.bind(this.connection));
+    }
 
-    /**
-     * Register an event listener
-     */
     on<K extends keyof ClientEvents>(event: K, listener: EventListener<K>): void {
         eventBus.on(event, listener);
     }
 
-    /**
-     * Remove an event listener
-     */
     off<K extends keyof ClientEvents>(event: K, listener: EventListener<K>): void {
         eventBus.off(event, listener);
     }
 
-    /**
-     * Emit an event to all registered listeners
-     */
     emit<K extends keyof ClientEvents>(event: K, ...args: Params<ClientEvents[K]>): void {
         eventBus.emit(event, ...args);
     }
 
-    /**
-     * Connect to the WebSocket server
-     */
-    connect(manual: boolean = true): void {
-        try {
-            // Reset the flag when connecting
-            this.receivedFirstGmcp = false;
-            this.lastConnectManual = manual;
-            this.socket = new WebSocket(WEBSOCKET_URL, []);
-            this.socket.onmessage = (event: MessageEvent<string>) => {
-                try {
-                    const decodedData = this.inflate(atob(event.data));
-                    this.recorder.handleIncoming(decodedData);
-                    this.processIncomingData(decodedData);
-                } catch (error) {
-                    console.error('Error processing incoming message:', error);
-                }
-            };
+    connect(manual: boolean = true): void { this.connection.connect(manual); }
+    disconnect(): void { this.connection.disconnect(); }
+    isSocketOpen(): boolean { return this.connection.isSocketOpen(); }
+    hasReceivedFirstGmcp(): boolean { return this.protocol.hasReceivedFirstGmcp(); }
+    setStoredPassword(password: string | null): void { this.connection.setStoredPassword(password); }
+    setStoredCharacter(character: string | null): void { this.connection.setStoredCharacter(character); }
+    sendRaw(message: string): void { this.connection.sendRaw(message); }
+    send(message: string, echo: boolean = true): void { this.connection.send(message, echo); }
+    sendCommand(command: string, echo: boolean = true): void { this.send(command, echo); }
+    sendGmcp(path: string, payload: any = {}): void { this.connection.sendGmcp(path, payload); }
 
-            this.socket.onerror = (error: Event) => {
-                this.emit('error', error);
-            };
+    output(text?: string, type?: string) { this.emit('message', text, type); }
+    parseAnsiPatterns(text: string) { return parseAnsiPatterns(text); }
+    flushMessageBuffer() { this.protocol.flushMessageBuffer(); }
+    processIncomingData(data: string) { this.protocol.processIncomingData(data); }
 
-            this.socket.onclose = (event: CloseEvent) => {
-                this.emit('close', event);
-                this.emit('client.disconnect');
-                this.stopPing();
-
-                // @ts-ignore
-                this.readInflator = new pako.Inflate()
-            };
-
-            this.socket.onopen = (event: Event) => {
-                this.emit('open', event);
-                this.emit('client.connect');
-                this.mccp = false;
-                this.startPing();
-                if (!this.lastConnectManual && this.userCommand && this.passwordCommand) {
-                    this.send(this.userCommand, false);
-                    if (this.passwordCommand !== this.userCommand) {
-                        this.send(this.passwordCommand, false);
-                    }
-                }
-            };
-        } catch (error) {
-            this.emit('error', error);
-        }
-    }
-
-    private inflate(decodedData: string) {
-        if (this.mccp) {
-            try {
-                const byteArray = decodedData.split("").map(function (char) {
-                    return char.charCodeAt(0);
-                });
-                this.readInflator.push(byteArray, 2);
-                if (this.readInflator.err) {
-                    console.error("MCCP decompression error: " + this.readInflator.msg);
-                    return decodedData;
-                }
-                const decompressed = new Uint16Array(this.readInflator.result);
-                const length = decompressed.length;
-                decodedData = "";
-                for (let i = 0; i < length; i++) {
-                    decodedData += String.fromCharCode(decompressed[i]);
-                }
-            } catch (error) {
-                console.log("MCCP decompression error: " + error.message);
-            }
-        }
-        return decodedData;
-    }
-
-    /**
-     * Disconnect from the WebSocket server
-     */
-    disconnect(): void {
-        if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-            this.socket.close();
-        }
-        this.mccp = false;
-        this.stopPing();
-    }
-
-    /**
-     * Check if the WebSocket is currently open
-     */
-    isSocketOpen(): boolean {
-        return !!this.socket && this.socket.readyState === WebSocket.OPEN;
-    }
-
-    /**
-     * Check if the first GMCP event has been received
-     */
-    hasReceivedFirstGmcp(): boolean {
-        return this.receivedFirstGmcp;
-    }
-
-    /**
-     * Manually set the stored password for automatic credential sending
-     */
-    setStoredPassword(password: string | null): void {
-        this.passwordCommand = password;
-    }
-
-    /**
-     * Manually set the stored character for automatic credential sending
-     */
-    setStoredCharacter(character: string | null): void {
-        this.userCommand = character;
-    }
-
-    sendRaw(message: string): void {
-        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
-            console.error('WebSocket is not connected');
-            return;
-        }
-        try {
-            this.socket.send(message);
-        } catch (error) {
-            console.error('Error sending message:', error);
-            this.emit('error', error);
-        }
-    }
-
-    /**
-     * Send a message through the WebSocket
-     */
-    send(message: string, echo: boolean = true): void {
-        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
-            console.error('WebSocket is not connected');
-            return;
-        }
-
-        if (!this.receivedFirstGmcp) {
-            if (!this.userCommand) {
-                this.userCommand = message;
-            }
-            this.passwordCommand = message;
-        }
-
-        try {
-            this.recorder.handleOutgoing(message);
-            this.socket.send(btoa(message + "\r\n"));
-            // Only echo commands if requested and we've received the first GMCP event
-            if (echo && this.receivedFirstGmcp && message) {
-                this.output("→ " + message, 'command');
-            }
-        } catch (error) {
-            console.error('Error sending message:', error);
-            this.emit('error', error);
-        }
-    }
-
-    sendGmcp(path: string, payload: any = {}): void {
-        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
-            return;
-        }
-        try {
-            const data = typeof payload === 'string' ? payload : JSON.stringify(payload);
-            const gmcpMessage = `\xFF\xFA${String.fromCharCode(GMCP_COMMAND_CODE)}${path} ${data}\xFF\xF0`;
-            this.socket.send(btoa(gmcpMessage));
-        } catch (error) {
-            console.error('Error sending GMCP message:', error);
-            this.emit('error', error);
-        }
-    }
-
-    private startPing() {
-        this.stopPing();
-        this.sendGmcp('core.ping');
-        this.pingTimer = window.setInterval(() => this.sendGmcp('core.ping'), 30000);
-    }
-
-    private stopPing() {
-        if (this.pingTimer !== null) {
-            clearInterval(this.pingTimer);
-            this.pingTimer = null;
-        }
-    }
-
-    /**
-     * Compatibility wrapper matching old client API
-     */
-    sendCommand(command: string, echo: boolean = true): void {
-        this.send(command, echo);
-    }
-
-    output(text?: string, type?: string) {
-        this.emit('message', text, type)
-    }
-
-    //Should be done on all ouput
-    parseAnsiPatterns(text: string) {
-        return parseAnsiPatterns(text)
-    }
-
-    /**
-     * Process incoming WebSocket data by removing telnet options
-     */
-    private processIncomingData(data: string) {
-        const leftOver = data.replace(TELNET_OPTION_REGEX, this.parseTelnetOption.bind(this)).trim();
-        const sanitized = leftOver.replace(/[ÿù]/g, "");
-        if (sanitized.length > 0) {
-            this.emit('message', sanitized)
-        }
-        this.flushMessageBuffer()
-    }
-
-    /**
-     * Parse telnet option from incoming data
-     */
-    private parseTelnetOption(optionData: string): string {
-        if (optionData.length === 3) {
-            //this.telnetNegotiator.parseOptionNegotiation(optionData)
-        } else {
-            this.parseTelnetSubnegotiation(optionData.substring(2, optionData.length - 2));
-        }
-        return "";
-    }
-
-    /**
-     * Parse telnet subnegotiation, specifically GMCP (Generic MUD Communication Protocol)
-     */
-    private parseTelnetSubnegotiation(data: string): void {
-        if (data.length === 0) return;
-
-        const firstChar = data.charCodeAt(0);
-        if (firstChar === MCCP_COMMAND_CODE) {
-            this.mccp = true;
-            console.log("MCCP enabled")
-        }
-
-        if (firstChar === GMCP_COMMAND_CODE) {
-            const gmcpData = data.substring(1);
-            if (!gmcpData.length) return;
-
-            const spaceIndex = gmcpData.indexOf(" ");
-            if (spaceIndex === -1) return;
-
-            const type = gmcpData.substring(0, spaceIndex).toLowerCase();
-            let payload = gmcpData.substring(spaceIndex + 1);
-
-            // Handle special case for gmcp_msgs
-            if (type === "gmcp_msgs") {
-                payload = payload.replace(//g, "\\u001B");
-            }
-
-            try {
-                const gmcp = JSON.parse(payload);
-                this.receivedFirstGmcp = this.receivedFirstGmcp || type === "char.info";
-                if (type === "gmcp_msgs") {
-                    let text = atob(gmcp.text)
-                    this.messageBuffer.push({text, type: gmcp.type})
-                } else {
-                    this.emit(`gmcp.${type}`, gmcp);
-                    this.emit('gmcp', {path: type, value: gmcp});
-                }
-            } catch (error) {
-                console.error('Error parsing GMCP JSON:', error);
-            }
-        }
-    }
-
-    flushMessageBuffer() {
-        let processed = [];
-        this.messageBuffer.forEach((message, i) => {
-            if (processed[processed.length - 1]?.type === message.type) {
-                processed[processed.length - 1].text += message.text
-            } else {
-                processed.push(message)
-            }
-        })
-        processed.forEach((message, i) => {
-            this.sendLine(message.text, message.type, i)
-        })
-        this.emit('output-sent', processed.length)
-        this.messageBuffer = []
-    }
-
-    private sendLine(text: string, type: string, i: number) {
-        text = window.clientExtension.onLine(text, type)
-        eventBus.on('output-sent', () => this.emit(`gmcp_msg.${type}`, text), {once: true})
-        Output.send(parseAnsiPatterns(text), type);
-        this.emit('line-sent')
-    }
-
-    startRecording(name: string) {
-        this.recorder.startRecording(name);
-    }
-
-    async stopRecording(save?: boolean) {
-        await this.recorder.stopRecording(save);
-    }
-
-    async loadRecording(name: string) {
-        await this.recorder.loadRecording(name);
-    }
-
-    listRecordings() {
-        return this.recorder.listRecordings();
-    }
-
-    deleteRecording(name: string) {
-        return this.recorder.deleteRecording(name);
-    }
-
-    stopPlayback() {
-        this.recorder.stopPlayback();
-    }
-
-    pausePlayback() {
-        this.recorder.pausePlayback();
-    }
-
-    resumePlayback() {
-        this.recorder.resumePlayback();
-    }
-
-    stepForward() {
-        this.recorder.stepForward();
-    }
-
-    stepBack() {
-        this.recorder.stepBack();
-    }
-
-    replayLast() {
-        this.recorder.replayLast();
-    }
-
-    getRecordedMessages() {
-        return this.recorder.getRecordedMessages();
-    }
-
-    setRecordedMessages(events: RecordedEvent[]) {
-        this.recorder.setRecordedMessages(events);
-    }
-
-    replayRecordedMessages() {
-        this.recorder.replayRecordedMessages();
-    }
-
-    replayRecordedMessagesTimed() {
-        this.recorder.replayRecordedMessagesTimed();
-    }
-
+    startRecording(name: string) { this.recorder.startRecording(name); }
+    async stopRecording(save?: boolean) { await this.recorder.stopRecording(save); }
+    async loadRecording(name: string) { await this.recorder.loadRecording(name); }
+    listRecordings() { return this.recorder.listRecordings(); }
+    deleteRecording(name: string) { return this.recorder.deleteRecording(name); }
+    stopPlayback() { this.recorder.stopPlayback(); }
+    pausePlayback() { this.recorder.pausePlayback(); }
+    resumePlayback() { this.recorder.resumePlayback(); }
+    stepForward() { this.recorder.stepForward(); }
+    stepBack() { this.recorder.stepBack(); }
+    replayLast() { this.recorder.replayLast(); }
+    getRecordedMessages() { return this.recorder.getRecordedMessages(); }
+    setRecordedMessages(events: RecordedEvent[]) { this.recorder.setRecordedMessages(events); }
+    replayRecordedMessages() { this.recorder.replayRecordedMessages(); }
+    replayRecordedMessagesTimed() { this.recorder.replayRecordedMessagesTimed(); }
 }
 
-export default new ArkadiaClient();
+const recorder = new Recorder({
+    processIncomingData: () => {},
+    sendCommand: () => {},
+    emit: () => {}
+});
+
+const client = new ArkadiaClient(recorder);
+
+recorder.setHooks({
+    processIncomingData: (d) => client.processIncomingData(d),
+    sendCommand: (cmd, echo) => client.sendCommand(cmd, echo),
+    emit: (ev, ...args) => client.emit(ev as any, ...args)
+});
+
+export default client;

--- a/web-client/src/ConnectionManager.ts
+++ b/web-client/src/ConnectionManager.ts
@@ -1,0 +1,173 @@
+import ProtocolHandler from './ProtocolHandler';
+import Recorder from './Recorder';
+
+const WEBSOCKET_URL = 'wss://arkadia.rpg.pl/wss';
+const GMCP_COMMAND_CODE = 201;
+
+export default class ConnectionManager {
+    private socket!: WebSocket;
+    private mccp = false;
+    // @ts-ignore
+    private readInflator = new pako.Inflate();
+    private userCommand: string | null = null;
+    private passwordCommand: string | null = null;
+    private lastConnectManual = true;
+    private pingTimer: number | null = null;
+
+    constructor(
+        private protocol: ProtocolHandler,
+        private recorder: Recorder,
+        private emit: (event: string, ...args: any[]) => void,
+    ) {}
+
+    connect(manual = true) {
+        try {
+            this.lastConnectManual = manual;
+            this.socket = new WebSocket(WEBSOCKET_URL, []);
+            this.socket.onmessage = (event: MessageEvent<string>) => {
+                try {
+                    const decodedData = this.inflate(atob(event.data));
+                    this.recorder.handleIncoming(decodedData);
+                    this.protocol.processIncomingData(decodedData);
+                } catch (error) {
+                    console.error('Error processing incoming message:', error);
+                }
+            };
+            this.socket.onerror = (error: Event) => {
+                this.emit('error', error);
+            };
+            this.socket.onclose = (event: CloseEvent) => {
+                this.emit('close', event);
+                this.emit('client.disconnect');
+                this.stopPing();
+                // @ts-ignore
+                this.readInflator = new pako.Inflate();
+            };
+            this.socket.onopen = (event: Event) => {
+                this.emit('open', event);
+                this.emit('client.connect');
+                this.mccp = false;
+                this.startPing();
+                if (!this.lastConnectManual && this.userCommand && this.passwordCommand) {
+                    this.send(this.userCommand, false);
+                    if (this.passwordCommand !== this.userCommand) {
+                        this.send(this.passwordCommand, false);
+                    }
+                }
+            };
+        } catch (error) {
+            this.emit('error', error);
+        }
+    }
+
+    disconnect() {
+        if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+            this.socket.close();
+        }
+        this.mccp = false;
+        this.stopPing();
+    }
+
+    isSocketOpen(): boolean {
+        return !!this.socket && this.socket.readyState === WebSocket.OPEN;
+    }
+
+    setStoredPassword(password: string | null) {
+        this.passwordCommand = password;
+    }
+
+    setStoredCharacter(character: string | null) {
+        this.userCommand = character;
+    }
+
+    sendRaw(message: string) {
+        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+            console.error('WebSocket is not connected');
+            return;
+        }
+        try {
+            this.socket.send(message);
+        } catch (error) {
+            console.error('Error sending message:', error);
+            this.emit('error', error);
+        }
+    }
+
+    send(message: string, echo: boolean = true) {
+        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+            console.error('WebSocket is not connected');
+            return;
+        }
+        if (!this.protocol.hasReceivedFirstGmcp()) {
+            if (!this.userCommand) {
+                this.userCommand = message;
+            }
+            this.passwordCommand = message;
+        }
+        try {
+            this.recorder.handleOutgoing(message);
+            this.socket.send(btoa(message + "\r\n"));
+            if (echo && this.protocol.hasReceivedFirstGmcp() && message) {
+                this.emit('message', "→ " + message, 'command');
+            }
+        } catch (error) {
+            console.error('Error sending message:', error);
+            this.emit('error', error);
+        }
+    }
+
+    sendGmcp(path: string, payload: any = {}) {
+        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+            return;
+        }
+        try {
+            const data = typeof payload === 'string' ? payload : JSON.stringify(payload);
+            const gmcpMessage = `\xFF\xFA${String.fromCharCode(GMCP_COMMAND_CODE)}${path} ${data}\xFF\xF0`;
+            this.socket.send(btoa(gmcpMessage));
+        } catch (error) {
+            console.error('Error sending GMCP message:', error);
+            this.emit('error', error);
+        }
+    }
+
+    private startPing() {
+        this.stopPing();
+        this.sendGmcp('core.ping');
+        this.pingTimer = window.setInterval(() => this.sendGmcp('core.ping'), 30000);
+    }
+
+    private stopPing() {
+        if (this.pingTimer !== null) {
+            clearInterval(this.pingTimer);
+            this.pingTimer = null;
+        }
+    }
+
+    enableMccp() {
+        this.mccp = true;
+    }
+
+    private inflate(decodedData: string) {
+        if (this.mccp) {
+            try {
+                const byteArray = decodedData.split("").map(function (char) {
+                    return char.charCodeAt(0);
+                });
+                this.readInflator.push(byteArray, 2);
+                if (this.readInflator.err) {
+                    console.error("MCCP decompression error: " + this.readInflator.msg);
+                    return decodedData;
+                }
+                const decompressed = new Uint16Array(this.readInflator.result);
+                const length = decompressed.length;
+                decodedData = "";
+                for (let i = 0; i < length; i++) {
+                    decodedData += String.fromCharCode(decompressed[i]);
+                }
+            } catch (error) {
+                console.log("MCCP decompression error: " + error.message);
+            }
+        }
+        return decodedData;
+    }
+}

--- a/web-client/src/ProtocolHandler.ts
+++ b/web-client/src/ProtocolHandler.ts
@@ -1,0 +1,104 @@
+import {parseAnsiPatterns} from './ansiParser';
+import TelnetOptionNegotiation from './TelnetOptionNegotiation.ts';
+import eventBus from "@client/src/eventBus.ts";
+
+const GMCP_COMMAND_CODE = 201;
+const MCCP_COMMAND_CODE = 86;
+const TELNET_OPTION_REGEX = /\u00FF\u00FA.*?\u00FF\u00F0|\u00FF.[^\u00FF]/g;
+
+export default class ProtocolHandler {
+    private telnetNegotiator: TelnetOptionNegotiation;
+    private messageBuffer: { text: string, type: string }[] = [];
+    private receivedFirstGmcp = false;
+
+    constructor(
+        sendRaw: (data: string) => void,
+        private emit: (event: string, ...args: any[]) => void,
+        private enableMccp: () => void,
+    ) {
+        this.telnetNegotiator = new TelnetOptionNegotiation(sendRaw);
+    }
+
+    setSendRaw(sendRaw: (data: string) => void) {
+        this.telnetNegotiator = new TelnetOptionNegotiation(sendRaw);
+    }
+
+    hasReceivedFirstGmcp() {
+        return this.receivedFirstGmcp;
+    }
+
+    processIncomingData(data: string) {
+        const leftOver = data.replace(TELNET_OPTION_REGEX, this.parseTelnetOption.bind(this)).trim();
+        const sanitized = leftOver.replace(/[ÿù]/g, "");
+        if (sanitized.length > 0) {
+            this.emit('message', sanitized);
+        }
+        this.flushMessageBuffer();
+    }
+
+    private parseTelnetOption(optionData: string): string {
+        if (optionData.length === 3) {
+            //this.telnetNegotiator.parseOptionNegotiation(optionData);
+        } else {
+            this.parseTelnetSubnegotiation(optionData.substring(2, optionData.length - 2));
+        }
+        return "";
+    }
+
+    private parseTelnetSubnegotiation(data: string) {
+        if (data.length === 0) return;
+        const firstChar = data.charCodeAt(0);
+        if (firstChar === MCCP_COMMAND_CODE) {
+            this.enableMccp();
+            console.log("MCCP enabled");
+        }
+        if (firstChar === GMCP_COMMAND_CODE) {
+            const gmcpData = data.substring(1);
+            if (!gmcpData.length) return;
+            const spaceIndex = gmcpData.indexOf(" ");
+            if (spaceIndex === -1) return;
+            const type = gmcpData.substring(0, spaceIndex).toLowerCase();
+            let payload = gmcpData.substring(spaceIndex + 1);
+            if (type === "gmcp_msgs") {
+                payload = payload.replace(/g/g, "\\u001B");
+            }
+            try {
+                const gmcp = JSON.parse(payload);
+                this.receivedFirstGmcp = this.receivedFirstGmcp || type === "char.info";
+                if (type === "gmcp_msgs") {
+                    let text = atob(gmcp.text);
+                    this.messageBuffer.push({ text, type: gmcp.type });
+                } else {
+                    this.emit(`gmcp.${type}`, gmcp);
+                    this.emit('gmcp', { path: type, value: gmcp });
+                }
+            } catch (error) {
+                console.error('Error parsing GMCP JSON:', error);
+            }
+        }
+    }
+
+    flushMessageBuffer() {
+        let processed: { text: string, type?: string }[] = [];
+        this.messageBuffer.forEach((message) => {
+            if (processed[processed.length - 1]?.type === message.type) {
+                processed[processed.length - 1].text += message.text;
+            } else {
+                processed.push(message);
+            }
+        });
+        processed.forEach((message, i) => {
+            this.sendLine(message.text, message.type!, i);
+        });
+        this.emit('output-sent', processed.length);
+        this.messageBuffer = [];
+    }
+
+    private sendLine(text: string, type: string, i: number) {
+        text = window.clientExtension.onLine(text, type);
+        eventBus.on('output-sent', () => this.emit(`gmcp_msg.${type}`, text), { once: true });
+        // @ts-ignore
+        Output.send(parseAnsiPatterns(text), type);
+        this.emit('line-sent');
+    }
+}

--- a/web-client/src/Recorder.ts
+++ b/web-client/src/Recorder.ts
@@ -17,8 +17,15 @@ export default class Recorder {
     private pausedDelay = 0;
     private isPlaying = false;
     private paused = false;
+    private hooks: RecorderHooks;
 
-    constructor(private hooks: RecorderHooks) {}
+    constructor(hooks: RecorderHooks) {
+        this.hooks = hooks;
+    }
+
+    setHooks(hooks: RecorderHooks) {
+        this.hooks = hooks;
+    }
 
     handleIncoming(message: string) {
         if (this.isRecording) {

--- a/web-client/src/TelnetOptionNegotiation.ts
+++ b/web-client/src/TelnetOptionNegotiation.ts
@@ -1,8 +1,4 @@
-import ArkadiaClient from "./ArkadiaClient.ts";
-
 export default class TelnetOptionNegotiation {
-
-    client: typeof ArkadiaClient;
 
     IAC = String.fromCharCode(255);
     WILL = String.fromCharCode(251);
@@ -18,12 +14,10 @@ export default class TelnetOptionNegotiation {
         opt_mccp: false
     }
 
-    constructor(client: typeof ArkadiaClient) {
-        this.client = client;
-    }
+    constructor(private sendRaw: (data: string) => void) {}
 
     send(data: string) {
-        this.client.sendRaw(btoa(data));
+        this.sendRaw(btoa(data));
     }
 
     handleWillOption(option) {


### PR DESCRIPTION
## Summary
- extract ConnectionManager to manage WebSocket and ping lifecycle
- add ProtocolHandler for telnet negotiation and GMCP parsing
- inject Recorder and wire modules through a leaner ArkadiaClient facade

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6897b8441088832ab88cf700c752a8d3