### PR TITLE
Add configurable map positioning options

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -16,7 +16,7 @@
     <title>Arkadia</title>
 </head>
 <body>
-<div id="main-container">
+<div id="main-container" data-map-position="top-overlay">
     <div id="iframe-container">
         <canvas id="map" resize="true"></canvas>
         <div id="location-wrapper">
@@ -33,24 +33,26 @@
             </div>
         </div>
     </div>
-    <div id="main_text_output_msg_wrapper">
-        <div id="split-bottom" class="split-hidden">
-            <div id="sticky-area"></div>
+    <div id="app-content">
+        <div id="main_text_output_msg_wrapper">
+            <div id="split-bottom" class="split-hidden">
+                <div id="sticky-area"></div>
+            </div>
         </div>
+        <div id="char-state" data-emoji-labels="0" data-footer-mode="0">
+            <span id="char-state-text"></span>
+            <span id="state-info"></span>
+            <div id="char-state-bars"></div>
+            <span id="lamp-timer"></span>
+            <span id="break-item-warning"></span>
+            <span id="package-status"></span>
+            <span id="attack-mode"></span>
+            <span id="release-guard"></span>
+            <span id="cover-timer"></span>
+            <span id="zask-timer"></span>
+        </div>
+        <div id="objects-list"></div>
     </div>
-    <div id="char-state" data-emoji-labels="0" data-footer-mode="0">
-        <span id="char-state-text"></span>
-        <span id="state-info"></span>
-        <div id="char-state-bars"></div>
-        <span id="lamp-timer"></span>
-        <span id="break-item-warning"></span>
-        <span id="package-status"></span>
-        <span id="attack-mode"></span>
-        <span id="release-guard"></span>
-        <span id="cover-timer"></span>
-        <span id="zask-timer"></span>
-    </div>
-    <div id="objects-list"></div>
     <button id="recording-button" class="btn btn-danger btn-sm" style="position:absolute;top:0.5rem;right:0.5rem;z-index:1012;display:none;">Zatrzymaj i zapisz</button>
     <div id="playback-controls" class="btn-group btn-group-sm" style="position:absolute;top:2.5rem;right:0.5rem;z-index:1013;display:none;">
         <button id="playback-pause" class="btn btn-secondary">Pauza</button>
@@ -301,6 +303,18 @@
                     </label>
                     <label class="form-label">Wysokość mapy (vh)
                         <input id="ui-map-height" type="number" step="1" class="form-control" />
+                    </label>
+                    <label class="form-label">Pozycja mapy
+                        <select id="ui-map-position" class="form-select">
+                            <option value="top-overlay">Góra (nakładka)</option>
+                            <option value="bottom-overlay">Dół (nakładka)</option>
+                            <option value="left-overlay">Lewa (nakładka)</option>
+                            <option value="right-overlay">Prawa (nakładka)</option>
+                            <option value="top-no-overlay">Góra (bez nakładki)</option>
+                            <option value="bottom-no-overlay">Dół (bez nakładki)</option>
+                            <option value="left-no-overlay">Lewa (bez nakładki)</option>
+                            <option value="right-no-overlay">Prawa (bez nakładki)</option>
+                        </select>
                     </label>
                     <label class="form-label">Zasięg renderowania mapy
                         <input id="ui-map-limit" type="number" step="1" min="1" value="35" class="form-control" />

--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <div id="sandbox-layout" class="sandbox-layout">
-<div id="main-container">
+<div id="main-container" data-map-position="top-overlay">
     <div id="iframe-container">
         <canvas id="map" resize="true"></canvas>
         <div id="location-wrapper">
@@ -34,23 +34,25 @@
             </div>
         </div>
     </div>
-    <div id="main_text_output_msg_wrapper">
-        <div id="split-bottom" class="split-hidden">
-            <div id="sticky-area"></div>
+    <div id="app-content">
+        <div id="main_text_output_msg_wrapper">
+            <div id="split-bottom" class="split-hidden">
+                <div id="sticky-area"></div>
+            </div>
         </div>
+        <div id="char-state" data-emoji-labels="0" data-footer-mode="0">
+            <span id="char-state-text"></span>
+            <span id="state-info"></span>
+            <div id="char-state-bars"></div>
+            <span id="lamp-timer"></span>
+            <span id="break-item-warning"></span>
+            <span id="package-status"></span>
+            <span id="attack-mode"></span>
+            <span id="release-guard"></span>
+            <span id="cover-timer"></span>
+        </div>
+        <div id="objects-list"></div>
     </div>
