### PR TITLE
Fix object list color for non-fighting non-team members

### DIFF
--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -149,7 +149,11 @@ export default class ObjectList {
                 }
                 const classAttr = classes.length ? ` class="${classes.join(" ")}"` : "";
                 coloredDesc = `<span${classAttr} style="${style}">${rawDesc}</span>`;
-            } else if (inCombat && typeof obj.state === "number") {
+            } else if (
+                typeof obj.state === "number" &&
+                obj.attack_num !== false &&
+                obj.attack_num !== undefined
+            ) {
                 coloredDesc = `<span style="color:#b19cd9">${rawDesc}</span>`;
             }
             const desc = coloredDesc + " ".repeat(Math.max(0, descWidth - rawDesc.length));

--- a/web-client/test/ObjectList.test.ts
+++ b/web-client/test/ObjectList.test.ts
@@ -1,0 +1,29 @@
+import ObjectList from '../src/ObjectList';
+
+jest.mock('@client/src/storage', () => ({
+  getItemSync: jest.fn(),
+  setItemSync: jest.fn(),
+}));
+
+class MockClient {
+  ObjectManager = { getObjectsOnLocation: () => [] as any[] };
+  TeamManager = { isInTeam: () => false };
+  addEventListener() {}
+}
+
+describe('ObjectList', () => {
+  test('non team members not fighting are not purple', () => {
+    document.body.innerHTML = '<div id="objects-list"></div>';
+    const client = new MockClient();
+    const objectList = new ObjectList(client as any);
+    const objects = [
+      { shortcut: '1', desc: 'Goblin', state: 10 },
+      { shortcut: '2', desc: 'Orc', state: 10, attack_num: true },
+    ];
+    client.ObjectManager.getObjectsOnLocation = () => objects;
+    (objectList as any).render();
+    const html = (document.getElementById('objects-list') as HTMLElement).innerHTML.split('<br>');
+    expect(html[0]).not.toContain('#b19cd9');
+    expect(html[1]).toContain('#b19cd9');
+  });
+});


### PR DESCRIPTION
## Summary
- only tint purple objects that are actively fighting
- add unit test for object list color selection

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a7abe51354832ab11a216ce5cf180d