### PR TITLE
Highlight blocked exits in tan

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -65,6 +65,7 @@ import initFollowSpecialExits from './scripts/followSpecialExits'
 import initMountain from './scripts/mountain'
 import initLanguage from './scripts/language'
 import initIdleFullHp from './scripts/idleFullHp'
+import initNoExitHighlight from './scripts/noExitHighlight'
 import Client from "./Client";
 
 
@@ -88,6 +89,8 @@ export function registerScripts(client: Client) {
             client.Map.moveBack()
         }, 'blocker')
     })
+
+    initNoExitHighlight(client)
 
     client.Triggers.registerTrigger(/^.*[pP]odazasz (|skradajac sie )za (.*)\.$/, (_, __, matches): undefined => {
         const tokenized = matches[2].split(' ')

--- a/client/src/scripts/noExitHighlight.ts
+++ b/client/src/scripts/noExitHighlight.ts
@@ -1,0 +1,13 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+export default function initNoExitHighlight(client: Client) {
+    const TAN = findClosestColor("#d2b48c");
+    const patterns = [
+        /^[ >]*Nie widzisz zadnego wyjscia prowadzacego na .*\.$/,
+        /^[ >]*Jestes tak zmeczon(?:y|a), ze nie mozesz dalej podazac w tym kierunku\.$/
+    ];
+    patterns.forEach(p => {
+        client.Triggers.registerTrigger(p, (raw) => colorString(raw, TAN), "no-exit-highlight");
+    });
+}


### PR DESCRIPTION
## Summary
- highlight messages about missing exits or exhaustion in tan color
- wire the new highlight script into client initialization

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a6d7008a74832a962d586e25d64e3b