### PR TITLE
Notify when idle and HP full

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -64,6 +64,7 @@ import initCompareAll from './scripts/compareAll'
 import initFollowSpecialExits from './scripts/followSpecialExits'
 import initMountain from './scripts/mountain'
 import initLanguage from './scripts/language'
+import initIdleFullHp from './scripts/idleFullHp'
 import Client from "./Client";
 
 
@@ -165,6 +166,7 @@ export function registerScripts(client: Client) {
     initLeaderAttackWarning(client)
     initBreakItem(client)
     initHpAlert(client)
+    initIdleFullHp(client)
     initNoWeaponAlert(client)
     initNewMail(client)
     initMagikZnika(client)

--- a/client/src/scripts/idleFullHp.ts
+++ b/client/src/scripts/idleFullHp.ts
@@ -1,0 +1,18 @@
+import Client from "../Client";
+import createIdleTimer from "../utils/idleTimer";
+
+export default function initIdleFullHp(client: Client) {
+    const FULL_HP = 6;
+    let prevHp = -1;
+    const idleTimer = createIdleTimer(client);
+
+    client.addEventListener('gmcp.char.state', (ev: CustomEvent) => {
+        const hp = ev.detail?.hp;
+        if (typeof hp !== 'number') return;
+        if (hp === FULL_HP && prevHp < FULL_HP && idleTimer.isIdle()) {
+            client.notify('Masz pelne zycie');
+            client.sendEvent('notify', { text: 'Masz pelne zycie' });
+        }
+        prevHp = hp;
+    });
+}

--- a/client/src/utils/idleTimer.ts
+++ b/client/src/utils/idleTimer.ts
@@ -1,0 +1,25 @@
+import Client from "../Client";
+
+export default function createIdleTimer(client: Client, timeout = 120000) {
+    let idle = false;
+    let timer: number | undefined;
+
+    const reset = () => {
+        idle = false;
+        if (timer !== undefined) {
+            window.clearTimeout(timer);
+        }
+        timer = window.setTimeout(() => {
+            idle = true;
+        }, timeout);
+    };
+
+    reset();
+    client.addEventListener('command', reset);
+
+    return {
+        isIdle: () => idle,
+        reset,
+    };
+}
+

--- a/client/test/idleFullHp.test.ts
+++ b/client/test/idleFullHp.test.ts
@@ -1,0 +1,54 @@
+import initIdleFullHp from '../src/scripts/idleFullHp';
+import { EventEmitter } from 'events';
+
+describe('idle full hp notification', () => {
+  class FakeClient {
+    private emitter = new EventEmitter();
+    notify = jest.fn();
+    sendEvent(type: string, detail?: any) {
+      this.emitter.emit(type, { detail });
+    }
+    addEventListener(event: string, cb: any) {
+      this.emitter.on(event, cb);
+    }
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('notifies when reaching full hp after idle', () => {
+    const client = new FakeClient();
+    initIdleFullHp((client as unknown) as any);
+    client.sendEvent('gmcp.char.state', { hp: 5 });
+    jest.advanceTimersByTime(120000);
+    client.sendEvent('gmcp.char.state', { hp: 6 });
+    expect(client.notify).toHaveBeenCalledWith('Masz pelne zycie');
+  });
+
+  test('does not notify before idle threshold', () => {
+    const client = new FakeClient();
+    initIdleFullHp((client as unknown) as any);
+    client.sendEvent('gmcp.char.state', { hp: 5 });
+    jest.advanceTimersByTime(119000);
+    client.sendEvent('gmcp.char.state', { hp: 6 });
+    expect(client.notify).not.toHaveBeenCalled();
+  });
+
+  test('command resets idle timer', () => {
+    const client = new FakeClient();
+    initIdleFullHp((client as unknown) as any);
+    client.sendEvent('gmcp.char.state', { hp: 5 });
+    jest.advanceTimersByTime(90000);
+    client.sendEvent('command', 'look');
+    jest.advanceTimersByTime(90000);
+    client.sendEvent('gmcp.char.state', { hp: 5 });
+    jest.advanceTimersByTime(30000);
+    client.sendEvent('gmcp.char.state', { hp: 6 });
+    expect(client.notify).toHaveBeenCalledWith('Masz pelne zycie');
+  });
+});

--- a/client/test/idleTimer.test.ts
+++ b/client/test/idleTimer.test.ts
@@ -1,0 +1,32 @@
+import createIdleTimer from '../src/utils/idleTimer';
+import { EventEmitter } from 'events';
+
+describe('idle timer', () => {
+  class FakeClient {
+    private emitter = new EventEmitter();
+    addEventListener(event: string, cb: any) {
+      this.emitter.on(event, cb);
+    }
+    sendEvent(type: string, detail?: any) {
+      this.emitter.emit(type, { detail });
+    }
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('marks idle after threshold and resets on command', () => {
+    const client = new FakeClient();
+    const timer = createIdleTimer((client as unknown) as any, 1000);
+    expect(timer.isIdle()).toBe(false);
+    jest.advanceTimersByTime(1000);
+    expect(timer.isIdle()).toBe(true);
+    client.sendEvent('command');
+    expect(timer.isIdle()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable idle timer utility
- use idle timer to trigger full HP notifications after two minutes idle
- cover idle timer behavior with unit tests

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6898c76c3f40832aa2124d2684d65d75