### PR TITLE
Echo commands during recording playback

### DIFF
--- a/web-client/src/Recorder.ts
+++ b/web-client/src/Recorder.ts
@@ -170,8 +170,9 @@ export default class Recorder {
         if (ev.direction === 'in') {
             this.hooks.processIncomingData(ev.message);
         } else {
-            window.clientExtension.sendCommand(ev.message)
-            this.hooks.sendCommand(ev.message);
+            Output.send('-> ' + ev.message);
+            window.clientExtension.sendCommand(ev.message, false);
+            this.hooks.sendCommand(ev.message, false);
         }
     }
 

--- a/web-client/test/Recorder.test.ts
+++ b/web-client/test/Recorder.test.ts
@@ -1,0 +1,21 @@
+import Recorder from '../src/Recorder';
+
+describe('Recorder playback', () => {
+  test('replayRecordedMessagesTimed echoes outgoing commands', () => {
+    const hooks = {
+      processIncomingData: jest.fn(),
+      sendCommand: jest.fn(),
+      emit: jest.fn(),
+    };
+    const recorder = new Recorder(hooks as any);
+    (window as any).clientExtension = { sendCommand: jest.fn() };
+    (window as any).Output = { send: jest.fn() };
+    recorder.setRecordedMessages([
+      { message: 'look', timestamp: 0, direction: 'out' },
+    ]);
+    jest.useFakeTimers();
+    recorder.replayRecordedMessagesTimed();
+    jest.runAllTimers();
+    expect((window as any).Output.send).toHaveBeenCalledWith('-> look');
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure recorder playback echoes outgoing commands to the output stream
- Add tests for recorder playback command echoing

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68c1342cbbf4832a91f1d28f323d13aa