### PR TITLE
Add SQLite multibind import for Bindowanie

### DIFF
--- a/web-client/package.json
+++ b/web-client/package.json
@@ -21,6 +21,7 @@
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
+    "sql.js": "^1.13.0",
     "vite-tsconfig-paths": "^5.1.4"
   },
   "devDependencies": {

--- a/web-client/src/MockPort.ts
+++ b/web-client/src/MockPort.ts
@@ -1,7 +1,7 @@
 import storage, { setItemSync, getItemSync } from "@client/src/storage";
+import { readMultibinds, replaceMultibinds } from "./multibindStorage";
 
 const DB_CONFIG = { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' } as const;
-const MULTIBIND_DB = { dbName: 'ArkadiaMultibindsDB', storeName: 'multibinds', keyPath: 'key' } as const;
 
 function openDb(): Promise<IDBDatabase> {
     return new Promise((resolve, reject) => {
@@ -45,74 +45,6 @@ async function saveNpcs(list: any[]) {
     });
 }
 
-function openMultibindDb(): Promise<IDBDatabase> {
-    return new Promise((resolve, reject) => {
-        const request = indexedDB.open(MULTIBIND_DB.dbName, 1);
-        request.onupgradeneeded = () => {
-            const db = request.result;
-            if (!db.objectStoreNames.contains(MULTIBIND_DB.storeName)) {
-                const store = db.createObjectStore(MULTIBIND_DB.storeName, { keyPath: MULTIBIND_DB.keyPath });
-                store.createIndex('roomId', 'roomId', { unique: false });
-            }
-        };
-        request.onsuccess = () => resolve(request.result);
-        request.onerror = () => reject(new Error('Failed to open multibinds IndexedDB'));
-    });
-}
-
-async function getMultibinds(): Promise<any[]> {
-    try {
-        const db = await openMultibindDb();
-        return new Promise((resolve, reject) => {
-            const tx = db.transaction([MULTIBIND_DB.storeName], 'readonly');
-            const store = tx.objectStore(MULTIBIND_DB.storeName);
-            const req = store.getAll();
-            req.onsuccess = () => {
-                const result = Array.isArray(req.result) ? req.result.map((entry: any) => ({
-                    roomId: Number(entry.roomId),
-                    index: Number(entry.index),
-                    action: entry.action ?? '',
-                })) : [];
-                resolve(result.filter(item => !Number.isNaN(item.roomId) && !Number.isNaN(item.index)));
-            };
-            req.onerror = () => reject(new Error('Failed to read multibinds data'));
-        });
-    } catch {
-        return [];
-    }
-}
-
-async function saveMultibinds(list: any[]): Promise<any[]> {
-    const db = await openMultibindDb();
-    return new Promise((resolve, reject) => {
-        const tx = db.transaction([MULTIBIND_DB.storeName], 'readwrite');
-        const store = tx.objectStore(MULTIBIND_DB.storeName);
-        const sanitized = Array.isArray(list) ? list : [];
-        const normalized: any[] = [];
-        const clearReq = store.clear();
-        clearReq.onerror = () => reject(new Error('Failed to clear multibinds'));
-        clearReq.onsuccess = () => {
-            sanitized.forEach((item: any) => {
-                const roomId = Number(item.roomId);
-                const index = Number(item.index);
-                if (Number.isNaN(roomId) || Number.isNaN(index)) {
-                    return;
-                }
-                const record = {
-                    [MULTIBIND_DB.keyPath]: `${roomId}:${index}`,
-                    roomId,
-                    index,
-                    action: item.action ?? '',
-                };
-                normalized.push({ roomId, index, action: record.action });
-                store.put(record);
-            });
-        };
-        tx.oncomplete = () => resolve(normalized);
-        tx.onerror = () => reject(new Error('Failed to store multibinds'));
-    });
-}
-
 export default class MockPort {
     listeners: Array<(msg: any) => void> = [];
     onMessage = {
@@ -150,7 +82,7 @@ export default class MockPort {
             return;
         }
         if (message.type === 'MULTIBINDS_LOAD') {
-            getMultibinds()
+            readMultibinds()
                 .then(list => {
                     this.dispatch({ multibindsStorage: list });
                 })
@@ -159,7 +91,7 @@ export default class MockPort {
         }
         if (message.type === 'MULTIBINDS_SAVE') {
             const list = Array.isArray(message.value) ? message.value : [];
-            saveMultibinds(list)
+            replaceMultibinds(list)
                 .then((normalized) => {
                     this.dispatch({ multibindsStorage: normalized });
                 })

--- a/web-client/src/multibindStorage.ts
+++ b/web-client/src/multibindStorage.ts
@@ -1,0 +1,93 @@
+export const MULTIBIND_DB = {
+    dbName: 'ArkadiaMultibindsDB',
+    storeName: 'multibinds',
+    keyPath: 'key',
+} as const;
+
+export interface StoredMultibindRecord {
+    roomId: number;
+    index: number;
+    action: string;
+}
+
+function normalizeEntry(entry: any): StoredMultibindRecord | null {
+    const roomId = Number(entry?.roomId);
+    const index = Number(entry?.index);
+    if (!Number.isFinite(roomId) || !Number.isFinite(index)) {
+        return null;
+    }
+    return {
+        roomId,
+        index,
+        action: typeof entry?.action === 'string' ? entry.action : String(entry?.action ?? ''),
+    };
+}
+
+export function openMultibindDb(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open(MULTIBIND_DB.dbName, 1);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(MULTIBIND_DB.storeName)) {
+                const store = db.createObjectStore(MULTIBIND_DB.storeName, { keyPath: MULTIBIND_DB.keyPath });
+                store.createIndex('roomId', 'roomId', { unique: false });
+            }
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(new Error('Failed to open multibinds IndexedDB'));
+    });
+}
+
+export async function readMultibinds(): Promise<StoredMultibindRecord[]> {
+    try {
+        const db = await openMultibindDb();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction([MULTIBIND_DB.storeName], 'readonly');
+            const store = tx.objectStore(MULTIBIND_DB.storeName);
+            const req = store.getAll();
+            req.onsuccess = () => {
+                const result = Array.isArray(req.result) ? req.result : [];
+                const normalized: StoredMultibindRecord[] = [];
+                result.forEach(item => {
+                    const entry = normalizeEntry(item);
+                    if (entry) {
+                        normalized.push(entry);
+                    }
+                });
+                resolve(normalized);
+            };
+            req.onerror = () => reject(new Error('Failed to read multibinds data'));
+        });
+    } catch {
+        return [];
+    }
+}
+
+export async function replaceMultibinds(list: StoredMultibindRecord[]): Promise<StoredMultibindRecord[]> {
+    const db = await openMultibindDb();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction([MULTIBIND_DB.storeName], 'readwrite');
+        const store = tx.objectStore(MULTIBIND_DB.storeName);
+        const normalized: StoredMultibindRecord[] = [];
+        const clearReq = store.clear();
+        clearReq.onerror = () => reject(new Error('Failed to clear multibinds'));
+        clearReq.onsuccess = () => {
+            (Array.isArray(list) ? list : []).forEach(item => {
+                const entry = normalizeEntry(item);
+                if (!entry) {
+                    return;
+                }
+                const key = `${entry.roomId}:${entry.index}`;
+                store.put({
+                    [MULTIBIND_DB.keyPath]: key,
+                    roomId: entry.roomId,
+                    index: entry.index,
+                    action: entry.action,
+                });
+                normalized.push({ ...entry });
+            });
+        };
+        tx.oncomplete = () => resolve(normalized);
+        tx.onerror = () => reject(new Error('Failed to store multibinds'));
+    });
+}

