### PR TITLE
Add przemykanie timer to footer

### DIFF
--- a/client/src/eventBus.ts
+++ b/client/src/eventBus.ts
@@ -16,6 +16,8 @@ export interface KnownEvents {
     'contentWidth': number;
     'enterLocation': { id: number; room: any };
     'npc': any;
+    'zaskTimer': { seconds: number; ok: boolean } | null;
+    'moveModeChanged': number;
 }
 
 export type ClientEvents = KnownEvents & {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -10,6 +10,7 @@ import initSeat from './scripts/seat'
 import initAttackBeep from './scripts/attackBeep'
 import initLamp from './scripts/lamp'
 import initCoverTimer from './scripts/coverTimer'
+import initZaskTimer from './scripts/zaskTimer'
 import initBinds from './scripts/binds'
 import initMoveMode from './scripts/moveMode'
 import initCarriage from './scripts/carriage'
@@ -137,6 +138,7 @@ export function registerScripts(client: Client) {
     initAttackBeep(client)
     initLamp(client)
     initCoverTimer(client)
+    initZaskTimer(client)
     initBinds(client, aliases)
     initMoveMode(client)
     initCarriage(client)

--- a/client/src/scripts/moveMode.ts
+++ b/client/src/scripts/moveMode.ts
@@ -13,10 +13,15 @@ export default function initMoveMode(client: Client) {
         button.title = `Ruch: ${TITLES[client.moveMode]}`;
     }
 
+    function emitChange() {
+        client.sendEvent('moveModeChanged', client.moveMode);
+    }
+
     function toggle(notify = false) {
         if (client.carriageMode) return;
         client.moveMode = (client.moveMode + 1) % LABELS.length;
         update();
+        emitChange();
         if (notify) {
             client.println(`Tryb ruchu: ${TITLES[client.moveMode]}`);
         }
@@ -34,4 +39,6 @@ export default function initMoveMode(client: Client) {
             ev.preventDefault();
         }
     });
+
+    emitChange();
 }

--- a/client/src/scripts/zaskTimer.ts
+++ b/client/src/scripts/zaskTimer.ts
@@ -1,0 +1,68 @@
+import Client from "../Client";
+
+const SAFE_THRESHOLD_SECONDS = 30;
+
+interface ZaskTimerPayload {
+    seconds: number;
+    ok: boolean;
+}
+
+export default function initZaskTimer(client: Client) {
+    let timer: number | null = null;
+    let start = 0;
+    let active = false;
+
+    function clearTimer() {
+        if (timer != null) {
+            clearInterval(timer);
+            timer = null;
+        }
+    }
+
+    function emit(payload: ZaskTimerPayload | null) {
+        client.sendEvent('zaskTimer', payload);
+    }
+
+    function stopTimer() {
+        clearTimer();
+        if (active) {
+            active = false;
+            emit(null);
+        }
+    }
+
+    function updateTimer() {
+        if (!active) return;
+        const seconds = Math.floor((Date.now() - start) / 1000);
+        if (seconds >= SAFE_THRESHOLD_SECONDS) {
+            clearTimer();
+            emit({ seconds, ok: true });
+        } else {
+            emit({ seconds, ok: false });
+        }
+    }
+
+    function startTimer() {
+        start = Date.now();
+        active = true;
+        clearTimer();
+        updateTimer();
+        timer = window.setInterval(updateTimer, 1000);
+    }
+
+    client.addEventListener('gmcp.room.info', () => {
+        if (client.moveMode > 0) {
+            startTimer();
+        } else {
+            stopTimer();
+        }
+    });
+
+    client.addEventListener('moveModeChanged', (event: CustomEvent<number>) => {
+        if (event.detail === 0) {
+            stopTimer();
+        }
+    });
+
+    emit(null);
+}

