### PR TITLE
Add mobile button lock option

### DIFF
--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -85,6 +85,7 @@ export interface Settings {
     solo: LayoutSettings;
     team: LayoutSettings;
     leader: LayoutSettings;
+    locked: boolean;
 }
 
 export function createDefaultLayout(): LayoutSettings {
@@ -101,8 +102,9 @@ export async function loadSettings(): Promise<Settings> {
                 order: Array.isArray(set?.order) ? set.order : [...defaultOrder],
                 cols: typeof set?.cols === 'number' && set.cols > 0 ? set.cols : defaultCols,
             });
+            const locked = !!raw.locked;
             if (raw.solo && raw.team && raw.leader && (raw.solo.buttons || raw.team.buttons || raw.leader.buttons)) {
-                return { solo: parseSet(raw.solo), team: parseSet(raw.team), leader: parseSet(raw.leader) };
+                return { solo: parseSet(raw.solo), team: parseSet(raw.team), leader: parseSet(raw.leader), locked };
             }
             const order = Array.isArray(raw.order) ? raw.order : [...defaultOrder];
             const cols = typeof raw.cols === 'number' && raw.cols > 0 ? raw.cols : defaultCols;
@@ -110,10 +112,11 @@ export async function loadSettings(): Promise<Settings> {
                 solo: { buttons: { ...defaultSettings, ...(raw.solo || {}) }, order: [...order], cols },
                 team: { buttons: { ...defaultSettings, ...(raw.team || raw.solo || {}) }, order: [...order], cols },
                 leader: { buttons: { ...defaultSettings, ...(raw.leader || raw.team || raw.solo || {}) }, order: [...order], cols },
+                locked,
             };
         }
     } catch {}
-    return { solo: createDefaultLayout(), team: createDefaultLayout(), leader: createDefaultLayout() };
+    return { solo: createDefaultLayout(), team: createDefaultLayout(), leader: createDefaultLayout(), locked: false };
 }
 
 export function saveSettings(settings: Settings) {
@@ -124,6 +127,12 @@ export function applySettings(settings: Settings, inTeam = false, isLeader = fal
     const set = isLeader ? settings.leader : inTeam ? settings.team : settings.solo;
     const container = document.getElementById('mobile-direction-buttons') as HTMLDivElement | null;
     if (container) {
+        container.classList.toggle('drag-locked', settings.locked);
+        if (settings.locked) {
+            container.setAttribute('data-drag-locked', 'true');
+        } else {
+            container.removeAttribute('data-drag-locked');
+        }
         container.style.gridTemplateColumns = `repeat(${set.cols}, auto)`;
 
         // Preserve current button size

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -44,6 +44,7 @@ function MobileButtons() {
         solo: { buttons: {}, order: [...defaultOrder], cols: defaultCols },
         team: { buttons: {}, order: [...defaultOrder], cols: defaultCols },
         leader: { buttons: {}, order: [...defaultOrder], cols: defaultCols },
+        locked: false,
     });
     const [syncDirs, setSyncDirs] = useState(true);
     const [active, setActive] = useState<{ set: Mode; id: string } | null>(null);
@@ -287,6 +288,14 @@ function MobileButtons() {
                 <Button size="sm" variant="secondary" onClick={() => restoreDefaults(view)}>
                     Domyślne
                 </Button>
+                <Form.Check
+                    id="mobile-buttons-lock"
+                    type="checkbox"
+                    className="ms-auto user-select-none"
+                    label="Zablokuj przyciski"
+                    checked={settings.locked}
+                    onChange={e => setSettings(prev => ({ ...prev, locked: e.target.checked }))}
+                />
             </div>
             <div className="d-flex flex-column align-items-center mb-2">
                 <div className="d-flex gap-1 mb-2">

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -48,11 +48,13 @@ export default class MobileDirectionButtons {
         solo: { buttons: {}, order: [], cols: 0 },
         team: { buttons: {}, order: [], cols: 0 },
         leader: { buttons: {}, order: [], cols: 0 },
+        locked: false,
     };
     private buttonSettings: Record<string, ButtonSetting> = {};
     private teamMode = false;
     private leaderMode = false;
     private hapticEnabled = true;
+    private dragLocked = false;
 
 
     constructor(client: Client) {
@@ -94,6 +96,8 @@ export default class MobileDirectionButtons {
 
         loadMobileButtonSettings().then(settings => {
             this.allSettings = settings;
+            this.dragLocked = !!settings.locked;
+            this.updateDragLock();
             this.updateTeamMode();
             this.setupEventHandlers();
             this.applyActiveSettings();
@@ -188,6 +192,8 @@ export default class MobileDirectionButtons {
             });
             loadMobileButtonSettings().then(s => {
                 this.allSettings = s;
+                this.dragLocked = !!s.locked;
+                this.updateDragLock();
                 this.updateTeamMode();
             });
         });
@@ -344,8 +350,19 @@ export default class MobileDirectionButtons {
         });
     }
 
-    private dragStart(x: number, y: number, preventDefault?: () => void) {
+    private updateDragLock() {
         if (!this.container) return;
+        if (this.dragLocked) {
+            this.container.classList.add('drag-locked');
+            this.container.setAttribute('data-drag-locked', 'true');
+        } else {
+            this.container.classList.remove('drag-locked');
+            this.container.removeAttribute('data-drag-locked');
+        }
+    }
+
+    private dragStart(x: number, y: number, preventDefault?: () => void) {
+        if (!this.container || this.dragLocked) return;
 
         if (this.isScrolling) return;
 
@@ -419,30 +436,36 @@ export default class MobileDirectionButtons {
     }
 
     private handleTouchStart(e: TouchEvent) {
+        if (this.dragLocked) return;
         const touch = e.touches[0];
         this.dragStart(touch.clientX, touch.clientY, () => e.preventDefault());
     }
 
     private handleTouchMove(e: TouchEvent) {
+        if (this.dragLocked) return;
         e.preventDefault();
         const touch = e.touches[0];
         this.dragMove(touch.clientX, touch.clientY);
     }
 
     private handleTouchEnd(e: TouchEvent) {
+        if (this.dragLocked) return;
         this.dragEnd(() => e.preventDefault());
     }
 
     private handleMouseDown(e: MouseEvent) {
+        if (this.dragLocked) return;
         if (e.button !== 0) return;
         this.dragStart(e.clientX, e.clientY);
     }
 
     private handleMouseMove(e: MouseEvent) {
+        if (this.dragLocked) return;
         this.dragMove(e.clientX, e.clientY);
     }
 
     private handleMouseUp(e: MouseEvent) {
+        if (this.dragLocked) return;
         this.dragEnd(() => e.preventDefault());
     }
 
@@ -589,6 +612,8 @@ export default class MobileDirectionButtons {
 
     private applyActiveSettings() {
         const set = this.leaderMode ? this.allSettings.leader : this.teamMode ? this.allSettings.team : this.allSettings.solo;
+        this.dragLocked = !!this.allSettings.locked;
+        this.updateDragLock();
         this.buttonSettings = set.buttons;
         Object.keys(this.buttonSettings).forEach(id => {
             const btn = document.getElementById(id) as HTMLButtonElement | null;


### PR DESCRIPTION
## Summary
- add a persisted `locked` flag to mobile button settings and update the DOM when applied
- expose a lock checkbox in the mobile buttons popup so users can disable dragging
- honor the lock flag in the mobile direction buttons script to prevent drag interactions

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68d2688df0b0832a9c9b6189dd72a61e