### PR TITLE
feat: allow configuring low hp alert level

### DIFF
--- a/client/src/defaultSettings.ts
+++ b/client/src/defaultSettings.ts
@@ -13,6 +13,7 @@ export interface Settings {
     herbPreUseCommand: string;
     herbPostUseCommand: string;
     fullHpMessage: boolean;
+    lowHpAlert: number;
 }
 
 export const defaultSettings: Settings = {
@@ -30,4 +31,5 @@ export const defaultSettings: Settings = {
     herbPreUseCommand: '',
     herbPostUseCommand: '',
     fullHpMessage: false,
+    lowHpAlert: 2,
 };

--- a/client/src/scripts/hpAlert.ts
+++ b/client/src/scripts/hpAlert.ts
@@ -14,11 +14,32 @@ export default function initHpAlert(client: Client) {
         'w swietnej kondycji',
     ];
     let prev = Infinity;
+    let alertLevel = 2;
+
+    client.addEventListener('settings', (ev: CustomEvent) => {
+        const settings = ev.detail || {};
+        if (typeof settings.lowHpAlert === 'boolean') {
+            alertLevel = settings.lowHpAlert ? 2 : 0;
+            return;
+        }
+        const value = Number(settings.lowHpAlert);
+        if (Number.isFinite(value)) {
+            const max = CONDITIONS.length - 1;
+            alertLevel = Math.max(0, Math.min(max, Math.floor(value)));
+        } else {
+            alertLevel = 2;
+        }
+    });
+
     client.addEventListener('gmcp.char.state', (ev: CustomEvent) => {
         let hp = ev.detail?.hp;
         if (typeof hp !== 'number') return;
         hp++;
-        if (hp < prev && hp < 3) {
+        if (alertLevel <= 0) {
+            prev = hp;
+            return;
+        }
+        if (hp < prev && hp <= alertLevel) {
             const plain = `Jestes ${CONDITIONS[hp] ?? ''}`;
             const msg = colorString(plain, ORANGE);
             client.playSound('beep');

--- a/client/test/hpAlert.test.ts
+++ b/client/test/hpAlert.test.ts
@@ -23,13 +23,14 @@ describe('hp alert', () => {
     client = new FakeClient();
     initHpAlert((client as unknown) as any);
     jest.clearAllMocks();
+    client.sendEvent('settings', { lowHpAlert: 2 });
   });
 
   function send(hp: number) {
     client.sendEvent('gmcp.char.state', { hp });
   }
 
-  test('beeps and prints when hp drops below 3', () => {
+  test('beeps and prints when hp drops to configured threshold', () => {
     send(3);
     send(1);
     expect(client.playSound).toHaveBeenCalledTimes(1);
@@ -61,5 +62,25 @@ describe('hp alert', () => {
     expect(client.playSound).not.toHaveBeenCalled();
     expect(client.println).not.toHaveBeenCalled();
     expect(client.notify).not.toHaveBeenCalled();
+  });
+
+  test('disabling alert prevents notifications', () => {
+    client.sendEvent('settings', { lowHpAlert: 0 });
+    send(3);
+    send(1);
+    expect(client.playSound).not.toHaveBeenCalled();
+    expect(client.println).not.toHaveBeenCalled();
+    expect(client.notify).not.toHaveBeenCalled();
+  });
+
+  test('higher threshold expands alert range', () => {
+    client.sendEvent('settings', { lowHpAlert: 3 });
+    send(4);
+    send(2);
+    expect(client.playSound).toHaveBeenCalledTimes(1);
+    const plain = 'Jestes w zlej kondycji';
+    const msg = colorString(plain, color);
+    expect(client.println).toHaveBeenCalledWith(`\n\n${msg}\n\n`);
+    expect(client.notify).toHaveBeenCalledWith(plain);
   });
 });

--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -44,6 +44,17 @@ const languageOptions = [
     "ghassall",
 ]
 
+const lowHpAlertOptions = [
+    { value: 0, label: '0 - Wylaczony' },
+    { value: 1, label: '1 - Ledwo zywy' },
+    { value: 2, label: '2 - Ciezko ranny' },
+    { value: 3, label: '3 - W zlej kondycji' },
+    { value: 4, label: '4 - Ranny' },
+    { value: 5, label: '5 - Lekko ranny' },
+    { value: 6, label: '6 - W dobrym stanie' },
+    { value: 7, label: '7 - W swietnej kondycji' },
+];
+
 function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void }) {
     const [settings, setSettings] = useState<FormSettings>({ ...defaultSettings });
 
@@ -78,7 +89,11 @@ function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void
     useEffect(() => {
         const load = () => {
             storage.getItem("settings").then(res => {
-                setSettings(Object.assign({}, defaultSettings, res?.settings));
+                const merged = Object.assign({}, defaultSettings, res?.settings);
+                if (typeof merged.lowHpAlert !== 'number') {
+                    merged.lowHpAlert = merged.lowHpAlert ? 2 : 0;
+                }
+                setSettings(merged);
             });
         };
 
@@ -134,6 +149,20 @@ function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void
                         onChange={e => onChangeSetting(s => s.fullHpMessage = e.target.checked)}
                         className="me-2"
                     />
+                    <Form.Group className="d-flex align-items-center me-2">
+                        <Form.Label className="me-1 mb-0" htmlFor="lowHpAlert">Alarm niskiego zdrowia:</Form.Label>
+                        <Form.Select
+                            size="sm"
+                            id="lowHpAlert"
+                            value={settings.lowHpAlert}
+                            onChange={e => onChangeSetting(s => s.lowHpAlert = parseInt(e.target.value) || 0)}
+                            className="w-auto"
+                        >
+                            {lowHpAlertOptions.map(option => (
+                                <option value={option.value} key={option.value}>{option.label}</option>
+                            ))}
+                        </Form.Select>
+                    </Form.Group>
                 </div>
             </div>
             <div className="mb-4 border rounded p-3">


### PR DESCRIPTION
## Summary
- change the low HP alert preference from a boolean toggle to a numeric level with sensible defaults
- honor the configured level in the client alert script and keep backwards compatibility with saved boolean values
- expose the new choices in character settings and expand tests to cover the configurable thresholds

## Testing
- yarn --cwd client test hpAlert.test.ts
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68de7059b224832a9bd8979a41f103e7