### PR TITLE
Release cover when shielding from object list

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -277,6 +277,10 @@ export default class Client {
         }
     }
 
+    releaseGuard() {
+        this.sendCommand('przestan zaslaniac')
+    }
+
     sendCommand(command: string, echo: boolean = true) {
         if (command) {
             command = stripPolishCharacters(command)

--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -29,7 +29,7 @@ export default function initObjectAliases(
             const cmd = isTeam ? `zaslon ob_${obj.num}` : `zaslon przed ob_${obj.num}`;
             client.sendCommand(cmd);
             if (releaseGuard) {
-                client.sendCommand("przestan zaslaniac");
+                client.releaseGuard();
             }
         }
     }
@@ -39,7 +39,7 @@ export default function initObjectAliases(
         if (obj) {
             client.sendCommand(`gzwycofaj sie za ob_${obj.num}`);
             if (releaseGuard) {
-                client.sendCommand("przestan zaslaniac");
+                client.releaseGuard();
             }
         }
     }
@@ -95,7 +95,7 @@ export default function initObjectAliases(
                     const cmd = isTeam ? `zaslon ob_${id}` : `zaslon przed ob_${id}`;
                     client.sendCommand(cmd);
                     if (releaseGuard) {
-                        client.sendCommand("przestan zaslaniac");
+                        client.releaseGuard();
                     }
                 }
             }
@@ -118,7 +118,7 @@ export default function initObjectAliases(
                     const cmd = isTeam ? `zaslon ob_${id}` : `zaslon przed ob_${id}`;
                     client.sendCommand(cmd);
                     if (releaseGuard) {
-                        client.sendCommand("przestan zaslaniac");
+                        client.releaseGuard();
                     }
                 }
             }

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -11,6 +11,7 @@ class FakeClient {
     getAccumulatedObjectsData: jest.fn(() => ({})),
   };
   sendCommand = jest.fn();
+  releaseGuard = jest.fn(() => this.sendCommand('przestan zaslaniac'));
   sendGMCP = jest.fn();
   print = jest.fn();
   sendEvent = jest.fn();

--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -142,21 +142,23 @@ export default class ObjectList {
         if (this.isMobile) return;
         const target = e.target;
         if (!(target instanceof HTMLElement)) return;
-        const numEl = target.closest(".object-num[data-object-id]") as HTMLElement | null;
+        const numEl = target.closest(
+            ".object-num[data-object-num]"
+        ) as HTMLElement | null;
         if (numEl) {
-            const id = numEl.getAttribute("data-object-id");
-            if (id) {
-                this.client.sendCommand(`zabij ob_${id}`);
+            const num = numEl.getAttribute("data-object-num");
+            if (num) {
+                this.client.sendCommand(`/z ${num}`);
             }
             return;
         }
-        const descEl = target.closest(".object-desc[data-object-id]") as HTMLElement | null;
+        const descEl = target.closest(
+            ".object-desc[data-object-num]"
+        ) as HTMLElement | null;
         if (descEl) {
-            const id = descEl.getAttribute("data-object-id");
-            const teammate = descEl.getAttribute("data-teammate") === "true";
-            if (id) {
-                const cmd = teammate ? `zaslon ob_${id}` : `zaslon przed ob_${id}`;
-                this.client.sendCommand(cmd);
+            const num = descEl.getAttribute("data-object-num");
+            if (num) {
+                this.client.sendCommand(`/za ${num}`);
             }
         }
     };
@@ -213,7 +215,7 @@ export default class ObjectList {
             const isTeammate = tm?.isInTeam?.(rawDesc) ? "true" : "false";
             const desc = isPlayer
                 ? `${rawDesc}${padding}`
-                : `<span class="object-desc" data-object-id="${obj.num}" data-object-desc="${rawDesc}" data-teammate="${isTeammate}">${coloredDesc}</span>${padding}`;
+                : `<span class="object-desc" data-object-id="${obj.num}" data-object-num="${num}" data-object-desc="${rawDesc}" data-teammate="${isTeammate}">${coloredDesc}</span>${padding}`;
             let bar = "";
             if (typeof obj.state === "number") {
                 const hp = Math.max(0, Math.min(6, obj.state)) + 1;

--- a/web-client/test/ObjectList.test.ts
+++ b/web-client/test/ObjectList.test.ts
@@ -127,12 +127,12 @@ describe('ObjectList', () => {
     const objects = [ { shortcut: '1', desc: 'Orc', num: 123 } ];
     client.ObjectManager.getObjectsOnLocation = () => objects;
     (objectList as any).render();
-    const num = document.querySelector('.object-num[data-object-id="123"]') as HTMLElement;
+    const num = document.querySelector('.object-num[data-object-num="1"]') as HTMLElement;
     num.click();
-    expect(client.sendCommand).toHaveBeenCalledWith('zabij ob_123');
+    expect(client.sendCommand).toHaveBeenCalledWith('/z 1');
   });
 
-    test('clicking teammate shields them', () => {
+  test('clicking teammate shields them', () => {
     document.body.innerHTML = '<div id="objects-list"></div>';
     const client = new MockClient();
     client.TeamManager.isInTeam = (d: string) => d === 'Ally';
@@ -140,9 +140,9 @@ describe('ObjectList', () => {
     const objects = [ { shortcut: '1', desc: 'Ally', num: 42 } ];
     client.ObjectManager.getObjectsOnLocation = () => objects;
     (objectList as any).render();
-    const desc = document.querySelector('.object-desc[data-object-id="42"]') as HTMLElement;
+    const desc = document.querySelector('.object-desc[data-object-num="1"]') as HTMLElement;
     desc.click();
-    expect(client.sendCommand).toHaveBeenCalledWith('zaslon ob_42');
+    expect(client.sendCommand).toHaveBeenCalledWith('/za 1');
   });
 
   test('clicking enemy shields against them', () => {
@@ -152,9 +152,9 @@ describe('ObjectList', () => {
     const objects = [ { shortcut: '1', desc: 'Goblin', num: 77 } ];
     client.ObjectManager.getObjectsOnLocation = () => objects;
     (objectList as any).render();
-    const desc = document.querySelector('.object-desc[data-object-id="77"]') as HTMLElement;
+    const desc = document.querySelector('.object-desc[data-object-num="1"]') as HTMLElement;
     desc.click();
-    expect(client.sendCommand).toHaveBeenCalledWith('zaslon przed ob_77');
+    expect(client.sendCommand).toHaveBeenCalledWith('/za 1');
   });
 
   test('player object is not clickable', () => {


### PR DESCRIPTION
## Summary
- Add `releaseGuard` helper to client
- Use object list aliases to handle kill and cover actions
- Include object shortcuts on list entries so aliases can auto-release cover

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68aa1d26dcf8832a87f25c36498be549