### PR TITLE
fix: disable context menu on mobile direction buttons

### DIFF
--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -288,6 +288,9 @@ export default class MobileDirectionButtons {
     private setupDraggable() {
         if (!this.container || !this.contentArea) return;
 
+        // Prevent native context menu on long press which breaks dragging
+        this.container.addEventListener('contextmenu', (e) => e.preventDefault());
+
         // Set initial position from storage if available
         const savedData = getItemSync('mobileButtonsPosition');
         const savedPosition = savedData?.mobileButtonsPosition;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -550,6 +550,7 @@ button:focus-visible {
   touch-action: none; /* Prevent scrolling when interacting with the buttons */
   user-select: none; /* Prevent text selection */
   -webkit-user-select: none;
+  -webkit-touch-callout: none; /* Disable long-press menu on iOS */
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2); /* Subtle shadow by default */
   display: grid;
   grid-template-columns: repeat(4, auto);


### PR DESCRIPTION
## Summary
- prevent native context menu on long press while dragging mobile buttons
- disable iOS long-press callout for mobile buttons

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6898fb462774832ab24dd42b958b2da4