### PR TITLE
Add wycofaj mobile list

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -402,7 +402,6 @@
     <div id="mobile-direction-buttons" class="mobile-direction-buttons">
         <button class="mobile-button mobile-button-text top-button" id="z-list-toggle">/z</button>
         <button class="mobile-button mobile-button-text top-button" id="zas-list-toggle">/za</button>
-        <button class="mobile-button mobile-button-text top-button" id="w-list-toggle">/w</button>
         <button class="mobile-button mobile-button-text top-button" id="go-button">/go</button>
         <button class="mobile-button mobile-button-text top-button" id="buttons-toggle">⇩</button>
         <button class="mobile-button mobile-button-text top-button" id="bracket-right-button">]</button>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -402,6 +402,7 @@
     <div id="mobile-direction-buttons" class="mobile-direction-buttons">
         <button class="mobile-button mobile-button-text top-button" id="z-list-toggle">/z</button>
         <button class="mobile-button mobile-button-text top-button" id="zas-list-toggle">/za</button>
+        <button class="mobile-button mobile-button-text top-button" id="w-list-toggle">/w</button>
         <button class="mobile-button mobile-button-text top-button" id="go-button">/go</button>
         <button class="mobile-button mobile-button-text top-button" id="buttons-toggle">⇩</button>
         <button class="mobile-button mobile-button-text top-button" id="bracket-right-button">]</button>
@@ -422,6 +423,7 @@
         <button class="mobile-button mobile-button-text direction-button" id="special-exit-button" title="">3</button>
         <div id="z-buttons-list" class="mobile-z-buttons"></div>
         <div id="zas-buttons-list" class="mobile-z-buttons"></div>
