### PR TITLE
feat: import aliases from Blowtorch XML

### DIFF
--- a/web-client/src/options/Aliases.tsx
+++ b/web-client/src/options/Aliases.tsx
@@ -1,12 +1,8 @@
-import { useEffect, useState, ChangeEvent } from "react";
+import { useEffect, useState, ChangeEvent, useRef } from "react";
 import { Button, Form } from "react-bootstrap";
 import { TiDelete, TiEdit } from "react-icons/ti";
 import storage from "@client/src/storage";
-
-interface Alias {
-    pattern: string;
-    command: string;
-}
+import { parseBlowtorch, Alias } from "./importBlowtorch";
 
 function Aliases() {
     const [aliases, setAliases] = useState<Alias[]>([]);
@@ -15,6 +11,7 @@ function Aliases() {
     const [editIndex, setEditIndex] = useState<number | null>(null);
     const [showCreateForm, setShowCreateForm] = useState(false);
     const [filter, setFilter] = useState("");
+    const fileInputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         storage.getItem("aliases").then(res => {
@@ -38,6 +35,30 @@ function Aliases() {
     function openNew() {
         resetForm();
         setShowCreateForm(true);
+    }
+
+    function openImport() {
+        fileInputRef.current?.click();
+    }
+
+    async function handleImport(e: ChangeEvent<HTMLInputElement>) {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        try {
+            const text = await file.text();
+            const imported = parseBlowtorch(text);
+            const filtered = imported.filter(a => !aliases.some(b => b.pattern === a.pattern));
+            if (filtered.length) {
+                saveList([...aliases, ...filtered]);
+                alert(`Zaimportowano ${filtered.length} aliasów`);
+            } else {
+                alert("Brak nowych aliasów");
+            }
+        } catch {
+            alert("Nie udało się zaimportować pliku");
+        } finally {
+            e.target.value = "";
+        }
     }
 
     function openEdit(idx: number) {
@@ -92,6 +113,14 @@ function Aliases() {
                     style={{width: '100%', maxWidth: '12rem'}}
                 />
                 <Button size="sm" onClick={openNew}>Dodaj alias</Button>
+                <Button size="sm" onClick={openImport}>Importuj z Blowtorch</Button>
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".xml"
+                    style={{ display: 'none' }}
+                    onChange={handleImport}
+                />
             </div>
             
             {showCreateForm && (

--- a/web-client/src/options/importBlowtorch.ts
+++ b/web-client/src/options/importBlowtorch.ts
@@ -1,0 +1,31 @@
+export interface Alias {
+    pattern: string;
+    command: string;
+}
+
+function escapeRegex(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function parseBlowtorch(text: string): Alias[] {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(text, "application/xml");
+    const nodes = Array.from(doc.querySelectorAll("aliases > alias"));
+    const result: Alias[] = [];
+    for (const el of nodes) {
+        const pre = el.getAttribute("pre");
+        const post = el.getAttribute("post");
+        if (!pre || !post) continue;
+        let pattern = escapeRegex(pre.trim());
+        const matches = Array.from(post.matchAll(/\$(\d+)/g));
+        if (matches.length) {
+            const count = Math.max(...matches.map(m => Number(m[1])));
+            for (let i = 1; i <= count; i++) {
+                pattern += `\\s+(\\w+)`;
+            }
+        }
+        pattern = `^${pattern}$`;
+        result.push({ pattern, command: post.trim() });
+    }
+    return result;
+}

--- a/web-client/test/blowtorchImport.test.ts
+++ b/web-client/test/blowtorchImport.test.ts
@@ -1,0 +1,12 @@
+import { parseBlowtorch } from "../src/options/importBlowtorch";
+
+describe("parseBlowtorch", () => {
+    it("parses aliases with parameters", () => {
+        const xml = `<blowtorch xmlversion="2"><aliases><alias pre="test" post="cmd" enabled="true"/><alias pre="say" post="say $1 $2" enabled="true"/></aliases></blowtorch>`;
+        const res = parseBlowtorch(xml);
+        expect(res).toEqual([
+            { pattern: "^test$", command: "cmd" },
+            { pattern: "^say\\s+(\\w+)\\s+(\\w+)$", command: "say $1 $2" }
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary
- add "Importuj z Blowtorch" button in aliases options to upload XML
- parse Blowtorch alias definitions into regex patterns and commands
- cover Blowtorch parser with unit tests

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68b40b8c5568832a9c951c39eeabcc4f