### PR TITLE
feat: unify character settings with guilds

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -60,14 +60,17 @@
     </div>
     <span id="content-width-measure" style="visibility:hidden;position:absolute;white-space:pre">M</span>
     <div id="options-modal" class="modal fade" tabindex="-1">
-        <div class="modal-dialog modal-lg modal-dialog-scrollable">
-            <div class="modal-content">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable h-100">
+            <div class="modal-content h-100">
                 <div class="modal-header">
                     <h5 class="modal-title">Opcje</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
-                <div class="modal-body">
-                    <div id="options"></div>
+                <div class="modal-body p-0 d-flex flex-column overflow-hidden" style="min-height:0;">
+                    <div id="options" class="h-100 flex-grow-1 overflow-hidden" style="min-height:0;"></div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" id="options-save">Zapisz</button>
                 </div>
             </div>
         </div>
@@ -159,19 +162,6 @@
                 </div>
                 <div class="modal-body">
                     <div id="shortcuts-options"></div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div id="guilds-modal" class="modal fade" tabindex="-1">
-        <div class="modal-dialog modal-lg modal-dialog-scrollable">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Gildie</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">
-                    <div id="guilds-options"></div>
                 </div>
             </div>
         </div>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -28,7 +28,7 @@ import Npc from "./options/Npc.tsx"
 import Scripts from "./options/Scripts.tsx"
 import Aliases from "./options/Aliases.tsx"
 import Recordings from "./options/Recordings.tsx"
-import Guilds from "./options/Guilds.tsx"
+import CharacterSettings from "./options/CharacterSettings.tsx"
 import UserTriggers from "./options/UserTriggers.tsx"
 import Shortcuts from "./options/Shortcuts.tsx"
 import MobileButtons from "./options/MobileButtons.tsx"
@@ -429,6 +429,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const connectButtonFloat = document.getElementById('connect-button-float') as HTMLButtonElement | null;
     const menuButton = document.getElementById('menu-button') as HTMLButtonElement | null;
     const optionsButton = document.getElementById('options-button') as HTMLButtonElement;
+    const optionsSave = document.getElementById('options-save') as HTMLButtonElement | null;
     const bindsButton = document.getElementById('binds-button') as HTMLButtonElement | null;
     const npcButton = document.getElementById('npc-button') as HTMLButtonElement | null;
     const guildsButton = document.getElementById('guilds-button') as HTMLButtonElement | null;
@@ -456,8 +457,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const bindsModal = bindsModalElement ? new Modal(bindsModalElement) : null;
     const npcModalElement = document.getElementById('npc-modal');
     const npcModal = npcModalElement ? new Modal(npcModalElement) : null;
-    const guildsModalElement = document.getElementById('guilds-modal');
-    const guildsModal = guildsModalElement ? new Modal(guildsModalElement) : null;
     const scriptsModalElement = document.getElementById('scripts-modal');
     const scriptsModal = scriptsModalElement ? new Modal(scriptsModalElement) : null;
     const aliasesModalElement = document.getElementById('aliases-modal');
