### PR TITLE
Add carriage movement mode triggered by carriage boarding

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -82,7 +82,8 @@ export default class Client {
     suppressMapMoveEvent = false;
     suppressItemEvaluation = false;
     moveMode = 0;
-    moveModeButton?: HTMLInputElement;
+    carriageMode = false;
+    moveModeButton?: HTMLInputElement | HTMLButtonElement;
 
 
     constructor(clientAdapter: ClientAdapter, port: any) {
@@ -323,6 +324,7 @@ export default class Client {
 
     private applyMoveMode(cmd: string, moved?: boolean): string {
         if (!moved) return cmd
+        if (this.carriageMode) return `jedz na ${cmd}`
         if (this.moveMode === 1) return `przemknij ${cmd}`
         if (this.moveMode === 2) return `przemknij z druzyna ${cmd}`
         return cmd

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -12,6 +12,7 @@ import initLamp from './scripts/lamp'
 import initCoverTimer from './scripts/coverTimer'
 import initBinds from './scripts/binds'
 import initMoveMode from './scripts/moveMode'
+import initCarriage from './scripts/carriage'
 import initIdz from './scripts/idz'
 import { initKillCounter } from './scripts/kill'
 import { initImproveCounter } from './scripts/improveCounter'
@@ -130,6 +131,7 @@ export function registerScripts(client: Client) {
     initCoverTimer(client)
     initBinds(client, aliases)
     initMoveMode(client)
+    initCarriage(client)
     initIdz(client, aliases)
     const killCounter = initKillCounter(client, aliases)
     ;(client as any).killCounter = killCounter

--- a/client/src/scripts/carriage.ts
+++ b/client/src/scripts/carriage.ts
@@ -1,0 +1,20 @@
+import Client from "../Client";
+
+export default function initCarriage(client: Client) {
+    const enable = () => {
+        client.carriageMode = true;
+        if (client.moveModeButton) {
+            client.moveModeButton.disabled = true;
+        }
+        return undefined;
+    };
+    const disable = () => {
+        client.carriageMode = false;
+        if (client.moveModeButton) {
+            client.moveModeButton.disabled = false;
+        }
+        return undefined;
+    };
+    client.Triggers.registerTrigger(/^Siadasz w (.*) bryczce\.$/, enable, "carriageMode");
+    client.Triggers.registerTrigger(/^Zsiadasz z (.*) bryczki\.$/, disable, "carriageMode");
+}

--- a/client/src/scripts/moveMode.ts
+++ b/client/src/scripts/moveMode.ts
@@ -14,6 +14,7 @@ export default function initMoveMode(client: Client) {
     }
 
     function toggle() {
+        if (client.carriageMode) return;
         client.moveMode = (client.moveMode + 1) % LABELS.length;
         update();
     }

--- a/client/test/carriage.test.ts
+++ b/client/test/carriage.test.ts
@@ -1,0 +1,28 @@
+import initCarriage from '../src/scripts/carriage';
+import Triggers from '../src/Triggers';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+  carriageMode = false;
+  moveModeButton = document.createElement('input');
+}
+
+describe('carriage mode triggers', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initCarriage((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+  });
+
+  test('turns carriage mode on and off', () => {
+    parse('Siadasz w malej bryczce.');
+    expect(client.carriageMode).toBe(true);
+    expect(client.moveModeButton.disabled).toBe(true);
+    parse('Zsiadasz z malej bryczki.');
+    expect(client.carriageMode).toBe(false);
+    expect(client.moveModeButton.disabled).toBe(false);
+  });
+});

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -708,6 +708,7 @@ export default class MobileDirectionButtons {
                     this.client.support();
                     break;
                 case 'moveMode':
+                    if (this.client.carriageMode) break;
                     this.client.moveMode = (this.client.moveMode + 1) % MOVE_MODE_LABELS.length;
                     newBtn.textContent = `${cfg.label} ${MOVE_MODE_LABELS[this.client.moveMode]}`;
                     newBtn.title = `${cfg.label} ${MOVE_MODE_TITLES[this.client.moveMode]}`;
@@ -727,6 +728,7 @@ export default class MobileDirectionButtons {
             this.client.moveModeButton = newBtn;
             newBtn.textContent = `${cfg.label} ${MOVE_MODE_LABELS[this.client.moveMode]}`;
             newBtn.title = `${cfg.label} ${MOVE_MODE_TITLES[this.client.moveMode]}`;
+            newBtn.disabled = this.client.carriageMode;
         } else if (cfg.macro === 'specialExit') {
             const updateLabel = () => {
                 const specialExits = this.client.Map.currentRoom?.specialExits ?? {};


### PR DESCRIPTION
## Summary
- add carriage movement mode that sends `jedz na` directions
- disable manual move mode switching while in carriage
- auto-toggle carriage mode using bryczka messages

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a78c4f10d8832ab08a237277a06979