### PR TITLE
Add attack mode switch

### DIFF
--- a/client/src/eventBus.ts
+++ b/client/src/eventBus.ts
@@ -12,6 +12,7 @@ export interface KnownEvents {
     'breakItem': { text: string; command?: string };
     'packageStatus': { recipient: string; seconds?: number } | null;
     'releaseGuard': boolean;
+    'attackMode': string;
     'contentWidth': number;
     'enterLocation': { id: number; room: any };
     'npc': any;

--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -65,6 +65,23 @@ export default function initObjectAliases(
         }
     }
 
+    function attackById(id: string) {
+        client.sendCommand(`zabij ob_${id}`);
+        if (attackMode !== 'A') {
+            client.sendCommand(`wskaz ob_${id} jako cel ataku`);
+            if (attackMode === 'AWR') {
+                client.sendCommand('rozkaz zaatakowac');
+            }
+        }
+    }
+
+    function attack(short: string) {
+        const obj = findByShortcut(short);
+        if (obj) {
+            attackById(obj.num.toString());
+        }
+    }
+
     let releaseGuard = true;
     const ON_COLOR = findClosestColor("#7cfc00");
     const OFF_COLOR = findClosestColor("#ff6347");
@@ -73,11 +90,17 @@ export default function initObjectAliases(
         releaseGuard = event.detail;
     });
 
+    let attackMode: 'A' | 'AW' | 'AWR' = 'A';
+    client.sendEvent('attackMode', attackMode);
+    client.addEventListener('attackMode', (event: CustomEvent<'A' | 'AW' | 'AWR'>) => {
+        attackMode = event.detail;
+    });
+
 
     if (aliases) {
         aliases.push({
             pattern: /\/z ([0-9]+)$/,
-            callback: (m: RegExpMatchArray) => exec(m[1], "zabij")
+            callback: (m: RegExpMatchArray) => attack(m[1])
         });
         aliases.push({
             pattern: /\/zas ([A-Za-z0-9@]+)$/,
@@ -88,7 +111,7 @@ export default function initObjectAliases(
             callback: () => {
                 const id = client.TeamManager.getAttackTargetId();
                 if (id) {
-                    client.sendCommand(`zabij ob_${id}`);
+                    attackById(id);
                 }
             }
         });

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -37,6 +37,7 @@ describe('object aliases', () => {
   let orderShieldTarget: () => void;
   let markAttack: (m: RegExpMatchArray) => void;
   let markDefense: (m: RegExpMatchArray) => void;
+  let setAttackMode: (ev: { detail: 'A' | 'AW' | 'AWR' }) => void;
 
   beforeEach(() => {
     client = new FakeClient();
@@ -61,12 +62,32 @@ describe('object aliases', () => {
     (global as any).Input = { send: jest.fn() };
     (window as any).gmcp = gmcp;
     gmcp.char = { options: { group_cover: 1 } } as any;
+
+    const attackModeCall = client.addEventListener.mock.calls.find(c => c[0] === 'attackMode');
+    setAttackMode = attackModeCall && attackModeCall[1];
   });
 
   test('kill alias sends zabij with object number', () => {
     client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 5, shortcut: '1' }]);
     kill(['', '1'] as unknown as RegExpMatchArray);
     expect(client.sendCommand).toHaveBeenCalledWith('zabij ob_5');
+  });
+
+  test('kill alias in AW mode marks target', () => {
+    client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 5, shortcut: '1' }]);
+    setAttackMode({ detail: 'AW' });
+    kill(['', '1'] as unknown as RegExpMatchArray);
+    expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'zabij ob_5');
+    expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'wskaz ob_5 jako cel ataku');
+  });
+
+  test('kill alias in AWR mode orders attack', () => {
+    client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 5, shortcut: '1' }]);
+    setAttackMode({ detail: 'AWR' });
+    kill(['', '1'] as unknown as RegExpMatchArray);
+    expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'zabij ob_5');
+    expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'wskaz ob_5 jako cel ataku');
+    expect(client.sendCommand).toHaveBeenNthCalledWith(3, 'rozkaz zaatakowac');
   });
 
   test('zaslon alias sends zaslon with object number when target is in team', () => {

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -45,6 +45,7 @@
         <span id="lamp-timer"></span>
         <span id="break-item-warning"></span>
         <span id="package-status"></span>
+        <span id="attack-mode"></span>
         <span id="release-guard"></span>
         <span id="cover-timer"></span>
     </div>

--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -46,6 +46,7 @@
         <span id="lamp-timer"></span>
         <span id="break-item-warning"></span>
         <span id="package-status"></span>
+        <span id="attack-mode"></span>
         <span id="release-guard"></span>
         <span id="cover-timer"></span>
     </div>

--- a/web-client/src/AttackMode.ts
+++ b/web-client/src/AttackMode.ts
@@ -1,0 +1,31 @@
+import ArkadiaClient from "./ArkadiaClient.ts";
+
+const MODES = ["A", "AW", "AWR"] as const;
+type Mode = typeof MODES[number];
+
+export default class AttackMode {
+  private container: HTMLElement | null;
+  private index = 0;
+  constructor(client: typeof ArkadiaClient) {
+    this.container = document.getElementById("attack-mode");
+    if (this.container) {
+      this.container.addEventListener("click", () => {
+        this.index = (this.index + 1) % MODES.length;
+        client.emit("attackMode", MODES[this.index]);
+      });
+    }
+    client.on("attackMode", (mode: Mode) => {
+      this.index = MODES.indexOf(mode);
+      this.update();
+    });
+    this.update();
+  }
+
+  private update() {
+    if (!this.container) return;
+    const mode = MODES[this.index];
+    this.container.textContent = `Atk: ${mode}`;
+    this.container.style.display = 'block';
+    this.container.className = mode;
+  }
+}

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -11,6 +11,7 @@ import BreakItemWarning from "./BreakItemWarning";
 import PackageStatus from "./PackageStatus";
 import CharStateInfo from "./CharStateInfo";
 import ReleaseGuard from "./ReleaseGuard";
+import AttackMode from "./AttackMode";
 import FightTitle from "./FightTitle";
 import HpTitle from "./HpTitle";
 import initSessionLogger from "./sessionLogger";
@@ -914,6 +915,7 @@ document.addEventListener('DOMContentLoaded', () => {
     new CoverTimer(arkadiaClient);
     new BreakItemWarning(arkadiaClient);
     new ReleaseGuard(arkadiaClient);
+    new AttackMode(arkadiaClient);
     new PackageStatus(arkadiaClient);
     const fightTitle = new FightTitle(arkadiaClient);
     new HpTitle(arkadiaClient, fightTitle);

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -209,6 +209,22 @@ h1 {
   color: tomato;
 }
 
+#attack-mode {
+  display: none;
+}
+
+#attack-mode.A {
+  color: springgreen;
+}
+
+#attack-mode.AW {
+  color: gold;
+}
+
+#attack-mode.AWR {
+  color: deepskyblue;
+}
+
 #objects-list {
   position: absolute;
   top: 0;

