### PR TITLE
Highlight arrivals with lavender color

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -41,6 +41,7 @@ import initNoWeaponAlert from './scripts/noWeaponAlert'
 import initMagikZnika from './scripts/magikZnika'
 import initSeasonPrint from './scripts/seasonPrint'
 import initDajeCiHighlight from './scripts/dajeCiHighlight'
+import initPrzybywajaHighlight from './scripts/przybywajaHighlight'
 import initPriceEvaluation from './scripts/priceEvaluation'
 import initStoneValue from './scripts/stoneValue'
 import initSelfEvaluation from './scripts/selfEvaluation'
@@ -172,6 +173,7 @@ export function registerScripts(client: Client) {
     initMagikZnika(client)
     initSeasonPrint(client)
     initDajeCiHighlight(client)
+    initPrzybywajaHighlight(client)
     initGuildPostfix(client)
     initLanguage(client, aliases)
     initShortcuts(client, aliases)

--- a/client/src/scripts/przybywajaHighlight.ts
+++ b/client/src/scripts/przybywajaHighlight.ts
@@ -1,0 +1,11 @@
+import Client from "../Client";
+import { colorStringInLine, findClosestColor } from "../Colors";
+
+export default function initPrzybywajaHighlight(client: Client) {
+    const HIGHLIGHT = findClosestColor('#ccb3ff');
+    const pattern = /\b(przybyw(?:a|aja))\b/i;
+    client.Triggers.registerTrigger(pattern, (raw, _line, matches) => {
+        const start = matches.index ?? 0;
+        return colorStringInLine(raw, matches[1], HIGHLIGHT, start);
+    }, 'przybywaja-highlight');
+}


### PR DESCRIPTION
## Summary
- highlight text matching `(przybyw(a|aja))` in lavender
- wire the new arrival highlighter into the client script registration

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a6d649de58832a82dde5e45ff2506f