-    <div id="char-state" data-emoji-labels="0" data-footer-mode="0">
-        <span id="char-state-text"></span>
-        <span id="state-info"></span>
-        <div id="char-state-bars"></div>
-        <span id="lamp-timer"></span>
-        <span id="break-item-warning"></span>
-        <span id="package-status"></span>
-        <span id="attack-mode"></span>
-        <span id="release-guard"></span>
-        <span id="cover-timer"></span>
-    </div>
-    <div id="objects-list"></div>
     <button id="recording-button" class="btn btn-danger btn-sm" style="position:absolute;top:0.5rem;right:0.5rem;z-index:1012;display:none;">Zatrzymaj i zapisz</button>
     <div id="playback-controls" class="btn-group btn-group-sm" style="position:absolute;top:2.5rem;right:0.5rem;z-index:1013;display:none;">
         <button id="playback-pause" class="btn btn-secondary">Pauza</button>
@@ -292,6 +294,18 @@
                     </label>
                     <label class="form-label">Wysokość mapy (vh)
                         <input id="ui-map-height" type="number" step="1" class="form-control" />
+                    </label>
+                    <label class="form-label">Pozycja mapy
+                        <select id="ui-map-position" class="form-select">
+                            <option value="top-overlay">Góra (nakładka)</option>
+                            <option value="bottom-overlay">Dół (nakładka)</option>
+                            <option value="left-overlay">Lewa (nakładka)</option>
+                            <option value="right-overlay">Prawa (nakładka)</option>
+                            <option value="top-no-overlay">Góra (bez nakładki)</option>
+                            <option value="bottom-no-overlay">Dół (bez nakładki)</option>
+                            <option value="left-no-overlay">Lewa (bez nakładki)</option>
+                            <option value="right-no-overlay">Prawa (bez nakładki)</option>
+                        </select>
                     </label>
                     <label class="form-label">Zasięg renderowania mapy
                         <input id="ui-map-limit" type="number" step="1" min="1" value="35" class="form-control" />

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -122,12 +122,26 @@ client.addEventListener('binds', (ev: CustomEvent) => {
 });
 
 if (navigator.userAgent.includes('iPhone') || navigator.userAgent.includes('iPad') || navigator.userAgent.includes('iPod')) {
-    const baseOffset = window.outerHeight - window.visualViewport.height
-    window.visualViewport.addEventListener("resize", () => {
-        const offset = window.outerHeight - window.visualViewport.height - baseOffset
-        document.getElementById("iframe-container").style.top = offset + 'px'
-        document.getElementById("main-container").style.paddingTop = offset + 2 + 'px'
-    })
+    const visualViewport = window.visualViewport;
+    const iframeContainer = document.getElementById('iframe-container') as HTMLElement | null;
+    const mainContainer = document.getElementById('main-container') as HTMLElement | null;
+    if (visualViewport && iframeContainer && mainContainer) {
+        const baseOffset = window.outerHeight - visualViewport.height;
+        const updateOffsets = () => {
+            const position = mainContainer.getAttribute('data-map-position') ?? 'top-overlay';
+            if (position === 'top-overlay') {
+                const offset = window.outerHeight - visualViewport.height - baseOffset;
+                iframeContainer.style.top = offset + 'px';
+                mainContainer.style.paddingTop = offset + 2 + 'px';
+            } else {
+                iframeContainer.style.removeProperty('top');
+                mainContainer.style.removeProperty('padding-top');
+            }
+        };
+        visualViewport.addEventListener('resize', updateOffsets);
+        window.addEventListener('mapPositionChange', updateOffsets);
+        updateOffsets();
+    }
 }
 
 const progressContainer = document.getElementById('map-progress-container')!;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -48,11 +48,22 @@ h1 {
 }
 
 #main-container {
+  --map-size: 30vh;
   display: flex;
   flex-direction: column;
   height: 100svh;
   height: 100dvh;
   width: 100vw;
+  position: relative;
+}
+
+#app-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+  position: relative;
 }
 
 #main_text_output_msg_wrapper {
@@ -473,14 +484,104 @@ button:focus-visible {
 }
 
 #iframe-container {
-  position: absolute;
-  top: 0;
+  position: relative;
   width: 100%;
-  height: 30vh;
-  max-height: 30vh;
+  height: var(--map-size);
+  max-height: var(--map-size);
   overflow: hidden;
