### PR TITLE
feat(client): add percent placeholders for aliases

### DIFF
--- a/client/src/scripts/userAliases.ts
+++ b/client/src/scripts/userAliases.ts
@@ -27,7 +27,18 @@ export default function initUserAliases(client: Client, aliases?: { pattern: Reg
             return {
                 pattern: regexp,
                 callback: (m: RegExpMatchArray) => {
-                    const cmd = item.command.replace(/\$(\d+)/g, (_, n) => m[parseInt(n)] ?? '');
+                    const input = m.input ?? '';
+                    const words = input.trim().split(/\s+/).filter(Boolean);
+                    const cmd = item.command
+                        .replace(/%%/g, input)
+                        .replace(/%(-?\d+)/g, (_, n) => {
+                            const idx = parseInt(n, 10);
+                            if (idx >= 0) {
+                                return words[idx] ?? '';
+                            }
+                            return words.slice(-idx).join(' ');
+                        })
+                        .replace(/\$(\d+)/g, (_, n) => m[parseInt(n)] ?? '');
                     client.sendCommand(cmd);
                 }
             };

--- a/client/test/userAliases.test.ts
+++ b/client/test/userAliases.test.ts
@@ -1,0 +1,22 @@
+import initUserAliases, { UserAlias } from '../src/scripts/userAliases';
+
+class FakeClient {
+  aliases: { pattern: RegExp; callback: (m: RegExpMatchArray) => void }[] = [];
+  addEventListener = jest.fn();
+  port = { postMessage: jest.fn() } as any;
+  sendCommand = jest.fn();
+}
+
+describe('userAliases', () => {
+  test('supports percent placeholders', () => {
+    const client = new FakeClient();
+    initUserAliases((client as unknown) as any);
+    const apply = client.addEventListener.mock.calls.find(c => c[0] === 'storage')[1];
+    const list: UserAlias[] = [{ pattern: 'foo.*', command: 'cmd %% %0 %1 %-1 %-2' }];
+    apply({ detail: { key: 'aliases', value: list } } as any);
+    const alias = client.aliases[0];
+    const m = 'foo bar baz'.match(alias.pattern)!;
+    alias.callback(m);
+    expect(client.sendCommand).toHaveBeenCalledWith('cmd foo bar baz foo bar bar baz baz');
+  });
+});

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -2,7 +2,7 @@
 
 Poniższa lista opisuje dostępne aliasy w rozszerzeniu:
 
-Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorzec jest wyrażeniem regularnym, a w komendzie można używać `$1`, `$2` itd. aby odwołać się do odpowiednich grup z dopasowania. Można też korzystać ze skrótów obiektów (np. `@1`, `@A`, `@@`), które zostaną zamienione na identyfikatory obiektów.
+Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorzec jest wyrażeniem regularnym, a w komendzie można używać `$1`, `$2` itd. aby odwołać się do odpowiednich grup z dopasowania. Można też korzystać ze skrótów obiektów (np. `@1`, `@A`, `@@`), które zostaną zamienione na identyfikatory obiektów. Dodatkowo dostępne są znaczniki `%`, gdzie `%%` wstawi cały tekst z pola komend, `%0`, `%1` itd. kolejne wyrazy polecenia (z `%0` oznaczającym użyty alias), a `%-1`, `%-2` itd. tekst z pominięciem odpowiednio pierwszego, drugiego itd. wyrazu.
 
 ## Ogólne
 - **/fake _tekst_** - wyświetla podany tekst jak zwykłą wiadomość klienta.


### PR DESCRIPTION
## Summary
- allow user aliases to reference command words via % placeholders
- document percent placeholders for aliases
- test alias expansion of percent placeholders

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68b4215e4948832aa99e5cd93e7b5073