### PR TITLE
Show login error on failed login

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -241,6 +241,7 @@
                 <input id="login-character" class="form-control" placeholder="Postać">
                 <input id="login-password" type="password" class="form-control" placeholder="Hasło">
                 <button id="login-submit" class="btn btn-primary" type="submit">Zaloguj</button>
+                <div id="login-error" class="alert alert-danger d-none" role="alert"></div>
             </form>
         </div>
         <div id="commit-info"></div>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -473,6 +473,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const loginCharacter = document.getElementById('login-character') as HTMLInputElement | null;
     const loginPassword = document.getElementById('login-password') as HTMLInputElement | null;
     const loginForm = document.getElementById('login-form') as HTMLFormElement | null;
+    const loginError = document.getElementById('login-error') as HTMLElement | null;
     const authClose = document.getElementById('auth-close') as HTMLButtonElement | null;
     const notificationCenter = document.getElementById('notification-center') as HTMLElement | null;
     const enableNotificationsSettings = document.getElementById('ui-enable-notifications') as HTMLButtonElement | null;
@@ -481,6 +482,25 @@ document.addEventListener('DOMContentLoaded', () => {
     const locationQrImage = document.getElementById('location-qr-image') as HTMLImageElement | null;
     const locationShareModalElement = document.getElementById('location-share-modal');
     const locationShareModal = locationShareModalElement ? new Modal(locationShareModalElement) : null;
+
+    const hideLoginError = () => {
+        if (loginError) {
+            loginError.classList.add('d-none');
+            loginError.textContent = '';
+        }
+    };
+
+    arkadiaClient.on('gmcp_msg.system.login', (text: string) => {
+        if (!loginError) return;
+        const authOverlay = document.getElementById('auth-overlay') as HTMLElement | null;
+        if (authOverlay && authOverlay.style.display !== 'none') {
+            const msg = text.split('Podaj swe haslo:')[1]?.trim();
+            if (msg) {
+                loginError.textContent = msg;
+                loginError.classList.remove('d-none');
+            }
+        }
+    });
 
     if (enableNotificationsSettings || enableNotificationsConnection) {
         const updateVisibility = () => {
@@ -717,6 +737,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (loginForm) {
         loginForm.addEventListener('submit', async (e) => {
             e.preventDefault();
+            hideLoginError();
             const character = loginCharacter?.value || '';
             const password = loginPassword?.value || '';
 
@@ -886,6 +907,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Handle connect/disconnect button click
     const handleConnect = () => {
+        hideLoginError();
         if (isConnected) {
             arkadiaClient.disconnect();
         } else {


### PR DESCRIPTION
## Summary
- display system login errors under the login form when auth overlay is visible
- clear previous login errors when reconnecting

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test` *(fails: ansiParser.test)*
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68baa317b64c832ab5c39c8b010e86f2