-  background-color: rgba(0, 0, 0, 0.50);
-  z-index: 5
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 5;
+  flex: 0 0 auto;
+}
+
+#main-container[data-map-position$="overlay"] #iframe-container {
+  position: absolute;
+}
+
+#main-container[data-map-position="top-overlay"] #iframe-container {
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--map-size);
+}
+
+#main-container[data-map-position="bottom-overlay"] #iframe-container {
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: var(--map-size);
+}
+
+#main-container[data-map-position="left-overlay"] #iframe-container,
+#main-container[data-map-position="right-overlay"] #iframe-container {
+  top: 0;
+  height: 100%;
+  max-height: 100%;
+  width: var(--map-size);
+  max-width: var(--map-size);
+}
+
+#main-container[data-map-position="left-overlay"] #iframe-container {
+  left: 0;
+}
+
+#main-container[data-map-position="right-overlay"] #iframe-container {
+  right: 0;
+}
+
+#main-container[data-map-position="top-no-overlay"] #iframe-container {
+  order: 0;
+}
+
+#main-container[data-map-position="top-no-overlay"] #app-content {
+  order: 1;
+}
+
+#main-container[data-map-position="bottom-no-overlay"] #iframe-container {
+  order: 1;
+}
+
+#main-container[data-map-position="bottom-no-overlay"] #app-content {
+  order: 0;
+}
+
+#main-container[data-map-position="left-no-overlay"],
+#main-container[data-map-position="right-no-overlay"] {
+  flex-direction: row;
+}
+
+#main-container[data-map-position="left-no-overlay"] #iframe-container,
+#main-container[data-map-position="right-no-overlay"] #iframe-container {
+  height: 100%;
+  max-height: 100%;
+  width: var(--map-size);
+  max-width: var(--map-size);
+  flex: 0 0 auto;
+}
+
+#main-container[data-map-position="left-no-overlay"] #iframe-container {
+  order: 0;
+}
+
+#main-container[data-map-position="left-no-overlay"] #app-content {
+  order: 1;
+}
+
+#main-container[data-map-position="right-no-overlay"] #iframe-container {
+  order: 1;
+}
+
+#main-container[data-map-position="right-no-overlay"] #app-content {
+  order: 0;
+}
+
+#main-container[data-map-position="left-no-overlay"] #app-content,
+#main-container[data-map-position="right-no-overlay"] #app-content {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 #map {
@@ -524,9 +625,8 @@ button:focus-visible {
   width: 100%;
   }
 
-  #iframe-container {
-  height: 25vh;
-  max-height: 25vh;
+  #main-container {
+  --map-size: 25vh;
   }
 
   #main_text_output_msg_wrapper {

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -1,5 +1,15 @@
 import Modal from "bootstrap/js/dist/modal";
 
