### PR TITLE
feat: add /pro team alias

### DIFF
--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -44,6 +44,13 @@ export default function initObjectAliases(
         }
     }
 
+    function passLeadership(short: string) {
+        const obj = findByShortcut(short);
+        if (obj) {
+            client.sendCommand(`przekaz prowadzenie ob_${obj.num}`);
+        }
+    }
+
     function breakDefenseTarget(short?: string) {
         let id: string | undefined;
         if (short) {
@@ -145,6 +152,10 @@ export default function initObjectAliases(
         aliases.push({
             pattern: /\/w ([A-Za-z0-9@]+)$/,
             callback: (m: RegExpMatchArray) => withdraw(m[1])
+        });
+        aliases.push({
+            pattern: /\/pro ([A-Za-z0-9@]+)$/,
+            callback: (m: RegExpMatchArray) => passLeadership(m[1])
         });
         aliases.push({
             pattern: /\/prze(?: ([A-Za-z0-9@]+))?$/,

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -27,6 +27,7 @@ describe('object aliases', () => {
   let toggle: () => void;
   let shieldGroup: (m: RegExpMatchArray) => void;
   let withdraw: (m: RegExpMatchArray) => void;
+  let passLeadership: (m: RegExpMatchArray) => void;
   let breakDefense: (m?: RegExpMatchArray) => void;
   let orderAttack: (m: RegExpMatchArray) => void;
   let orderAttackTarget: () => void;
@@ -47,13 +48,14 @@ describe('object aliases', () => {
     toggle = aliases[7].callback as any;
     shieldGroup = aliases[8].callback as any;
     withdraw = aliases[9].callback as any;
-    breakDefense = aliases[10].callback as any;
-    orderAttack = aliases[11].callback as any;
-    orderAttackTarget = aliases[12].callback as any;
-    orderShield = aliases[13].callback as any;
-    orderShieldTarget = aliases[14].callback as any;
-    markAttack = aliases[15].callback as any;
-    markDefense = aliases[16].callback as any;
+    passLeadership = aliases[10].callback as any;
+    breakDefense = aliases[11].callback as any;
+    orderAttack = aliases[12].callback as any;
+    orderAttackTarget = aliases[13].callback as any;
+    orderShield = aliases[14].callback as any;
+    orderShieldTarget = aliases[15].callback as any;
+    markAttack = aliases[16].callback as any;
+    markDefense = aliases[17].callback as any;
     (global as any).Input = { send: jest.fn() };
     (window as any).gmcp = gmcp;
     gmcp.char = { options: { group_cover: 1 } } as any;
@@ -141,6 +143,12 @@ describe('object aliases', () => {
     withdraw(['', 'Y'] as unknown as RegExpMatchArray);
     expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'gzwycofaj sie za ob_18');
     expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'przestan zaslaniac');
+  });
+
+  test('/pro alias passes leadership to object', () => {
+    client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 31, shortcut: 'A' }]);
+    passLeadership(['', 'A'] as unknown as RegExpMatchArray);
+    expect(client.sendCommand).toHaveBeenCalledWith('przekaz prowadzenie ob_31');
   });
 
   test('/prze alias breaks defense of attack target', () => {

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -85,6 +85,7 @@ Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorze
 - **/za3 _skrot_** - zasłania obiekt z poziomem krycia 3.
 - **/za4 _skrot_** - zasłania obiekt z poziomem krycia 4.
 - **/w _skrot_** - wycofuje postać za wskazany obiekt.
+- **/pro _skrot_** - przekazuje prowadzenie obiektowi o podanym skrócie.
 - **/prze** - przełamuje obronę oznaczonego celu.
 - **/puszczaj** - przełącza automatyczne zwalnianie zasłony przy użyciu `/za` lub `/zas`.
 - **/zap** - wykonuje polecenie `zapal lampe`.


### PR DESCRIPTION
## Summary
- add /pro alias to hand over team leadership by shortcut
- keep /prze for breaking defense
- document /pro alias

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68aa2958e654832a8e2bb8be8c97361c