### PR TITLE
feat: add optional haptic feedback for mobile buttons

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -271,6 +271,10 @@
                         Pokaż przyciski na ekranie
                     </label>
                     <label class="form-label">
+                        <input id="ui-haptic-feedback" type="checkbox" class="form-check-input me-2" />
+                        Wibracje przycisków mobilnych
+                    </label>
+                    <label class="form-label">
                         <input id="ui-emoji-labels" type="checkbox" class="form-check-input me-2" />
                         Etykiety emoji w stanie postaci
                     </label>

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -50,6 +50,7 @@ export default class MobileDirectionButtons {
     private buttonSettings: Record<string, ButtonSetting> = {};
     private teamMode = false;
     private leaderMode = false;
+    private hapticEnabled = true;
 
 
     constructor(client: Client) {
@@ -142,15 +143,16 @@ export default class MobileDirectionButtons {
         // Listen for UI settings changes
         this.client.addEventListener("uiSettings", (event: CustomEvent) => {
             const detail = event.detail || {};
-            if (!Object.prototype.hasOwnProperty.call(detail, "mobileDirectionButtons")) {
-                return;
+            if (Object.prototype.hasOwnProperty.call(detail, "hapticFeedback")) {
+                this.hapticEnabled = detail.hapticFeedback !== false;
             }
-            // Only disable if explicitly set to false
-            const disabled = detail.mobileDirectionButtons === false;
-            if (disabled) {
-                this.disable();
-            } else {
-                this.enable();
+            if (Object.prototype.hasOwnProperty.call(detail, "mobileDirectionButtons")) {
+                const disabled = detail.mobileDirectionButtons === false;
+                if (disabled) {
+                    this.disable();
+                } else {
+                    this.enable();
+                }
             }
         });
 
@@ -633,6 +635,7 @@ export default class MobileDirectionButtons {
         }
 
         const handler = () => {
+            if (this.hapticEnabled) navigator.vibrate?.(20);
             switch (cfg.macro) {
                 case 'empty':
                     break;

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -7,6 +7,7 @@ interface UiSettings {
     mapScale: number;
     mapLimit: number;
     showButtons: boolean;
+    hapticFeedback: boolean;
     mapHeight: number;
     emojiLabels: boolean;
     fightTitleIcon: boolean;
@@ -22,6 +23,7 @@ const defaultSettings: UiSettings = {
     mapScale: 0.30,
     mapLimit: 35,
     showButtons: true,
+    hapticFeedback: true,
     mapHeight: typeof window !== 'undefined' && window.innerWidth < 768 ? 25 : 30,
     emojiLabels: false,
     fightTitleIcon: true,
@@ -81,6 +83,7 @@ function apply(settings: UiSettings) {
             new CustomEvent('uiSettings', {
                 detail: {
                     mobileDirectionButtons: settings.showButtons,
+                    hapticFeedback: settings.hapticFeedback,
                     emojiLabels: settings.emojiLabels,
                     xtermPalette: settings.xtermPalette,
                     footerMode: settings.footerMode,
@@ -114,7 +117,8 @@ async function load(): Promise<UiSettings> {
             const footerMode = typeof parsed.footerMode === 'number' ? parsed.footerMode : defaultSettings.footerMode;
             const explorationMode = !!parsed.explorationMode;
             const fightTitleIcon = typeof parsed.fightTitleIcon === 'boolean' ? parsed.fightTitleIcon : defaultSettings.fightTitleIcon;
-            return { ...defaultSettings, ...parsed, mapScale, mapLimit, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode, fightTitleIcon };
+            const hapticFeedback = typeof parsed.hapticFeedback === 'boolean' ? parsed.hapticFeedback : defaultSettings.hapticFeedback;
+            return { ...defaultSettings, ...parsed, mapScale, mapLimit, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode, fightTitleIcon, hapticFeedback };
         }
     } catch {
         // ignore malformed data
@@ -141,6 +145,7 @@ export default async function initUiSettings() {
     const explorationInput = modalEl.querySelector('#ui-exploration-mode') as HTMLInputElement;
     const explorationStats = modalEl.querySelector('#ui-exploration-stats') as HTMLElement | null;
     const showButtonsInput = modalEl.querySelector('#ui-show-buttons') as HTMLInputElement;
+    const hapticFeedbackInput = modalEl.querySelector('#ui-haptic-feedback') as HTMLInputElement;
     const emojiLabelsInput = modalEl.querySelector('#ui-emoji-labels') as HTMLInputElement;
     const fightTitleIconInput = modalEl.querySelector('#ui-fight-title-icon') as HTMLInputElement;
     const xtermPaletteInput = modalEl.querySelector('#ui-xterm-palette') as HTMLSelectElement;
@@ -156,6 +161,7 @@ export default async function initUiSettings() {
     mapLimitInput.value = String(current.mapLimit);
     explorationInput.checked = current.explorationMode;
     showButtonsInput.checked = current.showButtons;
+    hapticFeedbackInput.checked = current.hapticFeedback;
     emojiLabelsInput.checked = current.emojiLabels;
     fightTitleIconInput.checked = current.fightTitleIcon;
     xtermPaletteInput.value = current.xtermPalette;
@@ -194,6 +200,7 @@ export default async function initUiSettings() {
             mapLimit,
             mapHeight: parseFloat(mapHeightInput.value) || defaultSettings.mapHeight,
             showButtons: showButtonsInput.checked,
+            hapticFeedback: hapticFeedbackInput.checked,
             emojiLabels: emojiLabelsInput.checked,
             fightTitleIcon: fightTitleIconInput.checked,
             xtermPalette: (xtermPaletteInput.value as 'arkadia' | 'proper') || defaultSettings.xtermPalette,


### PR DESCRIPTION
## Summary
- add haptic feedback for mobile buttons with navigator.vibrate
- allow enabling/disabling vibration via new UI setting

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6899af0e3738832aa2a24fb3a9f4caec