### PR TITLE
feat: notify after sustained full hp

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -66,6 +66,7 @@ import initFollowSpecialExits from './scripts/followSpecialExits'
 import initMountain from './scripts/mountain'
 import initLanguage from './scripts/language'
 import initIdleFullHp from './scripts/idleFullHp'
+import initFullHpTimer from './scripts/fullHpTimer'
 import initNoExitHighlight from './scripts/noExitHighlight'
 import Client from "./Client";
 
@@ -171,6 +172,7 @@ export function registerScripts(client: Client) {
     initBreakItem(client)
     initHpAlert(client)
     initIdleFullHp(client)
+    initFullHpTimer(client)
     initNoWeaponAlert(client)
     initNewMail(client)
     initMagikZnika(client)

--- a/client/src/scripts/fullHpTimer.ts
+++ b/client/src/scripts/fullHpTimer.ts
@@ -1,0 +1,56 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+import { isType } from "../Triggers";
+
+export default function initFullHpTimer(client: Client) {
+    const FULL_HP = 6;
+    const SPRING_GREEN = findClosestColor("#00ff7f");
+    const tag = "fullHpTimer";
+    let timer: number | null = null;
+    let enabled = false;
+
+    function clearTimer() {
+        if (timer !== null) {
+            clearTimeout(timer);
+            timer = null;
+        }
+    }
+
+    function startTimer() {
+        if (!enabled || timer !== null) return;
+        timer = window.setTimeout(() => {
+            const plain = "Jestes w pelni zdrowia.";
+            const msg = colorString(plain, SPRING_GREEN);
+            client.println(`\n\n${msg}\n\n`);
+            client.notify(plain);
+            client.sendEvent("notify", { text: plain });
+            timer = null;
+        }, 180000);
+    }
+
+    client.addEventListener("settings", (ev: CustomEvent) => {
+        const settings = ev.detail || {};
+        enabled = !!settings.fullHpMessage;
+        if (!enabled) {
+            clearTimer();
+        }
+    });
+
+    client.addEventListener("gmcp.char.state", (ev: CustomEvent) => {
+        const hp = ev.detail?.hp;
+        if (typeof hp !== "number") return;
+        if (hp === FULL_HP) {
+            startTimer();
+        } else {
+            clearTimer();
+        }
+    });
+
+    ["combat.avatar", "combat.team", "combat.others"].forEach(type => {
+        client.Triggers.registerTrigger(isType(type), () => {
+            clearTimer();
+            return undefined;
+        }, tag);
+    });
+}
+

--- a/client/test/fullHpTimer.test.ts
+++ b/client/test/fullHpTimer.test.ts
@@ -1,0 +1,55 @@
+import initFullHpTimer from '../src/scripts/fullHpTimer';
+import { EventEmitter } from 'events';
+import Triggers from '../src/Triggers';
+import { colorString, findClosestColor } from '../src/Colors';
+
+describe('full hp timer', () => {
+  class FakeClient {
+    private emitter = new EventEmitter();
+    Triggers = new Triggers((this as unknown) as any);
+    notify = jest.fn();
+    println = jest.fn();
+    addEventListener(event: string, cb: any) {
+      this.emitter.on(event, cb);
+    }
+    sendEvent(type: string, detail?: any) {
+      this.emitter.emit(type, { detail });
+    }
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function enable(client: FakeClient) {
+    client.sendEvent('settings', { fullHpMessage: true });
+  }
+
+  test('prints message after three minutes at full hp', () => {
+    const client = new FakeClient();
+    initFullHpTimer((client as unknown) as any);
+    enable(client);
+    client.sendEvent('gmcp.char.state', { hp: 6 });
+    jest.advanceTimersByTime(180000);
+    const color = findClosestColor('#00ff7f');
+    const msg = colorString('Jestes w pelni zdrowia.', color);
+    expect(client.println).toHaveBeenCalledWith(`\n\n${msg}\n\n`);
+    expect(client.notify).toHaveBeenCalledWith('Jestes w pelni zdrowia.');
+  });
+
+  test('timer is cancelled on combat', () => {
+    const client = new FakeClient();
+    initFullHpTimer((client as unknown) as any);
+    enable(client);
+    client.sendEvent('gmcp.char.state', { hp: 6 });
+    client.Triggers.parseLine('hit', 'combat.avatar');
+    jest.advanceTimersByTime(180000);
+    expect(client.println).not.toHaveBeenCalled();
+    expect(client.notify).not.toHaveBeenCalled();
+  });
+});
+

--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -140,6 +140,14 @@ function SettingsForm() {
                         onChange={e => onChangeSetting(s => s.shortenExits = e.target.checked)}
                         className="me-2"
                     />
+                    <Form.Check
+                        type="checkbox"
+                        id="fullHpMessage"
+                        label="Informacja o pelnym zdrowiu"
+                        checked={settings.fullHpMessage}
+                        onChange={e => onChangeSetting(s => s.fullHpMessage = e.target.checked)}
+                        className="me-2"
+                    />
                 </div>
             </div>
             <div className="mb-4 border rounded p-3">

--- a/web-client/src/options/defaultSettings.ts
+++ b/web-client/src/options/defaultSettings.ts
@@ -12,6 +12,7 @@ export interface Settings {
     languageAliases: { alias: string; adjective: string; language: string }[];
     herbPreUseCommand: string;
     herbPostUseCommand: string;
+    fullHpMessage: boolean;
 }
 
 export const defaultSettings: Settings = {
@@ -28,4 +29,5 @@ export const defaultSettings: Settings = {
     languageAliases: [],
     herbPreUseCommand: '',
     herbPostUseCommand: '',
+    fullHpMessage: false,
 };


### PR DESCRIPTION
## Summary
- add per-character option to display spring green message after 3 minutes at full HP
- reset timer when HP drops or combat begins
- expose toggle in options UI
- restore idle full hp timer

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a6ddee5728832abb8534d0262de6af