### PR TITLE
fix: register service worker from base path

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -426,7 +426,7 @@ export default class Client {
             return
         }
         if ('serviceWorker' in navigator && navigator.serviceWorker) {
-            navigator.serviceWorker.register('/sw.js').catch(() => {})
+            navigator.serviceWorker.register('sw.js').catch(() => {})
         }
         if (Notification.permission === 'default') {
             Notification.requestPermission()

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -91,8 +91,25 @@ test('registers service worker if available', () => {
   (navigator as any).serviceWorker = { register: jest.fn().mockResolvedValue(undefined) };
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   client.enableNotifications();
-  expect((navigator as any).serviceWorker.register).toHaveBeenCalledWith('/sw.js');
+  expect((navigator as any).serviceWorker.register).toHaveBeenCalledWith('sw.js');
+  const calledPath = (navigator as any).serviceWorker.register.mock.calls[0][0];
+  expect(new URL(calledPath, document.baseURI).pathname).toBe('/sw.js');
   (navigator as any).serviceWorker = original;
+  delete (global as any).Notification;
+});
+
+test('registers service worker using base path', () => {
+  (global as any).Notification = { permission: 'granted', requestPermission: jest.fn() };
+  document.head.innerHTML = '<base href="/test/">';
+  const original = (navigator as any).serviceWorker;
+  (navigator as any).serviceWorker = { register: jest.fn().mockResolvedValue(undefined) };
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  client.enableNotifications();
+  expect((navigator as any).serviceWorker.register).toHaveBeenCalledWith('sw.js');
+  const calledPath = (navigator as any).serviceWorker.register.mock.calls[0][0];
+  expect(new URL(calledPath, document.baseURI).pathname).toBe('/test/sw.js');
+  (navigator as any).serviceWorker = original;
+  document.head.innerHTML = '';
   delete (global as any).Notification;
 });
 


### PR DESCRIPTION
## Summary
- register service worker using relative path so browser resolves against document base
- verify service worker path resolution with and without `<base>` tag

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_689a205f0d5c832aac6e3561fcc4cca4