### PR TITLE
Refactor herb counter test setup

### DIFF
--- a/client/test/helpers/herbClient.ts
+++ b/client/test/helpers/herbClient.ts
@@ -1,0 +1,50 @@
+import { EventEmitter } from 'events';
+import initHerbCounter from '../../src/scripts/herbCounter';
+
+export class FakeClient {
+  private emitter = new EventEmitter();
+  aliases: { pattern: RegExp; callback: Function }[] = [];
+  Triggers = { registerTrigger: jest.fn() } as any;
+  sendCommand = jest.fn();
+  println = jest.fn();
+  port = { postMessage: jest.fn() } as any;
+  addEventListener(event: string, cb: any) {
+    this.emitter.on(event, cb);
+  }
+  removeEventListener(event: string, cb: any) {
+    this.emitter.off(event, cb);
+  }
+  dispatch(event: string, detail: any) {
+    this.emitter.emit(event, { detail });
+  }
+}
+
+export const defaultHerbData = {
+  herb_id_to_odmiana: {
+    deliona: {
+      mianownik: 'zolty jasny kwiat',
+      dopelniacz: 'zoltego jasnego kwiata',
+      biernik: 'zolty jasny kwiat',
+      mnoga_mianownik: 'zolte jasne kwiaty',
+      mnoga_dopelniacz: 'zoltych jasnych kwiatow',
+      mnoga_biernik: 'zolte jasne kwiaty'
+    }
+  },
+  version: 1,
+  herb_id_to_use: {}
+};
+
+export function initHerbClient(
+  client: { aliases: { pattern: RegExp; callback: Function }[]; dispatch(event: string, detail: any): void },
+  herbCounts: Record<number, Record<string, number>> = {},
+  herbData: any = defaultHerbData,
+  aliases = client.aliases
+) {
+  (global as any).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(herbData)
+  });
+  initHerbCounter((client as unknown) as any, aliases);
+  client.dispatch('storage', { key: 'herb_counts', value: herbCounts });
+}
+

--- a/client/test/herbCounter.test.ts
+++ b/client/test/herbCounter.test.ts
@@ -1,6 +1,6 @@
-import initHerbCounter from '../src/scripts/herbCounter';
 import Triggers, { stripAnsiCodes } from '../src/Triggers';
 import { EventEmitter } from 'events';
