### PR TITLE
Clean up locationId query parameter after initial use

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -48,6 +48,13 @@ const initialLocationId = locationParam ? parseInt(locationParam) : NaN;
 if (!isNaN(initialLocationId)) {
     const handleInitialLocation = () => {
         client.Map.setMapRoomById(initialLocationId);
+
+        const params = new URLSearchParams(window.location.search);
+        params.delete('locationId');
+        const base = window.location.origin + window.location.pathname;
+        const rest = params.toString();
+        window.history.replaceState({}, '', rest ? `${base}?${rest}` : base);
+
         client.removeEventListener('gmcp.room.info', handleInitialLocation);
     };
     client.addEventListener('gmcp.room.info', handleInitialLocation);


### PR DESCRIPTION
## Summary
- Remove `locationId` from URL after setting initial map location
- Keep location change listener one-time by removing it after firing

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68aad2025e14832a84e969f8e021ab9a