### PR TITLE
Add tests for color utilities and settings propagation

### DIFF
--- a/web-client/test/colors.test.ts
+++ b/web-client/test/colors.test.ts
@@ -1,0 +1,43 @@
+import { getColorLevel, COLOR_BAR_CLASS, COLOR_TEXT, COLOR_OBJECT } from '../src/colors';
+
+describe('getColorLevel', () => {
+  test('computes color level based on ratio', () => {
+    expect(getColorLevel(0, 0)).toBe('danger');
+    expect(getColorLevel(1, 3)).toBe('danger');
+    expect(getColorLevel(2, 3)).toBe('warning');
+    expect(getColorLevel(3, 3)).toBe('success');
+  });
+
+  test('supports reverse mode', () => {
+    expect(getColorLevel(2, 3, true)).toBe('danger');
+    expect(getColorLevel(1, 3, true)).toBe('warning');
+    expect(getColorLevel(0, 3, true)).toBe('success');
+  });
+
+  test('supports HP thresholds', () => {
+    expect(getColorLevel(2, 10, false, true)).toBe('danger');
+    expect(getColorLevel(5, 10, false, true)).toBe('warning');
+    expect(getColorLevel(6, 10, false, true)).toBe('success');
+  });
+});
+
+describe('color constants', () => {
+  test('bar classes', () => {
+    expect(COLOR_BAR_CLASS.success).toBe('bg-success');
+    expect(COLOR_BAR_CLASS.warning).toBe('bg-warning');
+    expect(COLOR_BAR_CLASS.danger).toBe('bg-danger');
+  });
+
+  test('text colors', () => {
+    expect(COLOR_TEXT.success).toBe('green');
+    expect(COLOR_TEXT.warning).toBe('yellow');
+    expect(COLOR_TEXT.danger).toBe('red');
+  });
+
+  test('object colors', () => {
+    expect(COLOR_OBJECT.success).toBe('springgreen');
+    expect(COLOR_OBJECT.warning).toBe('yellow');
+    expect(COLOR_OBJECT.danger).toBe('tomato');
+  });
+});
+

--- a/web-client/test/settingsPropagation.test.ts
+++ b/web-client/test/settingsPropagation.test.ts
@@ -1,0 +1,44 @@
+import storage from '@client/src/storage';
+import initShortExits from '@client/src/scripts/shortExits';
+import Triggers from '@client/src/Triggers';
+import { colorString, findClosestColor } from '@client/src/Colors';
+import { defaultSettings } from '@client/src/defaultSettings';
+
+const ORANGE = findClosestColor('#ffa500');
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+  println = jest.fn();
+  private handlers: Record<string, Array<(ev: any) => void>> = {};
+  addEventListener(event: string, handler: (ev: any) => void) {
+    (this.handlers[event] = this.handlers[event] || []).push(handler);
+  }
+  dispatch(event: string, detail: any) {
+    (this.handlers[event] || []).forEach(h => h({ detail }));
+  }
+}
+
+describe('settings propagation to scripts', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('shortenExits setting affects script', async () => {
+    const client = new FakeClient();
+    initShortExits(client as any);
+    const parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    const line = 'Sa tutaj dwa widoczne wyjscia: polnoc i wschod.';
+    expect(parse(line)).toBe(line);
+
+    storage.onChanged?.addListener(changes => {
+      if (changes.settings) {
+        client.dispatch('settings', changes.settings.newValue);
+      }
+    });
+
+    await storage.setItem('settings', { ...defaultSettings, shortenExits: true });
+    await new Promise(res => setTimeout(res, 0));
+
+    expect(parse(line)).toBe(colorString('-----: N E', ORANGE));
+  });
+});


### PR DESCRIPTION
## Summary
- test color level calculation and color constant mappings
- verify that storing updated settings notifies scripts

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68b87b010770832a8b1bd1bca65dfba7