### PR TITLE
Fix postepy spacing to prevent text truncation

### DIFF
--- a/client/src/scripts/improveCounter.ts
+++ b/client/src/scripts/improveCounter.ts
@@ -217,9 +217,11 @@ export default class ImproveCounter {
         this.entries.forEach((e, idx) => {
             lines.push(
                 pad(
-                    `${(idx + 1).toString().padStart(2, " ")}. ${e.state.padEnd(15)} : ${formatDate(
+                    `${(idx + 1)
+                        .toString()
+                        .padStart(2, " ")}. ${e.state.padEnd(15)} : ${formatDate(
                         new Date(e.time)
-                    )}    : czas ${formatDuration(e.delta)}    :  zabici ${e.killsMy}/${
+                    )} : czas ${formatDuration(e.delta)} : zabici ${e.killsMy}/${
                         e.killsMy + e.killsTeam
                     }`
                 )


### PR DESCRIPTION
## Summary
- tighten spacing in improve counter entries so lines aren't truncated

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a6fffc7dec832abf8b8f3cc984643b