### PR TITLE
Persist object number and emit reset on change

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -16,7 +16,7 @@ import TeamManager from "./TeamManager";
 import ObjectManager from "./ObjectManager";
 import {beepSound} from "./sounds";
 import {attachGmcpListener} from "./gmcp";
-import { setCurrentCharacter } from "./storage";
+import { setCurrentCharacter, getItemSync, setItemSync } from "./storage";
 import {color, Colors} from "./Colors";
 import {SKIP_LINE} from "./ControlConstants";
 import {stripPolishCharacters} from "./stripPolishCharacters";
@@ -199,6 +199,14 @@ export default class Client {
                         this.port!.postMessage({ type: 'GET_STORAGE', key: k });
                     });
                 }
+            }
+            if (typeof ev.detail?.object_num !== 'undefined') {
+                const newNum = String(ev.detail.object_num);
+                const stored = getItemSync('object_num')?.object_num;
+                if (typeof stored !== 'undefined' && String(stored) !== newNum) {
+                    this.sendEvent('reset');
+                }
+                setItemSync('object_num', newNum);
             }
         })
 

--- a/client/src/storage.ts
+++ b/client/src/storage.ts
@@ -34,6 +34,7 @@ const characterScopedKeys = new Set([
     'herbs_data',
     'mapperRoomId',
     'lastLang',
+    'object_num',
 ]);
 
 let currentCharacter: string | null = localStorage.getItem('currentCharacter');

--- a/client/test/objectNumReset.test.ts
+++ b/client/test/objectNumReset.test.ts
@@ -1,0 +1,84 @@
+import Client from '../src/Client';
+import { getItemSync } from '../src/storage';
+
+(window as any).Input = { send: jest.fn() };
+(window as any).Output = { send: jest.fn(), flush_buffer: jest.fn(), buffer: [] };
+(window as any).Text = { parse_patterns: jest.fn((v: any) => v) };
+(window as any).Maps = {
+  refresh_position: jest.fn(),
+  set_position: jest.fn(),
+  unset_position: jest.fn(),
+  data: undefined,
+};
+(window as any).Gmcp = { parse_option_subnegotiation: jest.fn() };
+const parseCommand = jest.fn((cmd: string) => `parsed:${cmd}`);
+
+jest.mock('../src/Triggers', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    parseLine: jest.fn((l: string) => l),
+    parseMultiline: jest.fn((l: string) => l),
+  })),
+}));
+
+jest.mock('../src/PackageHelper', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('../src/OutputHandler', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('../src/scripts/functionalBind', () => ({
+  FunctionalBind: jest.fn().mockImplementation(() => ({
+    set: jest.fn(),
+    clear: jest.fn(),
+    newMessage: jest.fn(),
+  })),
+}));
+
+jest.mock('howler', () => {
+  const instance = {
+    state: jest.fn(() => 'loaded'),
+    play: jest.fn(),
+    stop: jest.fn(),
+    once: jest.fn(),
+    load: jest.fn(),
+  };
+  return { Howl: jest.fn(() => instance) };
+});
+
+jest.mock('../src/MapHelper', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    parseCommand,
+    move: jest.fn((dir: string) => ({ direction: dir, moved: false })),
+    followMove: jest.fn(),
+  })),
+}));
+
+describe('object_num persistence and reset event', () => {
+  let client: Client;
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = '<div id="panel_buttons_bottom"></div><iframe id="cm-frame"></iframe>';
+    (window as any).Output = { flush_buffer: jest.fn(), send: jest.fn() };
+    (window as any).Text = { parse_patterns: jest.fn((v: any) => v) };
+    (window as any).dispatchEvent = jest.fn();
+    (global as any).portMock = { onMessage: { addListener: jest.fn() }, postMessage: jest.fn() };
+    (global as any).clientAdapterMock = { send: jest.fn(), stop: jest.fn(), connect: jest.fn(), output: jest.fn(), sendGmcp: jest.fn() };
+    client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  });
+
+  test('stores object_num and emits reset when changed', () => {
+    let resets = 0;
+    client.addEventListener('reset', () => { resets++; });
+
+    client.sendEvent('gmcp.char.info', { name: 'Hero', object_num: 1 });
+    expect(getItemSync('object_num')?.object_num).toBe('1');
+    expect(resets).toBe(0);
+
+    client.sendEvent('gmcp.char.info', { name: 'Hero', object_num: 1 });
+    expect(resets).toBe(0);
+
+    client.sendEvent('gmcp.char.info', { name: 'Hero', object_num: 2 });
+    expect(resets).toBe(1);
+    expect(getItemSync('object_num')?.object_num).toBe('2');
+  });
+});
+


### PR DESCRIPTION
## Summary
- persist player object_num per character and trigger a reset event if it changes
- track object_num in character-scoped storage
- test reset emission and storage persistence

## Testing
- `corepack yarn --cwd client test`
- `corepack yarn --cwd web-client test`
- `corepack yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a5fee9b1c4832ab392a12e3e569d5b