+type MapPosition =
+    | 'top-overlay'
+    | 'bottom-overlay'
+    | 'left-overlay'
+    | 'right-overlay'
+    | 'top-no-overlay'
+    | 'bottom-no-overlay'
+    | 'left-no-overlay'
+    | 'right-no-overlay';
+
 interface UiSettings {
     contentFontSize: number;
     objectsFontSize: number;
@@ -14,7 +24,20 @@ interface UiSettings {
     xtermPalette: 'arkadia' | 'proper';
     footerMode: number;
     explorationMode: boolean;
+    mapPosition: MapPosition;
 }
+
+const MAP_POSITIONS: readonly MapPosition[] = [
+    'top-overlay',
+    'bottom-overlay',
+    'left-overlay',
+    'right-overlay',
+    'top-no-overlay',
+    'bottom-no-overlay',
+    'left-no-overlay',
+    'right-no-overlay',
+];
+const MAP_POSITION_SET = new Set<MapPosition>(MAP_POSITIONS);
 
 const defaultSettings: UiSettings = {
     contentFontSize: 0.775,
@@ -30,9 +53,20 @@ const defaultSettings: UiSettings = {
     xtermPalette: 'arkadia',
     footerMode: 0,
     explorationMode: false,
+    mapPosition: 'top-overlay',
 };
 
 function apply(settings: UiSettings) {
+    const mainContainer = document.getElementById('main-container');
+    if (mainContainer) {
+        mainContainer.setAttribute('data-map-position', settings.mapPosition);
+        mainContainer.style.setProperty('--map-size', settings.mapHeight + 'vh');
+    }
+    const iframeContainer = document.getElementById('iframe-container') as HTMLElement | null;
+    if (iframeContainer) {
+        iframeContainer.style.removeProperty('height');
+        iframeContainer.style.removeProperty('max-height');
+    }
     const content = document.getElementById('main_text_output_msg_wrapper');
     if (content) {
         content.style.fontSize = settings.contentFontSize + 'rem';
@@ -45,12 +79,6 @@ function apply(settings: UiSettings) {
     const objects = document.getElementById('objects-list');
     if (objects) {
         objects.style.fontSize = settings.objectsFontSize + 'rem';
-    }
-    const iframeContainer = document.getElementById('iframe-container');
-    if (iframeContainer) {
-        const height = settings.mapHeight + 'vh';
-        (iframeContainer as HTMLElement).style.height = height;
-        (iframeContainer as HTMLElement).style.maxHeight = height;
     }
     document.querySelectorAll<HTMLButtonElement>('.mobile-button').forEach(btn => {
         const baseSize = 36; // default width/height in px
@@ -92,6 +120,7 @@ function apply(settings: UiSettings) {
             })
         );
     }
+    window.dispatchEvent(new CustomEvent('mapPositionChange', { detail: settings.mapPosition }));
 }
 
 import storage from "@client/src/storage";
@@ -118,7 +147,8 @@ async function load(): Promise<UiSettings> {
             const explorationMode = !!parsed.explorationMode;
             const fightTitleIcon = typeof parsed.fightTitleIcon === 'boolean' ? parsed.fightTitleIcon : defaultSettings.fightTitleIcon;
             const hapticFeedback = typeof parsed.hapticFeedback === 'boolean' ? parsed.hapticFeedback : defaultSettings.hapticFeedback;
-            return { ...defaultSettings, ...parsed, mapScale, mapLimit, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode, fightTitleIcon, hapticFeedback };
+            const mapPosition = MAP_POSITION_SET.has(parsed.mapPosition) ? parsed.mapPosition as MapPosition : defaultSettings.mapPosition;
+            return { ...defaultSettings, ...parsed, mapScale, mapLimit, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode, fightTitleIcon, hapticFeedback, mapPosition };
         }
     } catch {
         // ignore malformed data
@@ -141,6 +171,7 @@ export default async function initUiSettings() {
     const buttonInput = modalEl.querySelector('#ui-button-size') as HTMLInputElement;
     const mapInput = modalEl.querySelector('#ui-map-scale') as HTMLInputElement;
     const mapHeightInput = modalEl.querySelector('#ui-map-height') as HTMLInputElement;
+    const mapPositionInput = modalEl.querySelector('#ui-map-position') as HTMLSelectElement;
     const mapLimitInput = modalEl.querySelector('#ui-map-limit') as HTMLInputElement;
     const explorationInput = modalEl.querySelector('#ui-exploration-mode') as HTMLInputElement;
     const explorationStats = modalEl.querySelector('#ui-exploration-stats') as HTMLElement | null;
@@ -158,6 +189,11 @@ export default async function initUiSettings() {
     buttonInput.value = String(current.buttonSize);
     mapInput.value = String(current.mapScale);
     mapHeightInput.value = String(current.mapHeight);
+    if (MAP_POSITION_SET.has(current.mapPosition)) {
+        mapPositionInput.value = current.mapPosition;
+    } else {
+        mapPositionInput.value = defaultSettings.mapPosition;
+    }
     mapLimitInput.value = String(current.mapLimit);
     explorationInput.checked = current.explorationMode;
     showButtonsInput.checked = current.showButtons;
@@ -192,6 +228,12 @@ export default async function initUiSettings() {
             return limit;
         })();
 
+        const mapPositionValue = mapPositionInput.value as MapPosition;
+        const mapPosition = MAP_POSITION_SET.has(mapPositionValue) ? mapPositionValue : defaultSettings.mapPosition;
+        if (!MAP_POSITION_SET.has(mapPositionValue)) {
+            mapPositionInput.value = mapPosition;
+        }
+
         return {
             contentFontSize: parseFloat(contentInput.value) || defaultSettings.contentFontSize,
             objectsFontSize: parseFloat(objectsInput.value) || defaultSettings.objectsFontSize,
@@ -199,6 +241,7 @@ export default async function initUiSettings() {
             mapScale,
             mapLimit,
             mapHeight: parseFloat(mapHeightInput.value) || defaultSettings.mapHeight,
+            mapPosition,
             showButtons: showButtonsInput.checked,
             hapticFeedback: hapticFeedbackInput.checked,
             emojiLabels: emojiLabelsInput.checked,


### PR DESCRIPTION
## Summary
- wrap the main output in a new container and expose a map position selector so the map can be anchored to any edge with or without overlay
- extend the stylesheet to handle overlay and inline map placements for both the app and sandbox layouts
- persist the new map position setting, broadcast layout changes, and adjust iOS offset handling accordingly

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68d26884111c832abc8fe1928305a55f