### PR TITLE
Send command on Enter and refocus input

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -807,10 +807,20 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    sendButton.addEventListener('click', () => sendMessage(false));
+    sendButton.addEventListener('click', () => sendMessage());
 
-    messageInput.addEventListener('keypress', (e) => {
+    document.addEventListener('keydown', (e) => {
         if (e.key === 'Enter') {
+            const active = document.activeElement as HTMLElement | null;
+            const modalOpen = document.querySelector('.modal.show');
+            if (modalOpen && (!active || active.id !== 'message-input')) {
+                return;
+            }
+            if (active && active.id !== 'message-input' &&
+                (active.matches('input, textarea') || active.isContentEditable)) {
+                return;
+            }
+            e.preventDefault();
             sendMessage();
         }
     });


### PR DESCRIPTION
## Summary
- Capture Enter key globally to send the current command and restore focus to the command field
- Refocus command input after clicking the send button

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68aeb8e61cfc832a917d5b85d8a36be7