--- a/client/test/moveMode.test.ts
+++ b/client/test/moveMode.test.ts
@@ -6,6 +6,7 @@ class FakeClient {
   moveModeButton?: HTMLInputElement;
   moveModeBind = { key: 'Backquote' } as { key: string; ctrl?: boolean; alt?: boolean; shift?: boolean };
   println = jest.fn();
+  sendEvent = jest.fn();
   createButton(_name: string, callback: () => void) {
     const btn = document.createElement('input');
     btn.type = 'button';

--- a/client/test/zaskTimer.test.ts
+++ b/client/test/zaskTimer.test.ts
@@ -1,0 +1,61 @@
+import initZaskTimer from "../src/scripts/zaskTimer";
+
+describe("zask timer", () => {
+  class FakeClient extends EventTarget {
+    moveMode = 0;
+    sendEvent = jest.fn((type: string, detail?: any) => {
+      super.dispatchEvent(new CustomEvent(type, { detail }));
+    });
+
+    addEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: AddEventListenerOptions | boolean,
+    ) {
+      super.addEventListener(type, listener as EventListener, options);
+      return () => super.removeEventListener(type, listener as EventListener, options as any);
+    }
+
+    removeEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: EventListenerOptions,
+    ) {
+      if (listener) {
+        super.removeEventListener(type, listener as EventListener, options);
+      }
+    }
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("counts seconds in sneak mode and reports ok after threshold", () => {
+    const client = new FakeClient();
+    initZaskTimer((client as unknown) as any);
+    expect(client.sendEvent).toHaveBeenLastCalledWith("zaskTimer", null);
+    client.sendEvent.mockClear();
+
+    client.moveMode = 1;
+    client.dispatchEvent(new CustomEvent("gmcp.room.info"));
+    expect(client.sendEvent).toHaveBeenLastCalledWith("zaskTimer", { seconds: 0, ok: false });
+
+    jest.advanceTimersByTime(29000);
+    expect(client.sendEvent).toHaveBeenLastCalledWith("zaskTimer", { seconds: 29, ok: false });
+
+    jest.advanceTimersByTime(1000);
+    expect(client.sendEvent).toHaveBeenLastCalledWith("zaskTimer", expect.objectContaining({ ok: true }));
+
+    client.dispatchEvent(new CustomEvent("moveModeChanged", { detail: 0 }));
+    expect(client.sendEvent).toHaveBeenLastCalledWith("zaskTimer", null);
+
+    const callCount = client.sendEvent.mock.calls.length;
+    jest.advanceTimersByTime(2000);
+    expect(client.sendEvent.mock.calls.length).toBe(callCount);
+  });
+});

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -48,6 +48,7 @@
         <span id="attack-mode"></span>
         <span id="release-guard"></span>
         <span id="cover-timer"></span>
+        <span id="zask-timer"></span>
     </div>
     <div id="objects-list"></div>
     <button id="recording-button" class="btn btn-danger btn-sm" style="position:absolute;top:0.5rem;right:0.5rem;z-index:1012;display:none;">Zatrzymaj i zapisz</button>

--- a/web-client/src/ZaskTimer.ts
+++ b/web-client/src/ZaskTimer.ts
@@ -1,0 +1,40 @@
+import ArkadiaClient from "./ArkadiaClient.ts";
+
+interface ZaskTimerPayload {
+  seconds: number;
+  ok: boolean;
+}
+
+export default class ZaskTimer {
+  private container: HTMLElement | null;
+
+  constructor(client: typeof ArkadiaClient) {
+    this.container = document.getElementById("zask-timer");
+    client.on("zaskTimer", (payload: ZaskTimerPayload | null) => this.update(payload));
+    this.update(null);
+  }
+
+  private update(payload: ZaskTimerPayload | null) {
+    if (!this.container) return;
+
+    if (!payload) {
+      this.container.textContent = "";
+      this.container.className = "";
+      this.container.style.display = "none";
+      return;
+    }
+
+    this.container.style.display = "block";
+    if (payload.ok) {
+      this.container.textContent = "Zask: OK";
+      this.container.className = "green";
+    } else {
+      this.container.textContent = `Zask: ${payload.seconds}`;
+      if (payload.seconds >= 20) {
+        this.container.className = "yellow";
+      } else {
+        this.container.className = "red";
+      }
+    }
+  }
+}

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -7,6 +7,7 @@ import CharState from "./CharState";
 import ObjectList from "./ObjectList";
 import LampTimer from "./LampTimer";
 import CoverTimer from "./CoverTimer";
+import ZaskTimer from "./ZaskTimer";
 import BreakItemWarning from "./BreakItemWarning";
 import PackageStatus from "./PackageStatus";
 import CharStateInfo from "./CharStateInfo";
@@ -913,6 +914,7 @@ document.addEventListener('DOMContentLoaded', () => {
     new CharStateInfo(arkadiaClient);
     new LampTimer(arkadiaClient);
     new CoverTimer(arkadiaClient);
+    new ZaskTimer(arkadiaClient);
     new BreakItemWarning(arkadiaClient);
     new ReleaseGuard(arkadiaClient);
     new AttackMode(arkadiaClient);

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -737,6 +737,7 @@ export default class MobileDirectionButtons {
                     this.client.moveMode = (this.client.moveMode + 1) % MOVE_MODE_LABELS.length;
                     newBtn.textContent = `${cfg.label} ${MOVE_MODE_LABELS[this.client.moveMode]}`;
                     newBtn.title = `${cfg.label} ${MOVE_MODE_TITLES[this.client.moveMode]}`;
+                    this.client.sendEvent('moveModeChanged', this.client.moveMode);
                     break;
                 case 'specialExit':
                     const specialExits = this.client.Map.currentRoom?.specialExits ?? {};

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -187,6 +187,22 @@ h1 {
   color: yellow;
 }
 
+#zask-timer {
+  display: none;
+}
+
+#zask-timer.green {
+  color: springgreen;
+}
+
+#zask-timer.yellow {
+  color: yellow;
+}
+
+#zask-timer.red {
+  color: tomato;
+}
+
 #state-info {
   display: none;
 }


### PR DESCRIPTION
## Summary
- track gmcp room info events while in przemykanie move mode and emit a footer timer that turns "OK" after 30 seconds
- expose move mode change notifications from desktop and mobile controls so the timer can reset or clear correctly
- render the new Zask footer indicator with color-coded states and cover it with unit tests

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68cac5bde018832a8f0758ccefff5835