### PR TITLE
Fix default talking without adjective

### DIFF
--- a/client/src/scripts/language.ts
+++ b/client/src/scripts/language.ts
@@ -34,7 +34,7 @@ export default function initLanguage(client: Client, aliases?: { pattern: RegExp
     function say(lang: string, adj: string, msg: string) {
        setLanguage(lang);
         if (lang === 'potoczna' && adj === '') {
-            client.sendCommand("'" + msg);
+            client.send("'" + msg, false);
         } else {
             const verb = lang === 'potoczna' ? 'ppowiedz' : 'jppowiedz';
             const cmd = adj ? `${verb} ${adj} ${msg}` : `${verb} ${msg}`;


### PR DESCRIPTION
## Summary
- Avoid alias recursion by sending raw command when speaking in default language without adjective

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_689ba9d7f9bc832aa0860ff6911a9de2