### PR TITLE
feat: emit system rebirth event

### DIFF
--- a/client/src/scripts/worldRebirth.ts
+++ b/client/src/scripts/worldRebirth.ts
@@ -28,6 +28,7 @@ export default function initWorldRebirth(client: Client) {
         const ts = parseRebirthTime(matches[1]);
         if (ts) {
             setItemSync("last_world_rebirth", ts);
+            client.sendEvent("systemRebirth", ts);
         }
         return undefined;
     }, tag);

--- a/client/test/worldRebirth.test.ts
+++ b/client/test/worldRebirth.test.ts
@@ -4,6 +4,10 @@ import { getItemSync } from '../src/storage';
 
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
+  events: { type: string; payload: any }[] = [];
+  sendEvent(type: string, payload: any) {
+    this.events.push({ type, payload });
+  }
 }
 
 describe('world rebirth trigger', () => {
@@ -23,6 +27,9 @@ describe('world rebirth trigger', () => {
     parse(text);
     const saved = getItemSync('last_world_rebirth')?.['last_world_rebirth'];
     expect(typeof saved).toBe('number');
+    expect(client.events).toHaveLength(1);
+    expect(client.events[0].type).toBe('systemRebirth');
+    expect(client.events[0].payload).toBe(saved);
     const d = new Date(saved);
     expect(d.getFullYear()).toBe(2020);
     expect(d.getMonth()).toBe(0);


### PR DESCRIPTION
## Summary
- emit `systemRebirth` event with timestamp when world rebirth is detected
- test for rebirth event emission

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68b57d172404832aa81a6acb9718ea5e