### PR TITLE
Use GMCP combat detection for full HP timer

### DIFF
--- a/client/src/scripts/fullHpTimer.ts
+++ b/client/src/scripts/fullHpTimer.ts
@@ -1,13 +1,12 @@
 import Client from "../Client";
 import { colorString, findClosestColor } from "../Colors";
-import { isType } from "../Triggers";
 
 export default function initFullHpTimer(client: Client) {
     const FULL_HP = 6;
     const SPRING_GREEN = findClosestColor("#00ff7f");
-    const tag = "fullHpTimer";
     let timer: number | null = null;
     let enabled = false;
+    let playerNum: string | undefined;
 
     function clearTimer() {
         if (timer !== null) {
@@ -46,11 +45,25 @@ export default function initFullHpTimer(client: Client) {
         }
     });
 
-    ["combat.avatar", "combat.team", "combat.others"].forEach(type => {
-        client.Triggers.registerTrigger(isType(type), () => {
+    client.addEventListener("gmcp.char.info", (ev: CustomEvent) => {
+        const info = ev.detail || {};
+        if (info && typeof info.object_num !== "undefined") {
+            playerNum = String(info.object_num);
+        }
+    });
+
+    client.addEventListener("gmcp.objects.data", (ev: CustomEvent) => {
+        if (!playerNum) return;
+        const obj = ev.detail?.[playerNum];
+        if (!obj || obj.attack_num === undefined) return;
+        if (obj.attack_num !== false) {
             clearTimer();
-            return undefined;
-        }, tag);
+        }
+    });
+
+    client.addEventListener("client.disconnect", () => {
+        playerNum = undefined;
+        clearTimer();
     });
 }
 

--- a/client/test/fullHpTimer.test.ts
+++ b/client/test/fullHpTimer.test.ts
@@ -1,12 +1,10 @@
 import initFullHpTimer from '../src/scripts/fullHpTimer';
 import { EventEmitter } from 'events';
-import Triggers from '../src/Triggers';
 import { colorString, findClosestColor } from '../src/Colors';
 
 describe('full hp timer', () => {
   class FakeClient {
     private emitter = new EventEmitter();
-    Triggers = new Triggers((this as unknown) as any);
     notify = jest.fn();
     println = jest.fn();
     addEventListener(event: string, cb: any) {
@@ -41,15 +39,16 @@ describe('full hp timer', () => {
     expect(client.notify).toHaveBeenCalledWith('Jestes w pelni zdrowia.');
   });
 
-  test('timer is cancelled on combat', () => {
-    const client = new FakeClient();
-    initFullHpTimer((client as unknown) as any);
-    enable(client);
-    client.sendEvent('gmcp.char.state', { hp: 6 });
-    client.Triggers.parseLine('hit', 'combat.avatar');
-    jest.advanceTimersByTime(180000);
-    expect(client.println).not.toHaveBeenCalled();
-    expect(client.notify).not.toHaveBeenCalled();
-  });
+    test('timer is cancelled on combat', () => {
+      const client = new FakeClient();
+      initFullHpTimer((client as unknown) as any);
+      enable(client);
+      client.sendEvent('gmcp.char.info', { object_num: 1 });
+      client.sendEvent('gmcp.char.state', { hp: 6 });
+      client.sendEvent('gmcp.objects.data', { 1: { attack_num: 2 } });
+      jest.advanceTimersByTime(180000);
+      expect(client.println).not.toHaveBeenCalled();
+      expect(client.notify).not.toHaveBeenCalled();
+    });
 });
 


### PR DESCRIPTION
## Summary
- clear full HP timer when GMCP indicates combat, matching page title logic
- adjust tests for GMCP-based combat detection

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a6e37f2c68832aa0b782296c7d012e