### PR TITLE
fix: improve idle detection for full hp notification

### DIFF
--- a/client/src/utils/idleTimer.ts
+++ b/client/src/utils/idleTimer.ts
@@ -1,24 +1,19 @@
 import Client from "../Client";
 
 export default function createIdleTimer(client: Client, timeout = 120000) {
-    let idle = false;
-    let timer: number | undefined;
+    let lastActivity = Date.now();
 
     const reset = () => {
-        idle = false;
-        if (timer !== undefined) {
-            window.clearTimeout(timer);
-        }
-        timer = window.setTimeout(() => {
-            idle = true;
-        }, timeout);
+        lastActivity = Date.now();
     };
+
+    const isIdle = () => Date.now() - lastActivity >= timeout;
 
     reset();
     client.addEventListener('command', reset);
 
     return {
-        isIdle: () => idle,
+        isIdle,
         reset,
     };
 }

--- a/client/test/idleFullHp.test.ts
+++ b/client/test/idleFullHp.test.ts
@@ -15,6 +15,7 @@ describe('idle full hp notification', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
+    jest.setSystemTime(0);
   });
 
   afterEach(() => {
@@ -25,7 +26,7 @@ describe('idle full hp notification', () => {
     const client = new FakeClient();
     initIdleFullHp((client as unknown) as any);
     client.sendEvent('gmcp.char.state', { hp: 5 });
-    jest.advanceTimersByTime(120000);
+    jest.setSystemTime(120000);
     client.sendEvent('gmcp.char.state', { hp: 6 });
     expect(client.notify).toHaveBeenCalledWith('Masz pelne zycie');
   });
@@ -34,7 +35,7 @@ describe('idle full hp notification', () => {
     const client = new FakeClient();
     initIdleFullHp((client as unknown) as any);
     client.sendEvent('gmcp.char.state', { hp: 5 });
-    jest.advanceTimersByTime(119000);
+    jest.setSystemTime(119000);
     client.sendEvent('gmcp.char.state', { hp: 6 });
     expect(client.notify).not.toHaveBeenCalled();
   });
@@ -43,11 +44,11 @@ describe('idle full hp notification', () => {
     const client = new FakeClient();
     initIdleFullHp((client as unknown) as any);
     client.sendEvent('gmcp.char.state', { hp: 5 });
-    jest.advanceTimersByTime(90000);
+    jest.setSystemTime(90000);
     client.sendEvent('command', 'look');
-    jest.advanceTimersByTime(90000);
+    jest.setSystemTime(180000);
     client.sendEvent('gmcp.char.state', { hp: 5 });
-    jest.advanceTimersByTime(30000);
+    jest.setSystemTime(210000);
     client.sendEvent('gmcp.char.state', { hp: 6 });
     expect(client.notify).toHaveBeenCalledWith('Masz pelne zycie');
   });

--- a/client/test/idleTimer.test.ts
+++ b/client/test/idleTimer.test.ts
@@ -14,6 +14,7 @@ describe('idle timer', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
+    jest.setSystemTime(0);
   });
 
   afterEach(() => {
@@ -24,7 +25,7 @@ describe('idle timer', () => {
     const client = new FakeClient();
     const timer = createIdleTimer((client as unknown) as any, 1000);
     expect(timer.isIdle()).toBe(false);
-    jest.advanceTimersByTime(1000);
+    jest.setSystemTime(1000);
     expect(timer.isIdle()).toBe(true);
     client.sendEvent('command');
     expect(timer.isIdle()).toBe(false);


### PR DESCRIPTION
## Summary
- replace timer-based idle detection with timestamp tracking to ensure full HP notifications work even when timers pause
- update idle timer tests for timestamp approach

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6899e9ed5a34832aafb1e08ac5f9feda