### PR TITLE
feat: show gmcp events in sandbox

### DIFF
--- a/web-client/src/sandbox.css
+++ b/web-client/src/sandbox.css
@@ -50,3 +50,11 @@
   cursor: pointer;
   padding: 0 0.25rem;
 }
+
+.sandbox-gmcp-event {
+  border: 1px dashed #ccc;
+  padding: 0.25rem;
+  margin: 0.25rem 0;
+  white-space: pre-wrap;
+  font-family: monospace;
+}

--- a/web-client/src/sandbox.ts
+++ b/web-client/src/sandbox.ts
@@ -32,6 +32,14 @@ window.addEventListener('load', () => {
     const objectNums = new Set<number>();
     const hps = new Map<number, number>();
 
+    client.addEventListener?.('gmcp', (ev: CustomEvent<{ path: string; value: any }>) => {
+        const pre = document.createElement('pre');
+        pre.className = 'sandbox-gmcp-event';
+        const { path, value } = ev.detail || {};
+        pre.textContent = `${path}\n${JSON.stringify(value, null, 2)}`;
+        arkadiaClient.output(pre.outerHTML, 'command');
+    });
+
     function sendTeam(name: string, leaderFlag: boolean) {
         let memberId = ids.get(name);
         if (!memberId) {


### PR DESCRIPTION
## Summary
- log GMCP events in sandbox in main output with dashed border formatting

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68b9aad59f18832abdd1556907b76536