### PR TITLE
Align /za2 alias test with GMCP API

### DIFF
--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -105,9 +105,17 @@ describe('object aliases', () => {
     client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 11, shortcut: 'C' }]);
     client.TeamManager.getAccumulatedObjectsData.mockReturnValue({ 11: { team: true } });
     shieldGroup(['', '2', 'C'] as unknown as RegExpMatchArray);
-    expect(client.sendGMCP).toHaveBeenNthCalledWith(1, 'char.options.group_cover', 2);
+    expect(client.sendGMCP).toHaveBeenNthCalledWith(
+      1,
+      'char.options',
+      { group_cover: 2 }
+    );
     expect(client.sendCommand).toHaveBeenCalledWith('zaslon ob_11');
-    expect(client.sendGMCP).toHaveBeenNthCalledWith(2, 'char.options.group_cover', 1);
+    expect(client.sendGMCP).toHaveBeenNthCalledWith(
+      2,
+      'char.options',
+      { group_cover: 1 }
+    );
   });
 
   test('/w alias withdraws behind object', () => {


### PR DESCRIPTION
## Summary
- update /za2 alias test to match current GMCP group_cover calls

## Testing
- `CI=1 yarn --cwd client test`
- `CI=1 yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a7b9275ac0832a8108c36262ab227f