@@ -532,9 +531,6 @@ document.addEventListener('DOMContentLoaded', () => {
         if (npcModal) {
             npcModal.hide();
         }
-        if (guildsModal) {
-            guildsModal.hide();
-        }
         if (scriptsModal) {
             scriptsModal.hide();
         }
@@ -555,7 +551,14 @@ document.addEventListener('DOMContentLoaded', () => {
     // Add event listener to options button
     if (optionsButton && optionsModal) {
         optionsButton.addEventListener('click', () => {
+            window.dispatchEvent(new Event('show-general-settings'));
             optionsModal.show();
+        });
+    }
+
+    if (optionsSave) {
+        optionsSave.addEventListener('click', () => {
+            window.dispatchEvent(new Event('save-options'));
         });
     }
 
@@ -571,9 +574,10 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    if (guildsButton && guildsModal) {
+    if (guildsButton && optionsModal) {
         guildsButton.addEventListener('click', () => {
-            guildsModal.show();
+            window.dispatchEvent(new Event('show-guild-settings'));
+            optionsModal.show();
         });
     }
 
@@ -939,7 +943,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const rootElement = document.getElementById('options');
     if (rootElement) {
-        createRoot(rootElement).render(createElement(Settings));
+        createRoot(rootElement).render(createElement(CharacterSettings));
     }
 
     const bindsRoot = document.getElementById('binds-options');
@@ -952,10 +956,6 @@ document.addEventListener('DOMContentLoaded', () => {
         createRoot(npcRoot).render(createElement(Npc));
     }
 
-    const guildsRoot = document.getElementById('guilds-options');
-    if (guildsRoot) {
-        createRoot(guildsRoot).render(createElement(Guilds));
-    }
 
     const scriptsRoot = document.getElementById('scripts-options');
     if (scriptsRoot) {
@@ -1003,7 +1003,6 @@ window.client = arkadiaClient
 // background communication disabled
 
 import MobileDirectionButtons from "./scripts/mobileDirectionButtons"
-import Settings from "./options/Settings.tsx";
 import initUiSettings from "./uiSettings";
 import Client from "@client/src/Client.ts";
 import {registerScripts} from "@client/src/main.ts";

--- a/web-client/src/options/CharacterSettings.tsx
+++ b/web-client/src/options/CharacterSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import storage, { getCurrentCharacter } from "@client/src/storage";
 import GeneralSettings from "./Settings";
 import Guilds from "./Guilds";
@@ -7,15 +7,19 @@ type Tab = "general" | "guild";
 
 function CharacterSettings() {
     const [tab, setTab] = useState<Tab>("general");
-    const scrollRef = useRef<HTMLDivElement>(null);
+    const scrollRefs = {
+        general: useRef<HTMLDivElement>(null),
+        guild: useRef<HTMLDivElement>(null),
+    } as const;
     const scrollPos = useRef<Record<Tab, number>>({ general: 0, guild: 0 });
-    const saveRef = useRef<() => void>(() => {});
+    const saveRefs = useRef<Record<Tab, () => void>>({ general: () => {}, guild: () => {} });
     const [locked, setLocked] = useState(!getCurrentCharacter());
     const [char, setChar] = useState<string | null>(getCurrentCharacter());
 
     function changeTab(next: Tab) {
-        if (scrollRef.current) {
-            scrollPos.current[tab] = scrollRef.current.scrollTop;
+        const current = scrollRefs[tab].current;
+        if (current) {
+            scrollPos.current[tab] = current.scrollTop;
         }
         setTab(next);
     }
@@ -45,19 +49,32 @@ function CharacterSettings() {
         };
     }, []);
 
-    function registerSave(fn: () => void) {
-        saveRef.current = fn;
-    }
+    const registerGeneralSave = useCallback((fn: () => void) => {
+        saveRefs.current.general = fn;
+    }, []);
+
+    const registerGuildSave = useCallback((fn: () => void) => {
+        saveRefs.current.guild = fn;
+    }, []);
 
     useEffect(() => {
-        const handler = () => saveRef.current();
+        const handler = () => {
+            const saves = [
+                Promise.resolve(saveRefs.current.general()),
+                Promise.resolve(saveRefs.current.guild()),
+            ];
+            Promise.all(saves).then(() => {
+                window.dispatchEvent(new Event("close-options"));
+            });
+        };
         window.addEventListener("save-options", handler);
         return () => window.removeEventListener("save-options", handler);
     }, []);
 
     useEffect(() => {
-        if (scrollRef.current) {
-            scrollRef.current.scrollTop = scrollPos.current[tab];
+        const current = scrollRefs[tab].current;
+        if (current) {
+            current.scrollTop = scrollPos.current[tab];
         }
     }, [tab]);
 
@@ -90,12 +107,21 @@ function CharacterSettings() {
                     </button>
                 </div>
             </div>
-            <div ref={scrollRef} className="flex-grow-1 overflow-auto" style={{ minHeight: 0 }}>
-                {tab === "general" ? (
-                    <GeneralSettings registerSave={registerSave} />
-                ) : (
-                    <Guilds registerSave={registerSave} />
-                )}
+            <div className="flex-grow-1 overflow-hidden" style={{ minHeight: 0 }}>
+                <div
+                    ref={scrollRefs.general}
+                    className={`h-100 overflow-auto${tab === "general" ? "" : " d-none"}`}
+                    style={{ minHeight: 0 }}
+                >
+                    <GeneralSettings registerSave={registerGeneralSave} />
+                </div>
+                <div
+                    ref={scrollRefs.guild}
+                    className={`h-100 overflow-auto${tab === "guild" ? "" : " d-none"}`}
+                    style={{ minHeight: 0 }}
+                >
+                    <Guilds registerSave={registerGuildSave} />
+                </div>
             </div>
         </div>
     );

--- a/web-client/src/options/CharacterSettings.tsx
+++ b/web-client/src/options/CharacterSettings.tsx
@@ -1,0 +1,104 @@
+import { useState, useEffect, useRef } from "react";
+import storage, { getCurrentCharacter } from "@client/src/storage";
+import GeneralSettings from "./Settings";
+import Guilds from "./Guilds";
+
+type Tab = "general" | "guild";
+
+function CharacterSettings() {
+    const [tab, setTab] = useState<Tab>("general");
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const scrollPos = useRef<Record<Tab, number>>({ general: 0, guild: 0 });
+    const saveRef = useRef<() => void>(() => {});
+    const [locked, setLocked] = useState(!getCurrentCharacter());
+    const [char, setChar] = useState<string | null>(getCurrentCharacter());
+
+    function changeTab(next: Tab) {
+        if (scrollRef.current) {
+            scrollPos.current[tab] = scrollRef.current.scrollTop;
+        }
+        setTab(next);
+    }
+
+    useEffect(() => {
+        const showGeneral = () => changeTab("general");
+        const showGuild = () => changeTab("guild");
+        window.addEventListener("show-general-settings", showGeneral);
+        window.addEventListener("show-guild-settings", showGuild);
+        return () => {
+            window.removeEventListener("show-general-settings", showGeneral);
+            window.removeEventListener("show-guild-settings", showGuild);
+        };
+    }, [tab]);
+
+    useEffect(() => {
+        const update = () => {
+            const current = getCurrentCharacter();
+            setLocked(!current);
+            setChar(current);
+        };
+        storage.onChanged?.addListener(update);
+        window.addEventListener("storage", update);
+        return () => {
+            storage.onChanged?.removeListener?.(update);
+            window.removeEventListener("storage", update);
+        };
+    }, []);
+
+    function registerSave(fn: () => void) {
+        saveRef.current = fn;
+    }
+
+    useEffect(() => {
+        const handler = () => saveRef.current();
+        window.addEventListener("save-options", handler);
+        return () => window.removeEventListener("save-options", handler);
+    }, []);
+
+    useEffect(() => {
+        if (scrollRef.current) {
+            scrollRef.current.scrollTop = scrollPos.current[tab];
+        }
+    }, [tab]);
+
+    return (
+        <div className="p-2 d-flex flex-column h-100" style={{ minHeight: 0 }}>
+            {locked ? (
+                <div className="alert alert-info" role="alert">
+                    Opcje zależne od postaci są zablokowane do momentu jej wybrania.
+                </div>
+            ) : (
+                char && (
+                    <div className="alert alert-info" role="alert">
+                        Ustawienia dotyczą postaci: <strong>{char}</strong>
+                    </div>
+                )
+            )}
+            <div className="mb-3 pb-2 flex-shrink-0">
+                <div className="d-flex gap-2">
+                    <button
+                        className={`btn btn-sm ${tab === "general" ? "btn-primary" : "btn-secondary"}`}
+                        onClick={() => changeTab("general")}
+                    >
+                        Ogólne
+                    </button>
+                    <button
+                        className={`btn btn-sm ${tab === "guild" ? "btn-primary" : "btn-secondary"}`}
+                        onClick={() => changeTab("guild")}
+                    >
+                        Gildie
+                    </button>
+                </div>
+            </div>
+            <div ref={scrollRef} className="flex-grow-1 overflow-auto" style={{ minHeight: 0 }}>
+                {tab === "general" ? (
+                    <GeneralSettings registerSave={registerSave} />
+                ) : (
+                    <Guilds registerSave={registerSave} />
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default CharacterSettings;

--- a/web-client/src/options/Guilds.tsx
+++ b/web-client/src/options/Guilds.tsx
@@ -88,7 +88,7 @@ function Guilds({ registerSave }: { registerSave: (cb: () => void) => void }) {
     }
 
     useEffect(() => {
-        registerSave(() => {
+        registerSave(() =>
             storage.getItem("settings").then(res => {
                 const base = res && res.settings
                     ? { ...defaultSettings, ...res.settings }
@@ -99,11 +99,9 @@ function Guilds({ registerSave }: { registerSave: (cb: () => void) => void }) {
                     enemyGuilds: enemySelected,
                     guildColors: colors,
                 };
-                storage.setItem("settings", settings).then(() => {
-                    window.dispatchEvent(new Event("close-options"));
-                });
-            });
-        });
+                return storage.setItem("settings", settings);
+            })
+        );
     }, [registerSave, selected, enemySelected, colors]);
 
     return (

--- a/web-client/src/options/Guilds.tsx
+++ b/web-client/src/options/Guilds.tsx
@@ -1,11 +1,10 @@
 import { useEffect, useState, useMemo } from "react";
-import { Button } from "react-bootstrap";
 import storage, { getCurrentCharacter } from "@client/src/storage";
 import GuildSection from "./GuildSection";
 import guilds from "./guilds";
 import { defaultSettings } from "./defaultSettings";
 
-function Guilds() {
+function Guilds({ registerSave }: { registerSave: (cb: () => void) => void }) {
     const [selected, setSelected] = useState<string[]>([]);
     const [enemySelected, setEnemySelected] = useState<string[]>([]);
     const [colors, setColors] = useState<Record<string, string | undefined>>({});
@@ -88,36 +87,27 @@ function Guilds() {
         setEnemySelected(checked ? [...guilds] : []);
     }
 
-    function save() {
-        storage.getItem("settings").then(res => {
-            const base = res && res.settings
-                ? { ...defaultSettings, ...res.settings }
-                : { ...defaultSettings };
-            const settings = {
-                ...base,
-                guilds: selected,
-                enemyGuilds: enemySelected,
-                guildColors: colors,
-            };
-            storage.setItem("settings", settings).then(() => {
-                window.dispatchEvent(new Event('close-options'));
+    useEffect(() => {
+        registerSave(() => {
+            storage.getItem("settings").then(res => {
+                const base = res && res.settings
+                    ? { ...defaultSettings, ...res.settings }
+                    : { ...defaultSettings };
+                const settings = {
+                    ...base,
+                    guilds: selected,
+                    enemyGuilds: enemySelected,
+                    guildColors: colors,
+                };
+                storage.setItem("settings", settings).then(() => {
+                    window.dispatchEvent(new Event("close-options"));
+                });
             });
         });
-    }
-
-    const char = getCurrentCharacter();
+    }, [registerSave, selected, enemySelected, colors]);
 
     return (
-        <div className="m-2">
-            {locked ? (
-                <div className="alert alert-info" role="alert">
-                    Opcje zależne od postaci są zablokowane do momentu jej wybrania.
-                </div>
-            ) : char && (
-                <div className="alert alert-info" role="alert">
-                    Ustawienia dotyczą postaci: <strong>{char}</strong>
-                </div>
-            )}
+        <div className="p-2">
             <fieldset disabled={locked} className="p-0 border-0 m-0">
                 <GuildSection
                     selected={selected}
@@ -130,7 +120,6 @@ function Guilds() {
                     onChangeAll={onChangeAll}
                     onChangeAllEnemy={onChangeAllEnemy}
                 />
-                <Button onClick={save}>Zapisz</Button>
             </fieldset>
         </div>
     );

--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -1,9 +1,9 @@
-import '../style.css'
-import {useEffect, useState} from "react";
-import {Form, Button} from 'react-bootstrap';
+import "../style.css";
+import { useEffect, useState } from "react";
+import { Form, Button } from "react-bootstrap";
 import storage, { getCurrentCharacter } from "@client/src/storage";
-import { defaultSettings } from './defaultSettings';
-import type { Settings as BaseSettings } from './defaultSettings';
+import { defaultSettings } from "./defaultSettings";
+import type { Settings as BaseSettings } from "./defaultSettings";
 
 interface FormSettings extends BaseSettings {
 }
@@ -44,19 +44,18 @@ const languageOptions = [
     "ghassall",
 ]
 
-function SettingsForm() {
+function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void }) {
+    const [settings, setSettings] = useState<FormSettings>({ ...defaultSettings });
 
-    const [settings, setSettings] = useState<FormSettings>({ ...defaultSettings })
-
-    const [locked, setLocked] = useState(!getCurrentCharacter())
+    const [locked, setLocked] = useState(!getCurrentCharacter());
 
     useEffect(() => {
         const update = () => setLocked(!getCurrentCharacter());
         storage.onChanged?.addListener(update);
-        window.addEventListener('storage', update);
+        window.addEventListener("storage", update);
         return () => {
             storage.onChanged?.removeListener?.(update);
-            window.removeEventListener('storage', update);
+            window.removeEventListener("storage", update);
         };
     }, []);
 
@@ -72,12 +71,12 @@ function SettingsForm() {
             return updated
         })
     }
-
-
-    function handleSubmission() {
-        storage.setItem("settings", settings);
-        window.dispatchEvent(new Event('close-options'));
-    }
+    useEffect(() => {
+        registerSave(() => {
+            storage.setItem("settings", settings);
+            window.dispatchEvent(new Event("close-options"));
+        });
+    }, [registerSave, settings]);
 
     useEffect(() => {
         const load = () => {
@@ -100,19 +99,8 @@ function SettingsForm() {
         };
     }, []);
 
-    const char = getCurrentCharacter();
-
     return (
-        <div className="my-4 p-2">
-            {locked ? (
-                <div className="alert alert-info" role="alert">
-                    Opcje zależne od postaci są zablokowane do momentu jej wybrania.
-                </div>
-            ) : char && (
-                <div className="alert alert-info" role="alert">
-                    Ustawienia dotyczą postaci: <strong>{char}</strong>
-                </div>
-            )}
+        <div className="p-2">
             <fieldset disabled={locked} className="p-0 border-0 m-0">
             <div className="mb-4 border rounded p-3">
                 <h5 className="fw-bold mb-2">Pozostałe opcje</h5>
@@ -374,10 +362,9 @@ function SettingsForm() {
                     </tbody>
                 </table>
             </div>
-            <Button onClick={handleSubmission}>Zapisz</Button>
             </fieldset>
         </div>
-    )
+    );
 }
 
-export default SettingsForm
+export default SettingsForm;

--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -72,10 +72,7 @@ function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void
         })
     }
     useEffect(() => {
-        registerSave(() => {
-            storage.setItem("settings", settings);
-            window.dispatchEvent(new Event("close-options"));
-        });
+        registerSave(() => storage.setItem("settings", settings));
     }, [registerSave, settings]);
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- integrate guild settings into character settings page
- add navigation buttons between general and guild settings
- open shared modal from guilds menu item
- replace sticky sections with flex layout for stable scrolling
- keep section tabs fixed at top and save button fixed at bottom while content scrolls
- move shared save button to modal footer and restore scrollable body
- display character info header above tabs and ensure scrollable options content
- fill modal height to allow inner settings area to scroll
- preserve individual scroll positions for each settings tab

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68b46b7c8cc8832a92a3cda98ba0abb6