### PR TITLE
Add configurable map placement options

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -15,27 +15,29 @@
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
     <title>Arkadia</title>
 </head>
-<body>
+<body data-map-position="top-overlay">
 <div id="main-container">
-    <div id="iframe-container">
-        <canvas id="map" resize="true"></canvas>
-        <div id="location-wrapper">
-            <div id="location-label">
-                <span id="location-text"></span>
+    <div id="content-area">
+        <div id="iframe-container">
+            <canvas id="map" resize="true"></canvas>
+            <div id="location-wrapper">
+                <div id="location-label">
+                    <span id="location-text"></span>
+                </div>
+                <span id="pause-icon" hidden>⏸</span>
             </div>
-            <span id="pause-icon" hidden>⏸</span>
-        </div>
-        <div id="notification-center"></div>
-        <div id="map-progress-container" class="position-absolute top-50 start-50 translate-middle w-75">
-            <div class="progress">
-                <div id="map-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated"
-                     style="width: 0"></div>
+            <div id="notification-center"></div>
+            <div id="map-progress-container" class="position-absolute top-50 start-50 translate-middle w-75">
+                <div class="progress">
+                    <div id="map-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated"
+                         style="width: 0"></div>
+                </div>
             </div>
         </div>
-    </div>
-    <div id="main_text_output_msg_wrapper">
-        <div id="split-bottom" class="split-hidden">
-            <div id="sticky-area"></div>
+        <div id="main_text_output_msg_wrapper">
+            <div id="split-bottom" class="split-hidden">
+                <div id="sticky-area"></div>
+            </div>
         </div>
     </div>
     <div id="char-state" data-emoji-labels="0" data-footer-mode="0">
@@ -301,6 +303,18 @@
                     </label>
                     <label class="form-label">Wysokość mapy (vh)
                         <input id="ui-map-height" type="number" step="1" class="form-control" />
+                    </label>
+                    <label class="form-label">Położenie mapy
+                        <select id="ui-map-position" class="form-select">
+                            <option value="top-overlay">Góra (nakładka)</option>
+                            <option value="bottom-overlay">Dół (nakładka)</option>
+                            <option value="right-overlay">Prawa (nakładka)</option>
+                            <option value="left-overlay">Lewa (nakładka)</option>
+                            <option value="top">Góra</option>
+                            <option value="bottom">Dół</option>
+                            <option value="right">Prawa</option>
+                            <option value="left">Lewa</option>
+                        </select>
                     </label>
                     <label class="form-label">Zasięg renderowania mapy
                         <input id="ui-map-limit" type="number" step="1" min="1" value="35" class="form-control" />

--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -15,28 +15,30 @@
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
     <title>Arkadia</title>
 </head>
-<body>
+<body data-map-position="top-overlay">
 <div id="sandbox-layout" class="sandbox-layout">
 <div id="main-container">
-    <div id="iframe-container">
-        <canvas id="map" resize="true"></canvas>
-        <div id="location-wrapper">
-            <div id="location-label">
-                <span id="location-text"></span>
+    <div id="content-area">
+        <div id="iframe-container">
+            <canvas id="map" resize="true"></canvas>
+            <div id="location-wrapper">
+                <div id="location-label">
+                    <span id="location-text"></span>
+                </div>
+                <span id="pause-icon" hidden>⏸</span>
             </div>
-            <span id="pause-icon" hidden>⏸</span>
-        </div>
-        <div id="notification-center"></div>
-        <div id="map-progress-container" class="position-absolute top-50 start-50 translate-middle w-75">
-            <div class="progress">
-                <div id="map-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated"
-                     style="width: 0"></div>
+            <div id="notification-center"></div>
+            <div id="map-progress-container" class="position-absolute top-50 start-50 translate-middle w-75">
+                <div class="progress">
+                    <div id="map-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated"
+                         style="width: 0"></div>
+                </div>
             </div>
         </div>
-    </div>
-    <div id="main_text_output_msg_wrapper">
-        <div id="split-bottom" class="split-hidden">
-            <div id="sticky-area"></div>
+        <div id="main_text_output_msg_wrapper">
+            <div id="split-bottom" class="split-hidden">
+                <div id="sticky-area"></div>
+            </div>
         </div>
     </div>
     <div id="char-state" data-emoji-labels="0" data-footer-mode="0">
