### PR TITLE
Fix herb popup menu to use /zi alias

### DIFF
--- a/client/src/scripts/herbDescriptions.ts
+++ b/client/src/scripts/herbDescriptions.ts
@@ -31,7 +31,7 @@ export default async function initHerbDescriptions(client: Client) {
                     label: `${a.action} ${n}`,
                     action: () => {
                         preUseCommands.forEach(cmd => client.sendCommand(cmd));
-                        client.sendCommand(`/z ${a.action} ${herbId} ${n}`);
+                        client.sendCommand(`/zi ${a.action} ${herbId} ${n}`);
                         postUseCommands.forEach(cmd => client.sendCommand(cmd));
                     }
                 }))


### PR DESCRIPTION
## Summary
- update the herb descriptions context menu to send /zi commands instead of /z

## Testing
- yarn --cwd client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68e1b92e8504832a801f55b0cf623861