### PR TITLE
fix: remove runtime Settings import

### DIFF
--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -2,7 +2,8 @@ import '../style.css'
 import {useEffect, useState} from "react";
 import {Form, Button} from 'react-bootstrap';
 import storage, { getCurrentCharacter } from "@client/src/storage";
-import { Settings as BaseSettings, defaultSettings } from './defaultSettings';
+import { defaultSettings } from './defaultSettings';
+import type { Settings as BaseSettings } from './defaultSettings';
 
 interface FormSettings extends BaseSettings {
 }

--- a/web-client/src/options/defaultSettings.ts
+++ b/web-client/src/options/defaultSettings.ts
@@ -1,1 +1,2 @@
-export { Settings, defaultSettings } from '@client/src/defaultSettings';
+export { defaultSettings } from '@client/src/defaultSettings';
+export type { Settings } from '@client/src/defaultSettings';


### PR DESCRIPTION
## Summary
- export Settings type separately so vite doesn't look for a runtime export
- use type-only import for Settings in options component

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68af22377f54832aa07ed29a87003238