### PR TITLE
feat: import aliases from arkadia client

### DIFF
--- a/web-client/src/options/Aliases.tsx
+++ b/web-client/src/options/Aliases.tsx
@@ -3,6 +3,7 @@ import { Button, Form } from "react-bootstrap";
 import { TiDelete, TiEdit } from "react-icons/ti";
 import storage from "@client/src/storage";
 import { parseBlowtorch, Alias } from "./importBlowtorch";
+import { parseArkadia } from "./importArkadia";
 
 function Aliases() {
     const [aliases, setAliases] = useState<Alias[]>([]);
@@ -12,6 +13,7 @@ function Aliases() {
     const [showCreateForm, setShowCreateForm] = useState(false);
     const [filter, setFilter] = useState("");
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const arkadiaInputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         storage.getItem("aliases").then(res => {
@@ -37,8 +39,36 @@ function Aliases() {
         setShowCreateForm(true);
     }
 
+    function openArkadiaImport() {
+        arkadiaInputRef.current?.click();
+    }
+
     function openImport() {
         fileInputRef.current?.click();
+    }
+
+    async function handleArkadiaImport(e: ChangeEvent<HTMLInputElement>) {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        try {
+            const text = await file.text();
+            const { imported, skipped } = parseArkadia(text);
+            const filtered = imported.filter(a => !aliases.some(b => b.pattern === a.pattern));
+            if (filtered.length) {
+                saveList([...aliases, ...filtered]);
+            }
+            let message = `Zaimportowano ${filtered.length} aliasów`;
+            if (skipped.length) {
+                message += `\nPominięto: ${skipped.join(", ")}`;
+            } else if (!filtered.length) {
+                message = "Brak nowych aliasów";
+            }
+            alert(message);
+        } catch {
+            alert("Nie udało się zaimportować pliku");
+        } finally {
+            e.target.value = "";
+        }
     }
 
     async function handleImport(e: ChangeEvent<HTMLInputElement>) {
@@ -115,7 +145,15 @@ function Aliases() {
                     style={{width: '100%', maxWidth: '12rem'}}
                 />
                 <Button size="sm" onClick={openNew}>Dodaj alias</Button>
+                <Button size="sm" onClick={openArkadiaImport}>Importuj z klienta Arkadii</Button>
                 <Button size="sm" onClick={openImport}>Importuj z Blowtorch</Button>
+                <input
+                    ref={arkadiaInputRef}
+                    type="file"
+                    accept=".json"
+                    style={{ display: 'none' }}
+                    onChange={handleArkadiaImport}
+                />
                 <input
                     ref={fileInputRef}
                     type="file"

--- a/web-client/src/options/importArkadia.ts
+++ b/web-client/src/options/importArkadia.ts
@@ -1,0 +1,45 @@
+import { Alias } from "./importBlowtorch";
+
+function escapeRegex(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export interface ParseResult {
+    imported: Alias[];
+    skipped: string[];
+}
+
+export function parseArkadia(text: string): ParseResult {
+    let data: any;
+    try {
+        data = JSON.parse(text);
+    } catch {
+        return { imported: [], skipped: [] };
+    }
+    const aliasesObj = data.aliases;
+    if (!aliasesObj || typeof aliasesObj !== "object") {
+        return { imported: [], skipped: [] };
+    }
+    const imported: Alias[] = [];
+    const skipped: string[] = [];
+    for (const [key, value] of Object.entries<string>(aliasesObj as Record<string, string>)) {
+        if (/%0|%-\d+|%%/.test(value)) {
+            skipped.push(key);
+            continue;
+        }
+        let command = value.replace(/\$(\d+)/g, "@$1");
+        const matches = Array.from(value.match(/%(\d+)/g) || []).map(m => Number(m.slice(1)));
+        if (matches.length) {
+            command = command.replace(/%(\d+)/g, (_m, g1) => `$${g1}`);
+        }
+        const count = matches.length ? Math.max(...matches) : 0;
+        let pattern = escapeRegex(key.trim());
+        for (let i = 1; i <= count; i++) {
+            pattern += `\\s+(\\w+)`;
+        }
+        pattern = `^${pattern}$`;
+        imported.push({ pattern, command: command.trim() });
+    }
+    return { imported, skipped };
+}
+

--- a/web-client/test/arkadiaImport.test.ts
+++ b/web-client/test/arkadiaImport.test.ts
@@ -1,0 +1,26 @@
+import { parseArkadia } from "../src/options/importArkadia";
+
+describe("parseArkadia", () => {
+    it("parses aliases and reports skipped ones", () => {
+        const json = JSON.stringify({
+            aliases: {
+                a: "cmd",
+                b: "do $1",
+                c: "say %1 %2",
+                d: "test %0",
+                e: "test %-1",
+                f: "test %%"
+            }
+        });
+        const res = parseArkadia(json);
+        expect(res).toEqual({
+            imported: [
+                { pattern: "^a$", command: "cmd" },
+                { pattern: "^b$", command: "do @1" },
+                { pattern: "^c\\s+(\\w+)\\s+(\\w+)$", command: "say $1 $2" }
+            ],
+            skipped: ["d", "e", "f"]
+        });
+    });
+});
+


### PR DESCRIPTION
## Summary
- add parser for Arkadia client alias files
- allow importing Arkadia aliases in options UI
- cover Arkadia alias parsing with tests

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68b43f5e1bc4832a9c8d26e2d05f222b