### PR TITLE
Add instant map move toggle to UI settings

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -317,6 +317,10 @@
                             <option value="left">Lewa</option>
                         </select>
                     </label>
+                    <label class="form-label">
+                        <input id="ui-instant-map-move" type="checkbox" class="form-check-input me-2" />
+                        Natychmiastowe przesuwanie mapy
+                    </label>
                     <label class="form-label d-flex align-items-center">
                         <input id="ui-exploration-mode" type="checkbox" class="form-check-input me-2" />
                         Tryb eksploracji mapy <span id="ui-exploration-stats" class="ms-1 text-muted"></span>

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -66,6 +66,7 @@ export class EmbeddedMap {
     private highlights: number[] = []
     private zoom: number;
     private explorationMode = false;
+    private instantMapMove = false;
     private visited = new Set<number>();
     private totalRooms: number;
 
@@ -92,6 +93,7 @@ export class EmbeddedMap {
         });
         let zoom = 0.30;
         let explorationMode = false;
+        let instantMapMove = false;
         let initialRoom = startId ?? 1;
         try {
             const data = getItemSync('uiSettings');
@@ -102,6 +104,9 @@ export class EmbeddedMap {
                 }
                 if (typeof parsed.explorationMode === 'boolean') {
                     explorationMode = parsed.explorationMode;
+                }
+                if (typeof parsed.instantMapMove === 'boolean') {
+                    instantMapMove = parsed.instantMapMove;
                 }
             }
         } catch {
@@ -116,6 +121,7 @@ export class EmbeddedMap {
         } catch {
         }
         this.zoom = zoom;
+        this.instantMapMove = instantMapMove;
         this.renderer = new Renderer(this.map, this.reader);
         this.setExplorationMode(explorationMode);
 
@@ -193,7 +199,7 @@ export class EmbeddedMap {
     }
 
     renderRoom(roomId: number) {
-        this.renderer.setPosition(roomId)
+        this.setRendererPosition(roomId);
         this.renderer.setZoom(this.zoom);
         const area = this.renderer.getCurrentArea()
         this.currentRoom = roomId;
@@ -228,6 +234,25 @@ export class EmbeddedMap {
         });
     }
 
+    private setRendererPosition(roomId: number) {
+        const renderer: any = this.renderer as any;
+        const controls = renderer?.controls;
+
+        if (this.instantMapMove && typeof controls?.centerRoom === 'function') {
+            controls.centerRoom(roomId);
+            return;
+        }
+
+        if (typeof renderer?.setPosition === 'function') {
+            renderer.setPosition(roomId);
+            return;
+        }
+
+        if (typeof controls?.centerRoom === 'function') {
+            controls.centerRoom(roomId);
+        }
+    }
+
     private getPath(from: number, to: number): number[] | null {
         return this.pathFinder?.findPath(from, to) ?? null;
     }
@@ -257,6 +282,13 @@ export class EmbeddedMap {
     setZoom(zoom: number) {
         this.zoom = zoom;
         this.renderer.setZoom(zoom);
+    }
+
+    setInstantMapMove(on: boolean) {
+        this.instantMapMove = on;
+        if (typeof this.currentRoom === 'number') {
+            this.setRendererPosition(this.currentRoom);
+        }
     }
 
     leadTo(id?: string) {

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -27,6 +27,7 @@ interface UiSettings {
     xtermPalette: 'arkadia' | 'proper';
     footerMode: number;
     explorationMode: boolean;
+    instantMapMove: boolean;
 }
 
 const defaultSettings: UiSettings = {
@@ -43,6 +44,7 @@ const defaultSettings: UiSettings = {
     xtermPalette: 'arkadia',
     footerMode: 0,
     explorationMode: false,
+    instantMapMove: false,
 };
 
 function apply(settings: UiSettings) {
@@ -108,6 +110,7 @@ function apply(settings: UiSettings) {
     if ((window as any).embedded?.renderer) {
         (window as any).embedded.setZoom?.(settings.mapScale);
         (window as any).embedded.setExplorationMode?.(settings.explorationMode);
+        (window as any).embedded.setInstantMapMove?.(settings.instantMapMove);
         (window as any).embedded.refresh();
     }
     if ((window as any).clientExtension?.eventTarget) {
@@ -120,6 +123,7 @@ function apply(settings: UiSettings) {
                     xtermPalette: settings.xtermPalette,
                     footerMode: settings.footerMode,
                     fightTitleIcon: settings.fightTitleIcon,
+                    instantMapMove: settings.instantMapMove,
                 },
             })
         );
@@ -152,7 +156,8 @@ async function load(): Promise<UiSettings> {
             const explorationMode = !!parsed.explorationMode;
             const fightTitleIcon = typeof parsed.fightTitleIcon === 'boolean' ? parsed.fightTitleIcon : defaultSettings.fightTitleIcon;
             const hapticFeedback = typeof parsed.hapticFeedback === 'boolean' ? parsed.hapticFeedback : defaultSettings.hapticFeedback;
-            return { ...defaultSettings, ...parsed, mapScale, mapPosition, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode, fightTitleIcon, hapticFeedback };
+            const instantMapMove = typeof parsed.instantMapMove === 'boolean' ? parsed.instantMapMove : defaultSettings.instantMapMove;
+            return { ...defaultSettings, ...parsed, mapScale, mapPosition, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode, fightTitleIcon, hapticFeedback, instantMapMove };
         }
     } catch {
         // ignore malformed data
@@ -182,6 +187,7 @@ export default async function initUiSettings() {
     const hapticFeedbackInput = modalEl.querySelector('#ui-haptic-feedback') as HTMLInputElement;
     const emojiLabelsInput = modalEl.querySelector('#ui-emoji-labels') as HTMLInputElement;
     const fightTitleIconInput = modalEl.querySelector('#ui-fight-title-icon') as HTMLInputElement;
+    const instantMapMoveInput = modalEl.querySelector('#ui-instant-map-move') as HTMLInputElement;
     const xtermPaletteInput = modalEl.querySelector('#ui-xterm-palette') as HTMLSelectElement;
     const footerModeInput = modalEl.querySelector('#ui-footer-mode') as HTMLSelectElement;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
@@ -198,6 +204,7 @@ export default async function initUiSettings() {
     hapticFeedbackInput.checked = current.hapticFeedback;
     emojiLabelsInput.checked = current.emojiLabels;
     fightTitleIconInput.checked = current.fightTitleIcon;
+    instantMapMoveInput.checked = current.instantMapMove;
     xtermPaletteInput.value = current.xtermPalette;
     footerModeInput.value = String(current.footerMode);
     apply(current);
@@ -230,6 +237,7 @@ export default async function initUiSettings() {
             hapticFeedback: hapticFeedbackInput.checked,
             emojiLabels: emojiLabelsInput.checked,
             fightTitleIcon: fightTitleIconInput.checked,
+            instantMapMove: instantMapMoveInput.checked,
             xtermPalette: (xtermPaletteInput.value as 'arkadia' | 'proper') || defaultSettings.xtermPalette,
             footerMode: parseInt(footerModeInput.value) || defaultSettings.footerMode,
             explorationMode: explorationInput.checked,


### PR DESCRIPTION
## Summary
- add an "instant map move" checkbox to the Interfejs modal
- persist the preference, dispatch it with other UI settings, and forward it to the embedded map implementation for immediate centering

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build *(fails: PathFinder is not exported by mudlet-map-renderer)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c18a59b8832a89dfb5871028e634