### PR TITLE
refactor: reuse direction helpers

### DIFF
--- a/client/src/scripts/inlineCompassRose.ts
+++ b/client/src/scripts/inlineCompassRose.ts
@@ -1,37 +1,13 @@
 import Client from "../Client";
 import { color, findClosestColor } from "../Colors";
-import {gmcp} from "../gmcp";
+import { gmcp } from "../gmcp";
+import { getShortDir, longToShort } from "../utils/directions";
 
 const SPRING_GREEN = findClosestColor("#00ff7f");
 const DIM_GRAY = findClosestColor("#696969");
 const RESET = "\x1B[0m";
 
-const shortToLong: Record<string, string> = {
-    n: "north",
-    s: "south",
-    e: "east",
-    w: "west",
-    ne: "northeast",
-    nw: "northwest",
-    se: "southeast",
-    sw: "southwest",
-    u: "up",
-    d: "down",
-};
-
-const polishToShort: Record<string, string> = {
-    polnoc: "n",
-    poludnie: "s",
-    wschod: "e",
-    zachod: "w",
-    "polnocny-wschod": "ne",
-    "polnocny-zachod": "nw",
-    "poludniowy-wschod": "se",
-    "poludniowy-zachod": "sw",
-    dol: "d",
-    gora: "u",
-    gore: "u",
-};
+const VALID_SHORT_DIRS = new Set(Object.values(longToShort));
 
 export default class InlineCompassRose {
     private client: Client;
@@ -80,16 +56,9 @@ export default class InlineCompassRose {
             const e = detail.room.exits;
             list = Array.isArray(e) ? e : Object.keys(e);
         }
-        return list.map((e) => this.toShort(e)).filter(Boolean);
-    }
-
-    private toShort(exit: string): string {
-        if (polishToShort[exit]) return polishToShort[exit];
-        if (shortToLong[exit]) return exit;
-        const long = exit.toLowerCase();
-        const short = Object.entries(shortToLong).find(([_, l]) => l === long);
-        if (short) return short[0];
-        return "";
+        return list
+            .map((e) => getShortDir(e))
+            .filter((dir) => VALID_SHORT_DIRS.has(dir));
     }
 
     private hasExit(short: string): boolean {

--- a/client/test/inlineCompassRose.test.ts
+++ b/client/test/inlineCompassRose.test.ts
@@ -10,7 +10,6 @@ describe('InlineCompassRose parsing', () => {
   const client = new FakeClient();
   const rose = new InlineCompassRose((client as unknown) as any);
   const parse = (detail: any) => (rose as any).parseExits(detail);
-  const toShort = (exit: string) => (rose as any).toShort(exit);
 
   test('parseExits accepts various formats', () => {
     expect(parse(['north', 'south'])).toEqual(['n', 's']);
@@ -19,10 +18,7 @@ describe('InlineCompassRose parsing', () => {
     expect(parse({ room: { exits: { up: 3 } } })).toEqual(['u']);
   });
 
-  test('toShort converts directions', () => {
-    expect(toShort('polnoc')).toBe('n');
-    expect(toShort('south')).toBe('s');
-    expect(toShort('north')).toBe('n');
-    expect(toShort('unknown')).toBe('');
+  test('parseExits converts directions', () => {
+    expect(parse(['polnoc', 'south', 'north', 'unknown'])).toEqual(['n', 's', 'n']);
   });
 });


### PR DESCRIPTION
## Summary
- reuse shared direction helpers in InlineCompassRose
- drop local direction maps and delegate conversions to helper
- update tests for shared direction conversion

## Testing
- `CI=1 yarn --cwd client test`
- `CI=1 yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a841b7b5b8832a94ca488dcd9c4afc