### PR TITLE
feat: add notification test button in debug modal

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -425,6 +425,9 @@ export default class Client {
         if (typeof Notification === 'undefined') {
             return
         }
+        if ('serviceWorker' in navigator && navigator.serviceWorker) {
+            navigator.serviceWorker.register('/sw.js').catch(() => {})
+        }
         if (Notification.permission === 'default') {
             Notification.requestPermission()
         }
@@ -435,7 +438,13 @@ export default class Client {
             return
         }
         if (Notification.permission === 'granted') {
-            new Notification(message)
+            if ('serviceWorker' in navigator && navigator.serviceWorker) {
+                navigator.serviceWorker.ready
+                    .then((reg) => reg.showNotification(message))
+                    .catch(() => {})
+            } else {
+                new Notification(message)
+            }
         }
     }
 

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -85,6 +85,17 @@ test('does not request notification permission when already decided', () => {
   delete (global as any).Notification;
 });
 
+test('registers service worker if available', () => {
+  (global as any).Notification = { permission: 'granted', requestPermission: jest.fn() };
+  const original = (navigator as any).serviceWorker;
+  (navigator as any).serviceWorker = { register: jest.fn().mockResolvedValue(undefined) };
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  client.enableNotifications();
+  expect((navigator as any).serviceWorker.register).toHaveBeenCalledWith('/sw.js');
+  (navigator as any).serviceWorker = original;
+  delete (global as any).Notification;
+});
+
 test('port messages trigger window events', () => {
   new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   const listener = (global as any).portMock.onMessage.addListener.mock.calls[0][0];

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -368,6 +368,7 @@
                     <h5 class="modal-title">Debug Log</h5>
                     <div class="d-flex gap-2 align-items-center">
                         <button type="button" class="btn btn-secondary btn-sm" id="trigger-tester-button">Tester triggerów</button>
+                        <button type="button" class="btn btn-secondary btn-sm" id="notification-schedule-button">Powiadomienie</button>
                         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                     </div>
                 </div>

--- a/web-client/public/sw.js
+++ b/web-client/public/sw.js
@@ -1,0 +1,2 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());

--- a/web-client/src/debug.ts
+++ b/web-client/src/debug.ts
@@ -42,6 +42,7 @@ function initDebug() {
     scheduleButton.addEventListener("click", () => {
       const client = (window as any).clientExtension;
       if (!client) return;
+      client.enableNotifications?.();
       client.sendEvent?.("notify", { text: "Powiadomienie za 5s" });
       setTimeout(() => {
         client.notify?.("Test notification");

--- a/web-client/src/debug.ts
+++ b/web-client/src/debug.ts
@@ -7,6 +7,7 @@ function initDebug() {
 
   const modal = new Modal(modalEl);
   const content = modalEl.querySelector("#debug-content") as HTMLElement;
+  const scheduleButton = modalEl.querySelector("#notification-schedule-button") as HTMLButtonElement | null;
 
   const methods: Array<keyof Console> = ["log", "error", "warn", "info"];
   methods.forEach((m) => {
@@ -36,6 +37,18 @@ function initDebug() {
   debugButton.addEventListener("click", () => {
     modal.show();
   });
+
+  if (scheduleButton) {
+    scheduleButton.addEventListener("click", () => {
+      const client = (window as any).clientExtension;
+      if (!client) return;
+      client.sendEvent?.("notify", { text: "Powiadomienie za 5s" });
+      setTimeout(() => {
+        client.notify?.("Test notification");
+        client.sendEvent?.("notify", { text: "Test notification" });
+      }, 5000);
+    });
+  }
 }
 
 document.addEventListener("DOMContentLoaded", initDebug);


### PR DESCRIPTION
## Summary
- add button in debug modal for scheduling a test notification
- schedule a sample notification via client after 5s

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_6899ffec4038832a8af73a5f2bef28ce