### PR TITLE
feat: colorize skill levels

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -71,6 +71,7 @@ import initLanguage from './scripts/language'
 import initIdleFullHp from './scripts/idleFullHp'
 import initFullHpTimer from './scripts/fullHpTimer'
 import initNoExitHighlight from './scripts/noExitHighlight'
+import initSkills from './scripts/skills'
 import Client from "./Client";
 
 
@@ -199,6 +200,7 @@ export function registerScripts(client: Client) {
     initWeaponEvaluation(client)
     initArmorEvaluation(client)
     initParryShieldEvaluation(client)
+    initSkills(client)
 
     new People(client)
     registerGagTriggers(client)

--- a/client/src/scripts/skills.ts
+++ b/client/src/scripts/skills.ts
@@ -3,7 +3,6 @@ import { colorString, findClosestColor } from "../Colors";
 
 const COLORS = [
     findClosestColor("#ff0000"),
-    findClosestColor("#ffa500"),
     findClosestColor("#ffff00"),
     findClosestColor("#00ff00"),
     findClosestColor("#87ceeb"),
@@ -23,14 +22,16 @@ const skillsDesc: Record<string, number> = {
 };
 
 function getColor(level: number) {
-    if (level === 10) {
-        return COLORS[COLORS.length - 1];
+    if (level <= 3) {
+        return COLORS[0];
     }
-    return COLORS[Math.min(COLORS.length - 2, Math.floor((level - 1) / 2))];
-}
-
-function padLevel(level: number) {
-    return level.toString().padStart(2, " ");
+    if (level <= 6) {
+        return COLORS[1];
+    }
+    if (level <= 9) {
+        return COLORS[2];
+    }
+    return COLORS[3];
 }
 
 function formatLine(line: string) {
@@ -44,15 +45,18 @@ function formatLine(line: string) {
             const color = getColor(level);
             const leading = skillPart.match(/^\s*/)?.[0] ?? "";
             const skill = skillPart.trim();
-            const coloredSkill = colorString(skill, color);
-            const coloredLevel = colorString(`[${padLevel(level)}/10]`, color);
+            const coloredSkill = colorString(`${skill}:`, color);
+
+            const levelStr = `[${level}/10]`;
+            const paddedLevel = `${level < 10 ? " " : ""}${levelStr}`;
+            const coloredLevel = colorString(paddedLevel, color);
 
             const beforeLevelSpacesCount = Math.max(1, trailing.length - 3);
             const afterLevelSpacesCount = Math.min(3, trailing.length);
             const beforeLevelSpaces = " ".repeat(beforeLevelSpacesCount);
             const afterLevelSpaces = " ".repeat(afterLevelSpacesCount);
 
-            return `${leading}${coloredSkill}:${afterColon}${desc}${beforeLevelSpaces}${coloredLevel}${afterLevelSpaces}`;
+            return `${leading}${coloredSkill}${afterColon}${desc}${beforeLevelSpaces}${coloredLevel}${afterLevelSpaces}`;
         }
     );
 }

--- a/client/src/scripts/skills.ts
+++ b/client/src/scripts/skills.ts
@@ -37,12 +37,15 @@ function formatLine(line: string) {
             const color = getColor(level);
             const leading = skillPart.match(/^\s*/)?.[0] ?? "";
             const skill = skillPart.trim();
-            const coloredSkill = colorString(`${skill}:`, color);
 
             const paddedLevel = `[${String(level).padStart(2, " ")}/10]`;
             const coloredLevel = colorString(paddedLevel, color);
+            const totalAfter = desc.length + trailing.length;
+            const newTrailing = trailing
+                ? " ".repeat(Math.max(0, totalAfter - paddedLevel.length))
+                : "";
 
-            return `${leading}${coloredSkill}${afterColon}${coloredLevel}${trailing}`;
+            return `${leading}${skill}:${afterColon}${coloredLevel}${newTrailing}`;
         }
     );
 }

