### PR TITLE
Handle idz command as reverse exit

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -93,6 +93,22 @@ export default class MapHelper {
         }
         if (command.trim() === "idz") {
             this.refreshPosition = true;
+            if (this.currentRoom) {
+                const allExits = Object.assign(
+                    {},
+                    this.currentRoom.exits ?? {},
+                    this.currentRoom.specialExits ?? {}
+                );
+                const exitDirs = Object.keys(allExits);
+                if (exitDirs.length === 2 && this.locationHistory.length >= 2) {
+                    const prevId = this.locationHistory[this.locationHistory.length - 2];
+                    const cameFrom = exitDirs.find(d => allExits[d] === prevId);
+                    const alt = exitDirs.find(d => d !== cameFrom);
+                    if (alt) {
+                        return longToShort[alt] ?? alt;
+                    }
+                }
+            }
         }
         if (this.currentRoom) {
             if (this.currentRoom.userData.dir_bind) {

--- a/client/test/mapHelperIdz.test.ts
+++ b/client/test/mapHelperIdz.test.ts
@@ -1,0 +1,14 @@
+import MapHelper from '../src/MapHelper';
+
+jest.mock('mudlet-map-renderer', () => ({ MapReader: function () {} }));
+
+describe('MapHelper parseCommand', () => {
+  test('idz chooses alternate exit', () => {
+    const client: any = { addEventListener: () => {}, sendEvent: () => {} };
+    const map = new MapHelper(client);
+    map.currentRoom = { exits: { north: 1, south: 3 } } as any;
+    map.locationHistory = [1, 2];
+    const res = map.parseCommand('idz');
+    expect(res).toBe('s');
+  });
+});


### PR DESCRIPTION
## Summary
- choose the opposite exit when issuing `idz` and auto-move the map
- add test ensuring `idz` resolves to the alternate direction

## Testing
- `yarn --cwd client test`
- `yarn --cwd web-client test`
- `yarn --cwd web-client build`


------
https://chatgpt.com/codex/tasks/task_e_68c3deea107c832aaff14e4f9248b47a