### PR TITLE
Add sandbox mode for web client

### DIFF
--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -1,0 +1,472 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content">
+    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="mobile-web-app-capable" content="yes"/>
+    <meta name="theme-color" content="#000000" />
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+    <title>Arkadia</title>
+</head>
+<body>
+<div id="main-container">
+    <div id="iframe-container">
+        <canvas id="map" resize="true"></canvas>
+        <div id="location-wrapper">
+            <div id="location-label">
+                <span id="location-text"></span>
+            </div>
+            <span id="pause-icon" hidden>⏸</span>
+        </div>
+        <div id="notification-center"></div>
+        <div id="map-progress-container" class="position-absolute top-50 start-50 translate-middle w-75">
+            <div class="progress">
+                <div id="map-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated"
+                     style="width: 0"></div>
+            </div>
+        </div>
+    </div>
+    <div id="main_text_output_msg_wrapper">
+        <div id="split-bottom" class="split-hidden">
+            <div id="sticky-area"></div>
+        </div>
+    </div>
+    <div id="char-state" data-emoji-labels="0" data-footer-mode="0">
+        <span id="char-state-text"></span>
+        <span id="state-info"></span>
+        <div id="char-state-bars"></div>
+        <span id="lamp-timer"></span>
+        <span id="break-item-warning"></span>
+        <span id="package-status"></span>
+        <span id="release-guard"></span>
+        <span id="cover-timer"></span>
+    </div>
+    <div id="objects-list"></div>
+    <button id="recording-button" class="btn btn-danger btn-sm" style="position:absolute;top:0.5rem;right:0.5rem;z-index:1012;display:none;">Zatrzymaj i zapisz</button>
+    <div id="playback-controls" class="btn-group btn-group-sm" style="position:absolute;top:2.5rem;right:0.5rem;z-index:1013;display:none;">
+        <button id="playback-pause" class="btn btn-secondary">Pauza</button>
+        <button id="playback-stop" class="btn btn-secondary">Zatrzymaj</button>
+        <span id="playback-info" class="px-1 text-light"></span>
+        <button id="playback-replay" class="btn btn-secondary">Powtórz</button>
+        <button id="playback-step-back" class="btn btn-secondary">Wstecz</button>
+        <button id="playback-step" class="btn btn-secondary">Krok</button>
+    </div>
+    <span id="content-width-measure" style="visibility:hidden;position:absolute;white-space:pre">M</span>
+    <div id="options-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Opcje</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="binds-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Bindowanie</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="binds-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="npc-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Odbiorcy paczek</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="npc-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="scripts-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Skrypty</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="scripts-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="aliases-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Aliasy</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="aliases-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="triggers-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Triggery</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="triggers-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="recordings-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Nagrania</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="recordings-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="shortcuts-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Skróty</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="shortcuts-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="guilds-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Gildie</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="guilds-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="input-area">
+        <div id="history-buttons">
+            <button id="history-up-button">▲</button>
+            <button id="history-down-button">▼</button>
+        </div>
+        <input type="search" id="message-input" autocomplete="false" autocapitalize="off" spellcheck="false"/>
+        <button id="send-button">➢</button>
+        <div class="dropdown me-0 me-md-2">
+            <button id="menu-button" class="dropdown-toggle h-100" data-bs-toggle="dropdown">⋮</button>
+            <ul class="dropdown-menu dropdown-menu-end mb-1 gap-2">
+                <li>
+                    <button class="w-100 p-1" id="options-button">Ustawienia</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="ui-settings-button">Interfejs</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="mobile-buttons-button">Przyciski</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="binds-button">Bindowanie</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="npc-button">Odbiorcy paczek</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="guilds-button">Gildie</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="scripts-button">Skrypty</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="aliases-button">Aliasy</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="triggers-button">Triggery</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="recordings-button">Nagrania</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="shortcuts-button">Skróty</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="docs-button">Dokumentacja</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="logs-button">Logi</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="debug-button">Debugowanie</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="share-location-button">Kod QR lokacji</button>
+                </li>
+                <li>
+                    <button class="w-100 p-1" id="fullscreen-button" title="Pełny ekran">⛶</button>
+                </li>
+            </ul>
+        </div>
+    </div>
+
+    <div id="auth-overlay">
+        <button id="auth-close" class="overlay-close">✖</button>
+        <button id="enable-notifications-connection" class="btn btn-warning btn-sm">Włącz powiadomienia</button>
+        <div id="auth-panel">
+            <img src="logo.png" class="logo mb-3" />
+            <div id="connecting-spinner" class="spinner-border text-light"></div>
+            <button id="connect-button">Connect</button>
+            <div class="auth-or">- LUB -</div>
+            <form id="login-form" class="d-flex flex-column gap-2">
+                <input id="login-character" class="form-control" placeholder="Postać">
+                <input id="login-password" type="password" class="form-control" placeholder="Hasło">
+                <button id="login-submit" class="btn btn-primary" type="submit">Zaloguj</button>
+            </form>
+        </div>
+        <div id="commit-info"></div>
+    </div>
+
+    <button id="connect-button-float">🔌</button>
+
+    <div id="ui-settings-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Ustawienia UI</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body d-flex flex-column gap-2">
+                    <label class="form-label">Rozmiar czcionki treści (rem)
+                        <input id="ui-content-font" type="number" step="0.1" class="form-control" />
+                    </label>
+                    <label class="form-label">Rozmiar czcionki listy obiektów (rem)
+                        <input id="ui-objects-font" type="number" step="0.1" class="form-control" />
+                    </label>
+                    <label class="form-label">Rozmiar przycisków mobilnych (%)
+                        <input id="ui-button-size" type="number" step="0.1" class="form-control" />
+                    </label>
+                    <label class="form-label">
+                        <input id="ui-show-buttons" type="checkbox" class="form-check-input me-2" />
+                        Pokaż przyciski na ekranie
+                    </label>
+                    <label class="form-label">
+                        <input id="ui-haptic-feedback" type="checkbox" class="form-check-input me-2" />
+                        Wibracje przycisków mobilnych
+                    </label>
+                    <label class="form-label">
+                        <input id="ui-emoji-labels" type="checkbox" class="form-check-input me-2" />
+                        Etykiety emoji w stanie postaci
+                    </label>
+                    <label class="form-label">
+                        <input id="ui-fight-title-icon" type="checkbox" class="form-check-input me-2" />
+                        Ikona walki w tytule
+                    </label>
+                    <label class="form-label">Paleta kolorów
+                        <select id="ui-xterm-palette" class="form-select">
+                            <option value="arkadia">Arkadia</option>
+                            <option value="proper">XTerm</option>
+                        </select>
+                    </label>
+                    <label class="form-label">Tryb stopki
+                        <select id="ui-footer-mode" class="form-select">
+                            <option value="0">Liczbowy</option>
+                            <option value="1">Pasek</option>
+                            <option value="2">Pasek jednolity</option>
+                            <option value="3">Pasek graficzny</option>
+                        </select>
+                    </label>
+                    <label class="form-label">Powiększenie mapy
+                        <input id="ui-map-scale" type="number" step="0.05" min="0.05" class="form-control" />
+                    </label>
+                    <label class="form-label">Wysokość mapy (vh)
+                        <input id="ui-map-height" type="number" step="1" class="form-control" />
+                    </label>
+                    <label class="form-label">Zasięg renderowania mapy
+                        <input id="ui-map-limit" type="number" step="1" min="1" value="35" class="form-control" />
+                    </label>
+                    <label class="form-label d-flex align-items-center">
+                        <input id="ui-exploration-mode" type="checkbox" class="form-check-input me-2" />
+                        Tryb eksploracji mapy <span id="ui-exploration-stats" class="ms-1 text-muted"></span>
+                    </label>
+                    <button type="button" class="btn btn-warning" id="ui-enable-notifications">Włącz powiadomienia</button>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" id="ui-settings-save">Zapisz</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="mobile-buttons-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Przyciski mobilne</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body position-relative d-flex flex-column align-items-center gap-2">
+                    <div id="mobile-buttons-options"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="trigger-tester-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Tester triggerów</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body d-flex flex-column gap-2">
+                    <div>
+                        <label for="trigger-tester-filter" class="form-label mb-1">Filtr wzorca</label>
+                        <input id="trigger-tester-filter" class="form-control" />
+                    </div>
+                    <div>
+                        <label class="form-label mb-1">Wybierz trigger</label>
+                        <div id="trigger-tester-tree" class="border p-1" style="max-height:15rem;overflow:auto;"></div>
+                    </div>
+                    <div>
+                        <label for="trigger-tester-line" class="form-label mb-1">Linia</label>
+                        <input id="trigger-tester-line" class="form-control" />
+                    </div>
+                    <div>
+                        <label for="trigger-tester-type" class="form-label mb-1">Typ GMCP</label>
+                        <input id="trigger-tester-type" class="form-control" />
+                    </div>
+                    <button class="btn btn-primary" id="trigger-tester-run">Testuj</button>
+                    <pre id="trigger-tester-output" class="mb-0"></pre>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="debug-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-xl modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Debug Log</h5>
+                    <div class="d-flex gap-2 align-items-center">
+                        <button type="button" class="btn btn-secondary btn-sm" id="trigger-tester-button">Tester triggerów</button>
+                        <button type="button" class="btn btn-secondary btn-sm" id="notification-schedule-button">Powiadomienie</button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                </div>
+                <div id="debug-content" class="debug-content modal-body overflow-auto"></div>
+            </div>
+        </div>
+    </div>
+
+    <div id="logs-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Logi</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body d-flex flex-column gap-2">
+                    <div class="form-check form-switch">
+                        <input id="logs-enabled" class="form-check-input" type="checkbox">
+                        <label class="form-check-label" for="logs-enabled">Zapisuj logi</label>
+                    </div>
+                    <div class="d-flex gap-2">
+                        <select id="logs-session-select" class="form-select"></select>
+                        <button id="logs-download" class="btn btn-secondary">Pobierz</button>
+                    </div>
+                    <div id="logs-preview" class="border"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="location-share-modal" class="modal fade" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Kod QR lokacji</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body d-flex justify-content-center">
+                    <img id="location-qr-image" alt="QR code">
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="mobile-direction-buttons" class="mobile-direction-buttons">
+        <button class="mobile-button mobile-button-text top-button" id="z-list-toggle">/z</button>
+        <button class="mobile-button mobile-button-text top-button" id="zas-list-toggle">/za</button>
+        <button class="mobile-button mobile-button-text top-button" id="go-button">/go</button>
+        <button class="mobile-button mobile-button-text top-button" id="buttons-toggle">⇩</button>
+        <button class="mobile-button mobile-button-text top-button" id="bracket-right-button">]</button>
+        <button class="mobile-button mobile-button-text top-button" id="button-1">wesprzyj</button>
+        <button class="mobile-button mobile-button-text top-button" id="button-2">/z cel</button>
+        <button class="mobile-button mobile-button-text top-button" id="button-3">/zas cel</button>
+        <button class="mobile-button direction-button" id="nw-button">↖</button>
+        <button class="mobile-button direction-button" id="n-button">↑</button>
+        <button class="mobile-button direction-button" id="ne-button">↗</button>
+        <button class="mobile-button mobile-button-text direction-button" id="u-button">u</button>
+        <button class="mobile-button direction-button" id="w-button">←</button>
+        <button class="mobile-button mobile-button-text direction-button" id="c-button">zerknij</button>
+        <button class="mobile-button direction-button" id="e-button">→</button>
+        <button class="mobile-button mobile-button-text direction-button" id="d-button">d</button>
+        <button class="mobile-button direction-button" id="sw-button">↙</button>
+        <button class="mobile-button direction-button" id="s-button">↓</button>
+        <button class="mobile-button direction-button" id="se-button">↘</button>
+        <button class="mobile-button mobile-button-text direction-button" id="special-exit-button" title="">3</button>
+        <div id="z-buttons-list" class="mobile-z-buttons"></div>
+        <div id="zas-buttons-list" class="mobile-z-buttons"></div>
+        <div id="w-buttons-list" class="mobile-z-buttons"></div>
+        <div id="prze-buttons-list" class="mobile-z-buttons"></div>
+        <div id="idz-buttons-list" class="mobile-idz-buttons"></div>
+    </div>
+</div>
+<div id="sandbox-panel" class="sandbox-panel">
+    <h5>Sandbox</h5>
+    <div class="mb-2">
+        <input id="sandbox-member-name" class="form-control" placeholder="Team member" />
+        <button id="sandbox-add-member" class="btn btn-secondary btn-sm w-100 mt-1">Add Member</button>
+    </div>
+    <div>
+        <input id="sandbox-leader-name" class="form-control" placeholder="Leader" />
+        <button id="sandbox-set-leader" class="btn btn-secondary btn-sm w-100 mt-1">Set Leader</button>
+    </div>
+</div>
+<div id="context-menu" class="context-menu"></div>
+<script src="/pako.min.js"></script>
+<script type="module" src="/src/plugin.ts"></script>
+<script type="module" src="/src/sandbox.ts"></script>
+<script type="module" src="/src/main.ts"></script>
+<script type="module" src="/src/docs.ts"></script>
+<script type="module" src="/src/debug.ts"></script>
+<script type="module" src="/src/logBrowser.ts"></script>
+</body>
+</html>

