### PR TITLE
Fix char state form when GMCP form option disabled

### DIFF
--- a/web-client/src/CharState.ts
+++ b/web-client/src/CharState.ts
@@ -1,5 +1,4 @@
 import ArkadiaClient from "./ArkadiaClient.ts";
-import { gmcp } from "@client/src/gmcp";
 import { COLOR_BAR_CLASS, COLOR_TEXT, getColorLevel } from "./colors.ts";
 
 export interface CharStateData {
@@ -76,6 +75,7 @@ export default class CharState {
   private bars: HTMLElement | null;
   private config: Record<keyof CharStateData, CharStateConfig>;
   private state: Partial<CharStateData> = {};
+  private options: { form?: number } = {};
   private useEmoji = false;
   private mode = 0;
   private labelElements: Record<keyof CharStateData, HTMLSpanElement> =
@@ -185,6 +185,11 @@ export default class CharState {
       "gmcp.char.state",
       (state: Partial<CharStateData>) => this.update(state),
     );
+
+    this.client.on('gmcp.char.options', (options: any) => {
+      this.options = { ...this.options, ...options };
+      this.update({});
+    });
   }
 
   private update(partialState: Partial<CharStateData>) {
@@ -197,7 +202,7 @@ export default class CharState {
         if (
           key === 'form' &&
           this.state[key] === 0 &&
-          gmcp.char?.options?.form === 0
+          this.options.form === 0
         ) {
           return false;
         }

--- a/web-client/test/CharState.test.ts
+++ b/web-client/test/CharState.test.ts
@@ -25,4 +25,13 @@ describe('CharState', () => {
     expect(valueSpan).not.toBeNull();
     expect(valueSpan.style.color).toBe('white');
   });
+
+  test('form is hidden when gmcp option disables form', () => {
+    client.emit('gmcp.char.state', { form: 0 });
+    let formBar = document.querySelector('#char-state-bars .char-state-bar[title="form"]');
+    expect(formBar).not.toBeNull();
+    client.emit('gmcp.char.options', { form: 0 });
+    formBar = document.querySelector('#char-state-bars .char-state-bar[title="form"]');
+    expect(formBar).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- track GMCP options in CharState and listen for `gmcp.char.options`
- filter out form stat when GMCP form option is disabled
- test: verify form disappears once GMCP option is received

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_689861782e50832aa042775e1f8baf6b