@@ -292,6 +294,18 @@
                     </label>
                     <label class="form-label">Wysokość mapy (vh)
                         <input id="ui-map-height" type="number" step="1" class="form-control" />
+                    </label>
+                    <label class="form-label">Położenie mapy
+                        <select id="ui-map-position" class="form-select">
+                            <option value="top-overlay">Góra (nakładka)</option>
+                            <option value="bottom-overlay">Dół (nakładka)</option>
+                            <option value="right-overlay">Prawa (nakładka)</option>
+                            <option value="left-overlay">Lewa (nakładka)</option>
+                            <option value="top">Góra</option>
+                            <option value="bottom">Dół</option>
+                            <option value="right">Prawa</option>
+                            <option value="left">Lewa</option>
+                        </select>
                     </label>
                     <label class="form-label">Zasięg renderowania mapy
                         <input id="ui-map-limit" type="number" step="1" min="1" value="35" class="form-control" />

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -121,14 +121,34 @@ client.addEventListener('binds', (ev: CustomEvent) => {
     }
 });
 
+const iframeContainerEl = document.getElementById("iframe-container") as HTMLElement | null;
+const mainContainerEl = document.getElementById("main-container") as HTMLElement | null;
+let iosKeyboardOffset = 0;
+
+const updateMapLayoutOffsets = () => {
+    if (!iframeContainerEl || !mainContainerEl) {
+        return;
+    }
+    if (document.body?.dataset.mapPosition === 'top-overlay') {
+        iframeContainerEl.style.top = iosKeyboardOffset + 'px';
+        mainContainerEl.style.paddingTop = iosKeyboardOffset + 2 + 'px';
+    } else {
+        iframeContainerEl.style.top = '';
+        mainContainerEl.style.paddingTop = '';
+    }
+};
+
+window.addEventListener('map-position-change', updateMapLayoutOffsets);
+
 if (navigator.userAgent.includes('iPhone') || navigator.userAgent.includes('iPad') || navigator.userAgent.includes('iPod')) {
     const baseOffset = window.outerHeight - window.visualViewport.height
     window.visualViewport.addEventListener("resize", () => {
-        const offset = window.outerHeight - window.visualViewport.height - baseOffset
-        document.getElementById("iframe-container").style.top = offset + 'px'
-        document.getElementById("main-container").style.paddingTop = offset + 2 + 'px'
+        iosKeyboardOffset = window.outerHeight - window.visualViewport.height - baseOffset
+        updateMapLayoutOffsets()
     })
 }
+
+updateMapLayoutOffsets()
 
 const progressContainer = document.getElementById('map-progress-container')!;
 const progressBar = document.getElementById('map-progress-bar') as HTMLElement;

--- a/web-client/src/sandbox.css
+++ b/web-client/src/sandbox.css
@@ -10,10 +10,6 @@
   position: relative;
 }
 
-.sandbox-layout #iframe-container {
-  position: relative;
-}
-
 .sandbox-panel {
   flex: 0 0 16rem;
   background-color: rgba(0, 0, 0, 0.6);

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -55,6 +55,15 @@ h1 {
   width: 100vw;
 }
 
+#content-area {
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  --map-size: 30vh;
+}
+
 #main_text_output_msg_wrapper {
   flex: 1;
   overflow-y: auto;
@@ -63,6 +72,8 @@ h1 {
   font-size: 0.775rem;
   overflow-wrap: break-word;
   position: relative;
+  min-height: 0;
+  min-width: 0;
 }
 
 #logs-preview {
@@ -472,15 +483,102 @@ button:focus-visible {
   }
 }
 
-#iframe-container {
+#content-area #iframe-container {
+  background-color: rgba(0, 0, 0, 0.50);
+  overflow: hidden;
+  z-index: 5;
+}
+
+body[data-map-position="top-overlay"] #content-area #iframe-container {
   position: absolute;
   top: 0;
+  left: 0;
   width: 100%;
