### PR TITLE
Refactor map initialization to use direct calls

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -4,6 +4,8 @@ import { getItemSync, setItemSync } from "./storage";
 import { getLongDir, getShortDir, longToShort } from "./utils/directions";
 import Room = MapData.Room;
 
+type MapReadyPayload = { mapData: MapData.Map; colors: any };
+
 const STORAGE_KEY = 'mapperRoomId';
 
 export { longToShort };
@@ -27,13 +29,15 @@ export default class MapHelper {
     currentRoom: Room;
     locationHistory: number[] = []
     client: Client
-    mapReader: MapReader
+    mapReader: MapReader | null = null
     refreshPosition = true;
     hashes = {};
     gmcpPosition: Position;
     paused = false;
     savedRoomId: number | null = null;
     areas: Record<string, string> = {}
+    private readyListeners: ((payload: MapReadyPayload) => void)[] = [];
+    private readyPayload: MapReadyPayload | null = null;
 
     constructor(clientExtension: Client) {
         this.client = clientExtension
@@ -43,17 +47,6 @@ export default class MapHelper {
             this.savedRoomId = parseInt(saved);
         }
         this.client.addEventListener('enterLocation', (event) => this.handleNewLocation(event.detail))
-        window.addEventListener('map-ready', (event: CustomEvent) => {
-            this.mapReader = new MapReader(event.detail.mapData, event.detail.colors)
-            // @ts-ignore
-            Object.values(this.mapReader.roomIndex).forEach(room => this.hashes[room.hash] = room);
-            window.dispatchEvent(new CustomEvent('map-ready-with-data', {detail: {mapData: event.detail.mapData, colors: event.detail.colors}}))
-            const startId = this.savedRoomId ?? 1;
-            this.renderRoomById(startId)
-            this.mapReader.getAreas().forEach(area => {
-                this.areas[area.areaId] = area.areaName
-            })
-        })
 
         this.client.addEventListener('gmcp.room.info', (event: CustomEvent) => {
             this.gmcpPosition = event.detail.map;
@@ -81,6 +74,31 @@ export default class MapHelper {
         });
 
         this.client.sendEvent('refreshPositionWhenAble');
+    }
+
+    initialize(mapData: MapData.Map, colors: any): number {
+        const reader = new MapReader(mapData, colors)
+        this.mapReader = reader
+        this.hashes = {}
+        // @ts-ignore
+        Object.values(reader.roomIndex).forEach((room: any) => this.hashes[room.hash] = room)
+        this.areas = {}
+        reader.getAreas().forEach(area => {
+            this.areas[area.areaId] = area.areaName
+        })
+        const payload: MapReadyPayload = { mapData, colors }
+        this.readyPayload = payload
+        this.readyListeners.splice(0).forEach(listener => listener(payload))
+        const startId = this.savedRoomId ?? 1
+        return startId
+    }
+
+    onReady(listener: (payload: MapReadyPayload) => void) {
+        if (this.readyPayload) {
+            listener(this.readyPayload)
+            return
+        }
+        this.readyListeners.push(listener)
     }
 
     setPaused(paused: boolean) {
@@ -125,6 +143,10 @@ export default class MapHelper {
         if (this.paused) {
             return {direction, moved: false}
         }
+        const reader = this.mapReader;
+        if (!reader) {
+            return {direction, moved: false}
+        }
         let actualDirection = direction
         if (this.currentRoom) {
             const allExits = Object.assign(
@@ -135,7 +157,7 @@ export default class MapHelper {
             const potentialExit = getLongDir(direction);
             if (!this.currentRoom.exits || !this.currentRoom.exits[potentialExit]) {
                 const exits = Object.entries(allExits).filter(([_, id]) => {
-                    const target = this.mapReader.getRoomById(id);
+                    const target = reader.getRoomById(id);
                     return this.findRoomByExit(this.currentRoom, target, getLongDir(direction));
                 }).map(([exit]) => exit);
                 if (exits.length > 0) {
@@ -208,13 +230,21 @@ export default class MapHelper {
     }
 
     setMapRoomById(id: number) {
+        const reader = this.mapReader;
+        if (!reader) {
+            this.savedRoomId = id;
+            return;
+        }
         if (this.currentRoom?.id === id) {
             return;
         }
-        this.setMapRoom(this.mapReader.getRoomById(id))
+        this.setMapRoom(reader.getRoomById(id))
     }
 
-    setMapRoom(room: Room) {
+    setMapRoom(room: Room | undefined) {
+        if (!room) {
+            return;
+        }
         this.locationHistory = [room.id]
         this.renderRoom(room);
         if (!this.client.suppressMapMoveEvent) {
@@ -244,10 +274,18 @@ export default class MapHelper {
     }
 
     renderRoomById(id: number, sendEvent = true) {
-        this.currentRoom = this.mapReader.getRoomById(id)
+        const reader = this.mapReader;
+        if (!reader) {
+            return;
+        }
+        const room = reader.getRoomById(id)
+        if (!room) {
+            return;
+        }
+        this.currentRoom = room
         setItemSync(STORAGE_KEY, id.toString())
         if (sendEvent) {
-            this.client.sendEvent('enterLocation', {id: id, room: this.currentRoom});
+            this.client.sendEvent('enterLocation', {id: id, room});
         }
     }
 

--- a/client/src/scripts/gps.ts
+++ b/client/src/scripts/gps.ts
@@ -87,7 +87,7 @@ export default function initGps(client: Client) {
         });
     }
 
-    window.addEventListener('map-ready', (ev: CustomEvent) => {
-        register(ev.detail.mapData);
+    client.Map.onReady(({ mapData }) => {
+        register(mapData);
     });
 }

--- a/client/test/gps.test.ts
+++ b/client/test/gps.test.ts
@@ -1,9 +1,23 @@
 import initGps from '../src/scripts/gps';
 import Triggers from '../src/Triggers';
 
+class FakeMap {
+  setMapRoomById = jest.fn();
+  currentRoom = { id: 10, areaId: 'Area' } as any;
+  private readyCallback: ((payload: { mapData: MapData.Map; colors: any }) => void) | null = null;
+
+  onReady(callback: (payload: { mapData: MapData.Map; colors: any }) => void) {
+    this.readyCallback = callback;
+  }
+
+  triggerReady(mapData: MapData.Map, colors: any = []) {
+    this.readyCallback?.({ mapData, colors });
+  }
+}
+
 class FakeClient {
   Triggers = new Triggers({} as unknown as any);
-  Map = { setMapRoomById: jest.fn(), currentRoom: { id: 10, areaId: 'Area' } } as any;
+  Map = new FakeMap();
   sendEvent = jest.fn();
 }
 
@@ -42,7 +56,7 @@ describe('gps triggers', () => {
         labels: []
       }
     ];
-    window.dispatchEvent(new CustomEvent('map-ready', { detail: { mapData, colors: [] } }));
+    client.Map.triggerReady(mapData as any);
   });
 
   test('gps lines set map location when different from current', () => {

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -392,9 +392,7 @@ export default class EmbeddedMap {
 }
 
 export const createMap = (data: { mapData: any; colors: any; startId?: number }) => {
-    (window as any).embedded = new EmbeddedMap(data.mapData, data.colors, data.startId);
+    const map = new EmbeddedMap(data.mapData, data.colors, data.startId);
+    (window as any).embedded = map;
+    return map;
 };
-
-window.addEventListener('map-ready-with-data', (e: Event) =>
-    createMap((e as CustomEvent).detail)
-);

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -23,7 +23,7 @@ import MockPort from "./MockPort.ts";
 import NoSleep from 'nosleep.js';
 import {loadMapData, loadColors} from "./mapDataLoader.ts";
 import {loadNpcData} from "./npcDataLoader.ts";
-import "./embed.ts"
+import { createMap } from "./embed.ts";
 import {createElement} from 'react'
 import {createRoot} from 'react-dom/client'
 import Binds from "./options/Binds.tsx"
@@ -233,11 +233,9 @@ Promise.all([mapDataPromise, colorsPromise])
     .then(([mapData, colors]) => {
         console.log('Map data and colors loaded successfully');
         progressContainer.style.display = 'none';
-        window.dispatchEvent(new CustomEvent("map-ready", {
-            detail: {
-                mapData, colors
-            }
-        }));
+        const startId = client.Map.initialize(mapData, colors);
+        createMap({ mapData, colors, startId });
+        client.Map.renderRoomById(startId);
     })
     .catch(error => {
         progressContainer.style.display = 'none';


### PR DESCRIPTION
## Summary
- expose MapHelper.initialize/onReady to set up the reader and notify dependants without DOM events
- have embed.ts return the EmbeddedMap instance and call it directly from main.ts
- update the GPS script and tests to consume the new map-ready hook

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68e19dfc48a0832a89cabb8cd263d3b1