### PR TITLE
Restore haptic feedback on mobile buttons

### DIFF
--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -634,8 +634,12 @@ export default class MobileDirectionButtons {
             newBtn.removeAttribute('data-direction');
         }
 
-        const handler = () => {
+        const handleVibration = () => {
             if (this.hapticEnabled) navigator.vibrate?.(20);
+        };
+        newBtn.addEventListener('pointerdown', handleVibration);
+
+        const handler = () => {
             switch (cfg.macro) {
                 case 'empty':
                     break;


### PR DESCRIPTION
## Summary
- trigger vibration on pointerdown instead of click so haptic feedback works again

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_689a5419f9a0832aabda498cd56fa8d0