-  height: 30vh;
-  max-height: 30vh;
-  overflow: hidden;
-  background-color: rgba(0, 0, 0, 0.50);
-  z-index: 5
+  height: var(--map-size);
+  max-height: var(--map-size);
+}
+
+body[data-map-position="bottom-overlay"] #content-area #iframe-container {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: var(--map-size);
+  max-height: var(--map-size);
+}
+
+body[data-map-position="left-overlay"] #content-area #iframe-container,
+body[data-map-position="right-overlay"] #content-area #iframe-container {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: var(--map-size);
+  height: 100%;
+  max-height: none;
+}
+
+body[data-map-position="left-overlay"] #content-area #iframe-container {
+  left: 0;
+}
+
+body[data-map-position="right-overlay"] #content-area #iframe-container {
+  right: 0;
+}
+
+body[data-map-position="top"] #content-area {
+  flex-direction: column;
+}
+
+body[data-map-position="top"] #content-area #iframe-container {
+  position: relative;
+  width: 100%;
+  height: var(--map-size);
+  max-height: var(--map-size);
+  order: 0;
+}
+
+body[data-map-position="top"] #content-area #main_text_output_msg_wrapper {
+  order: 1;
+}
+
+body[data-map-position="bottom"] #content-area {
+  flex-direction: column;
+}
+
+body[data-map-position="bottom"] #content-area #iframe-container {
+  position: relative;
+  width: 100%;
+  height: var(--map-size);
+  max-height: var(--map-size);
+  order: 2;
+}
+
+body[data-map-position="bottom"] #content-area #main_text_output_msg_wrapper {
+  order: 1;
+}
+
+body[data-map-position="left"] #content-area,
+body[data-map-position="right"] #content-area {
+  flex-direction: row;
+}
+
+body[data-map-position="right"] #content-area {
+  flex-direction: row-reverse;
+}
+
+body[data-map-position="left"] #content-area #iframe-container,
+body[data-map-position="right"] #content-area #iframe-container {
+  position: relative;
+  flex: 0 0 var(--map-size);
+  width: var(--map-size);
+  height: auto;
+  max-height: none;
+  align-self: stretch;
+}
+
+body[data-map-position="left"] #content-area #main_text_output_msg_wrapper,
+body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
+  flex: 1;
 }
 
 #map {
@@ -524,9 +622,8 @@ button:focus-visible {
   width: 100%;
   }
 
-  #iframe-container {
-  height: 25vh;
-  max-height: 25vh;
+  #content-area {
+  --map-size: 25vh;
   }
 
   #main_text_output_msg_wrapper {

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -1,5 +1,18 @@
 import Modal from "bootstrap/js/dist/modal";
 
