### PR TITLE
Add instant map move control to UI settings

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -317,6 +317,7 @@
                             <option value="left">Lewa</option>
                         </select>
                     </label>
+                    <button type="button" class="btn btn-secondary" id="ui-map-instant-move">Włącz natychmiastowe przesuwanie mapy</button>
                     <label class="form-label d-flex align-items-center">
                         <input id="ui-exploration-mode" type="checkbox" class="form-check-input me-2" />
                         Tryb eksploracji mapy <span id="ui-exploration-stats" class="ms-1 text-muted"></span>

--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -307,6 +307,7 @@
                             <option value="left">Lewa</option>
                         </select>
                     </label>
+                    <button type="button" class="btn btn-secondary" id="ui-map-instant-move">Włącz natychmiastowe przesuwanie mapy</button>
                     <label class="form-label d-flex align-items-center">
                         <input id="ui-exploration-mode" type="checkbox" class="form-check-input me-2" />
                         Tryb eksploracji mapy <span id="ui-exploration-stats" class="ms-1 text-muted"></span>

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -1,4 +1,5 @@
 import Modal from "bootstrap/js/dist/modal";
+import { Settings } from "mudlet-map-renderer";
 
 const mapPositions = [
     'top-overlay',
@@ -184,6 +185,7 @@ export default async function initUiSettings() {
     const fightTitleIconInput = modalEl.querySelector('#ui-fight-title-icon') as HTMLInputElement;
     const xtermPaletteInput = modalEl.querySelector('#ui-xterm-palette') as HTMLSelectElement;
     const footerModeInput = modalEl.querySelector('#ui-footer-mode') as HTMLSelectElement;
+    const mapInstantMoveButton = modalEl.querySelector('#ui-map-instant-move') as HTMLButtonElement | null;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
 
     let current = await load();
@@ -201,6 +203,23 @@ export default async function initUiSettings() {
     xtermPaletteInput.value = current.xtermPalette;
     footerModeInput.value = String(current.footerMode);
     apply(current);
+
+    function updateInstantMoveButton() {
+        if (!mapInstantMoveButton) return;
+        if (Settings.instantMove) {
+            mapInstantMoveButton.disabled = true;
+            mapInstantMoveButton.textContent = 'Natychmiastowe przesuwanie mapy włączone';
+            mapInstantMoveButton.classList.remove('btn-secondary');
+            mapInstantMoveButton.classList.add('btn-success');
+        } else {
+            mapInstantMoveButton.disabled = false;
+            mapInstantMoveButton.textContent = 'Włącz natychmiastowe przesuwanie mapy';
+            mapInstantMoveButton.classList.remove('btn-success');
+            mapInstantMoveButton.classList.add('btn-secondary');
+        }
+    }
+
+    updateInstantMoveButton();
 
     function refreshExplorationStats() {
         const map = (window as any).embedded;
@@ -243,8 +262,16 @@ export default async function initUiSettings() {
         modal.hide();
     });
 
+    if (mapInstantMoveButton) {
+        mapInstantMoveButton.addEventListener('click', () => {
+            Settings.instantMove = true;
+            updateInstantMoveButton();
+        });
+    }
+
     button.addEventListener('click', () => {
         refreshExplorationStats();
+        updateInstantMoveButton();
         modal.show();
     });
 }


### PR DESCRIPTION
## Summary
- add an instant move button to the interface settings modal (and sandbox variant)
- hook the new control to set `Settings.instantMove` and update its visual state

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build *(fails: PathFinder is not exported by mudlet-map-renderer)*

------
https://chatgpt.com/codex/tasks/task_e_68e1cbea8044832a9095b6f9a5971fa3