### PR TITLE
Store rebirth time as unix seconds

### DIFF
--- a/client/src/scripts/worldRebirth.ts
+++ b/client/src/scripts/worldRebirth.ts
@@ -11,7 +11,7 @@ function parseRebirthTime(rebirth: string): number | undefined {
     if (month <= 0) {
         return undefined;
     }
-    return new Date(
+    const ms = new Date(
         Number(m[3]),
         month - 1,
         Number(m[1]),
@@ -19,6 +19,7 @@ function parseRebirthTime(rebirth: string): number | undefined {
         Number(m[5]),
         Number(m[6])
     ).getTime();
+    return Math.floor(ms / 1000);
 }
 
 export default function initWorldRebirth(client: Client) {
@@ -26,7 +27,7 @@ export default function initWorldRebirth(client: Client) {
     const pattern = /Swiat odrodzil sie\s*:\s*(.+)\s[\s\S]*Ciemnosc\.$/m;
     client.Triggers.registerMultilineTrigger(pattern, (_raw, _line, matches) => {
         const ts = parseRebirthTime(matches[1]);
-        if (ts) {
+        if (ts !== undefined) {
             setItemSync("last_world_rebirth", ts);
             client.sendEvent("systemRebirth", ts);
         }

--- a/client/test/worldRebirth.test.ts
+++ b/client/test/worldRebirth.test.ts
@@ -30,7 +30,7 @@ describe('world rebirth trigger', () => {
     expect(client.events).toHaveLength(1);
     expect(client.events[0].type).toBe('systemRebirth');
     expect(client.events[0].payload).toBe(saved);
-    const d = new Date(saved);
+    const d = new Date(saved * 1000);
     expect(d.getFullYear()).toBe(2020);
     expect(d.getMonth()).toBe(0);
     expect(d.getDate()).toBe(1);


### PR DESCRIPTION
## Summary
- store world rebirth timestamp in unix seconds instead of milliseconds
- update world rebirth test to expect seconds

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68b5b0450e28832a99ca5b123984dd6d