--- a/client/src/scripts/skills.ts
+++ b/client/src/scripts/skills.ts
@@ -23,7 +23,19 @@ const skillsDesc: Record<string, number> = {
 };
 
 function getColor(level: number) {
-    return COLORS[Math.min(COLORS.length - 1, Math.floor((level - 1) / 2))];
+    if (level === 10) {
+        return COLORS[4];
+    }
+    if (level >= 7) {
+        return COLORS[3];
+    }
+    if (level >= 5) {
+        return COLORS[2];
+    }
+    if (level >= 3) {
+        return COLORS[1];
+    }
+    return COLORS[0];
 }
 
 function formatLine(line: string) {
@@ -34,18 +46,24 @@ function formatLine(line: string) {
             if (!level) {
                 return substring;
             }
+
             const color = getColor(level);
             const leading = skillPart.match(/^\s*/)?.[0] ?? "";
             const skill = skillPart.trim();
 
-            const paddedLevel = `[${String(level).padStart(2, " ")}/10]`;
-            const coloredLevel = colorString(paddedLevel, color);
-            const totalAfter = desc.length + trailing.length;
-            const newTrailing = trailing
-                ? " ".repeat(Math.max(0, totalAfter - paddedLevel.length))
-                : "";
+            const bracket = level === 10 ? "[10/10]" : `[${level}/10]`;
+            const coloredSkill = colorString(`${skill}:`, color);
+            const coloredBracket = colorString(bracket, color);
 
-            return `${leading}${skill}:${afterColon}${coloredLevel}${newTrailing}`;
+            const trailingLen = trailing.length;
+            let spacesAfter = trailingLen >= 3 ? 3 : 0;
+            let spacesBefore = trailingLen - spacesAfter;
+            if (spacesBefore < 1) {
+                spacesBefore = 1;
+                spacesAfter = Math.max(0, trailingLen - spacesBefore);
+            }
+
+            return `${leading}${coloredSkill}${afterColon}${desc}${" ".repeat(spacesBefore)}${coloredBracket}${" ".repeat(spacesAfter)}`;
         }
     );
 }

