### PR TITLE
feat: track improvements via gmcp

### DIFF
--- a/client/src/scripts/improveCounter.ts
+++ b/client/src/scripts/improveCounter.ts
@@ -80,6 +80,7 @@ export default class ImproveCounter {
     private entries: Entry[] = [];
     private lastTime: number = 0;
     private lastKills = { my: 0, team: 0 };
+    private level: number = -1;
     private static readonly STORAGE_KEY = "improve_counter";
 
     constructor(client: Client, killCounter: any) {
@@ -101,20 +102,12 @@ export default class ImproveCounter {
             key: ImproveCounter.STORAGE_KEY,
         });
 
-        const states = STATES.join("|");
-        const regex = new RegExp(
-            `^(?:.*? )?(?<state>${states}) postepy(?! w poznawaniu)`,
-            "i",
-        );
-        this.client.Triggers.registerTrigger(
-            regex,
-            (_raw, _line, matches) => {
-                const state = (matches.groups?.state || "").toLowerCase();
-                this.record(state);
-                return undefined;
-            },
-            "improveCounter"
-        );
+        this.client.addEventListener("gmcp.char.state", (ev: CustomEvent) => {
+            const level = ev.detail?.improve;
+            if (typeof level === "number") {
+                this.handleLevel(level);
+            }
+        });
     }
 
     private getKills() {
@@ -128,7 +121,24 @@ export default class ImproveCounter {
         this.entries = [];
         this.lastTime = Date.now();
         this.lastKills = this.getKills();
+        this.level = -1;
         this.persist();
+    }
+
+    private handleLevel(level: number) {
+        if (this.level < 0) {
+            this.level = level;
+            this.persist();
+            return;
+        }
+        if (level > this.level) {
+            this.level = level;
+            const state = STATES[level] ?? String(level);
+            this.record(state);
+        } else if (level < this.level) {
+            this.level = level;
+            this.persist();
+        }
     }
 
     private record(state: string) {
@@ -158,6 +168,7 @@ export default class ImproveCounter {
         this.entries = Array.isArray(data.entries) ? data.entries : [];
         this.lastTime = typeof data.lastTime === "number" && data.lastTime > 0 ? data.lastTime : Date.now();
         this.lastKills = data.lastKills || this.getKills();
+        this.level = typeof data.level === "number" ? data.level : -1;
     }
 
     private persist = () => {
@@ -168,6 +179,7 @@ export default class ImproveCounter {
                 entries: this.entries,
                 lastTime: this.lastTime,
                 lastKills: this.lastKills,
+                level: this.level,
             },
         });
     };

--- a/client/src/storage.ts
+++ b/client/src/storage.ts
@@ -28,6 +28,7 @@ const download = async (storage: Storage, url: string, ttl: number) => {
 const characterScopedKeys = new Set([
     'settings',
     'kill_counter',
+    'improve_counter',
     'deposits',
     'containers',
     'herb_counts',

--- a/client/test/improveCounter.test.ts
+++ b/client/test/improveCounter.test.ts
@@ -46,9 +46,10 @@ describe('improve counter', () => {
   });
 
   test('records state changes, prints notification and table', () => {
+    client.dispatch('gmcp.char.state', { improve: 2 });
     parse('Zabiles smoka chaosu.');
     jest.advanceTimersByTime(30000);
-    parse('Poczyniles male postepy, od momentu kiedy wszedles do gry.');
+    client.dispatch('gmcp.char.state', { improve: 3 });
     const orange = findClosestColor('#ffa500');
     const message = colorString('\tWlasnie wbiles postepy: male (czas: 0:30)', orange);
     expect(client.println).toHaveBeenCalledWith(message);
@@ -59,17 +60,17 @@ describe('improve counter', () => {
     expect(printed).toMatch(/zabici 1\/1/);
   });
 
-  test('ignores poznawanie swiata messages', () => {
-    parse(
-      'Masz wrazenie, iz ostatnimi czasy poczyniles nieznaczne postepy w poznawaniu swiata.'
-    );
+  test('does nothing when level does not change', () => {
+    client.dispatch('gmcp.char.state', { improve: 2 });
+    client.dispatch('gmcp.char.state', { improve: 2 });
     expect(client.println).not.toHaveBeenCalled();
   });
 
   test('reset event clears entries', () => {
+    client.dispatch('gmcp.char.state', { improve: 2 });
     parse('Zabiles smoka chaosu.');
     jest.advanceTimersByTime(30000);
-    parse('Poczyniles male postepy, od momentu kiedy wszedles do gry.');
+    client.dispatch('gmcp.char.state', { improve: 3 });
     show();
     client.print.mockClear();
     client.dispatch('reset', undefined);


### PR DESCRIPTION
## Summary
- track improvements through `gmcp.char.state` events
- persist improve level per character and reset on session reset
- scope improve counter storage to character

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a623f99850832a940b2b2246013035