### PR TITLE
Add configurable skills command with adaptive formatting

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -48,6 +48,7 @@ import initPrzybywajaCount from './scripts/przybywajaCount'
 import initPriceEvaluation from './scripts/priceEvaluation'
 import initStoneValue from './scripts/stoneValue'
 import initSelfEvaluation from './scripts/selfEvaluation'
+import initSkills from './scripts/skills'
 import initCoinColors from './scripts/coinColors'
 import initWeaponColors from './scripts/weaponColors'
 import initNewMail from './scripts/newMail'
@@ -175,6 +176,7 @@ export function registerScripts(client: Client) {
     initPriceEvaluation(client)
     initStoneValue(client, aliases)
     initSelfEvaluation(client, aliases)
+    initSkills(client, aliases)
     initCoinColors(client)
     initWeaponColors(client)
     initLeaderAttackWarning(client)

--- a/client/src/scripts/skills.ts
+++ b/client/src/scripts/skills.ts
@@ -33,11 +33,16 @@ function pad(str: string, len: number) {
     return str + " ".repeat(Math.max(0, len - plain.length));
 }
 
-function colorLevel(level: string) {
+function colorLevel(level: string, maxLevel: number) {
     const num = skillsDesc[level.toLowerCase()];
-    if (!num) return level;
+    const bracketWidth = "[10/10]".length;
+    if (!num) {
+        return pad(level, maxLevel + 1 + bracketWidth);
+    }
     const color = COLORS[num - 1];
-    return colorString(level, color);
+    const word = pad(level, maxLevel);
+    const bracket = `[${num}/10]`.padStart(bracketWidth);
+    return colorString(`${word} ${bracket}`, color);
 }
 
 export default function initSkills(
@@ -60,10 +65,9 @@ export default function initSkills(
         maxName: number,
         maxLevel: number
     ) {
-        const colored = colorLevel(level);
-        const n = pad(name, maxName);
-        const l = pad(colored, maxLevel);
-        return `${n}: ${l}`;
+        const n = pad(`${name}:`, maxName + 1);
+        const l = colorLevel(level, maxLevel);
+        return `${n} ${l}`;
     }
 
     function process(raw: string) {

--- a/client/src/scripts/skills.ts
+++ b/client/src/scripts/skills.ts
@@ -117,10 +117,10 @@ export default function initSkills(
             tag
         );
         timer = setTimeout(disable, 1000);
-        client.sendCommand("um");
+        client.send("um");
     }
 
     if (aliases) {
-        aliases.push({ pattern: /^\/um$/, callback: run });
+        aliases.push({ pattern: /^um$/, callback: run });
     }
 }

--- a/client/src/scripts/skills.ts
+++ b/client/src/scripts/skills.ts
@@ -1,0 +1,128 @@
+import Client from "../Client";
+import { colorString, findClosestColor } from "../Colors";
+import { stripAnsiCodes } from "../Triggers";
+import { SKIP_LINE } from "../ControlConstants";
+
+const COLORS = [
+    findClosestColor("#ff0000"),
+    findClosestColor("#ff0000"),
+    findClosestColor("#ff0000"),
+    findClosestColor("#ffa500"),
+    findClosestColor("#ffa500"),
+    findClosestColor("#ffff00"),
+    findClosestColor("#ffff00"),
+    findClosestColor("#00ff00"),
+    findClosestColor("#00ff00"),
+    findClosestColor("#87ceeb"),
+];
+
+const skillsDesc: Record<string, number> = {
+    ledwo: 1,
+    troche: 2,
+    pobieznie: 3,
+    zadowalajaco: 4,
+    niezle: 5,
+    dobrze: 6,
+    znakomicie: 7,
+    doskonale: 8,
+    perfekcyjnie: 9,
+    mistrzowsko: 10,
+};
+
+function pad(str: string, len: number) {
+    const plain = stripAnsiCodes(str);
+    return str + " ".repeat(Math.max(0, len - plain.length));
+}
+
+function colorLevel(level: string) {
+    const num = skillsDesc[level.toLowerCase()];
+    if (!num) return level;
+    const color = COLORS[num - 1];
+    return colorString(level, color);
+}
+
+export default function initSkills(
+    client: Client,
+    aliases?: { pattern: RegExp; callback: Function }[]
+) {
+    const tag = "skills";
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let lines: string[] = [];
+
+    function finish() {
+        client.Triggers.removeByTag(tag);
+        timer = undefined;
+        if (!lines.length) return;
+
+        const skills: { name: string; level: string }[] = [];
+        lines.forEach((l) => {
+            const pairs = l.match(/[^:]+:\s+\S+/g);
+            pairs?.forEach((p) => {
+                const m = p.match(/([^:]+):\s+(\S+)/);
+                if (m) skills.push({ name: m[1].trim(), level: m[2].trim() });
+            });
+        });
+        lines = [];
+        if (!skills.length) return;
+
+        const maxName = Math.max(...skills.map((s) => s.name.length));
+        const maxLevel = Math.max(...skills.map((s) => s.level.length));
+        const result: string[] = [];
+        for (let i = 0; i < skills.length; i += 2) {
+            const col1 = formatSkill(skills[i], maxName, maxLevel);
+            if (i + 1 < skills.length) {
+                const col2 = formatSkill(skills[i + 1], maxName, maxLevel);
+                const combined = `${col1}  ${col2}`;
+                if (
+                    client.contentWidth &&
+                    stripAnsiCodes(combined).length > client.contentWidth
+                ) {
+                    result.push(col1, col2);
+                } else {
+                    result.push(combined);
+                }
+            } else {
+                result.push(col1);
+            }
+        }
+        client.println(result.join("\n"));
+    }
+
+    function formatSkill(
+        { name, level }: { name: string; level: string },
+        maxName: number,
+        maxLevel: number
+    ) {
+        const colored = colorLevel(level);
+        const n = pad(name, maxName);
+        const l = pad(colored, maxLevel);
+        return `${n}: ${l}`;
+    }
+
+    function startTimer() {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(finish, 1000);
+    }
+
+    function run() {
+        lines = [];
+        client.Triggers.removeByTag(tag);
+        client.Triggers.registerTrigger(
+            /.*/,
+            (_raw, line) => {
+                if (!/[^:]+:\s+\S+/.test(line)) return undefined;
+                lines.push(line);
+                startTimer();
+                return SKIP_LINE;
+            },
+            tag,
+            { stayOpenLines: 50 }
+        );
+        client.sendCommand("um");
+        startTimer();
+    }
+
+    if (aliases) {
+        aliases.push({ pattern: /^\/um$/, callback: run });
+    }
+}

--- a/client/src/scripts/skills.ts
+++ b/client/src/scripts/skills.ts
@@ -1,7 +1,6 @@
 import Client from "../Client";
 import { colorString, findClosestColor } from "../Colors";
 import { stripAnsiCodes } from "../Triggers";
-import { SKIP_LINE } from "../ControlConstants";
 
 const COLORS = [
     findClosestColor("#ff0000"),
@@ -47,13 +46,28 @@ export default function initSkills(
 ) {
     const tag = "skills";
     let timer: ReturnType<typeof setTimeout> | undefined;
-    let lines: string[] = [];
 
-    function finish() {
+    function disable() {
         client.Triggers.removeByTag(tag);
-        timer = undefined;
-        if (!lines.length) return;
+        if (timer) {
+            clearTimeout(timer);
+            timer = undefined;
+        }
+    }
 
+    function formatSkill(
+        { name, level }: { name: string; level: string },
+        maxName: number,
+        maxLevel: number
+    ) {
+        const colored = colorLevel(level);
+        const n = pad(name, maxName);
+        const l = pad(colored, maxLevel);
+        return `${n}: ${l}`;
+    }
+
+    function process(raw: string) {
+        const lines = raw.split("\n").filter((l) => /[^:]+:\s+\S+/.test(stripAnsiCodes(l)));
         const skills: { name: string; level: string }[] = [];
         lines.forEach((l) => {
             const pairs = l.match(/[^:]+:\s+\S+/g);
@@ -62,8 +76,7 @@ export default function initSkills(
                 if (m) skills.push({ name: m[1].trim(), level: m[2].trim() });
             });
         });
-        lines = [];
-        if (!skills.length) return;
+        if (!skills.length) return raw;
 
         const maxName = Math.max(...skills.map((s) => s.name.length));
         const maxLevel = Math.max(...skills.map((s) => s.level.length));
@@ -85,41 +98,22 @@ export default function initSkills(
                 result.push(col1);
             }
         }
-        client.println(result.join("\n"));
-    }
-
-    function formatSkill(
-        { name, level }: { name: string; level: string },
-        maxName: number,
-        maxLevel: number
-    ) {
-        const colored = colorLevel(level);
-        const n = pad(name, maxName);
-        const l = pad(colored, maxLevel);
-        return `${n}: ${l}`;
-    }
-
-    function startTimer() {
-        if (timer) clearTimeout(timer);
-        timer = setTimeout(finish, 1000);
+        return result.join("\n");
     }
 
     function run() {
-        lines = [];
-        client.Triggers.removeByTag(tag);
-        client.Triggers.registerTrigger(
-            /.*/,
-            (_raw, line) => {
-                if (!/[^:]+:\s+\S+/.test(line)) return undefined;
-                lines.push(line);
-                startTimer();
-                return SKIP_LINE;
+        disable();
+        client.Triggers.registerMultilineTrigger(
+            /[^:]+:\s+\S+/,
+            (raw) => {
+                const out = process(raw);
+                disable();
+                return out;
             },
-            tag,
-            { stayOpenLines: 50 }
+            tag
         );
+        timer = setTimeout(disable, 1000);
         client.sendCommand("um");
-        startTimer();
     }
 
     if (aliases) {

--- a/client/test/skills.test.ts
+++ b/client/test/skills.test.ts
@@ -1,0 +1,59 @@
+import Triggers, { stripAnsiCodes } from '../src/Triggers';
+import { EventEmitter } from 'events';
+import initSkills from '../src/scripts/skills';
+
+class FakeClient {
+  private emitter = new EventEmitter();
+  Triggers = new Triggers(({} as unknown) as any);
+  sendCommand = jest.fn();
+  println = jest.fn();
+  contentWidth = 120;
+  addEventListener(event: string, cb: any) { this.emitter.on(event, cb); }
+  removeEventListener(event: string, cb: any) { this.emitter.off(event, cb); }
+  dispatch(event: string, detail: any) { this.emitter.emit(event, { detail }); }
+}
+
+const LINE1 = 'akrobatyka:             troche           alchemia:               troche';
+const LINE2 = 'gornictwo:              ledwo            lowiectwo:              pobieznie';
+const LINE3 = 'zielarstwo:             troche';
+
+describe('skills alias', () => {
+  test('formats skills in columns', () => {
+    jest.useFakeTimers();
+    const client = new FakeClient();
+    const aliases: { pattern: RegExp; callback: () => void }[] = [];
+    initSkills((client as unknown) as any, aliases);
+    const run = aliases[0].callback as any;
+    const parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+
+    run();
+    parse(LINE1);
+    parse(LINE2);
+    parse(LINE3);
+    jest.advanceTimersByTime(1000);
+
+    expect(client.sendCommand).toHaveBeenCalledWith('um');
+    const printed = stripAnsiCodes(client.println.mock.calls[0][0]).split('\n');
+    expect(printed.length).toBe(3);
+  });
+
+  test('splits columns when width is small', () => {
+    jest.useFakeTimers();
+    const client = new FakeClient();
+    client.contentWidth = 40;
+    const aliases: { pattern: RegExp; callback: () => void }[] = [];
+    initSkills((client as unknown) as any, aliases);
+    const run = aliases[0].callback as any;
+    const parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+
+    run();
+    parse(LINE1);
+    parse(LINE2);
+    parse(LINE3);
+    jest.advanceTimersByTime(1000);
+
+    const printed = stripAnsiCodes(client.println.mock.calls[0][0]).split('\n');
+    expect(printed.length).toBe(5);
+    printed.forEach((l) => expect(l.length).toBeLessThanOrEqual(40));
+  });
+});

--- a/client/test/skills.test.ts
+++ b/client/test/skills.test.ts
@@ -6,7 +6,6 @@ class FakeClient {
   private emitter = new EventEmitter();
   Triggers = new Triggers(({} as unknown) as any);
   sendCommand = jest.fn();
-  println = jest.fn();
   contentWidth = 120;
   addEventListener(event: string, cb: any) { this.emitter.on(event, cb); }
   removeEventListener(event: string, cb: any) { this.emitter.off(event, cb); }
@@ -18,42 +17,36 @@ const LINE2 = 'gornictwo:              ledwo            lowiectwo:              
 const LINE3 = 'zielarstwo:             troche';
 
 describe('skills alias', () => {
-  test('formats skills in columns', () => {
-    jest.useFakeTimers();
-    const client = new FakeClient();
-    const aliases: { pattern: RegExp; callback: () => void }[] = [];
-    initSkills((client as unknown) as any, aliases);
-    const run = aliases[0].callback as any;
-    const parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    test('formats skills in columns', () => {
+      jest.useFakeTimers();
+      const client = new FakeClient();
+      const aliases: { pattern: RegExp; callback: () => void }[] = [];
+      initSkills((client as unknown) as any, aliases);
+      const run = aliases[0].callback as any;
 
-    run();
-    parse(LINE1);
-    parse(LINE2);
-    parse(LINE3);
-    jest.advanceTimersByTime(1000);
+      run();
+      const raw = `${LINE1}\n${LINE2}\n${LINE3}`;
+      const processed = client.Triggers.parseMultiline(raw, '');
 
-    expect(client.sendCommand).toHaveBeenCalledWith('um');
-    const printed = stripAnsiCodes(client.println.mock.calls[0][0]).split('\n');
-    expect(printed.length).toBe(3);
+      expect(client.sendCommand).toHaveBeenCalledWith('um');
+      const printed = stripAnsiCodes(processed).split('\n');
+      expect(printed.length).toBe(3);
+    });
+
+    test('splits columns when width is small', () => {
+      jest.useFakeTimers();
+      const client = new FakeClient();
+      client.contentWidth = 40;
+      const aliases: { pattern: RegExp; callback: () => void }[] = [];
+      initSkills((client as unknown) as any, aliases);
+      const run = aliases[0].callback as any;
+
+      run();
+      const raw = `${LINE1}\n${LINE2}\n${LINE3}`;
+      const processed = client.Triggers.parseMultiline(raw, '');
+
+      const printed = stripAnsiCodes(processed).split('\n');
+      expect(printed.length).toBe(5);
+      printed.forEach((l) => expect(l.length).toBeLessThanOrEqual(40));
+    });
   });
-
-  test('splits columns when width is small', () => {
-    jest.useFakeTimers();
-    const client = new FakeClient();
-    client.contentWidth = 40;
-    const aliases: { pattern: RegExp; callback: () => void }[] = [];
-    initSkills((client as unknown) as any, aliases);
-    const run = aliases[0].callback as any;
-    const parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
-
-    run();
-    parse(LINE1);
-    parse(LINE2);
-    parse(LINE3);
-    jest.advanceTimersByTime(1000);
-
-    const printed = stripAnsiCodes(client.println.mock.calls[0][0]).split('\n');
-    expect(printed.length).toBe(5);
-    printed.forEach((l) => expect(l.length).toBeLessThanOrEqual(40));
-  });
-});

--- a/client/test/skills.test.ts
+++ b/client/test/skills.test.ts
@@ -5,6 +5,7 @@ import initSkills from '../src/scripts/skills';
 class FakeClient {
   private emitter = new EventEmitter();
   Triggers = new Triggers(({} as unknown) as any);
+  send = jest.fn();
   sendCommand = jest.fn();
   contentWidth = 120;
   addEventListener(event: string, cb: any) { this.emitter.on(event, cb); }
@@ -27,8 +28,8 @@ describe('skills alias', () => {
       run();
       const raw = `${LINE1}\n${LINE2}\n${LINE3}`;
       const processed = client.Triggers.parseMultiline(raw, '');
-
-      expect(client.sendCommand).toHaveBeenCalledWith('um');
+      expect(client.send).toHaveBeenCalledWith('um');
+      expect(client.sendCommand).not.toHaveBeenCalled();
       const printed = stripAnsiCodes(processed).split('\n');
       expect(printed.length).toBe(3);
       expect(printed[0]).toMatch(/akrobatyka:\s+troche\s+\[2\/10\]\s+alchemia:\s+troche\s+\[2\/10\]/);

--- a/client/test/skills.test.ts
+++ b/client/test/skills.test.ts
@@ -31,6 +31,9 @@ describe('skills alias', () => {
       expect(client.sendCommand).toHaveBeenCalledWith('um');
       const printed = stripAnsiCodes(processed).split('\n');
       expect(printed.length).toBe(3);
+      expect(printed[0]).toMatch(/akrobatyka:\s+troche\s+\[2\/10\]\s+alchemia:\s+troche\s+\[2\/10\]/);
+      expect(printed[1]).toMatch(/gornictwo:\s+ledwo\s+\[1\/10\]\s+lowiectwo:\s+pobieznie\s+\[3\/10\]/);
+      expect(printed[2]).toMatch(/zielarstwo:\s+troche\s+\[2\/10\]/);
     });
 
     test('splits columns when width is small', () => {


### PR DESCRIPTION
## Summary
- add `/um` alias that sends the `um` command
- colorize and align skill levels, splitting columns when terminal width is small
- cover new behavior with unit tests

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68b44ae597cc832ab8f3aa5717ab0472