--- a/client/src/scripts/skills.ts
+++ b/client/src/scripts/skills.ts
@@ -23,26 +23,38 @@ const skillsDesc: Record<string, number> = {
 };
 
 function getColor(level: number) {
-    return COLORS[Math.min(COLORS.length - 1, Math.floor((level - 1) / 2))];
+    if (level === 10) {
+        return COLORS[COLORS.length - 1];
+    }
+    return COLORS[Math.min(COLORS.length - 2, Math.floor((level - 1) / 2))];
 }
 
 function padLevel(level: number) {
-    return level < 10 ? ` ${level}` : `${level}`;
+    return level.toString().padStart(2, " ");
 }
 
 function formatLine(line: string) {
-    return line.replace(/([^:]+):\s+([a-z]+)/g, (substring, skillPart: string, desc: string) => {
-        const level = skillsDesc[desc as keyof typeof skillsDesc];
-        if (!level) {
-            return substring;
+    return line.replace(
+        /([^:]+):(\s+)([a-z]+)(\s*)/g,
+        (substring, skillPart: string, afterColon: string, desc: string, trailing: string) => {
+            const level = skillsDesc[desc as keyof typeof skillsDesc];
+            if (!level) {
+                return substring;
+            }
+            const color = getColor(level);
+            const leading = skillPart.match(/^\s*/)?.[0] ?? "";
+            const skill = skillPart.trim();
+            const coloredSkill = colorString(skill, color);
+            const coloredLevel = colorString(`[${padLevel(level)}/10]`, color);
+
+            const beforeLevelSpacesCount = Math.max(1, trailing.length - 3);
+            const afterLevelSpacesCount = Math.min(3, trailing.length);
+            const beforeLevelSpaces = " ".repeat(beforeLevelSpacesCount);
+            const afterLevelSpaces = " ".repeat(afterLevelSpacesCount);
+
+            return `${leading}${coloredSkill}:${afterColon}${desc}${beforeLevelSpaces}${coloredLevel}${afterLevelSpaces}`;
         }
-        const color = getColor(level);
-        const leading = skillPart.match(/^\s*/)?.[0] ?? "";
-        const skill = skillPart.trim();
-        const coloredSkill = colorString(skill, color);
-        const coloredLevel = colorString(`[${padLevel(level)}/10]`, color);
-        return `${leading}${coloredSkill}: ${coloredLevel}`;
-    });
+    );
 }
 
 export default function initSkills(client: Client) {

--- a/client/src/scripts/skills.ts
+++ b/client/src/scripts/skills.ts
@@ -1,0 +1,53 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+
+const COLORS = [
+    findClosestColor("#ff0000"),
+    findClosestColor("#ffa500"),
+    findClosestColor("#ffff00"),
+    findClosestColor("#00ff00"),
+    findClosestColor("#87ceeb"),
+];
+
+const skillsDesc: Record<string, number> = {
+    ledwo: 1,
+    troche: 2,
+    pobieznie: 3,
+    zadowalajaco: 4,
+    niezle: 5,
+    dobrze: 6,
+    znakomicie: 7,
+    doskonale: 8,
+    perfekcyjnie: 9,
+    mistrzowsko: 10,
+};
+
+function getColor(level: number) {
+    return COLORS[Math.min(COLORS.length - 1, Math.floor((level - 1) / 2))];
+}
+
+function padLevel(level: number) {
+    return level < 10 ? ` ${level}` : `${level}`;
+}
+
+function formatLine(line: string) {
+    return line.replace(/([^:]+):\s+([a-z]+)/g, (substring, skillPart: string, desc: string) => {
+        const level = skillsDesc[desc as keyof typeof skillsDesc];
+        if (!level) {
+            return substring;
+        }
+        const color = getColor(level);
+        const leading = skillPart.match(/^\s*/)?.[0] ?? "";
+        const skill = skillPart.trim();
+        const coloredSkill = colorString(skill, color);
+        const coloredLevel = colorString(`[${padLevel(level)}/10]`, color);
+        return `${leading}${coloredSkill}: ${coloredLevel}`;
+    });
+}
+
+export default function initSkills(client: Client) {
+    const tag = "skills";
+    const patterns = Object.keys(skillsDesc).map(d => new RegExp(d));
+    client.Triggers.registerTrigger(patterns, raw => formatLine(raw), tag);
+}
+

--- a/client/src/scripts/skills.ts
+++ b/client/src/scripts/skills.ts
@@ -3,6 +3,7 @@ import { colorString, findClosestColor } from "../Colors";
 
 const COLORS = [
     findClosestColor("#ff0000"),
+    findClosestColor("#ffa500"),
     findClosestColor("#ffff00"),
     findClosestColor("#00ff00"),
     findClosestColor("#87ceeb"),
@@ -22,16 +23,7 @@ const skillsDesc: Record<string, number> = {
 };
 
 function getColor(level: number) {
-    if (level <= 3) {
-        return COLORS[0];
-    }
-    if (level <= 6) {
-        return COLORS[1];
-    }
-    if (level <= 9) {
-        return COLORS[2];
-    }
-    return COLORS[3];
+    return COLORS[Math.min(COLORS.length - 1, Math.floor((level - 1) / 2))];
 }
 
 function formatLine(line: string) {
@@ -47,16 +39,10 @@ function formatLine(line: string) {
             const skill = skillPart.trim();
             const coloredSkill = colorString(`${skill}:`, color);
 
-            const levelStr = `[${level}/10]`;
-            const paddedLevel = `${level < 10 ? " " : ""}${levelStr}`;
+            const paddedLevel = `[${String(level).padStart(2, " ")}/10]`;
             const coloredLevel = colorString(paddedLevel, color);
 
-            const beforeLevelSpacesCount = Math.max(1, trailing.length - 3);
-            const afterLevelSpacesCount = Math.min(3, trailing.length);
-            const beforeLevelSpaces = " ".repeat(beforeLevelSpacesCount);
-            const afterLevelSpaces = " ".repeat(afterLevelSpacesCount);
-
-            return `${leading}${coloredSkill}${afterColon}${desc}${beforeLevelSpaces}${coloredLevel}${afterLevelSpaces}`;
+            return `${leading}${coloredSkill}${afterColon}${coloredLevel}${trailing}`;
         }
     );
 }

--- a/client/test/skills.test.ts
+++ b/client/test/skills.test.ts
@@ -16,51 +16,54 @@ describe('skills trigger', () => {
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
   });
 
-  test('colors skill name and level with padding before bracket', () => {
-    const line = 'akrobatyka: ledwo';
-    const colorCode = findClosestColor('#ff0000');
+  test('replaces descriptor with padded level and colors skill', () => {
+    const line = 'akrobatyka: pobieznie';
+    const colorCode = findClosestColor('#ffa500');
     const expected =
       colorString('akrobatyka:', colorCode) +
-      ' ledwo ' +
-      colorString(' [1/10]', colorCode);
+      ' ' +
+      colorString('[ 3/10]', colorCode);
     const result = parse(line);
     expect(result).toBe(expected);
-    expect(stripAnsiCodes(result)).toBe('akrobatyka: ledwo  [1/10]');
+    expect(stripAnsiCodes(result)).toBe('akrobatyka: [ 3/10]');
   });
 
-  test('uses yellow for mid levels', () => {
-    const line = 'ocena przeciwnika: dobrze';
-    const colorCode = findClosestColor('#ffff00');
-    const expected =
-      colorString('ocena przeciwnika:', colorCode) +
-      ' dobrze ' +
-      colorString(' [6/10]', colorCode);
-    const result = parse(line);
-    expect(result).toBe(expected);
-    expect(stripAnsiCodes(result)).toBe('ocena przeciwnika: dobrze  [6/10]');
+  test('maps levels to red/orange/yellow/green/SkyBlue', () => {
+    const samples: [string, string, string, string][] = [
+      ['ledwo', '#ff0000', '[ 1/10]', 'tarcza'],
+      ['zadowalajaco', '#ffa500', '[ 4/10]', 'blokowanie'],
+      ['niezle', '#ffff00', '[ 5/10]', 'ocena obiektu'],
+      ['doskonale', '#00ff00', '[ 8/10]', 'miecze'],
+      ['mistrzowsko', '#87ceeb', '[10/10]', 'silny cios'],
+    ];
+
+    for (const [desc, hex, bracket, skill] of samples) {
+      const line = `${skill}: ${desc}`;
+      const colorCode = findClosestColor(hex);
+      const expected =
+        colorString(`${skill}:`, colorCode) +
+        ' ' +
+        colorString(bracket, colorCode);
+      const result = parse(line);
+      expect(result).toBe(expected);
+      expect(stripAnsiCodes(result)).toBe(`${skill}: ${bracket}`);
+    }
   });
 
-  test('keeps green for level nine', () => {
-    const line = 'plywanie: perfekcyjnie';
-    const colorCode = findClosestColor('#00ff00');
+  test('colors multiple skills in one line', () => {
+    const line = 'akrobatyka: pobieznie   miecze: doskonale';
+    const orange = findClosestColor('#ffa500');
+    const green = findClosestColor('#00ff00');
     const expected =
-      colorString('plywanie:', colorCode) +
-      ' perfekcyjnie ' +
-      colorString(' [9/10]', colorCode);
+      colorString('akrobatyka:', orange) +
+      ' ' +
+      colorString('[ 3/10]', orange) +
+      '   ' +
+      colorString('miecze:', green) +
+      ' ' +
+      colorString('[ 8/10]', green);
     const result = parse(line);
     expect(result).toBe(expected);
-    expect(stripAnsiCodes(result)).toBe('plywanie: perfekcyjnie  [9/10]');
-  });
-
-  test('uses SkyBlue only for max level', () => {
-    const line = 'miecze: mistrzowsko';
-    const colorCode = findClosestColor('#87ceeb');
-    const expected =
-      colorString('miecze:', colorCode) +
-      ' mistrzowsko ' +
-      colorString('[10/10]', colorCode);
-    const result = parse(line);
-    expect(result).toBe(expected);
-    expect(stripAnsiCodes(result)).toBe('miecze: mistrzowsko [10/10]');
+    expect(stripAnsiCodes(result)).toBe('akrobatyka: [ 3/10]   miecze: [ 8/10]');
   });
 });

--- a/client/test/skills.test.ts
+++ b/client/test/skills.test.ts
@@ -16,11 +16,11 @@ describe('skills trigger', () => {
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
   });
 
-  test('replaces descriptor with padded level and colors skill', () => {
+  test('replaces descriptor with padded, colored level', () => {
     const line = 'akrobatyka: pobieznie';
     const colorCode = findClosestColor('#ffa500');
     const expected =
-      colorString('akrobatyka:', colorCode) +
+      'akrobatyka:' +
       ' ' +
       colorString('[ 3/10]', colorCode);
     const result = parse(line);
@@ -41,7 +41,7 @@ describe('skills trigger', () => {
       const line = `${skill}: ${desc}`;
       const colorCode = findClosestColor(hex);
       const expected =
-        colorString(`${skill}:`, colorCode) +
+        `${skill}:` +
         ' ' +
         colorString(bracket, colorCode);
       const result = parse(line);
@@ -55,15 +55,15 @@ describe('skills trigger', () => {
     const orange = findClosestColor('#ffa500');
     const green = findClosestColor('#00ff00');
     const expected =
-      colorString('akrobatyka:', orange) +
+      'akrobatyka:' +
       ' ' +
       colorString('[ 3/10]', orange) +
-      '   ' +
-      colorString('miecze:', green) +
+      '     ' +
+      'miecze:' +
       ' ' +
       colorString('[ 8/10]', green);
     const result = parse(line);
     expect(result).toBe(expected);
-    expect(stripAnsiCodes(result)).toBe('akrobatyka: [ 3/10]   miecze: [ 8/10]');
+    expect(stripAnsiCodes(result)).toBe('akrobatyka: [ 3/10]     miecze: [ 8/10]');
   });
 });

--- a/client/test/skills.test.ts
+++ b/client/test/skills.test.ts
@@ -1,0 +1,38 @@
+import initSkills from '../src/scripts/skills';
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
+import { colorString, findClosestColor } from '../src/Colors';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+}
+
+describe('skills trigger', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initSkills((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+  });
+
+  test('replaces descriptor with padded level and colors skill and level', () => {
+    const line = 'akrobatyka: ledwo';
+    const colorCode = findClosestColor('#ff0000');
+    const expected =
+      colorString('akrobatyka', colorCode) + ': ' + colorString('[ 1/10]', colorCode);
+    const result = parse(line);
+    expect(result).toBe(expected);
+    expect(stripAnsiCodes(result)).toBe('akrobatyka: [ 1/10]');
+  });
+
+  test('handles max level without padding', () => {
+    const line = 'miecze: mistrzowsko';
+    const colorCode = findClosestColor('#87ceeb');
+    const expected =
+      colorString('miecze', colorCode) + ': ' + colorString('[10/10]', colorCode);
+    const result = parse(line);
+    expect(result).toBe(expected);
+    expect(stripAnsiCodes(result)).toBe('miecze: [10/10]');
+  });
+});

--- a/client/test/skills.test.ts
+++ b/client/test/skills.test.ts
@@ -16,24 +16,26 @@ describe('skills trigger', () => {
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
   });
 
-  test('replaces descriptor with padded, colored level', () => {
+  test('keeps descriptor and appends padded, colored level', () => {
     const line = 'akrobatyka: pobieznie';
     const colorCode = findClosestColor('#ffa500');
     const expected =
-      'akrobatyka:' +
+      colorString('akrobatyka:', colorCode) +
       ' ' +
-      colorString('[ 3/10]', colorCode);
+      'pobieznie' +
+      ' ' +
+      colorString('[3/10]', colorCode);
     const result = parse(line);
     expect(result).toBe(expected);
-    expect(stripAnsiCodes(result)).toBe('akrobatyka: [ 3/10]');
+    expect(stripAnsiCodes(result)).toBe('akrobatyka: pobieznie [3/10]');
   });
 
   test('maps levels to red/orange/yellow/green/SkyBlue', () => {
     const samples: [string, string, string, string][] = [
-      ['ledwo', '#ff0000', '[ 1/10]', 'tarcza'],
-      ['zadowalajaco', '#ffa500', '[ 4/10]', 'blokowanie'],
-      ['niezle', '#ffff00', '[ 5/10]', 'ocena obiektu'],
-      ['doskonale', '#00ff00', '[ 8/10]', 'miecze'],
+      ['ledwo', '#ff0000', '[1/10]', 'tarcza'],
+      ['zadowalajaco', '#ffa500', '[4/10]', 'blokowanie'],
+      ['niezle', '#ffff00', '[5/10]', 'ocena obiektu'],
+      ['doskonale', '#00ff00', '[8/10]', 'miecze'],
       ['mistrzowsko', '#87ceeb', '[10/10]', 'silny cios'],
     ];
 
@@ -41,29 +43,35 @@ describe('skills trigger', () => {
       const line = `${skill}: ${desc}`;
       const colorCode = findClosestColor(hex);
       const expected =
-        `${skill}:` +
+        colorString(`${skill}:`, colorCode) +
+        ' ' +
+        `${desc}` +
         ' ' +
         colorString(bracket, colorCode);
       const result = parse(line);
       expect(result).toBe(expected);
-      expect(stripAnsiCodes(result)).toBe(`${skill}: ${bracket}`);
+      expect(stripAnsiCodes(result)).toBe(`${skill}: ${desc} ${bracket}`);
     }
   });
 
   test('colors multiple skills in one line', () => {
-    const line = 'akrobatyka: pobieznie   miecze: doskonale';
+    const line = 'akrobatyka: pobieznie           miecze: doskonale';
     const orange = findClosestColor('#ffa500');
     const green = findClosestColor('#00ff00');
     const expected =
-      'akrobatyka:' +
+      colorString('akrobatyka:', orange) +
       ' ' +
-      colorString('[ 3/10]', orange) +
-      '     ' +
-      'miecze:' +
+      'pobieznie' +
+      '        ' +
+      colorString('[3/10]', orange) +
+      '   ' +
+      colorString('miecze:', green) +
       ' ' +
-      colorString('[ 8/10]', green);
+      'doskonale' +
+      ' ' +
+      colorString('[8/10]', green);
     const result = parse(line);
     expect(result).toBe(expected);
-    expect(stripAnsiCodes(result)).toBe('akrobatyka: [ 3/10]     miecze: [ 8/10]');
+    expect(stripAnsiCodes(result)).toBe('akrobatyka: pobieznie        [3/10]   miecze: doskonale [8/10]');
   });
 });

--- a/client/test/skills.test.ts
+++ b/client/test/skills.test.ts
@@ -16,33 +16,51 @@ describe('skills trigger', () => {
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
   });
 
-  test('appends padded level and colors skill and level', () => {
+  test('colors skill name and level with padding before bracket', () => {
     const line = 'akrobatyka: ledwo';
     const colorCode = findClosestColor('#ff0000');
     const expected =
-      colorString('akrobatyka', colorCode) + ': ledwo ' + colorString('[ 1/10]', colorCode);
+      colorString('akrobatyka:', colorCode) +
+      ' ledwo ' +
+      colorString(' [1/10]', colorCode);
     const result = parse(line);
     expect(result).toBe(expected);
-    expect(stripAnsiCodes(result)).toBe('akrobatyka: ledwo [ 1/10]');
+    expect(stripAnsiCodes(result)).toBe('akrobatyka: ledwo  [1/10]');
   });
 
-  test('uses SkyBlue only for max level', () => {
-    const line = 'miecze: mistrzowsko';
-    const colorCode = findClosestColor('#87ceeb');
+  test('uses yellow for mid levels', () => {
+    const line = 'ocena przeciwnika: dobrze';
+    const colorCode = findClosestColor('#ffff00');
     const expected =
-      colorString('miecze', colorCode) + ': mistrzowsko ' + colorString('[10/10]', colorCode);
+      colorString('ocena przeciwnika:', colorCode) +
+      ' dobrze ' +
+      colorString(' [6/10]', colorCode);
     const result = parse(line);
     expect(result).toBe(expected);
-    expect(stripAnsiCodes(result)).toBe('miecze: mistrzowsko [10/10]');
+    expect(stripAnsiCodes(result)).toBe('ocena przeciwnika: dobrze  [6/10]');
   });
 
   test('keeps green for level nine', () => {
     const line = 'plywanie: perfekcyjnie';
     const colorCode = findClosestColor('#00ff00');
     const expected =
-      colorString('plywanie', colorCode) + ': perfekcyjnie ' + colorString('[ 9/10]', colorCode);
+      colorString('plywanie:', colorCode) +
+      ' perfekcyjnie ' +
+      colorString(' [9/10]', colorCode);
     const result = parse(line);
     expect(result).toBe(expected);
-    expect(stripAnsiCodes(result)).toBe('plywanie: perfekcyjnie [ 9/10]');
+    expect(stripAnsiCodes(result)).toBe('plywanie: perfekcyjnie  [9/10]');
+  });
+
+  test('uses SkyBlue only for max level', () => {
+    const line = 'miecze: mistrzowsko';
+    const colorCode = findClosestColor('#87ceeb');
+    const expected =
+      colorString('miecze:', colorCode) +
+      ' mistrzowsko ' +
+      colorString('[10/10]', colorCode);
+    const result = parse(line);
+    expect(result).toBe(expected);
+    expect(stripAnsiCodes(result)).toBe('miecze: mistrzowsko [10/10]');
   });
 });

--- a/client/test/skills.test.ts
+++ b/client/test/skills.test.ts
@@ -16,23 +16,33 @@ describe('skills trigger', () => {
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
   });
 
-  test('replaces descriptor with padded level and colors skill and level', () => {
+  test('appends padded level and colors skill and level', () => {
     const line = 'akrobatyka: ledwo';
     const colorCode = findClosestColor('#ff0000');
     const expected =
-      colorString('akrobatyka', colorCode) + ': ' + colorString('[ 1/10]', colorCode);
+      colorString('akrobatyka', colorCode) + ': ledwo ' + colorString('[ 1/10]', colorCode);
     const result = parse(line);
     expect(result).toBe(expected);
-    expect(stripAnsiCodes(result)).toBe('akrobatyka: [ 1/10]');
+    expect(stripAnsiCodes(result)).toBe('akrobatyka: ledwo [ 1/10]');
   });
 
-  test('handles max level without padding', () => {
+  test('uses SkyBlue only for max level', () => {
     const line = 'miecze: mistrzowsko';
     const colorCode = findClosestColor('#87ceeb');
     const expected =
-      colorString('miecze', colorCode) + ': ' + colorString('[10/10]', colorCode);
+      colorString('miecze', colorCode) + ': mistrzowsko ' + colorString('[10/10]', colorCode);
     const result = parse(line);
     expect(result).toBe(expected);
-    expect(stripAnsiCodes(result)).toBe('miecze: [10/10]');
+    expect(stripAnsiCodes(result)).toBe('miecze: mistrzowsko [10/10]');
+  });
+
+  test('keeps green for level nine', () => {
+    const line = 'plywanie: perfekcyjnie';
+    const colorCode = findClosestColor('#00ff00');
+    const expected =
+      colorString('plywanie', colorCode) + ': perfekcyjnie ' + colorString('[ 9/10]', colorCode);
+    const result = parse(line);
+    expect(result).toBe(expected);
+    expect(stripAnsiCodes(result)).toBe('plywanie: perfekcyjnie [ 9/10]');
   });
 });


### PR DESCRIPTION
## Summary
- replace skill descriptors with padded numeric levels and color both skill names and levels
- register skill level formatting on startup

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68aee9be087c832aa75706920e812112