### PR TITLE
feat: show gmcp events in sandbox

### DIFF
--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -442,6 +442,7 @@
         <button id="sandbox-add-enemy" class="btn btn-secondary btn-sm w-100">Add Enemy</button>
     </div>
     <ul id="sandbox-team-preview" class="sandbox-team-preview list-unstyled"></ul>
+    <div id="sandbox-gmcp-events" class="sandbox-gmcp-events"></div>
 </div>
 </div>
 <div id="context-menu" class="context-menu"></div>

--- a/web-client/src/sandbox.css
+++ b/web-client/src/sandbox.css
@@ -50,3 +50,17 @@
   cursor: pointer;
   padding: 0 0.25rem;
 }
+
+.sandbox-gmcp-events {
+  border: 1px dashed #ccc;
+  padding: 0.25rem;
+  margin-top: 0.5rem;
+  white-space: pre-wrap;
+  font-family: monospace;
+  max-height: 10rem;
+  overflow-y: auto;
+}
+
+.sandbox-gmcp-event {
+  margin-bottom: 0.5rem;
+}

--- a/web-client/src/sandbox.ts
+++ b/web-client/src/sandbox.ts
@@ -26,11 +26,22 @@ window.addEventListener('load', () => {
     const addMemberButton = document.getElementById('sandbox-add-member') as HTMLButtonElement | null;
     const addEnemyButton = document.getElementById('sandbox-add-enemy') as HTMLButtonElement | null;
     const preview = document.getElementById('sandbox-team-preview');
+    const gmcpLog = document.getElementById('sandbox-gmcp-events');
 
     let id = 1;
     const ids = new Map<string, number>();
     const objectNums = new Set<number>();
     const hps = new Map<number, number>();
+
+    client.addEventListener?.('gmcp', (ev: CustomEvent<{ path: string; value: any }>) => {
+        if (!gmcpLog) return;
+        const pre = document.createElement('pre');
+        pre.className = 'sandbox-gmcp-event';
+        const { path, value } = ev.detail || {};
+        pre.textContent = `${path}\n${JSON.stringify(value, null, 2)}`;
+        gmcpLog.appendChild(pre);
+        (gmcpLog as HTMLElement).scrollTop = (gmcpLog as HTMLElement).scrollHeight;
+    });
 
     function sendTeam(name: string, leaderFlag: boolean) {
         let memberId = ids.get(name);


### PR DESCRIPTION
## Summary
- log GMCP events in sandbox with dashed border formatting

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68b9aad59f18832abdd1556907b76536