### PR TITLE
Sort non-combat objects after combatants

### DIFF
--- a/client/src/ObjectManager.ts
+++ b/client/src/ObjectManager.ts
@@ -86,7 +86,7 @@ export default class ObjectManager {
             attack_num: boolean | number | undefined,
             avatar_target: boolean | undefined,
             shortcut?: string,
-            __category?: 'player' | 'team' | 'rest',
+            __category?: 'player' | 'team' | 'rest' | 'rest-noncombat',
         };
 
         const makeObj = (numStr: string): Obj => {
@@ -118,6 +118,17 @@ export default class ObjectManager {
             }
         });
 
+        const inCombat = [playerObj, ...team, ...rest].some(
+            o => o && o.attack_num !== false && o.attack_num !== undefined
+        );
+
+        const combatRest = inCombat
+            ? rest.filter(o => o.attack_num !== false && o.attack_num !== undefined)
+            : rest;
+        const nonCombatRest = inCombat
+            ? rest.filter(o => o.attack_num === false || o.attack_num === undefined)
+            : [];
+
         const ordered: Obj[] = [];
         if (playerObj) {
             playerObj.__category = 'player';
@@ -127,18 +138,27 @@ export default class ObjectManager {
             o.__category = 'team';
             ordered.push(o);
         });
-        rest.forEach(o => {
+        combatRest.forEach(o => {
             o.__category = 'rest';
             ordered.push(o);
         });
+        if (inCombat) {
+            nonCombatRest.forEach(o => {
+                o.__category = 'rest-noncombat';
+                ordered.push(o);
+            });
+        }
 
         let teamIndex = 0;
         let restIndex = 1;
+        let nonCombatIndex = 50;
         ordered.forEach(o => {
             if (o.__category === 'player') {
                 o.shortcut = '@';
             } else if (o.__category === 'team') {
                 o.shortcut = String.fromCharCode('A'.charCodeAt(0) + teamIndex++);
+            } else if (o.__category === 'rest-noncombat') {
+                o.shortcut = String(nonCombatIndex++);
             } else {
                 o.shortcut = String(restIndex++);
             }

--- a/client/test/ObjectManager.test.ts
+++ b/client/test/ObjectManager.test.ts
@@ -88,4 +88,18 @@ describe('ObjectManager', () => {
       { num: 4, desc: 'Ogre', state: 20, attack_num: undefined, avatar_target: undefined, shortcut: '2' },
     ]);
   });
+
+  test('places non-combat objects last with shortcuts starting at 50', () => {
+    client.sendEvent('gmcp.objects.data', {
+      '1': { desc: 'Fighter', attack_num: true },
+      '2': { desc: 'Rock' },
+      '3': { desc: 'Tree' },
+    });
+    client.sendEvent('gmcp.objects.nums', ['1', '2', '3']);
+    expect(manager.getObjectsOnLocation()).toEqual([
+      { num: 1, desc: 'Fighter', state: undefined, attack_num: true, avatar_target: undefined, shortcut: '1' },
+      { num: 2, desc: 'Rock', state: undefined, attack_num: undefined, avatar_target: undefined, shortcut: '50' },
+      { num: 3, desc: 'Tree', state: undefined, attack_num: undefined, avatar_target: undefined, shortcut: '51' },
+    ]);
+  });
 });

--- a/web-client/test/ObjectList.test.ts
+++ b/web-client/test/ObjectList.test.ts
@@ -1,5 +1,7 @@
 import ObjectList from '../src/ObjectList';
 import { getItemSync, setItemSync } from '@client/src/storage';
+import ObjectManager from '@client/src/ObjectManager';
+import { EventEmitter } from 'events';
 
 jest.mock('@client/src/storage', () => ({
   getItemSync: jest.fn(),
@@ -170,5 +172,33 @@ describe('ObjectList', () => {
     const textNode = container.firstChild as ChildNode;
     textNode.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(client.sendCommand).not.toHaveBeenCalled();
+  });
+
+  test('moves non-combat objects to the end with shortcuts starting at 50', () => {
+    document.body.innerHTML = '<div id="objects-list"></div>';
+    class TestClient {
+      private emitter = new EventEmitter();
+      ObjectManager = new ObjectManager(this as any);
+      TeamManager = { isInTeam: (_d: string) => false };
+      sendCommand = jest.fn();
+      addEventListener(event: string, cb: any) {
+        this.emitter.on(event, cb);
+      }
+      sendEvent(type: string, detail?: any) {
+        this.emitter.emit(type, { detail });
+      }
+    }
+    const client = new TestClient();
+    new ObjectList(client as any);
+    client.sendEvent('gmcp.objects.data', {
+      '1': { desc: 'Fighter', attack_num: true },
+      '2': { desc: 'Rock' },
+      '3': { desc: 'Tree' },
+    });
+    client.sendEvent('gmcp.objects.nums', ['1', '2', '3']);
+    const html = (document.getElementById('objects-list') as HTMLElement).innerHTML.split('<br>');
+    expect(html[0]).toContain('data-object-num="1"');
+    expect(html[1]).toContain('data-object-num="50"');
+    expect(html[2]).toContain('data-object-num="51"');
   });
 });


### PR DESCRIPTION
## Summary
- Reorder non-combat objects after combatants and assign shortcuts starting at 50 when combat is detected
- Test and document new ordering behavior in ObjectManager and ObjectList

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68aa3923ab68832a86b4937d7f03578b