### PR TITLE
Persist kill and improvement counters in storage

### DIFF
--- a/client/src/scripts/improveCounter.ts
+++ b/client/src/scripts/improveCounter.ts
@@ -80,12 +80,24 @@ export default class ImproveCounter {
     private entries: Entry[] = [];
     private lastTime: number = 0;
     private lastKills = { my: 0, team: 0 };
+    private static readonly STORAGE_KEY = "improve_counter";
 
     constructor(client: Client, killCounter: any) {
         this.client = client;
         this.killCounter = killCounter;
 
-        this.client.addEventListener("gmcp.char.info", () => this.reset());
+        this.client.addEventListener("storage", (event: CustomEvent) => {
+            if (event.detail.key === ImproveCounter.STORAGE_KEY) {
+                this.load(event.detail.value ?? {});
+            }
+        });
+
+        window.addEventListener("beforeunload", this.persist);
+
+        this.client.port?.postMessage({
+            type: "GET_STORAGE",
+            key: ImproveCounter.STORAGE_KEY,
+        });
 
         const states = STATES.join("|");
         const regex = new RegExp(
@@ -114,6 +126,7 @@ export default class ImproveCounter {
         this.entries = [];
         this.lastTime = Date.now();
         this.lastKills = this.getKills();
+        this.persist();
     }
 
     private record(state: string) {
@@ -129,6 +142,7 @@ export default class ImproveCounter {
         this.entries.push(entry);
         this.lastTime = now;
         this.lastKills = kills;
+        this.persist();
         const msg = colorString(
             `\tWlasnie wbiles postepy: ${state} (czas: ${formatDuration(
                 entry.delta,
@@ -137,6 +151,24 @@ export default class ImproveCounter {
         );
         this.client.println(msg);
     }
+
+    private load(data: any = {}) {
+        this.entries = Array.isArray(data.entries) ? data.entries : [];
+        this.lastTime = typeof data.lastTime === "number" && data.lastTime > 0 ? data.lastTime : Date.now();
+        this.lastKills = data.lastKills || this.getKills();
+    }
+
+    private persist = () => {
+        this.client.port?.postMessage({
+            type: "SET_STORAGE",
+            key: ImproveCounter.STORAGE_KEY,
+            value: {
+                entries: this.entries,
+                lastTime: this.lastTime,
+                lastKills: this.lastKills,
+            },
+        });
+    };
 
     private formatTable(): string {
         const WIDTH = 74;
@@ -217,6 +249,7 @@ export function initImproveCounter(
     const counter = new ImproveCounter(client, killCounter);
     if (aliases) {
         aliases.push({ pattern: /\/postepy$/, callback: () => counter.show() });
+        aliases.push({ pattern: /\/postepy_reset$/, callback: () => counter.reset() });
     }
     return counter;
 }

--- a/client/src/scripts/improveCounter.ts
+++ b/client/src/scripts/improveCounter.ts
@@ -92,6 +92,8 @@ export default class ImproveCounter {
             }
         });
 
+        this.client.addEventListener("reset", () => this.reset());
+
         window.addEventListener("beforeunload", this.persist);
 
         this.client.port?.postMessage({

--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -11,6 +11,7 @@ type KillEntry = {
 type KillCounts = Record<string, KillEntry>;
 
 const STORAGE_KEY = "kill_counter";
+const SESSION_STORAGE_KEY = "kill_counter_session";
 
 const KILL_HEADER_COLOR = findClosestColor("#7cfc00");
 const KILL_MY_COLOR = findClosestColor("#ffff00");
@@ -231,9 +232,13 @@ class KillCounter {
             if (event.detail.key === STORAGE_KEY) {
                 this.loadTotals(event.detail.value ?? {});
             }
+            if (event.detail.key === SESSION_STORAGE_KEY) {
+                this.loadSession(event.detail.value ?? {});
+            }
         });
 
         window.addEventListener("beforeunload", this.persistTotals);
+        window.addEventListener("beforeunload", this.persistSessions);
 
         const myKillRegex = /^[ >]*(Zabil(?:es|as) (?<name>[A-Za-z ()!,]+))\.$/;
         const teamKillRegex = /^[ >]*(?<player>[a-zA-Z (),!]+) zabil(?:a)? (?<name>[a-zA-Z (),!]+)\.$/;
@@ -264,6 +269,7 @@ class KillCounter {
         );
 
         this.client.port?.postMessage({ type: "GET_STORAGE", key: STORAGE_KEY });
+        this.client.port?.postMessage({ type: "GET_STORAGE", key: SESSION_STORAGE_KEY });
     }
 
     private loadTotals(totals: Record<string, number> = {}): void {
@@ -290,6 +296,29 @@ class KillCounter {
         });
     };
 
+    private loadSession(session: Record<string, { mySession: number; teamSession: number }> = {}): void {
+        Object.entries(session).forEach(([name, data]) => {
+            const entry = this.kills[name] ?? { mySession: 0, myTotal: 0, teamSession: 0 };
+            entry.mySession = data.mySession ?? 0;
+            entry.teamSession = data.teamSession ?? 0;
+            this.kills[name] = entry;
+        });
+    }
+
+    private persistSessions = () => {
+        const sessions: Record<string, { mySession: number; teamSession: number }> = {};
+        Object.entries(this.kills).forEach(([name, entry]) => {
+            if (entry.mySession || entry.teamSession) {
+                sessions[name] = { mySession: entry.mySession, teamSession: entry.teamSession };
+            }
+        });
+        this.client.port?.postMessage({
+            type: "SET_STORAGE",
+            key: SESSION_STORAGE_KEY,
+            value: sessions,
+        });
+    };
+
     private ensureEntry(name: string): KillEntry {
         if (!this.kills[name]) {
             this.kills[name] = { mySession: 0, myTotal: 0, teamSession: 0 };
@@ -306,6 +335,7 @@ class KillCounter {
         } else {
             entry.teamSession += 1;
         }
+        this.persistSessions();
         return entry;
     }
 
@@ -316,6 +346,14 @@ class KillCounter {
             totals.team += e.teamSession;
         });
         return totals;
+    }
+
+    resetSession() {
+        Object.values(this.kills).forEach((e) => {
+            e.mySession = 0;
+            e.teamSession = 0;
+        });
+        this.persistSessions();
     }
 
     private formatPrefix(
@@ -354,6 +392,7 @@ export function initKillCounter(
     if (aliases) {
         aliases.push({ pattern: /\/zabici$/, callback: () => counter.showSession() });
         aliases.push({ pattern: /\/zabici2$/, callback: () => counter.showLifetime() });
+        aliases.push({ pattern: /\/zabici_reset$/, callback: () => counter.resetSession() });
     }
     return counter;
 }

--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -237,6 +237,8 @@ class KillCounter {
             }
         });
 
+        this.client.addEventListener("reset", () => this.resetSession());
+
         window.addEventListener("beforeunload", this.persistTotals);
         window.addEventListener("beforeunload", this.persistSessions);
 

--- a/client/test/improveCounter.test.ts
+++ b/client/test/improveCounter.test.ts
@@ -65,4 +65,17 @@ describe('improve counter', () => {
     );
     expect(client.println).not.toHaveBeenCalled();
   });
+
+  test('reset event clears entries', () => {
+    parse('Zabiles smoka chaosu.');
+    jest.advanceTimersByTime(30000);
+    parse('Poczyniles male postepy, od momentu kiedy wszedles do gry.');
+    show();
+    client.print.mockClear();
+    client.dispatch('reset', undefined);
+    show();
+    const printed = stripAnsiCodes(client.print.mock.calls[0][0]);
+    expect(printed).toMatch(/Dzisiaj: 0/);
+    expect(printed).not.toMatch(/1\. male/);
+  });
 });

--- a/client/test/improveCounter.test.ts
+++ b/client/test/improveCounter.test.ts
@@ -34,15 +34,18 @@ describe('improve counter', () => {
     client = new FakeClient();
     const killCounter = initKillCounter((client as unknown) as any, []);
     client.dispatch('storage', { key: 'kill_counter', value: {} });
+    client.dispatch('storage', { key: 'kill_counter_session', value: {} });
     const improveAliases: { pattern: RegExp; callback: () => void }[] = [];
     initImproveCounter((client as unknown) as any, killCounter, improveAliases);
+    client.dispatch('storage', { key: 'improve_counter', value: {} });
     parse = (line: string) =>
       Triggers.prototype.parseLine.call(client.Triggers, line, '');
     show = improveAliases[0].callback;
+    // reset state using alias
+    improveAliases[1].callback();
   });
 
   test('records state changes, prints notification and table', () => {
-    client.dispatch('gmcp.char.info', {});
     parse('Zabiles smoka chaosu.');
     jest.advanceTimersByTime(30000);
     parse('Poczyniles male postepy, od momentu kiedy wszedles do gry.');

--- a/client/test/kill.test.ts
+++ b/client/test/kill.test.ts
@@ -113,6 +113,16 @@ describe('kill counter scenario', () => {
     printed = stripAnsiCodes(client.print.mock.calls.pop()[0]);
     expect(printed).not.toMatch(/smoka chaosu/);
   });
+
+  test('reset event clears session counts', () => {
+    parse('Zabiles smoka chaosu.');
+    printSessionTable();
+    client.print.mockClear();
+    client.dispatch('reset', undefined);
+    printSessionTable();
+    const printed = stripAnsiCodes(client.print.mock.calls.pop()[0]);
+    expect(printed).not.toMatch(/smoka chaosu/);
+  });
 });
 
 describe('parseName and formatTable', () => {

--- a/client/test/kill.test.ts
+++ b/client/test/kill.test.ts
@@ -29,6 +29,7 @@ describe('kill counter team kills', () => {
     client = new FakeClient();
     initKillCounter((client as unknown) as any, []);
     client.dispatch('storage', { key: 'kill_counter', value: {} });
+    client.dispatch('storage', { key: 'kill_counter_session', value: {} });
   });
 
   const parse = (line: string) => {
@@ -71,12 +72,14 @@ describe('kill counter scenario', () => {
   let client: FakeClient;
   let parse: (line: string) => string;
   let printSessionTable: () => void;
+  let aliases: { pattern: RegExp; callback: () => void }[];
 
   beforeEach(() => {
-    const aliases: { pattern: RegExp; callback: () => void }[] = [];
+    aliases = [];
     client = new FakeClient();
     initKillCounter((client as unknown) as any, aliases);
     client.dispatch('storage', { key: 'kill_counter', value: {} });
+    client.dispatch('storage', { key: 'kill_counter_session', value: {} });
     parse = (line: string) =>
       Triggers.prototype.parseLine.call(client.Triggers, line, '');
     // alias[0] corresponds to the /zabici command which prints
@@ -97,6 +100,18 @@ describe('kill counter scenario', () => {
     expect(printed).toMatch(/smoka chaosu .* 2/);
     expect(printed).toMatch(/LACZNIE:.*2/);
     expect(printed).toMatch(/DRUZYNA LACZNIE:.*3/);
+  });
+
+  test('zabici_reset clears session counts', () => {
+    parse('Zabiles smoka chaosu.');
+    printSessionTable();
+    let printed = stripAnsiCodes(client.print.mock.calls.pop()[0]);
+    expect(printed).toMatch(/smoka chaosu/);
+    // alias[2] corresponds to /zabici_reset
+    aliases[2].callback();
+    printSessionTable();
+    printed = stripAnsiCodes(client.print.mock.calls.pop()[0]);
+    expect(printed).not.toMatch(/smoka chaosu/);
   });
 });
 

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -8,8 +8,10 @@ Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorze
 - **/fake _tekst_** - wyświetla podany tekst jak zwykłą wiadomość klienta.
 - **/zabici** - pokazuje tabelę z liczbą twoich zabitych istot w bieżącej sesji.
 - **/zabici2** - wyświetla podsumowanie liczby zabitych istot.
+- **/zabici_reset** - zeruje licznik zabitych istot.
 - **/cechy** - uruchamia licznik poziomowania i wyświetla postępy.
 - **/postepy** - wyświetla postępy ulepszeń.
+- **/postepy_reset** - zeruje licznik postępów.
 - **/przejrzyj [_co_]** - pokazuje zawartość skrzyń z kluczami i magicznymi przedmiotami lub podanego pojemnika.
 - **/por [_skrot_]** - porównuje siłę, zręczność i wytrzymałość z podanym obiektem lub wszystkimi w pomieszczeniu.
 


### PR DESCRIPTION
## Summary
- persist improvement counter in character storage and add /postepy_reset alias
- store kill counter session data and add /zabici_reset alias
- document new reset aliases

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a5ff823574832a91098ecdf6a14657