### PR TITLE
Fix unclosed container around mobile buttons

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -447,9 +447,9 @@
         <div id="w-buttons-list" class="mobile-z-buttons"></div>
         <div id="prze-buttons-list" class="mobile-z-buttons"></div>
         <div id="idz-buttons-list" class="mobile-idz-buttons"></div>
-        </div>
-    <div id="context-menu" class="context-menu"></div>
+    </div>
 </div>
+<div id="context-menu" class="context-menu"></div>
 <script src="/pako.min.js"></script>
 <script type="module" src="/src/plugin.ts"></script>
 <script type="module" src="/src/main.ts"></script>


### PR DESCRIPTION
## Summary
- close the mobile direction buttons section and move the context menu outside so other popups work correctly

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68aadb2e4838832a858de905ebb45259