### PR TITLE
Store last world rebirth time

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -42,6 +42,7 @@ import initHpAlert from './scripts/hpAlert'
 import initNoWeaponAlert from './scripts/noWeaponAlert'
 import initMagikZnika from './scripts/magikZnika'
 import initSeasonPrint from './scripts/seasonPrint'
+import initWorldRebirth from './scripts/worldRebirth'
 import initDajeCiHighlight from './scripts/dajeCiHighlight'
 import initPrzybywajaHighlight from './scripts/przybywajaHighlight'
 import initPrzybywajaCount from './scripts/przybywajaCount'
@@ -188,6 +189,7 @@ export function registerScripts(client: Client) {
     initNewMail(client)
     initMagikZnika(client)
     initSeasonPrint(client)
+    initWorldRebirth(client)
     initDajeCiHighlight(client)
     initPrzybywajaHighlight(client)
     initPrzybywajaCount(client)

--- a/client/src/scripts/worldRebirth.ts
+++ b/client/src/scripts/worldRebirth.ts
@@ -1,0 +1,34 @@
+import Client from "../Client";
+import { setItemSync } from "../storage";
+
+function parseRebirthTime(rebirth: string): number | undefined {
+    const m = rebirth.match(/\w+, (\d+) ([IVX]+) (\d{4}), (\d+):(\d{2}):(\d{2})/);
+    if (!m) {
+        return undefined;
+    }
+    const roman = ["I","II","III","IV","V","VI","VII","VIII","IX","X","XI","XII"];
+    const month = roman.indexOf(m[2]) + 1;
+    if (month <= 0) {
+        return undefined;
+    }
+    return new Date(
+        Number(m[3]),
+        month - 1,
+        Number(m[1]),
+        Number(m[4]),
+        Number(m[5]),
+        Number(m[6])
+    ).getTime();
+}
+
+export default function initWorldRebirth(client: Client) {
+    const tag = "world-rebirth";
+    const pattern = /^Swiat odrodzil sie  : (.*)\nCiemnosc\.$/;
+    client.Triggers.registerMultilineTrigger(pattern, (_raw, _line, matches) => {
+        const ts = parseRebirthTime(matches[1]);
+        if (ts) {
+            setItemSync("last_world_rebirth", ts);
+        }
+        return undefined;
+    }, tag);
+}

--- a/client/src/scripts/worldRebirth.ts
+++ b/client/src/scripts/worldRebirth.ts
@@ -23,7 +23,7 @@ function parseRebirthTime(rebirth: string): number | undefined {
 
 export default function initWorldRebirth(client: Client) {
     const tag = "world-rebirth";
-    const pattern = /^Swiat odrodzil sie  : (.*)\nCiemnosc\.$/;
+    const pattern = /Swiat odrodzil sie\s*:\s*(.+)\s[\s\S]*Ciemnosc\.$/m;
     client.Triggers.registerMultilineTrigger(pattern, (_raw, _line, matches) => {
         const ts = parseRebirthTime(matches[1]);
         if (ts) {

--- a/client/test/worldRebirth.test.ts
+++ b/client/test/worldRebirth.test.ts
@@ -1,0 +1,34 @@
+import initWorldRebirth from '../src/scripts/worldRebirth';
+import Triggers from '../src/Triggers';
+import { getItemSync } from '../src/storage';
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+}
+
+describe('world rebirth trigger', () => {
+  let client: FakeClient;
+  let parse: (line: string) => string;
+
+  beforeEach(() => {
+    localStorage.clear();
+    client = new FakeClient();
+    initWorldRebirth((client as unknown) as any);
+    parse = (line: string) =>
+      Triggers.prototype.parseMultiline.call(client.Triggers, line, '');
+  });
+
+  test('stores parsed timestamp', () => {
+    const text = 'Swiat odrodzil sie  : Poniedzialek, 1 I 2020, 12:34:56\nCiemnosc.';
+    parse(text);
+    const saved = getItemSync('last_world_rebirth')?.['last_world_rebirth'];
+    expect(typeof saved).toBe('number');
+    const d = new Date(saved);
+    expect(d.getFullYear()).toBe(2020);
+    expect(d.getMonth()).toBe(0);
+    expect(d.getDate()).toBe(1);
+    expect(d.getHours()).toBe(12);
+    expect(d.getMinutes()).toBe(34);
+    expect(d.getSeconds()).toBe(56);
+  });
+});


### PR DESCRIPTION
## Summary
- track world rebirth announcements and record their timestamp
- add tests for storing the last world rebirth

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68b57137c610832a8b9d2740440cd68a