### PR TITLE
Store object list position relative to left edge

### DIFF
--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -8,7 +8,7 @@ export default class ObjectList {
     private isDragging = false;
     private startX = 0;
     private startY = 0;
-    private offsetRight = 0;
+    private offsetLeft = 0;
     private offsetTop = 0;
     private pointerId = 0;
 
@@ -30,9 +30,18 @@ export default class ObjectList {
         const saved = savedData?.objectsListPosition;
         if (saved) {
             try {
-                const { x, y } = saved as any;
-                this.container.style.right = `${x}px`;
-                this.container.style.top = `${y}px`;
+                let { left, top, right, x, y } = saved as any;
+                if (left === undefined && (right !== undefined || x !== undefined)) {
+                    const oldRight = right ?? x ?? 0;
+                    left = window.innerWidth - this.container.offsetWidth - oldRight;
+                }
+                top = top ?? y;
+                if (typeof left === "number") {
+                    this.container.style.left = `${left}px`;
+                }
+                if (typeof top === "number") {
+                    this.container.style.top = `${top}px`;
+                }
             } catch (e) {
                 console.error("Error parsing saved objects list position", e);
             }
@@ -51,7 +60,7 @@ export default class ObjectList {
         this.startX = e.clientX;
         this.startY = e.clientY;
         const rect = this.container.getBoundingClientRect();
-        this.offsetRight = window.innerWidth - rect.right;
+        this.offsetLeft = rect.left;
         this.offsetTop = rect.top;
         this.container.setPointerCapture(this.pointerId);
         e.preventDefault();
@@ -60,14 +69,14 @@ export default class ObjectList {
     private onPointerMove = (e: PointerEvent) => {
         if (!this.isDragging || !this.container || e.pointerId !== this.pointerId) return;
 
-        const deltaX = this.startX - e.clientX;
+        const deltaX = e.clientX - this.startX;
         const deltaY = e.clientY - this.startY;
-        const newRight = this.offsetRight + deltaX;
+        const newLeft = this.offsetLeft + deltaX;
         const newTop = this.offsetTop + deltaY;
-        const maxRight = window.innerWidth - this.container.offsetWidth;
-        const clampedRight = Math.min(maxRight, Math.max(0, newRight));
+        const maxLeft = window.innerWidth - this.container.offsetWidth;
+        const clampedLeft = Math.min(maxLeft, Math.max(0, newLeft));
         const clampedTop = Math.max(0, newTop);
-        this.container.style.right = `${clampedRight}px`;
+        this.container.style.left = `${clampedLeft}px`;
         this.container.style.top = `${clampedTop}px`;
     };
 
@@ -77,8 +86,8 @@ export default class ObjectList {
         this.container.releasePointerCapture(this.pointerId);
         const rect = this.container.getBoundingClientRect();
         const position = {
-            x: window.innerWidth - rect.right,
-            y: rect.top,
+            left: rect.left,
+            top: rect.top,
         };
         setItemSync("objectsListPosition", position);
         this.clampToViewport();
@@ -88,15 +97,15 @@ export default class ObjectList {
         if (!this.container) return;
         const rect = this.container.getBoundingClientRect();
         const styles = window.getComputedStyle(this.container);
-        let newRight = parseFloat(styles.right || "0");
+        let newLeft = parseFloat(styles.left || "0");
         let newTop = parseFloat(styles.top || "0");
 
-        const maxRight = window.innerWidth - this.container.offsetWidth;
+        const maxLeft = window.innerWidth - this.container.offsetWidth;
 
         if (rect.right > window.innerWidth) {
-            newRight = 0;
+            newLeft = maxLeft;
         } else if (rect.left < 0) {
-            newRight = maxRight;
+            newLeft = 0;
         }
 
         if (rect.bottom > window.innerHeight) {
@@ -105,9 +114,9 @@ export default class ObjectList {
             newTop = 0;
         }
 
-        newRight = Math.min(maxRight, Math.max(0, newRight));
+        newLeft = Math.min(maxLeft, Math.max(0, newLeft));
         newTop = Math.max(0, newTop);
-        this.container.style.right = `${newRight}px`;
+        this.container.style.left = `${newLeft}px`;
         this.container.style.top = `${newTop}px`;
     };
 

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -212,7 +212,7 @@ h1 {
 #objects-list {
   position: absolute;
   top: 0;
-  right: 0;
+  left: 0;
   padding: 0.5vh 1vh;
   font-family: monospace;
   font-size: 0.6rem;

--- a/web-client/test/ObjectList.test.ts
+++ b/web-client/test/ObjectList.test.ts
@@ -1,4 +1,5 @@
 import ObjectList from '../src/ObjectList';
+import { getItemSync, setItemSync } from '@client/src/storage';
 
 jest.mock('@client/src/storage', () => ({
   getItemSync: jest.fn(),
@@ -12,6 +13,14 @@ class MockClient {
 }
 
 describe('ObjectList', () => {
+  beforeEach(() => {
+    (getItemSync as jest.Mock).mockReset();
+    (setItemSync as jest.Mock).mockReset();
+    document.body.innerHTML = '';
+    Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 768, writable: true });
+  });
+
   test('non team members not fighting are not purple', () => {
     document.body.innerHTML = '<div id="objects-list"></div>';
     const client = new MockClient();
@@ -25,5 +34,50 @@ describe('ObjectList', () => {
     const html = (document.getElementById('objects-list') as HTMLElement).innerHTML.split('<br>');
     expect(html[0]).not.toContain('#b19cd9');
     expect(html[1]).toContain('#b19cd9');
+  });
+
+  test('converts stored right position to left', () => {
+    (getItemSync as jest.Mock).mockReturnValue({ objectsListPosition: { x: 100, y: 50 } });
+    Object.defineProperty(window, 'innerWidth', { value: 1000, writable: true });
+    document.body.innerHTML = '<div id="objects-list"></div>';
+    const container = document.getElementById('objects-list') as any;
+    Object.defineProperty(container, 'offsetWidth', { value: 200, configurable: true });
+    Object.defineProperty(container, 'offsetHeight', { value: 100, configurable: true });
+    container.getBoundingClientRect = () => ({
+      left: parseFloat(container.style.left || '0'),
+      top: parseFloat(container.style.top || '0'),
+      right: parseFloat(container.style.left || '0') + container.offsetWidth,
+      bottom: parseFloat(container.style.top || '0') + container.offsetHeight,
+      width: container.offsetWidth,
+      height: container.offsetHeight,
+    });
+    const client = new MockClient();
+    new ObjectList(client as any);
+    expect(container.style.left).toBe('700px');
+    expect(container.style.top).toBe('50px');
+  });
+
+  test('saves left position on pointer up', () => {
+    (getItemSync as jest.Mock).mockReturnValue(undefined);
+    document.body.innerHTML = '<div id="objects-list"></div>';
+    const container = document.getElementById('objects-list') as any;
+    Object.defineProperty(container, 'offsetWidth', { value: 200, configurable: true });
+    Object.defineProperty(container, 'offsetHeight', { value: 100, configurable: true });
+    container.getBoundingClientRect = () => ({
+      left: 400,
+      top: 60,
+      right: 600,
+      bottom: 160,
+      width: 200,
+      height: 100,
+    });
+    container.setPointerCapture = jest.fn();
+    container.releasePointerCapture = jest.fn();
+    const client = new MockClient();
+    const ol: any = new ObjectList(client as any);
+    const downEvent = { clientX: 0, clientY: 0, pointerId: 1, preventDefault: jest.fn() } as unknown as PointerEvent;
+    ol.onPointerDown(downEvent);
+    ol.onPointerUp({ pointerId: 1 } as unknown as PointerEvent);
+    expect(setItemSync).toHaveBeenCalledWith('objectsListPosition', { left: 400, top: 60 });
   });
 });


### PR DESCRIPTION
## Summary
- handle saved `objectsListPosition` relative to left side instead of right, migrating old data
- update drag logic and viewport clamping to use left coordinates
- test conversion from legacy right values and saving of left-based positions

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68a841f779a8832a98f33a5acbd6585c