### PR TITLE
Add chat history alias for GMCP comm messages

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -20,6 +20,7 @@ import { initImproveCounter } from './scripts/improveCounter'
 import initEscape from './scripts/escape'
 import { initItemCollector } from './scripts/itemCollector'
 import initContainers from './scripts/prettyContainers'
+import initChatHistory from './scripts/chatHistory'
 import initBagManager from './scripts/bagManager'
 import initDeposits from './scripts/deposits'
 import initHerbShop from './scripts/herbShop'
@@ -140,6 +141,7 @@ export function registerScripts(client: Client) {
     initCoverTimer(client)
     initZaskTimer(client)
     initBinds(client, aliases)
+    initChatHistory(client, aliases)
     initMoveMode(client)
     initCarriage(client)
     initIdz(client, aliases)

--- a/client/src/scripts/chatHistory.ts
+++ b/client/src/scripts/chatHistory.ts
@@ -1,0 +1,54 @@
+import Client from "../Client";
+
+const HISTORY_LIMIT = 20;
+
+type ChatEntry = {
+    timestamp: string;
+    text: string;
+};
+
+export default function initChatHistory(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
+    const history: ChatEntry[] = [];
+
+    function formatTimestamp(date: Date) {
+        return date.toLocaleTimeString(undefined, {
+            hour: "2-digit",
+            minute: "2-digit",
+            second: "2-digit",
+        });
+    }
+
+    function addEntry(text: string) {
+        const entry: ChatEntry = {
+            timestamp: formatTimestamp(new Date()),
+            text,
+        };
+        history.push(entry);
+        if (history.length > HISTORY_LIMIT) {
+            history.shift();
+        }
+    }
+
+    function printHistory() {
+        if (!history.length) {
+            client.print("Brak zapisanych wiadomosci czatu.");
+            return;
+        }
+        const lines = history.map((entry) => `[${entry.timestamp}] ${entry.text}`);
+        client.print(lines.join("\n"));
+    }
+
+    client.addEventListener("gmcp_msg.comm", (ev: CustomEvent<string>) => {
+        const text = ev.detail;
+        if (typeof text !== "string" || !text.trim()) return;
+        addEntry(text);
+    });
+
+    client.addEventListener("client.disconnect", () => {
+        history.length = 0;
+    });
+
+    if (aliases) {
+        aliases.push({ pattern: /^\/chat$/, callback: printHistory });
+    }
+}

--- a/client/src/scripts/chatHistory.ts
+++ b/client/src/scripts/chatHistory.ts
@@ -34,7 +34,13 @@ export default function initChatHistory(client: Client, aliases?: { pattern: Reg
             client.print("Brak zapisanych wiadomosci czatu.");
             return;
         }
-        const lines = history.map((entry) => `[${entry.timestamp}] ${entry.text}`);
+        const lines: string[] = [];
+        history.forEach((entry) => {
+            const messageLines = entry.text.split(/\r?\n/);
+            messageLines.forEach((line) => {
+                lines.push(`[${entry.timestamp}] ${line}`);
+            });
+        });
         client.print(lines.join("\n"));
     }
 

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -23,6 +23,7 @@ Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorze
 - **/postepy2_on** - włącza automatyczne dodawanie do globalnego licznika.
 - **/przejrzyj [_co_]** - pokazuje zawartość skrzyń z kluczami i magicznymi przedmiotami lub podanego pojemnika (wykorzystuje komendę `ob`).
 - **/por [_skrot_]** - porównuje siłę, zręczność i wytrzymałość z podanym obiektem lub wszystkimi w pomieszczeniu.
+- **/chat** - wyświetla ostatnie 20 wiadomości z czatu GMCP.
 
 ## Menedżer pojemników
 - **/pojemnik** - uruchamia konfigurację menedżera pojemników.


### PR DESCRIPTION
## Summary
- store the most recent 20 GMCP comm messages along with timestamps
- add a /chat alias that prints the stored chat history for quick review
- clear saved messages on disconnect and register the script with the client setup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9627ed654832abf0147b39bf9c30d