+        <div id="w-buttons-list" class="mobile-z-buttons"></div>
         <div id="prze-buttons-list" class="mobile-z-buttons"></div>
         <div id="idz-buttons-list" class="mobile-idz-buttons"></div>
         </div>

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -28,7 +28,6 @@ export const defaultSettings: Record<string, ButtonSetting> = {
     // top row buttons
     'z-list-toggle': { macro: 'zList', label: '/z', color: '#6EB4DC' },
     'zas-list-toggle': { macro: 'zaList', label: '/za', color: '#6EB4DC' },
-    'w-list-toggle': { macro: 'wList', label: '/w', color: '#6EB4DC' },
     'go-button': { macro: 'command', label: '/go', color: '#6EB4DC', command: '/go' },
     'buttons-toggle': { macro: 'toggleButtons', label: '⇩', color: '#6EB4DC' },
     'bracket-right-button': { macro: 'functional', label: ']', color: '#6EB4DC' },
@@ -54,7 +53,6 @@ export const defaultSettings: Record<string, ButtonSetting> = {
 export const defaultOrder = [
     'z-list-toggle',
     'zas-list-toggle',
-    'w-list-toggle',
     'go-button',
     'buttons-toggle',
     'bracket-right-button',

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -4,6 +4,7 @@ export type MacroType =
     | 'functional'
     | 'zList'
     | 'zaList'
+    | 'wList'
     | 'przeList'
     | 'idzList'
     | 'command'
@@ -27,6 +28,7 @@ export const defaultSettings: Record<string, ButtonSetting> = {
     // top row buttons
     'z-list-toggle': { macro: 'zList', label: '/z', color: '#6EB4DC' },
     'zas-list-toggle': { macro: 'zaList', label: '/za', color: '#6EB4DC' },
+    'w-list-toggle': { macro: 'wList', label: '/w', color: '#6EB4DC' },
     'go-button': { macro: 'command', label: '/go', color: '#6EB4DC', command: '/go' },
     'buttons-toggle': { macro: 'toggleButtons', label: '⇩', color: '#6EB4DC' },
     'bracket-right-button': { macro: 'functional', label: ']', color: '#6EB4DC' },
@@ -52,6 +54,7 @@ export const defaultSettings: Record<string, ButtonSetting> = {
 export const defaultOrder = [
     'z-list-toggle',
     'zas-list-toggle',
+    'w-list-toggle',
     'go-button',
     'buttons-toggle',
     'bracket-right-button',
@@ -138,11 +141,12 @@ export function applySettings(settings: Settings, inTeam = false, isLeader = fal
 
         const z = document.getElementById('z-buttons-list');
         const zas = document.getElementById('zas-buttons-list');
+        const w = document.getElementById('w-buttons-list');
         const prze = document.getElementById('prze-buttons-list');
         const idz = document.getElementById('idz-buttons-list');
         container.querySelectorAll('button').forEach(b => b.remove());
         const empty: ButtonSetting = { macro: 'empty', label: '', color: 'transparent' };
-        const insertBefore = z || zas || prze || idz || null;
+        const insertBefore = z || zas || w || prze || idz || null;
         set.order.forEach(id => {
             const cfg = set.buttons[id] || defaultSettings[id] || empty;
             const btn = document.createElement('button');

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -17,6 +17,7 @@ const macroOptions: { value: MacroType; label: string }[] = [
     { value: "functional", label: "Bind funkcyjny" },
     { value: "zList", label: "Lista /z" },
     { value: "zaList", label: "Lista /za" },
+    { value: "wList", label: "Lista /w" },
     { value: "przeList", label: "Lista /prze" },
     { value: "idzList", label: "Lista idz" },
     { value: "command", label: "Wyślij komendę" },

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -14,10 +14,12 @@ export default class MobileDirectionButtons {
     private readonly contentArea: HTMLElement | null = null;
     private readonly zList: HTMLDivElement | null = null;
     private readonly zasList: HTMLDivElement | null = null;
+    private readonly wList: HTMLDivElement | null = null;
     private readonly przeList: HTMLDivElement | null = null;
     private readonly idzList: HTMLDivElement | null = null;
     private readonly zToggle: HTMLButtonElement | null = null;
     private readonly zasToggle: HTMLButtonElement | null = null;
+    private wToggle: HTMLButtonElement | null = null;
     private przeToggle: HTMLButtonElement | null = null;
     private idzToggle: HTMLButtonElement | null = null;
     private bracketRightButton: HTMLButtonElement | null = null;
@@ -60,10 +62,12 @@ export default class MobileDirectionButtons {
         this.contentArea = document.getElementById('main_text_output_msg_wrapper');
         this.zList = document.getElementById('z-buttons-list') as HTMLDivElement;
         this.zasList = document.getElementById('zas-buttons-list') as HTMLDivElement;
+        this.wList = document.getElementById('w-buttons-list') as HTMLDivElement;
         this.przeList = document.getElementById('prze-buttons-list') as HTMLDivElement;
         this.idzList = document.getElementById('idz-buttons-list') as HTMLDivElement;
         this.zToggle = document.getElementById('z-list-toggle') as HTMLButtonElement;
         this.zasToggle = document.getElementById('zas-list-toggle') as HTMLButtonElement;
+        this.wToggle = document.getElementById('w-list-toggle') as HTMLButtonElement;
         this.idzToggle = null;
         this.bracketRightButton = document.getElementById('bracket-right-button') as HTMLButtonElement;
         this.toggleButton = document.getElementById('buttons-toggle') as HTMLButtonElement;
@@ -162,6 +166,7 @@ export default class MobileDirectionButtons {
             this.bracketRightButton = document.getElementById('bracket-right-button') as HTMLButtonElement | null;
             this.zToggle = document.getElementById('z-list-toggle') as HTMLButtonElement | null;
             this.zasToggle = document.getElementById('zas-list-toggle') as HTMLButtonElement | null;
+            this.wToggle = null;
             this.przeToggle = null;
             this.idzToggle = null;
             this.directionButtons = {
@@ -456,10 +461,12 @@ export default class MobileDirectionButtons {
     private hideLists() {
         if (this.zList) this.zList.style.display = 'none';
         if (this.zasList) this.zasList.style.display = 'none';
+        if (this.wList) this.wList.style.display = 'none';
         if (this.przeList) this.przeList.style.display = 'none';
         if (this.idzList) this.idzList.style.display = 'none';
         if (this.zToggle) this.zToggle.classList.remove('active');
         if (this.zasToggle) this.zasToggle.classList.remove('active');
+        if (this.wToggle) this.wToggle.classList.remove('active');
         if (this.przeToggle) this.przeToggle.classList.remove('active');
         if (this.idzToggle) this.idzToggle.classList.remove('active');
     }
@@ -542,6 +549,10 @@ export default class MobileDirectionButtons {
         this.renderList(this.zasList, /^[A-Z]$/, 'zas');
     }
 
+    private renderWList() {
+        this.renderList(this.wList, /^[A-Z]$/, 'w');
+    }
+
     private renderPrzeList() {
         this.renderList(this.przeList, /^[0-9]+$/, 'prze');
     }
@@ -611,6 +622,11 @@ export default class MobileDirectionButtons {
         }
         if (id === 'z-list-toggle') this.zToggle = newBtn;
         if (id === 'zas-list-toggle') this.zasToggle = newBtn;
+        if (cfg.macro === 'wList') {
+            this.wToggle = newBtn;
+        } else if (this.wToggle === newBtn) {
+            this.wToggle = null;
+        }
         if (cfg.macro === 'idzList') {
             this.idzToggle = newBtn;
         } else if (this.idzToggle === newBtn) {
@@ -668,6 +684,16 @@ export default class MobileDirectionButtons {
                         this.hideLists();
                         this.renderZasList();
                         if (this.zasList) this.zasList.style.display = 'grid';
+                        newBtn.classList.add('active');
+                    }
+                    break;
+                case 'wList':
+                    if (this.wList && this.wList.style.display === 'grid') {
+                        this.hideLists();
+                    } else {
+                        this.hideLists();
+                        this.renderWList();
+                        if (this.wList) this.wList.style.display = 'grid';
                         newBtn.classList.add('active');
                     }
                     break;

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -67,7 +67,6 @@ export default class MobileDirectionButtons {
         this.idzList = document.getElementById('idz-buttons-list') as HTMLDivElement;
         this.zToggle = document.getElementById('z-list-toggle') as HTMLButtonElement;
         this.zasToggle = document.getElementById('zas-list-toggle') as HTMLButtonElement;
-        this.wToggle = document.getElementById('w-list-toggle') as HTMLButtonElement;
         this.idzToggle = null;
         this.bracketRightButton = document.getElementById('bracket-right-button') as HTMLButtonElement;
         this.toggleButton = document.getElementById('buttons-toggle') as HTMLButtonElement;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -582,6 +582,7 @@ button:focus-visible {
 .mobile-direction-buttons.collapsed button:not(#buttons-toggle),
 .mobile-direction-buttons.collapsed #z-buttons-list,
 .mobile-direction-buttons.collapsed #zas-buttons-list,
+.mobile-direction-buttons.collapsed #w-buttons-list,
 .mobile-direction-buttons.collapsed #prze-buttons-list {
   display: none;
 }


### PR DESCRIPTION
## Summary
- add `wList` macro and default `/w` button configuration
- support rendering and toggling `/w` withdraw list on mobile
- include `/w` button and list in HTML and collapsed styles

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a82248ac20832ab888ece8dc1b15fd