+import { initHerbClient, defaultHerbData } from './helpers/herbClient';
 
 class FakeClient {
   private emitter = new EventEmitter();
@@ -29,24 +29,7 @@ describe('herb counter', () => {
   beforeEach(() => {
     client = new FakeClient();
     const aliases: { pattern: RegExp; callback: () => void }[] = [];
-    (global as any).fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({
-        herb_id_to_odmiana: {
-          deliona: {
-            mianownik: 'zolty jasny kwiat',
-            dopelniacz: 'zoltego jasnego kwiata',
-            biernik: 'zolty jasny kwiat',
-            mnoga_mianownik: 'zolte jasne kwiaty',
-            mnoga_dopelniacz: 'zoltych jasnych kwiatow',
-            mnoga_biernik: 'zolte jasne kwiaty'
-          }
-        },
-        version: 1,
-        herb_id_to_use: {}
-      })
-    });
-    initHerbCounter((client as unknown) as any, aliases);
+    initHerbClient((client as unknown) as any, {}, defaultHerbData, aliases);
     start = aliases[0].callback as any;
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
   });
@@ -69,31 +52,31 @@ describe('herb counter', () => {
   test('splits summary when width is limited', async () => {
     client.contentWidth = 40;
     client.dispatch('contentWidth', 40);
-    (global as any).fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          herb_id_to_odmiana: {
-            deliona: {
-              mianownik: 'zolty jasny kwiat',
-              dopelniacz: 'zoltego jasnego kwiata',
-              biernik: 'zolty jasny kwiat',
-              mnoga_mianownik: 'zolte jasne kwiaty',
-              mnoga_dopelniacz: 'zoltych jasnych kwiatow',
-              mnoga_biernik: 'zolte jasne kwiaty'
-            }
-          },
-          version: 1,
-          herb_id_to_use: {
-            deliona: [
-              { action: 'eat', effect: '+hp' },
-              { action: 'rub', effect: '+mana' }
-            ]
-          }
-        })
-    });
     const aliases: { pattern: RegExp; callback: () => void }[] = [];
-    initHerbCounter((client as unknown) as any, aliases);
+    initHerbClient(
+      (client as unknown) as any,
+      {},
+      {
+        herb_id_to_odmiana: {
+          deliona: {
+            mianownik: 'zolty jasny kwiat',
+            dopelniacz: 'zoltego jasnego kwiata',
+            biernik: 'zolty jasny kwiat',
+            mnoga_mianownik: 'zolte jasne kwiaty',
+            mnoga_dopelniacz: 'zoltych jasnych kwiatow',
+            mnoga_biernik: 'zolte jasne kwiaty'
+          }
+        },
+        version: 1,
+        herb_id_to_use: {
+          deliona: [
+            { action: 'eat', effect: '+hp' },
+            { action: 'rub', effect: '+mana' }
+          ]
+        }
+      },
+      aliases
+    );
     const start2 = aliases[0].callback as any;
     const parse2 = (line: string) =>
       Triggers.prototype.parseLine.call(client.Triggers, line, '');
@@ -111,7 +94,7 @@ describe('herb counter', () => {
 
   test('prints summary from storage', () => {
     const aliases: { pattern: RegExp; callback: () => void }[] = [];
-    initHerbCounter((client as unknown) as any, aliases);
+    initHerbClient((client as unknown) as any, {}, defaultHerbData, aliases);
     const show = aliases[1].callback as any;
     show();
     client.dispatch('storage', { key: 'herb_counts', value: { 1: { deliona: 2 } } });

--- a/client/test/wezz.test.ts
+++ b/client/test/wezz.test.ts
@@ -1,17 +1,4 @@
-import initHerbCounter from '../src/scripts/herbCounter';
-import { EventEmitter } from 'events';
-
-class FakeClient {
-  private emitter = new EventEmitter();
-  aliases: { pattern: RegExp; callback: Function }[] = [];
-  Triggers = { registerTrigger: jest.fn() } as any;
-  sendCommand = jest.fn();
-  println = jest.fn();
-  port = { postMessage: jest.fn() } as any;
-  addEventListener(event: string, cb: any) { this.emitter.on(event, cb); }
-  removeEventListener(event: string, cb: any) { this.emitter.off(event, cb); }
-  dispatch(event: string, detail: any) { this.emitter.emit(event, { detail }); }
-}
+import { FakeClient, initHerbClient } from './helpers/herbClient';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -21,29 +8,7 @@ describe('wezz alias', () => {
   let client: FakeClient;
   beforeEach(() => {
     client = new FakeClient();
-    (global as any).fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          herb_id_to_odmiana: {
-            deliona: {
-              mianownik: 'zolty jasny kwiat',
-              dopelniacz: 'zoltego jasnego kwiata',
-              biernik: 'zolty jasny kwiat',
-              mnoga_mianownik: 'zolte jasne kwiaty',
-              mnoga_dopelniacz: 'zoltych jasnych kwiatow',
-              mnoga_biernik: 'zolte jasne kwiaty'
-            }
-          },
-          version: 1,
-          herb_id_to_use: {}
-        })
-    });
-    initHerbCounter((client as unknown) as any, client.aliases);
-    client.dispatch('storage', {
-      key: 'herb_counts',
-      value: { 1: { deliona: 1 }, 2: { deliona: 1 } }
-    });
+    initHerbClient(client, { 1: { deliona: 1 }, 2: { deliona: 1 } });
   });
 
   test('takes herbs from multiple bags', async () => {

--- a/client/test/zi.test.ts
+++ b/client/test/zi.test.ts
@@ -1,17 +1,4 @@
-import initHerbCounter from '../src/scripts/herbCounter';
-import { EventEmitter } from 'events';
-
-class FakeClient {
-  private emitter = new EventEmitter();
-  aliases: { pattern: RegExp; callback: Function }[] = [];
-  Triggers = { registerTrigger: jest.fn() } as any;
-  sendCommand = jest.fn();
-  println = jest.fn();
-  port = { postMessage: jest.fn() } as any;
-  addEventListener(event: string, cb: any) { this.emitter.on(event, cb); }
-  removeEventListener(event: string, cb: any) { this.emitter.off(event, cb); }
-  dispatch(event: string, detail: any) { this.emitter.emit(event, { detail }); }
-}
+import { FakeClient, initHerbClient } from './helpers/herbClient';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -21,29 +8,7 @@ describe('/zi alias', () => {
   let client: FakeClient;
   beforeEach(() => {
     client = new FakeClient();
-    (global as any).fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          herb_id_to_odmiana: {
-            deliona: {
-              mianownik: 'zolty jasny kwiat',
-              dopelniacz: 'zoltego jasnego kwiata',
-              biernik: 'zolty jasny kwiat',
-              mnoga_mianownik: 'zolte jasne kwiaty',
-              mnoga_dopelniacz: 'zoltych jasnych kwiatow',
-              mnoga_biernik: 'zolte jasne kwiaty'
-            }
-          },
-          version: 1,
-          herb_id_to_use: {}
-        })
-    });
-    initHerbCounter((client as unknown) as any, client.aliases);
-    client.dispatch('storage', {
-      key: 'herb_counts',
-      value: { 1: { deliona: 1 } }
-    });
+    initHerbClient(client, { 1: { deliona: 1 } });
   });
 
   test('takes herb and performs action', async () => {


### PR DESCRIPTION
## Summary
- extract FakeClient and initHerbClient helper for herb tests
- reuse helper in wezz, zi, and herbCounter tests to remove duplication

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a841bd1a64832a83fde33f528b2b39