--- a/web-client/src/sandbox.ts
+++ b/web-client/src/sandbox.ts
@@ -1,0 +1,39 @@
+import arkadiaClient from "./ArkadiaClient.ts";
+
+// Disable connection to the remote server in sandbox mode
+arkadiaClient.connect = () => {
+    console.log('Sandbox mode: connection disabled');
+};
+arkadiaClient.send = () => {};
+arkadiaClient.sendGmcp = () => {};
+
+window.addEventListener('load', () => {
+    const client: any = (window as any).clientExtension;
+    const memberInput = document.getElementById('sandbox-member-name') as HTMLInputElement | null;
+    const addMemberButton = document.getElementById('sandbox-add-member') as HTMLButtonElement | null;
+    const leaderInput = document.getElementById('sandbox-leader-name') as HTMLInputElement | null;
+    const setLeaderButton = document.getElementById('sandbox-set-leader') as HTMLButtonElement | null;
+
+    let id = 1;
+    function sendTeam(name: string, leader: boolean) {
+        const obj: any = {};
+        obj[id++] = { desc: name, team: true, team_leader: leader };
+        client.sendEvent('gmcp.objects.data', obj);
+    }
+
+    addMemberButton?.addEventListener('click', () => {
+        const name = memberInput?.value.trim();
+        if (name) {
+            sendTeam(name, false);
+            memberInput!.value = '';
+        }
+    });
+
+    setLeaderButton?.addEventListener('click', () => {
+        const name = leaderInput?.value.trim();
+        if (name) {
+            sendTeam(name, true);
+            leaderInput!.value = '';
+        }
+    });
+});

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -868,3 +868,18 @@ button:focus-visible {
   background-color: rgba(0, 0, 0, 0.05);
   border-color: rgba(0, 0, 0, 0.3);
 }
+
+.sandbox-panel {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 16rem;
+  z-index: 2000;
+  background-color: rgba(0, 0, 0, 0.6);
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+}
+
+.sandbox-panel input {
+  width: 100%;
+}

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
             input: {
                 plugin: resolve('src/plugin.ts'),
                 client: resolve('index.html'),
+                sandbox: resolve('sandbox.html'),
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add sandbox HTML page with controls for simulating team events
- Implement sandbox script to disable server connection and emit mock GMCP objects
- Include sandbox page in build and style sandbox controls

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68b403a42674832a8564752e8d9117e7