### PR TITLE
refactor: centralize direction helpers

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -1,48 +1,13 @@
 import {MapReader} from "mudlet-map-renderer";
 import Client from "./Client";
 import { getItemSync, setItemSync } from "./storage";
+import { getLongDir, getShortDir, longToShort } from "./utils/directions";
 import Room = MapData.Room;
 
 const STORAGE_KEY = 'mapperRoomId';
 
-export const polishToEnglish = {
-    ["polnoc"]: "north",
-    ["poludnie"]: "south",
-    ["wschod"]: "east",
-    ["zachod"]: "west",
-    ["polnocny-wschod"]: "northeast",
-    ["polnocny-zachod"]: "northwest",
-    ["poludniowy-wschod"]: "southeast",
-    ["poludniowy-zachod"]: "southwest",
-    ["dol"]: "down",
-    ["gora"]: "up",
-    ["gore"]: "up"
-};
-export const longToShort = {
-    north: "n",
-    south: "s",
-    east: "e",
-    west: "w",
-    northeast: "ne",
-    northwest: "nw",
-    southeast: "se",
-    southwest: "sw",
-    up: "u",
-    down: "d"
-};
+export { longToShort };
 
-const exits = {
-    "e": "east",
-    "w": "west",
-    "n": "north",
-    "s": "south",
-    "sw": "southwest",
-    "se": "southeast",
-    "nw": "northwest",
-    "ne": "northeast",
-    "u": "up",
-    "d": "down"
-};
 
 const directionDeltas = {
     north: {x: 0, y: 1, z: 0},
@@ -56,14 +21,6 @@ const directionDeltas = {
     up: {x: 0, y: 0, z: 1},
     down: {x: 0, y: 0, z: -1}
 };
-
-function getLongDir(dir: string): string {
-    return polishToEnglish[dir] ?? exits[dir] ?? dir;
-}
-
-function getShortDir(dir: string): string {
-    return longToShort[dir] ?? dir;
-}
 
 export default class MapHelper {
 

--- a/client/src/scripts/shortExits.ts
+++ b/client/src/scripts/shortExits.ts
@@ -1,39 +1,10 @@
 import Client from "../Client";
 import { colorString, findClosestColor } from "../Colors";
+import { getShortDir } from "../utils/directions";
 
 const ORANGE = findClosestColor('#ffa500');
 
-const polishToEnglish: Record<string, string> = {
-    polnoc: "north",
-    poludnie: "south",
-    wschod: "east",
-    zachod: "west",
-    "polnocny-wschod": "northeast",
-    "polnocny-zachod": "northwest",
-    "poludniowy-wschod": "southeast",
-    "poludniowy-zachod": "southwest",
-    dol: "down",
-    gora: "up",
-    gore: "up",
-};
-
-const longToShort: Record<string, string> = {
-    north: "n",
-    south: "s",
-    east: "e",
-    west: "w",
-    northeast: "ne",
-    northwest: "nw",
-    southeast: "se",
-    southwest: "sw",
-    up: "u",
-    down: "d",
-};
-
-export function toShort(dir: string): string {
-    const long = polishToEnglish[dir] ?? dir.toLowerCase();
-    return longToShort[long] ?? dir;
-}
+export { getShortDir as toShort };
 
 export function parseExitString(str: string): string[] {
     return str
@@ -84,7 +55,7 @@ export default function initShortExits(client: Client) {
 
     const callback = (_r: string, _l: string, m: RegExpMatchArray) => {
         if (!enabled) return undefined;
-        const dirs = parseExitString(m[1]).map(toShort);
+        const dirs = parseExitString(m[1]).map(getShortDir);
         if (dirs.length === 0) return undefined;
         const str = "-----:" + dirs.map(d => " " + d.toUpperCase()).join("");
         return colorString(str, ORANGE);

--- a/client/src/utils/directions.ts
+++ b/client/src/utils/directions.ts
@@ -1,0 +1,50 @@
+export const polishToEnglish: Record<string, string> = {
+    "polnoc": "north",
+    "poludnie": "south",
+    "wschod": "east",
+    "zachod": "west",
+    "polnocny-wschod": "northeast",
+    "polnocny-zachod": "northwest",
+    "poludniowy-wschod": "southeast",
+    "poludniowy-zachod": "southwest",
+    "dol": "down",
+    "gora": "up",
+    "gore": "up",
+};
+
+export const longToShort: Record<string, string> = {
+    north: "n",
+    south: "s",
+    east: "e",
+    west: "w",
+    northeast: "ne",
+    northwest: "nw",
+    southeast: "se",
+    southwest: "sw",
+    up: "u",
+    down: "d",
+};
+
+const shortToLong: Record<string, string> = {
+    n: "north",
+    s: "south",
+    e: "east",
+    w: "west",
+    ne: "northeast",
+    nw: "northwest",
+    se: "southeast",
+    sw: "southwest",
+    u: "up",
+    d: "down",
+};
+
+export function getLongDir(dir: string): string {
+    const lower = dir.toLowerCase();
+    return polishToEnglish[lower] ?? shortToLong[lower] ?? lower;
+}
+
+export function getShortDir(dir: string): string {
+    const long = getLongDir(dir);
+    return longToShort[long] ?? dir;
+}
+

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -2,6 +2,7 @@ import Client from "@client/src/Client";
 import { formatLabel } from "@client/src/scripts/functionalBind";
 import { loadSettings as loadMobileButtonSettings, ButtonSetting, Settings } from "../mobileButtonSettings";
 import { getItemSync, setItemSync } from "@client/src/storage";
+import { getShortDir } from "@client/src/utils/directions.ts";
 
 const MOVE_MODE_LABELS = ["zwykly", "prz", "prz dr"];
 const MOVE_MODE_TITLES = ["zwykly", "przemknij", "przemknij z druzyna"];
@@ -50,37 +51,6 @@ export default class MobileDirectionButtons {
     private teamMode = false;
     private leaderMode = false;
 
-    private readonly polishToEnglish: Record<string, string> = {
-        "polnoc": "north",
-        "poludnie": "south",
-        "wschod": "east",
-        "zachod": "west",
-        "polnocny-wschod": "northeast",
-        "polnocny-zachod": "northwest",
-        "poludniowy-wschod": "southeast",
-        "poludniowy-zachod": "southwest",
-        "dol": "down",
-        "gora": "up",
-        "gore": "up",
-    };
-
-    private readonly longToShort: Record<string, string> = {
-        north: "n",
-        south: "s",
-        east: "e",
-        west: "w",
-        northeast: "ne",
-        northwest: "nw",
-        southeast: "se",
-        southwest: "sw",
-        up: "u",
-        down: "d",
-    };
-
-    private getShortDir(dir: string): string {
-        const long = this.polishToEnglish[dir] ?? dir;
-        return this.longToShort[long] ?? dir;
-    }
 
     constructor(client: Client) {
         this.client = client;
@@ -526,7 +496,7 @@ export default class MobileDirectionButtons {
     }
 
     private highlightExits(exits: string[]) {
-        const available = new Set(exits.map((e) => this.getShortDir(e)));
+        const available = new Set(exits.map((e) => getShortDir(e)));
         const buttons = this.container.querySelectorAll<HTMLButtonElement>(
             'button[data-direction]'
         );
@@ -654,7 +624,7 @@ export default class MobileDirectionButtons {
             }
         }
         if (cfg.macro === 'kierunek' && cfg.direction) {
-            newBtn.dataset.direction = this.getShortDir(cfg.direction);
+            newBtn.dataset.direction = getShortDir(cfg.direction);
         } else if (!newBtn.dataset.direction) {
             newBtn.removeAttribute('data-direction');
         }


### PR DESCRIPTION
## Summary
- add shared direction helpers
- consume centralized direction helpers in MapHelper, short exits, and mobile direction buttons

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6897cba63c1c832aafa62df0a850c1ea