### PR TITLE
feat: add sandbox html

### DIFF
--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Arkadia Sandbox</title>
+  <link rel="manifest" href="/manifest.json" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+</head>
+<body>
+<div id="sandbox-controls" style="position:fixed;right:0;top:0;width:200px;height:100vh;background:#222;padding:1rem;overflow:auto;">
+  <button id="add-member" class="btn btn-primary btn-sm w-100 mb-2">Add Team Member</button>
+  <button id="clear-team" class="btn btn-secondary btn-sm w-100">Clear Team</button>
+  <pre id="team-members" class="mt-3 text-light"></pre>
+</div>
+<div id="sandbox-output" style="margin-right:200px;padding:1rem;">
+  <p>Sandbox mode. No connection.</p>
+</div>
+<script type="module" src="/src/sandbox.ts"></script>
+</body>
+</html>

--- a/web-client/src/sandbox.ts
+++ b/web-client/src/sandbox.ts
@@ -1,0 +1,28 @@
+import 'bootswatch/dist/darkly/bootstrap.min.css';
+import './style.css';
+import ArkadiaClient from './ArkadiaClient.ts';
+import Client from '@client/src/Client.ts';
+import MockPort from './MockPort.ts';
+
+const client = new Client(ArkadiaClient, new MockPort());
+(window as any).clientExtension = client;
+(window as any).client = ArkadiaClient;
+
+const teamList = document.getElementById('team-members') as HTMLElement | null;
+const renderTeam = () => {
+  if (teamList) {
+    teamList.textContent = client.TeamManager.getTeamMembers().join('\n');
+  }
+};
+client.addEventListener('teamChange', renderTeam);
+
+document.getElementById('add-member')?.addEventListener('click', () => {
+  const name = window.prompt('Member name?');
+  if (name) {
+    (client.TeamManager as any).addMember(name);
+  }
+});
+
+document.getElementById('clear-team')?.addEventListener('click', () => {
+  (client.TeamManager as any).clearTeam();
+});


### PR DESCRIPTION
## Summary
- add standalone sandbox.html with controls for simulating team events
- wire sandbox.ts to manage team members without connecting to server

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68b3fed0f230832aa734f16cc6c33651