--- a/web-client/test/AttackMode.test.ts
+++ b/web-client/test/AttackMode.test.ts
@@ -1,0 +1,47 @@
+import AttackMode from '../src/AttackMode';
+
+class MockClient {
+  private events: Record<string, Function[]> = {};
+  on(event: string, listener: Function) {
+    (this.events[event] ||= []).push(listener);
+  }
+  emit = jest.fn((event: string, ...args: any[]) => {
+    (this.events[event] || []).forEach(fn => fn(...args));
+  });
+}
+
+describe('AttackMode', () => {
+  let container: HTMLElement;
+  let client: MockClient;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<span id="attack-mode"></span>';
+    container = document.getElementById('attack-mode')!;
+    client = new MockClient();
+    new AttackMode(client as any);
+  });
+
+  test('updates mode display', () => {
+    expect(container.textContent).toBe('Atk: A');
+    expect(container.style.display).toBe('block');
+    expect(container.className).toBe('A');
+
+    client.emit('attackMode', 'AW');
+    expect(container.textContent).toBe('Atk: AW');
+    expect(container.className).toBe('AW');
+  });
+
+  test('click cycles mode and emits event', () => {
+    container.click();
+    expect(client.emit).toHaveBeenLastCalledWith('attackMode', 'AW');
+    expect(container.textContent).toBe('Atk: AW');
+
+    container.click();
+    expect(client.emit).toHaveBeenLastCalledWith('attackMode', 'AWR');
+    expect(container.textContent).toBe('Atk: AWR');
+
+    container.click();
+    expect(client.emit).toHaveBeenLastCalledWith('attackMode', 'A');
+    expect(container.textContent).toBe('Atk: A');
+  });
+});


### PR DESCRIPTION
## Summary
- add footer attack mode switch cycling A/AW/AWR
- send extra commands for AW and AWR modes
- show and test attack mode component

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68b93980a4b4832ab0f5b55f313123d8