+const mapPositions = [
+    'top-overlay',
+    'bottom-overlay',
+    'right-overlay',
+    'left-overlay',
+    'top',
+    'bottom',
+    'right',
+    'left',
+] as const;
+
+type MapPosition = (typeof mapPositions)[number];
+
 interface UiSettings {
     contentFontSize: number;
     objectsFontSize: number;
@@ -9,6 +22,7 @@ interface UiSettings {
     showButtons: boolean;
     hapticFeedback: boolean;
     mapHeight: number;
+    mapPosition: MapPosition;
     emojiLabels: boolean;
     fightTitleIcon: boolean;
     xtermPalette: 'arkadia' | 'proper';
@@ -25,6 +39,7 @@ const defaultSettings: UiSettings = {
     showButtons: true,
     hapticFeedback: true,
     mapHeight: typeof window !== 'undefined' && window.innerWidth < 768 ? 25 : 30,
+    mapPosition: 'top-overlay',
     emojiLabels: false,
     fightTitleIcon: true,
     xtermPalette: 'arkadia',
@@ -33,6 +48,14 @@ const defaultSettings: UiSettings = {
 };
 
 function apply(settings: UiSettings) {
+    const contentArea = document.getElementById('content-area');
+    if (contentArea) {
+        contentArea.style.setProperty('--map-size', settings.mapHeight + 'vh');
+        contentArea.setAttribute('data-map-position', settings.mapPosition);
+    }
+    if (document?.body) {
+        document.body.dataset.mapPosition = settings.mapPosition;
+    }
     const content = document.getElementById('main_text_output_msg_wrapper');
     if (content) {
         content.style.fontSize = settings.contentFontSize + 'rem';
@@ -46,11 +69,19 @@ function apply(settings: UiSettings) {
     if (objects) {
         objects.style.fontSize = settings.objectsFontSize + 'rem';
     }
-    const iframeContainer = document.getElementById('iframe-container');
+    const iframeContainer = document.getElementById('iframe-container') as HTMLElement | null;
     if (iframeContainer) {
-        const height = settings.mapHeight + 'vh';
-        (iframeContainer as HTMLElement).style.height = height;
-        (iframeContainer as HTMLElement).style.maxHeight = height;
+        if (settings.mapPosition === 'top-overlay') {
+            if (!iframeContainer.style.top) {
+                iframeContainer.style.top = '0px';
+            }
+        } else {
+            iframeContainer.style.top = '';
+        }
+    }
+    const mainContainer = document.getElementById('main-container') as HTMLElement | null;
+    if (mainContainer && settings.mapPosition !== 'top-overlay') {
+        mainContainer.style.paddingTop = '';
     }
     document.querySelectorAll<HTMLButtonElement>('.mobile-button').forEach(btn => {
         const baseSize = 36; // default width/height in px
@@ -92,6 +123,9 @@ function apply(settings: UiSettings) {
             })
         );
     }
+    if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('map-position-change'));
+    }
 }
 
 import storage from "@client/src/storage";
@@ -113,12 +147,15 @@ async function load(): Promise<UiSettings> {
                 const value = parseInt(parsed.mapLimit);
                 return value > 0 ? value : defaultSettings.mapLimit;
             })();
+            const mapPosition = mapPositions.includes(parsed.mapPosition as MapPosition)
+                ? (parsed.mapPosition as MapPosition)
+                : defaultSettings.mapPosition;
             const xtermPalette = parsed.xtermPalette === 'proper' ? 'proper' : defaultSettings.xtermPalette;
             const footerMode = typeof parsed.footerMode === 'number' ? parsed.footerMode : defaultSettings.footerMode;
             const explorationMode = !!parsed.explorationMode;
             const fightTitleIcon = typeof parsed.fightTitleIcon === 'boolean' ? parsed.fightTitleIcon : defaultSettings.fightTitleIcon;
             const hapticFeedback = typeof parsed.hapticFeedback === 'boolean' ? parsed.hapticFeedback : defaultSettings.hapticFeedback;
-            return { ...defaultSettings, ...parsed, mapScale, mapLimit, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode, fightTitleIcon, hapticFeedback };
+            return { ...defaultSettings, ...parsed, mapScale, mapLimit, mapPosition, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode, fightTitleIcon, hapticFeedback };
         }
     } catch {
         // ignore malformed data
@@ -141,6 +178,7 @@ export default async function initUiSettings() {
     const buttonInput = modalEl.querySelector('#ui-button-size') as HTMLInputElement;
     const mapInput = modalEl.querySelector('#ui-map-scale') as HTMLInputElement;
     const mapHeightInput = modalEl.querySelector('#ui-map-height') as HTMLInputElement;
+    const mapPositionInput = modalEl.querySelector('#ui-map-position') as HTMLSelectElement;
     const mapLimitInput = modalEl.querySelector('#ui-map-limit') as HTMLInputElement;
     const explorationInput = modalEl.querySelector('#ui-exploration-mode') as HTMLInputElement;
     const explorationStats = modalEl.querySelector('#ui-exploration-stats') as HTMLElement | null;
@@ -158,6 +196,7 @@ export default async function initUiSettings() {
     buttonInput.value = String(current.buttonSize);
     mapInput.value = String(current.mapScale);
     mapHeightInput.value = String(current.mapHeight);
+    mapPositionInput.value = current.mapPosition;
     mapLimitInput.value = String(current.mapLimit);
     explorationInput.checked = current.explorationMode;
     showButtonsInput.checked = current.showButtons;
@@ -199,6 +238,7 @@ export default async function initUiSettings() {
             mapScale,
             mapLimit,
             mapHeight: parseFloat(mapHeightInput.value) || defaultSettings.mapHeight,
+            mapPosition: (mapPositionInput.value as MapPosition) || defaultSettings.mapPosition,
             showButtons: showButtonsInput.checked,
             hapticFeedback: hapticFeedbackInput.checked,
             emojiLabels: emojiLabelsInput.checked,


### PR DESCRIPTION
## Summary
- add a UI control for choosing map placement and expose it in the sandbox
- refactor the main layout and styles to support overlay and non-overlay map positions across edges
- extend UI settings and mobile offsets to persist and honor the new placement modes

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68d2c764a610832ab2ebcee364e1d0fc