### PR TITLE
feat: count arrivals

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -42,6 +42,7 @@ import initMagikZnika from './scripts/magikZnika'
 import initSeasonPrint from './scripts/seasonPrint'
 import initDajeCiHighlight from './scripts/dajeCiHighlight'
 import initPrzybywajaHighlight from './scripts/przybywajaHighlight'
+import initPrzybywajaCount from './scripts/przybywajaCount'
 import initPriceEvaluation from './scripts/priceEvaluation'
 import initStoneValue from './scripts/stoneValue'
 import initSelfEvaluation from './scripts/selfEvaluation'
@@ -179,6 +180,7 @@ export function registerScripts(client: Client) {
     initSeasonPrint(client)
     initDajeCiHighlight(client)
     initPrzybywajaHighlight(client)
+    initPrzybywajaCount(client)
     initGuildPostfix(client)
     initLanguage(client, aliases)
     initShortcuts(client, aliases)

--- a/client/src/scripts/przybywajaCount.ts
+++ b/client/src/scripts/przybywajaCount.ts
@@ -1,0 +1,13 @@
+import Client from "../Client";
+
+export default function initPrzybywajaCount(client: Client) {
+    const pattern = /^[ >]*(.*) przybywaja/;
+    client.Triggers.registerTrigger(pattern, (raw, _line, matches) => {
+        const names = matches[1]
+            .split(/,| i /)
+            .map(name => name.trim())
+            .filter(name => name.length > 0);
+        const count = names.length;
+        return `[${count}] ${raw}`;
+    }, 'przybywaja-count');
+}


### PR DESCRIPTION
## Summary
- count names for lines ending with `przybywaja`
- register arrival counter trigger

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a78b57b22c832a95e16f1f88384c31