### PR TITLE
Fix ANSI parser test for standard colors

### DIFF
--- a/web-client/test/ansiParser.test.ts
+++ b/web-client/test/ansiParser.test.ts
@@ -4,7 +4,7 @@ import { colorCodes } from '@client/src/Colors.ts';
 describe('parseAnsiPatterns', () => {
   test('parses standard ansi color', () => {
     const result = parseAnsiPatterns('\x1B[22;31mred\x1B[0m');
-    expect(result).toBe(`<span style="color: ${colorCodes.ansi.bright[1]}">red</span>`);
+    expect(result).toBe(`<span style="color: ${colorCodes.ansi.dark[1]}">red</span>`);
   });
 
   test('parses 256 color code', () => {


### PR DESCRIPTION
## Summary
- update ANSI parser test to expect dark palette colors for non-bold codes

## Testing
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_68bab9ebe248832a888d64f5c644dce3