### PR TITLE
Refine shared map initialization

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -2,7 +2,7 @@ import Client from "./Client";
 import { getItemSync, setItemSync } from "./storage";
 import { getLongDir, getShortDir, longToShort } from "./utils/directions";
 import Room = MapData.Room;
-import { MapReader, PathFinder } from "mudlet-map-renderer"
+import { MapReader } from "mudlet-map-renderer"
 
 const STORAGE_KEY = 'mapperRoomId';
 
@@ -27,14 +27,17 @@ export default class MapHelper {
     currentRoom: Room;
     locationHistory: number[] = []
     client: Client
-    mapReader: MapReader
-    pathFinder: PathFinder;
+    mapReader!: MapReader
     refreshPosition = true;
     hashes = {};
     gmcpPosition: Position;
     paused = false;
     savedRoomId: number | null = null;
     areas: Record<string, string> = {}
+    private mapReadyCallbacks: ((mapData: MapData.Map, colors: any) => void)[] = [];
+    private mapData?: MapData.Map;
+    private colors?: any;
+    private mapReady = false;
 
     constructor(clientExtension: Client) {
         this.client = clientExtension
@@ -44,17 +47,6 @@ export default class MapHelper {
             this.savedRoomId = parseInt(saved);
         }
         this.client.addEventListener('enterLocation', (event) => this.handleNewLocation(event.detail))
-        window.addEventListener('map-ready', (event: CustomEvent) => {
-            this.mapReader = new MapReader(JSON.parse(JSON.stringify(event.detail.mapData)), event.detail.colors)
-            this.pathFinder = new PathFinder(this.mapReader)
-            this.mapReader.getRooms().forEach(room => this.hashes[room.hash] = room.id)
-            window.dispatchEvent(new CustomEvent('map-ready-with-data', {detail: {mapData: event.detail.mapData, colors: event.detail.colors}}))
-            const startId = this.savedRoomId ?? 1;
-            this.renderRoomById(startId)
-            this.mapReader.getAreas().forEach(area => {
-                this.areas[area.getAreaId()] = area.getAreaName()
-            })
-        })
 
         this.client.addEventListener('gmcp.room.info', (event: CustomEvent) => {
             this.gmcpPosition = event.detail.map;
@@ -82,6 +74,39 @@ export default class MapHelper {
         });
 
         this.client.sendEvent('refreshPositionWhenAble');
+    }
+
+    initialize(mapData: MapData.Map, colors: any): { startId: number; reader: MapReader } {
+        this.mapData = mapData;
+        this.colors = colors;
+        this.mapReader = new MapReader(mapData, colors)
+        this.hashes = {}
+        this.areas = {}
+        this.mapReader.getRooms().forEach(room => this.hashes[room.hash] = room.id)
+        const startId = this.savedRoomId ?? 1;
+        this.renderRoomById(startId)
+        this.mapReader.getAreas().forEach(area => {
+            this.areas[area.getAreaId()] = area.getAreaName()
+        })
+        this.mapReady = true;
+        this.mapReadyCallbacks.forEach(cb => cb(mapData, colors));
+        this.mapReadyCallbacks = [];
+        return { startId, reader: this.mapReader };
+    }
+
+    onMapReady(callback: (mapData: MapData.Map, colors: any) => void) {
+        if (this.mapReady && this.mapData && this.colors) {
+            callback(this.mapData, this.colors)
+            return;
+        }
+        this.mapReadyCallbacks.push(callback)
+    }
+
+    getMapReader(): MapReader {
+        if (!this.mapReader) {
+            throw new Error("Map reader not initialized");
+        }
+        return this.mapReader
     }
 
     setPaused(paused: boolean) {
@@ -123,6 +148,9 @@ export default class MapHelper {
     }
 
     move(direction: string) {
+        if (!this.mapReader) {
+            return {direction, moved: false}
+        }
         if (this.paused) {
             return {direction, moved: false}
         }
@@ -241,7 +269,12 @@ export default class MapHelper {
     }
 
     renderRoomById(id: number, sendEvent = true) {
+        if (!this.mapReader) {
+            this.savedRoomId = id;
+            return;
+        }
         this.currentRoom = this.mapReader.getRoom(id)
+        this.savedRoomId = id;
         setItemSync(STORAGE_KEY, id.toString())
         if (sendEvent) {
             this.client.sendEvent('enterLocation', {id: id, room: this.currentRoom});
@@ -282,7 +315,10 @@ export default class MapHelper {
     }
 
     findPath(fromId: number, targetId: number) {
-        return this.pathFinder.findPath(fromId, targetId)
+        if (!this.mapReader) {
+            return null
+        }
+        return this.mapReader.getPath(fromId, targetId)
     }
 
 }

--- a/client/src/scripts/gps.ts
+++ b/client/src/scripts/gps.ts
@@ -87,7 +87,7 @@ export default function initGps(client: Client) {
         });
     }
 
-    window.addEventListener('map-ready', (ev: CustomEvent) => {
-        register(ev.detail.mapData);
+    client.Map.onMapReady((mapData) => {
+        register(mapData);
     });
 }

--- a/client/test/gps.test.ts
+++ b/client/test/gps.test.ts
@@ -3,7 +3,7 @@ import Triggers from '../src/Triggers';
 
 class FakeClient {
   Triggers = new Triggers({} as unknown as any);
-  Map = { setMapRoomById: jest.fn(), currentRoom: { id: 10, areaId: 'Area' } } as any;
+  Map = { setMapRoomById: jest.fn(), currentRoom: { id: 10, areaId: 'Area' }, onMapReady: (_cb: any) => {} } as any;
   sendEvent = jest.fn();
 }
 
@@ -13,9 +13,6 @@ describe('gps triggers', () => {
 
   beforeEach(() => {
     client = new FakeClient();
-    initGps(client as unknown as any);
-    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
-    client.Map.currentRoom.id = 1;
     const mapData = [
       {
         areaName: 'Area',
@@ -42,7 +39,10 @@ describe('gps triggers', () => {
         labels: []
       }
     ];
-    window.dispatchEvent(new CustomEvent('map-ready', { detail: { mapData, colors: [] } }));
+    client.Map.onMapReady = (cb: any) => cb(mapData);
+    initGps(client as unknown as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
+    client.Map.currentRoom.id = 1;
   });
 
   test('gps lines set map location when different from current', () => {

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -1,4 +1,4 @@
-import {MapReader, Renderer, PathFinder, RoomContextMenuEventDetail} from "mudlet-map-renderer";
+import {MapReader, Renderer, RoomContextMenuEventDetail} from "mudlet-map-renderer";
 import {getCurrentCharacter, getItemSync, setItemSync} from "@client/src/storage";
 
 const STORAGE_KEY = 'mapperRoomId';
@@ -56,11 +56,10 @@ async function saveVisitedRooms(rooms: number[]): Promise<void> {
     }
 }
 
-class EmbeddedMap {
+export class EmbeddedMap {
     private map: HTMLDivElement;
     private reader: MapReader;
     private renderer: Renderer;
-    private pathFinder: PathFinder;
     private currentRoom: any;
     private destinations: number[] = [];
     private highlights: number[] = []
@@ -69,13 +68,12 @@ class EmbeddedMap {
     private visited = new Set<number>();
     private totalRooms: number;
 
-    constructor(mapData: any, colors: any, startId?: number) {
+    constructor(reader: MapReader, startId?: number) {
         this.map = document.querySelector<HTMLDivElement>("#map")!;
         this.map.style.touchAction = 'none';
         this.map.addEventListener('zoom', () => this.onZoom());
         this.map.addEventListener('roomcontextmenu', (ev: CustomEvent<RoomContextMenuEventDetail>) => this.onContextMenu(ev));
-        this.reader = new MapReader(mapData, colors);
-        this.pathFinder = new PathFinder(this.reader)
+        this.reader = reader;
         this.totalRooms = this.reader.getRooms().length;
 
         window.addEventListener('pauserStart', () => {
@@ -209,7 +207,7 @@ class EmbeddedMap {
             let text = `#${roomId} ${area.getAreaName()}`;
             if (this.destinations.length > 0) {
                 const destId = this.destinations[0];
-                const path = this.pathFinder.findPath(roomId, destId);
+                const path = this.reader.getPath(roomId, destId);
                 console.log('path', path);
                 const distance = path ? path.length - 1 : 0;
                 const room = this.reader.getRoom(roomId)
@@ -263,11 +261,3 @@ class EmbeddedMap {
         this.refresh();
     }
 }
-
-export const createMap = (data: { mapData: any; colors: any; startId?: number }) => {
-    (window as any).embedded = new EmbeddedMap(data.mapData, data.colors, data.startId);
-};
-
-window.addEventListener('map-ready-with-data', (e: Event) =>
-    createMap((e as CustomEvent).detail)
-);

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -23,7 +23,7 @@ import MockPort from "./MockPort.ts";
 import NoSleep from 'nosleep.js';
 import {loadMapData, loadColors} from "./mapDataLoader.ts";
 import {loadNpcData} from "./npcDataLoader.ts";
-import "./embed.ts"
+import {EmbeddedMap} from "./embed.ts"
 import {createElement} from 'react'
 import {createRoot} from 'react-dom/client'
 import Binds from "./options/Binds.tsx"
@@ -233,11 +233,8 @@ Promise.all([mapDataPromise, colorsPromise])
     .then(([mapData, colors]) => {
         console.log('Map data and colors loaded successfully');
         progressContainer.style.display = 'none';
-        window.dispatchEvent(new CustomEvent("map-ready", {
-            detail: {
-                mapData, colors
-            }
-        }));
+        const { startId, reader } = client.Map.initialize(mapData, colors);
+        (window as any).embedded = new EmbeddedMap(reader, startId);
     })
     .catch(error => {
         progressContainer.style.display = 'none';


### PR DESCRIPTION
## Summary
- instantiate the map once in MapHelper, refresh cached area metadata, and return the shared MapReader to callers
- guard map operations until initialization completes so saved room IDs persist without crashing
- remove the window event helper by instantiating EmbeddedMap directly when map data loads

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68e1a5babf08832a9399d30acf068222