--- a/web-client/src/options/Binds.tsx
+++ b/web-client/src/options/Binds.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import {Alert, Button, Form, Modal, ProgressBar, Spinner, Table, Toast, ToastContainer} from 'react-bootstrap';
+import {Alert, Button, Form, Modal, ProgressBar, Spinner, Table} from 'react-bootstrap';
 import storage from "@client/src/storage";
 import { parseMultibindsDatabase, type MultibindImportRow } from "./multibindImport";
 import { readMultibinds, replaceMultibinds, type StoredMultibindRecord } from "../multibindStorage";
@@ -80,9 +80,9 @@ interface ImportPlan {
 }
 
 const CONFLICT_POLICIES: { value: ConflictPolicy; label: string }[] = [
-    { value: 'keep-last', label: 'Use last entry' },
-    { value: 'keep-first', label: 'Keep first entry' },
-    { value: 'skip-conflicts', label: 'Skip conflicting entries' },
+    { value: 'keep-last', label: 'Zachowaj ostatni wpis' },
+    { value: 'keep-first', label: 'Zachowaj pierwszy wpis' },
+    { value: 'skip-conflicts', label: 'Pomiń konflikty' },
 ];
 
 function toKey(roomId: number, index: number) {
@@ -165,7 +165,7 @@ function Binds() {
     const [overwriteExisting, setOverwriteExisting] = useState(true);
     const [showImportModal, setShowImportModal] = useState(false);
     const [importError, setImportError] = useState<string | null>(null);
-    const [importToast, setImportToast] = useState<{ newCount: number; updatedCount: number; skippedCount: number } | null>(null);
+    const [importResult, setImportResult] = useState<{ newCount: number; updatedCount: number; skippedCount: number } | null>(null);
     const [isParsingDb, setIsParsingDb] = useState(false);
     const [isRunningImport, setIsRunningImport] = useState(false);
     const [importProgress, setImportProgress] = useState<{ processed: number; total: number; eta: number | null } | null>(null);
@@ -258,6 +258,7 @@ function Binds() {
     function handleImportClick() {
         setImportError(null);
         setImportCancelled(false);
+        setImportResult(null);
         fileInputRef.current?.click();
     }
 
@@ -269,7 +270,7 @@ function Binds() {
         setIsParsingDb(true);
         setImportError(null);
         setImportCancelled(false);
-        setImportToast(null);
+        setImportResult(null);
         try {
             const buffer = await file.arrayBuffer();
             const parsed = await parseMultibindsDatabase(buffer);
@@ -301,6 +302,7 @@ function Binds() {
         setIsRunningImport(true);
         setImportCancelled(false);
         setImportError(null);
+        setImportResult(null);
         cancelImportRef.current = false;
         const total = importPlan.rows.length;
         setImportProgress({ processed: 0, total, eta: null });
@@ -369,13 +371,11 @@ function Binds() {
                 window.dispatchEvent(new CustomEvent('multibindsStorage', { detail: finalList }));
             }
             setMultibinds(finalList);
-            setImportToast({
+            setImportResult({
                 newCount,
                 updatedCount: overwriteExisting ? updateCount : 0,
                 skippedCount,
             });
-            setShowImportModal(false);
-            setImportData(null);
         } catch (err) {
             setImportError(err instanceof Error ? err.message : 'Nie udało się zapisać multibindów.');
         } finally {
@@ -392,12 +392,6 @@ function Binds() {
         cancelImportRef.current = true;
     }
 
-    function handleViewImported(ev: React.MouseEvent<HTMLButtonElement>) {
-        ev.preventDefault();
-        setImportToast(null);
-        window.dispatchEvent(new Event('close-options'));
-    }
-
     function closeImportModal() {
         if (isRunningImport) {
             return;
@@ -406,6 +400,7 @@ function Binds() {
         setImportData(null);
         setImportError(null);
         setImportCancelled(false);
+        setImportResult(null);
     }
 
     function handleCapture(name: keyof BindSettings, ev: React.KeyboardEvent) {
@@ -465,33 +460,9 @@ function Binds() {
                 style={{ display: 'none' }}
                 onChange={handleFileSelected}
             />
-            <ToastContainer position="bottom-end" className="p-3">
-                <Toast bg="dark" show={!!importToast} onClose={() => setImportToast(null)} delay={8000} autohide>
-                    <Toast.Header closeButton>
-                        <strong className="me-auto">Import completed</strong>
-                    </Toast.Header>
-                    <Toast.Body>
-                        {importToast && (
-                            <div className="d-flex flex-column gap-1">
-                                <div>New: {importToast.newCount}</div>
-                                <div>Updated: {importToast.updatedCount}</div>
-                                <div>Skipped: {importToast.skippedCount}</div>
-                                <Button
-                                    variant="link"
-                                    size="sm"
-                                    className="p-0 align-self-start"
-                                    onClick={handleViewImported}
-                                >
-                                    View imported bindings
-                                </Button>
-                            </div>
-                        )}
-                    </Toast.Body>
-                </Toast>
-            </ToastContainer>
             <Modal show={showImportModal} onHide={closeImportModal} backdrop={isRunningImport ? 'static' : true} keyboard={!isRunningImport}>
                 <Modal.Header closeButton={!isRunningImport}>
-                    <Modal.Title>Import database</Modal.Title>
+                    <Modal.Title>Import bazy</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
                     {importError && (
@@ -499,34 +470,34 @@ function Binds() {
                     )}
                     {importSummary ? (
                         <div className="d-flex flex-column gap-1">
-                            <div><strong>File:</strong> {importData?.fileName || '—'}</div>
-                            <div>Total rows: {importSummary.totalRows}</div>
-                            <div>Rows to import: {importSummary.toImport}</div>
-                            <div>New entries: {importSummary.newEntries}</div>
-                            <div>Updates: {importSummary.updates}</div>
-                            <div>Skipped: {importSummary.skipped}</div>
+                            <div><strong>Plik:</strong> {importData?.fileName || '—'}</div>
+                            <div>Łącznie wierszy: {importSummary.totalRows}</div>
+                            <div>Wiersze do importu: {importSummary.toImport}</div>
+                            <div>Nowe wpisy: {importSummary.newEntries}</div>
+                            <div>Aktualizacje: {importSummary.updates}</div>
+                            <div>Pominięte: {importSummary.skipped}</div>
                             {importSummary.invalidRows > 0 && (
-                                <div className="text-muted small">Invalid rows: {importSummary.invalidRows}</div>
+                                <div className="text-muted small">Nieprawidłowe wiersze: {importSummary.invalidRows}</div>
                             )}
                             {importSummary.duplicates > 0 && (
-                                <div className="text-muted small">Conflicts removed: {importSummary.duplicates}</div>
+                                <div className="text-muted small">Usunięte konflikty: {importSummary.duplicates}</div>
                             )}
                         </div>
                     ) : (
-                        !importError && <div>No data to import.</div>
+                        !importError && <div>Brak danych do importu.</div>
                     )}
                     {importPlan && (
                         <>
                             <Form.Check
                                 className="mt-3"
                                 type="checkbox"
-                                label="Overwrite existing entries with same uniqness"
+                                label="Nadpisuj wpisy o tej samej uniqness"
                                 checked={overwriteExisting}
                                 disabled={isRunningImport}
                                 onChange={ev => setOverwriteExisting(ev.target.checked)}
                             />
                             <Form.Group className="mt-3">
-                                <Form.Label>Conflict policy</Form.Label>
+                                <Form.Label>Polityka konfliktów</Form.Label>
                                 <Form.Select
                                     value={conflictPolicy}
                                     onChange={ev => setConflictPolicy(ev.target.value as ConflictPolicy)}
@@ -543,34 +514,44 @@ function Binds() {
                         <div className="mt-4">
                             <ProgressBar now={importProgress.total ? (importProgress.processed / importProgress.total) * 100 : 0} />
                             <div className="d-flex justify-content-between mt-2 small">
-                                <span>Rows processed: {importProgress.processed}/{importProgress.total}</span>
-                                <span>{importProgress.eta !== null ? `~${importProgress.eta.toFixed(1)} s remaining` : 'Estimating…'}</span>
+                                <span>Przetworzono wierszy: {importProgress.processed}/{importProgress.total}</span>
+                                <span>{importProgress.eta !== null ? `~${importProgress.eta.toFixed(1)} s do końca` : 'Szacowanie…'}</span>
                             </div>
                         </div>
                     )}
                     {isRunningImport && (
                         <div className="mt-3 d-flex align-items-center gap-2">
                             <Spinner animation="border" size="sm" role="status" />
-                            <span>Importing…</span>
+                            <span>Importowanie…</span>
                         </div>
                     )}
                     {importCancelled && (
-                        <Alert variant="warning" className="mt-3 mb-0">Import cancelled.</Alert>
+                        <Alert variant="warning" className="mt-3 mb-0">Import przerwany.</Alert>
+                    )}
+                    {importResult && !isRunningImport && (
+                        <Alert variant="success" className="mt-3 mb-0">
+                            <div className="d-flex flex-column gap-1">
+                                <div><strong>Import zakończony.</strong></div>
+                                <div>Nowe wpisy: {importResult.newCount}</div>
+                                <div>Zaktualizowane: {importResult.updatedCount}</div>
+                                <div>Pominięte: {importResult.skippedCount}</div>
+                            </div>
+                        </Alert>
                     )}
                 </Modal.Body>
                 <Modal.Footer>
                     {isRunningImport ? (
-                        <Button variant="secondary" onClick={handleCancelImport}>Cancel</Button>
+                        <Button variant="secondary" onClick={handleCancelImport}>Anuluj</Button>
                     ) : (
                         <>
-                            <Button variant="secondary" onClick={closeImportModal}>Close</Button>
-                            <Button onClick={runImport} disabled={!importPlan || importPlan.rows.length === 0}>Import</Button>
+                            <Button variant="secondary" onClick={closeImportModal}>Zamknij</Button>
+                            <Button onClick={runImport} disabled={!importPlan || importPlan.rows.length === 0 || !!importResult}>Importuj</Button>
                         </>
                     )}
                 </Modal.Footer>
             </Modal>
             <div className="d-flex align-items-center gap-2">
-                <Button size="sm" variant="secondary" onClick={handleImportClick} disabled={isParsingDb}>Import database…</Button>
+                <Button size="sm" variant="secondary" onClick={handleImportClick} disabled={isParsingDb}>Importuj bazę…</Button>
                 {isParsingDb && <Spinner animation="border" size="sm" role="status" />}
             </div>
             {importError && !showImportModal && (

--- a/web-client/src/options/Binds.tsx
+++ b/web-client/src/options/Binds.tsx
@@ -462,7 +462,7 @@ function Binds() {
             />
             <Modal show={showImportModal} onHide={closeImportModal} backdrop={isRunningImport ? 'static' : true} keyboard={!isRunningImport}>
                 <Modal.Header closeButton={!isRunningImport}>
-                    <Modal.Title>Import bazy</Modal.Title>
+                    <Modal.Title>Importuj bazę multibindów</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
                     {importError && (
@@ -491,7 +491,7 @@ function Binds() {
                             <Form.Check
                                 className="mt-3"
                                 type="checkbox"
-                                label="Nadpisuj wpisy o tej samej uniqness"
+                                label="Nadpisz wpisy o tej samej uniqness"
                                 checked={overwriteExisting}
                                 disabled={isRunningImport}
                                 onChange={ev => setOverwriteExisting(ev.target.checked)}
@@ -551,7 +551,7 @@ function Binds() {
                 </Modal.Footer>
             </Modal>
             <div className="d-flex align-items-center gap-2">
-                <Button size="sm" variant="secondary" onClick={handleImportClick} disabled={isParsingDb}>Importuj bazę…</Button>
+                <Button size="sm" variant="secondary" onClick={handleImportClick} disabled={isParsingDb}>Importuj bazę multibindów…</Button>
                 {isParsingDb && <Spinner animation="border" size="sm" role="status" />}
             </div>
             {importError && !showImportModal && (

--- a/web-client/src/options/Binds.tsx
+++ b/web-client/src/options/Binds.tsx
@@ -491,7 +491,7 @@ function Binds() {
                             <Form.Check
                                 className="mt-3"
                                 type="checkbox"
-                                label="Nadpisz wpisy o tej samej uniqness"
+                                label="Nadpisz wpisy"
                                 checked={overwriteExisting}
                                 disabled={isRunningImport}
                                 onChange={ev => setOverwriteExisting(ev.target.checked)}

--- a/web-client/src/options/Binds.tsx
+++ b/web-client/src/options/Binds.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from "react";
-import {Form, Button, Table} from 'react-bootstrap';
+import { useEffect, useMemo, useRef, useState } from "react";
+import {Alert, Button, Form, Modal, ProgressBar, Spinner, Table, Toast, ToastContainer} from 'react-bootstrap';
 import storage from "@client/src/storage";
+import { parseMultibindsDatabase, type MultibindImportRow } from "./multibindImport";
+import { readMultibinds, replaceMultibinds, type StoredMultibindRecord } from "../multibindStorage";
 
 interface Bind {
     key: string;
@@ -59,6 +61,87 @@ const defaultBinds: BindSettings = {
     custom: [],
 };
 
+type ConflictPolicy = 'keep-last' | 'keep-first' | 'skip-conflicts';
+
+interface ImportData {
+    fileName: string;
+    rows: MultibindImportRow[];
+    totalRows: number;
+    invalidRows: number;
+}
+
+interface ImportPlan {
+    rows: MultibindImportRow[];
+    totalRows: number;
+    invalidRows: number;
+    duplicatesDropped: number;
+    newEntries: number;
+    potentialUpdates: number;
+}
+
+const CONFLICT_POLICIES: { value: ConflictPolicy; label: string }[] = [
+    { value: 'keep-last', label: 'Use last entry' },
+    { value: 'keep-first', label: 'Keep first entry' },
+    { value: 'skip-conflicts', label: 'Skip conflicting entries' },
+];
+
+function toKey(roomId: number, index: number) {
+    return `${roomId}:${index}`;
+}
+
+function normalizeMultibinds(list: any): StoredMultibindRecord[] {
+    if (!Array.isArray(list)) {
+        return [];
+    }
+    return list
+        .map(item => {
+            const roomId = Number(item?.roomId);
+            const index = Number(item?.index);
+            if (!Number.isFinite(roomId) || !Number.isFinite(index)) {
+                return null;
+            }
+            return {
+                roomId,
+                index,
+                action: typeof item?.action === 'string' ? item.action : String(item?.action ?? ''),
+            } as StoredMultibindRecord;
+        })
+        .filter((entry): entry is StoredMultibindRecord => !!entry);
+}
+
+function applyConflictPolicy(rows: MultibindImportRow[], policy: ConflictPolicy) {
+    const map = new Map<string, MultibindImportRow>();
+    const removedKeys = new Set<string>();
+    let dropped = 0;
+
+    rows.forEach(row => {
+        const key = row.uniqness;
+        if (removedKeys.has(key)) {
+            dropped += 1;
+            return;
+        }
+        const existing = map.get(key);
+        if (!existing) {
+            map.set(key, row);
+            return;
+        }
+        if (policy === 'keep-first') {
+            dropped += 1;
+            return;
+        }
+        if (policy === 'keep-last') {
+            map.set(key, row);
+            dropped += 1;
+            return;
+        }
+        map.delete(key);
+        removedKeys.add(key);
+        dropped += 2;
+    });
+
+    return { rows: Array.from(map.values()), dropped };
+}
+
 function label(bind: Bind) {
     let key = bind.key;
     if (key.startsWith('Digit')) key = key.substring(5);
@@ -76,6 +159,19 @@ function label(bind: Bind) {
 
 function Binds() {
     const [binds, setBinds] = useState<BindSettings>(defaultBinds);
+    const [multibinds, setMultibinds] = useState<StoredMultibindRecord[]>([]);
+    const [importData, setImportData] = useState<ImportData | null>(null);
+    const [conflictPolicy, setConflictPolicy] = useState<ConflictPolicy>('keep-last');
+    const [overwriteExisting, setOverwriteExisting] = useState(true);
+    const [showImportModal, setShowImportModal] = useState(false);
+    const [importError, setImportError] = useState<string | null>(null);
+    const [importToast, setImportToast] = useState<{ newCount: number; updatedCount: number; skippedCount: number } | null>(null);
+    const [isParsingDb, setIsParsingDb] = useState(false);
+    const [isRunningImport, setIsRunningImport] = useState(false);
+    const [importProgress, setImportProgress] = useState<{ processed: number; total: number; eta: number | null } | null>(null);
+    const [importCancelled, setImportCancelled] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement | null>(null);
+    const cancelImportRef = useRef(false);
 
     useEffect(() => {
         storage.getItem('binds').then(res => {
@@ -94,6 +190,223 @@ function Binds() {
             });
         });
     }, []);
+
+    useEffect(() => {
+        let active = true;
+        readMultibinds().then(list => {
+            if (active) {
+                setMultibinds(list);
+            }
+        });
+        const handler = (ev: Event) => {
+            const detail = (ev as CustomEvent).detail;
+            setMultibinds(normalizeMultibinds(detail));
+        };
+        window.addEventListener('multibindsStorage', handler as EventListener);
+        window.clientExtension?.port?.postMessage?.({ type: 'MULTIBINDS_LOAD' });
+        return () => {
+            active = false;
+            window.removeEventListener('multibindsStorage', handler as EventListener);
+        };
+    }, []);
+
+    const importPlan = useMemo<ImportPlan | null>(() => {
+        if (!importData) {
+            return null;
+        }
+        const conflictResult = applyConflictPolicy(importData.rows, conflictPolicy);
+        const existingMap = new Map(multibinds.map(item => [toKey(item.roomId, item.index), item]));
+        let newEntries = 0;
+        let potentialUpdates = 0;
+        conflictResult.rows.forEach(row => {
+            const key = toKey(row.roomId, row.index);
+            if (existingMap.has(key)) {
+                potentialUpdates += 1;
+            } else {
+                newEntries += 1;
+            }
+        });
+        return {
+            rows: conflictResult.rows,
+            totalRows: importData.totalRows,
+            invalidRows: importData.invalidRows,
+            duplicatesDropped: conflictResult.dropped,
+            newEntries,
+            potentialUpdates,
+        };
+    }, [importData, conflictPolicy, multibinds]);
+
+    const importSummary = useMemo(() => {
+        if (!importPlan) {
+            return null;
+        }
+        const updates = overwriteExisting ? importPlan.potentialUpdates : 0;
+        const skippedFromUpdates = overwriteExisting ? 0 : importPlan.potentialUpdates;
+        const skipped = importPlan.invalidRows + importPlan.duplicatesDropped + skippedFromUpdates;
+        return {
+            totalRows: importPlan.totalRows,
+            toImport: importPlan.rows.length,
+            newEntries: importPlan.newEntries,
+            updates,
+            skipped,
+            invalidRows: importPlan.invalidRows,
+            duplicates: importPlan.duplicatesDropped,
+            potentialUpdates: importPlan.potentialUpdates,
+        };
+    }, [importPlan, overwriteExisting]);
+
+    function handleImportClick() {
+        setImportError(null);
+        setImportCancelled(false);
+        fileInputRef.current?.click();
+    }
+
+    async function handleFileSelected(ev: React.ChangeEvent<HTMLInputElement>) {
+        const file = ev.target.files?.[0];
+        if (!file) {
+            return;
+        }
+        setIsParsingDb(true);
+        setImportError(null);
+        setImportCancelled(false);
+        setImportToast(null);
+        try {
+            const buffer = await file.arrayBuffer();
+            const parsed = await parseMultibindsDatabase(buffer);
+            setImportData({
+                fileName: file.name,
+                rows: parsed.rows,
+                totalRows: parsed.totalRows,
+                invalidRows: parsed.invalidRows,
+            });
+            setConflictPolicy('keep-last');
+            setOverwriteExisting(true);
+            setShowImportModal(true);
+        } catch (err) {
+            setImportData(null);
+            setShowImportModal(false);
+            setImportError(err instanceof Error ? err.message : 'Nie udało się odczytać bazy danych.');
+        } finally {
+            setIsParsingDb(false);
+            if (fileInputRef.current) {
+                fileInputRef.current.value = '';
+            }
+        }
+    }
+
+    async function runImport() {
+        if (!importPlan || importPlan.rows.length === 0) {
+            return;
+        }
+        setIsRunningImport(true);
+        setImportCancelled(false);
+        setImportError(null);
+        cancelImportRef.current = false;
+        const total = importPlan.rows.length;
+        setImportProgress({ processed: 0, total, eta: null });
+        const existingMap = new Map(multibinds.map(item => [toKey(item.roomId, item.index), item]));
+        const finalMap = new Map(existingMap);
+        let processed = 0;
+        let newCount = 0;
+        let updateCount = 0;
+        let skippedCount = importPlan.invalidRows + importPlan.duplicatesDropped;
+        const startTime = performance.now();
+        for (const row of importPlan.rows) {
+            if (cancelImportRef.current) {
+                break;
+            }
+            const key = toKey(row.roomId, row.index);
+            const hasExisting = existingMap.has(key);
+            if (hasExisting) {
+                if (!overwriteExisting) {
+                    skippedCount += 1;
+                } else {
+                    updateCount += 1;
+                    finalMap.set(key, { roomId: row.roomId, index: row.index, action: row.action });
+                }
+            } else {
+                newCount += 1;
+                finalMap.set(key, { roomId: row.roomId, index: row.index, action: row.action });
+            }
+            processed += 1;
+            if (processed % 20 === 0 || processed === total) {
+                const elapsed = (performance.now() - startTime) / 1000;
+                const eta = processed ? ((total - processed) * (elapsed / processed)) : null;
+                setImportProgress({ processed, total, eta: eta && Number.isFinite(eta) ? Math.max(0, eta) : null });
+            }
+            if (processed % 200 === 0) {
+                await new Promise<void>(resolve => setTimeout(resolve, 0));
+            }
+        }
+        if (cancelImportRef.current) {
+            setIsRunningImport(false);
+            setImportProgress(null);
+            setImportCancelled(true);
+            return;
+        }
+        const finalList = Array.from(finalMap.values()).sort((a, b) => (a.roomId - b.roomId) || (a.index - b.index));
+        try {
+            if (window.clientExtension?.port) {
+                await new Promise<void>((resolve) => {
+                    let settled = false;
+                    const handler = () => {
+                        if (settled) return;
+                        settled = true;
+                        window.removeEventListener('multibindsStorage', handler as EventListener);
+                        resolve();
+                    };
+                    window.addEventListener('multibindsStorage', handler as EventListener, { once: true });
+                    window.clientExtension.port.postMessage({ type: 'MULTIBINDS_SAVE', value: finalList });
+                    setTimeout(() => {
+                        if (settled) return;
+                        settled = true;
+                        window.removeEventListener('multibindsStorage', handler as EventListener);
+                        resolve();
+                    }, 1500);
+                });
+            } else {
+                await replaceMultibinds(finalList);
+                window.dispatchEvent(new CustomEvent('multibindsStorage', { detail: finalList }));
+            }
+            setMultibinds(finalList);
+            setImportToast({
+                newCount,
+                updatedCount: overwriteExisting ? updateCount : 0,
+                skippedCount,
+            });
+            setShowImportModal(false);
+            setImportData(null);
+        } catch (err) {
+            setImportError(err instanceof Error ? err.message : 'Nie udało się zapisać multibindów.');
+        } finally {
+            setIsRunningImport(false);
+            setImportProgress(null);
+        }
+    }
+
+    function handleCancelImport() {
+        if (!isRunningImport) {
+            setShowImportModal(false);
+            return;
+        }
+        cancelImportRef.current = true;
+    }
+
+    function handleViewImported(ev: React.MouseEvent<HTMLButtonElement>) {
+        ev.preventDefault();
+        setImportToast(null);
+        window.dispatchEvent(new Event('close-options'));
+    }
+
+    function closeImportModal() {
+        if (isRunningImport) {
+            return;
+        }
+        setShowImportModal(false);
+        setImportData(null);
+        setImportError(null);
+        setImportCancelled(false);
+    }
 
     function handleCapture(name: keyof BindSettings, ev: React.KeyboardEvent) {
         ev.preventDefault();
@@ -145,6 +458,124 @@ function Binds() {
 
     return (
         <div className="m-2 d-flex flex-column gap-2">
+            <input
+                ref={fileInputRef}
+                type="file"
+                accept=".db,application/x-sqlite3"
+                style={{ display: 'none' }}
+                onChange={handleFileSelected}
+            />
+            <ToastContainer position="bottom-end" className="p-3">
+                <Toast bg="dark" show={!!importToast} onClose={() => setImportToast(null)} delay={8000} autohide>
+                    <Toast.Header closeButton>
+                        <strong className="me-auto">Import completed</strong>
+                    </Toast.Header>
+                    <Toast.Body>
+                        {importToast && (
+                            <div className="d-flex flex-column gap-1">
+                                <div>New: {importToast.newCount}</div>
+                                <div>Updated: {importToast.updatedCount}</div>
+                                <div>Skipped: {importToast.skippedCount}</div>
+                                <Button
+                                    variant="link"
+                                    size="sm"
+                                    className="p-0 align-self-start"
+                                    onClick={handleViewImported}
+                                >
+                                    View imported bindings
+                                </Button>
+                            </div>
+                        )}
+                    </Toast.Body>
+                </Toast>
+            </ToastContainer>
+            <Modal show={showImportModal} onHide={closeImportModal} backdrop={isRunningImport ? 'static' : true} keyboard={!isRunningImport}>
+                <Modal.Header closeButton={!isRunningImport}>
+                    <Modal.Title>Import database</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    {importError && (
+                        <Alert variant="danger">{importError}</Alert>
+                    )}
+                    {importSummary ? (
+                        <div className="d-flex flex-column gap-1">
+                            <div><strong>File:</strong> {importData?.fileName || '—'}</div>
+                            <div>Total rows: {importSummary.totalRows}</div>
+                            <div>Rows to import: {importSummary.toImport}</div>
+                            <div>New entries: {importSummary.newEntries}</div>
+                            <div>Updates: {importSummary.updates}</div>
+                            <div>Skipped: {importSummary.skipped}</div>
+                            {importSummary.invalidRows > 0 && (
+                                <div className="text-muted small">Invalid rows: {importSummary.invalidRows}</div>
+                            )}
+                            {importSummary.duplicates > 0 && (
+                                <div className="text-muted small">Conflicts removed: {importSummary.duplicates}</div>
+                            )}
+                        </div>
+                    ) : (
+                        !importError && <div>No data to import.</div>
+                    )}
+                    {importPlan && (
+                        <>
+                            <Form.Check
+                                className="mt-3"
+                                type="checkbox"
+                                label="Overwrite existing entries with same uniqness"
+                                checked={overwriteExisting}
+                                disabled={isRunningImport}
+                                onChange={ev => setOverwriteExisting(ev.target.checked)}
+                            />
+                            <Form.Group className="mt-3">
+                                <Form.Label>Conflict policy</Form.Label>
+                                <Form.Select
+                                    value={conflictPolicy}
+                                    onChange={ev => setConflictPolicy(ev.target.value as ConflictPolicy)}
+                                    disabled={isRunningImport}
+                                >
+                                    {CONFLICT_POLICIES.map(option => (
+                                        <option key={option.value} value={option.value}>{option.label}</option>
+                                    ))}
+                                </Form.Select>
+                            </Form.Group>
+                        </>
+                    )}
+                    {importProgress && (
+                        <div className="mt-4">
+                            <ProgressBar now={importProgress.total ? (importProgress.processed / importProgress.total) * 100 : 0} />
+                            <div className="d-flex justify-content-between mt-2 small">
+                                <span>Rows processed: {importProgress.processed}/{importProgress.total}</span>
+                                <span>{importProgress.eta !== null ? `~${importProgress.eta.toFixed(1)} s remaining` : 'Estimating…'}</span>
+                            </div>
+                        </div>
+                    )}
+                    {isRunningImport && (
+                        <div className="mt-3 d-flex align-items-center gap-2">
+                            <Spinner animation="border" size="sm" role="status" />
+                            <span>Importing…</span>
+                        </div>
+                    )}
+                    {importCancelled && (
+                        <Alert variant="warning" className="mt-3 mb-0">Import cancelled.</Alert>
+                    )}
+                </Modal.Body>
+                <Modal.Footer>
+                    {isRunningImport ? (
+                        <Button variant="secondary" onClick={handleCancelImport}>Cancel</Button>
+                    ) : (
+                        <>
+                            <Button variant="secondary" onClick={closeImportModal}>Close</Button>
+                            <Button onClick={runImport} disabled={!importPlan || importPlan.rows.length === 0}>Import</Button>
+                        </>
+                    )}
+                </Modal.Footer>
+            </Modal>
+            <div className="d-flex align-items-center gap-2">
+                <Button size="sm" variant="secondary" onClick={handleImportClick} disabled={isParsingDb}>Import database…</Button>
+                {isParsingDb && <Spinner animation="border" size="sm" role="status" />}
+            </div>
+            {importError && !showImportModal && (
+                <Alert variant="danger" className="mb-0">{importError}</Alert>
+            )}
             <fieldset className="p-0 border-0 m-0">
                 <Table bordered size="sm" className="table-zebra mb-2">
                     <tbody className="align-middle">

--- a/web-client/src/options/multibindImport.ts
+++ b/web-client/src/options/multibindImport.ts
@@ -1,0 +1,108 @@
+import initSqlJs, { type SqlJsStatic } from 'sql.js';
+import wasmUrl from 'sql.js/dist/sql-wasm.wasm?url';
+
+export interface MultibindImportRow {
+    uniqness: string;
+    roomId: number;
+    index: number;
+    action: string;
+}
+
+export interface ParsedMultibindDatabase {
+    rows: MultibindImportRow[];
+    totalRows: number;
+    invalidRows: number;
+}
+
+const REQUIRED_COLUMNS = ['_row_id', 'index', 'uniqness', 'room_id', 'action'] as const;
+const MAX_MULTIBIND_INDEX = 4;
+
+let sqlPromise: Promise<SqlJsStatic> | null = null;
+
+async function getSql(): Promise<SqlJsStatic> {
+    if (!sqlPromise) {
+        sqlPromise = initSqlJs({
+            locateFile: (file) => file === 'sql-wasm.wasm' ? wasmUrl : file,
+        });
+    }
+    return sqlPromise;
+}
+
+function normalizeUniqness(raw: unknown, roomId: number, index: number): string {
+    if (typeof raw === 'string') {
+        const trimmed = raw.trim();
+        if (trimmed) {
+            return trimmed;
+        }
+    }
+    return `${roomId}:${index}`;
+}
+
+function extractColumns(result: any): string[] {
+    if (!result || !Array.isArray(result.values)) {
+        return [];
+    }
+    return result.values
+        .map((row: any[]) => (row?.[1] !== undefined ? String(row[1]) : ''))
+        .filter(Boolean);
+}
+
+export async function parseMultibindsDatabase(buffer: ArrayBuffer): Promise<ParsedMultibindDatabase> {
+    const SQL = await getSql();
+    const db = new SQL.Database(new Uint8Array(buffer));
+    try {
+        const tables = db.exec("SELECT name FROM sqlite_master WHERE type='table'");
+        const tableName = tables
+            .flatMap(result => result.values as any[][])
+            .map(([name]) => String(name))
+            .find(name => name?.toLowerCase() === 'multibinds');
+        if (!tableName) {
+            throw new Error('Tabela "multibinds" nie została znaleziona.');
+        }
+
+        const pragma = db.exec(`PRAGMA table_info(\"${tableName}\")`);
+        const columns = extractColumns(pragma[0]);
+        const lowerColumns = columns.map(name => name.toLowerCase());
+        const missing = REQUIRED_COLUMNS.filter(col => !lowerColumns.includes(col));
+        if (missing.length) {
+            throw new Error(`Tabela "${tableName}" nie zawiera wymaganych kolumn: ${missing.join(', ')}`);
+        }
+
+        const columnMap = new Map<string, string>();
+        columns.forEach(name => columnMap.set(name.toLowerCase(), name));
+        const columnIndex = columnMap.get('index')!;
+        const columnUniq = columnMap.get('uniqness')!;
+        const columnRoom = columnMap.get('room_id')!;
+        const columnAction = columnMap.get('action')!;
+
+        const stmt = db.prepare(`SELECT "${columnIndex}" as idx, "${columnUniq}" as uniq, "${columnRoom}" as roomId, "${columnAction}" as action FROM "${tableName}"`);
+
+        const rows: MultibindImportRow[] = [];
+        let totalRows = 0;
+        let invalidRows = 0;
+        while (stmt.step()) {
+            totalRows += 1;
+            const row = stmt.getAsObject() as Record<string, unknown>;
+            const roomIdRaw = Number(row.roomId);
+            const indexRaw = Number(row.idx);
+            const action = typeof row.action === 'string' ? row.action : String(row.action ?? '');
+            if (!Number.isFinite(roomIdRaw) || !Number.isFinite(indexRaw)) {
+                invalidRows += 1;
+                continue;
+            }
+            const roomId = Math.trunc(roomIdRaw);
+            const index = Math.trunc(indexRaw);
+            if (index < 1 || index > MAX_MULTIBIND_INDEX || Number.isNaN(roomId)) {
+                invalidRows += 1;
+                continue;
+            }
+            const uniqness = normalizeUniqness(row.uniq, roomId, index);
+            rows.push({ uniqness, roomId, index, action });
+        }
+        stmt.free();
+
+        return { rows, totalRows, invalidRows };
+    } finally {
+        db.close();
+    }
+}

--- a/web-client/src/options/multibindImport.ts
+++ b/web-client/src/options/multibindImport.ts
@@ -1,4 +1,5 @@
-import initSqlJs, { type SqlJsStatic } from 'sql.js';
+import type { SqlJsStatic } from 'sql.js';
+import initSqlJs from 'sql.js/dist/sql-wasm.js';
 import wasmUrl from 'sql.js/dist/sql-wasm.wasm?url';
 
 export interface MultibindImportRow {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6907,6 +6907,11 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
+sql.js@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/sql.js/-/sql.js-1.13.0.tgz#f73cba7eaba0bc881f466c9149e00cf598fb01e0"
+  integrity sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==
+
 ssri@^10.0.0, ssri@^10.0.6:
   version "10.0.6"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-10.0.6.tgz#a8aade2de60ba2bce8688e3fa349bad05c7dc1e5"


### PR DESCRIPTION
## Summary
- add an SQLite import workflow with preview, progress and toast feedback to the Bindowanie modal
- validate and normalize multibind rows from uploaded databases using sql.js and shared storage helpers
- reuse the shared IndexedDB helpers inside MockPort and add the sql.js dependency

## Testing
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68d9cda7ca2c832a8d2c1db457e3b531