### PR TITLE
test: cover event bus and storage

### DIFF
--- a/client/test/eventBus.test.ts
+++ b/client/test/eventBus.test.ts
@@ -1,0 +1,41 @@
+import { EventBus } from '../src/eventBus';
+
+type TestEvents = {
+  single: number;
+  multi: [string, number];
+  void: void;
+};
+
+describe('EventBus', () => {
+  let bus: EventBus<TestEvents>;
+
+  beforeEach(() => {
+    bus = new EventBus<TestEvents>();
+  });
+
+  test('handles single argument events', () => {
+    const handler = jest.fn();
+    bus.on('single', handler);
+    bus.emit('single', 5);
+    expect(handler).toHaveBeenCalledWith(5);
+  });
+
+  test('handles multiple arguments and void events', () => {
+    const multiHandler = jest.fn();
+    const voidHandler = jest.fn();
+    bus.on('multi', multiHandler);
+    bus.on('void', voidHandler);
+    bus.emit('multi', 'test', 7);
+    bus.emit('void');
+    expect(multiHandler).toHaveBeenCalledWith('test', 7);
+    expect(voidHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test('off removes listener', () => {
+    const handler = jest.fn();
+    bus.on('single', handler);
+    bus.off('single', handler);
+    bus.emit('single', 1);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/client/test/storage.test.ts
+++ b/client/test/storage.test.ts
@@ -1,0 +1,31 @@
+import storage, { setCurrentCharacter, getCurrentCharacter, getItemSync, setItemSync } from '../src/storage';
+
+describe('storage character scoping', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setCurrentCharacter('');
+  });
+
+  test('setCurrentCharacter migrates unscoped data and notifies listeners', () => {
+    localStorage.setItem('settings', JSON.stringify({ foo: 1 }));
+    const listener = jest.fn();
+    storage.onChanged?.addListener(listener);
+    setCurrentCharacter('Alice');
+    expect(localStorage.getItem('settings')).toBeNull();
+    expect(localStorage.getItem('Alice:settings')).toBe(JSON.stringify({ foo: 1 }));
+    expect(getCurrentCharacter()).toBe('Alice');
+    expect(listener).toHaveBeenCalledWith({ settings: { oldValue: undefined, newValue: { foo: 1 } } });
+    storage.onChanged?.removeListener(listener);
+  });
+
+  test('setItemSync stores scoped values and triggers listeners', () => {
+    setCurrentCharacter('Bob');
+    const listener = jest.fn();
+    storage.onChanged?.addListener(listener);
+    setItemSync('settings', { bar: 2 });
+    expect(localStorage.getItem('Bob:settings')).toBe(JSON.stringify({ bar: 2 }));
+    expect(getItemSync('settings')).toEqual({ settings: { bar: 2 } });
+    expect(listener).toHaveBeenCalledWith({ settings: { oldValue: undefined, newValue: { bar: 2 } } });
+    storage.onChanged?.removeListener(listener);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for EventBus covering multiple argument and void events
- add storage tests validating character-scoped persistence and listener notifications

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a8324671d4832aaea8e8c637c3e493