### PR TITLE
Use 'ob' for /przejrzyj command

### DIFF
--- a/client/src/scripts/prettyContainers.ts
+++ b/client/src/scripts/prettyContainers.ts
@@ -464,7 +464,7 @@ export default function initContainers(client: Client) {
         callback: (m?: RegExpMatchArray) => {
             filter = magicAndKeysFilter;
             plugLinks = true;
-            client.send(`przejrzyj ${m?.[1] ?? 'skrzynie'}`);
+            client.send(`ob ${m?.[1] ?? 'skrzynie'}`);
         },
     });
 }

--- a/client/test/prettyContainers.test.ts
+++ b/client/test/prettyContainers.test.ts
@@ -1,4 +1,7 @@
-import {parseContainer, categorizeItems, createRegexpFilter, formatTable} from '../src/scripts/prettyContainers';
+jest.mock('../src/scripts/magicKeyLoader', () => jest.fn().mockResolvedValue([]));
+jest.mock('../src/scripts/magicsLoader', () => jest.fn().mockResolvedValue([]));
+
+import initContainers, {parseContainer, categorizeItems, createRegexpFilter, formatTable} from '../src/scripts/prettyContainers';
 
 describe('prettyContainers', () => {
   const input = 'Otwarty szary skorzany plecak zawiera zlocisty piryt, upiorny mglisty calun, skorzany buklak, gornicza lampe, oliwkowozielony serpentyn, zielonkawy awenturyn, zolty celestyn, bezbarwny gorski krysztal, mithrylowa monete, wiele zlotych monet, wiele srebrnych monet i wiele miedzianych monet.';
@@ -148,5 +151,23 @@ describe('prettyContainers', () => {
     const table = formatTable('POJEMNIK', cat, { columns: 2, maxWidth: 40 });
     const lines = table.split('\n').map(l => l.replace(/\x1b\[[0-9;]*m/g, ''));
     lines.forEach(l => expect(l.length).toBeLessThanOrEqual(40));
+  });
+
+  test('/przejrzyj alias sends ob command', () => {
+    class FakeClient {
+      aliases: { pattern: RegExp; callback: (m?: RegExpMatchArray) => void }[] = [];
+      send = jest.fn();
+      sendCommand = jest.fn();
+      OutputHandler = { makeStringClickable: (s: string) => s };
+      addEventListener = jest.fn();
+      Triggers = { removeByTag: jest.fn(), registerTrigger: jest.fn() };
+      print = jest.fn();
+      contentWidth = 80;
+    }
+    const client = new FakeClient();
+    initContainers((client as unknown) as any);
+    const alias = client.aliases[0];
+    alias.callback('/przejrzyj'.match(alias.pattern) as RegExpMatchArray);
+    expect(client.send).toHaveBeenCalledWith('ob skrzynie');
   });
 });

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -12,7 +12,7 @@ Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorze
 - **/cechy** - uruchamia licznik poziomowania i wyświetla postępy.
 - **/postepy** - wyświetla postępy ulepszeń.
 - **/postepy_reset** - zeruje licznik postępów.
-- **/przejrzyj [_co_]** - pokazuje zawartość skrzyń z kluczami i magicznymi przedmiotami lub podanego pojemnika.
+- **/przejrzyj [_co_]** - pokazuje zawartość skrzyń z kluczami i magicznymi przedmiotami lub podanego pojemnika (wykorzystuje komendę `ob`).
 - **/por [_skrot_]** - porównuje siłę, zręczność i wytrzymałość z podanym obiektem lub wszystkimi w pomieszczeniu.
 
 ## Menedżer pojemników


### PR DESCRIPTION
## Summary
- send `ob` instead of `przejrzyj` for `/przejrzyj` alias
- document `/przejrzyj` alias uses `ob`
- test that alias dispatches `ob`

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a62955ed28832abd3df978591fe52f