### PR TITLE
Round stored map zoom to two decimals

### DIFF
--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -1,5 +1,6 @@
 import {MapReader, Renderer, PathFinder, Settings, RoomContextMenuEventDetail} from "mudlet-map-renderer";
 import {getCurrentCharacter, getItemSync, setItemSync} from "@client/src/storage";
+import {roundMapZoom} from "./utils/roundMapZoom";
 
 const STORAGE_KEY = 'mapperRoomId';
 const VISITED_DB_NAME = 'ArkadiaVisitedRoomsDB';
@@ -99,7 +100,7 @@ export class EmbeddedMap {
             const parsed = data?.uiSettings as any;
             if (parsed) {
                 if (typeof parsed.mapScale === 'number' && parsed.mapScale > 0) {
-                    zoom = parsed.mapScale;
+                    zoom = roundMapZoom(parsed.mapScale);
                 }
                 if (typeof parsed.explorationMode === 'boolean') {
                     explorationMode = parsed.explorationMode;
@@ -119,7 +120,7 @@ export class EmbeddedMap {
             }
         } catch {
         }
-        this.zoom = zoom;
+        this.zoom = roundMapZoom(zoom);
         this.renderer = new Renderer(this.map, this.reader);
         this.setExplorationMode(explorationMode);
         this.setInstantMove(instantMove);
@@ -156,15 +157,22 @@ export class EmbeddedMap {
         try {
             const data = getItemSync('uiSettings');
             const parsed: any = data?.uiSettings ? {...data.uiSettings} : {};
-            parsed.mapScale = this.zoom;
+            const roundedZoom = roundMapZoom(this.zoom);
+            this.zoom = roundedZoom;
+            parsed.mapScale = roundedZoom;
             setItemSync('uiSettings', parsed);
         } catch {
         }
     }
 
     private onZoom() {
-        let shouldSave = this.renderer.getZoom() !== this.zoom;
-        this.zoom = this.renderer.getZoom();
+        const rendererZoom = this.renderer.getZoom();
+        const roundedZoom = roundMapZoom(rendererZoom);
+        let shouldSave = roundedZoom !== this.zoom;
+        if (rendererZoom !== roundedZoom) {
+            this.renderer.setZoom(roundedZoom);
+        }
+        this.zoom = roundedZoom;
         if (shouldSave) {
             this.saveZoom();
         }
@@ -260,8 +268,9 @@ export class EmbeddedMap {
     }
 
     setZoom(zoom: number) {
-        this.zoom = zoom;
-        this.renderer.setZoom(zoom);
+        const rounded = roundMapZoom(zoom);
+        this.zoom = rounded;
+        this.renderer.setZoom(rounded);
     }
 
     setInstantMove(on: boolean) {

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -1,5 +1,6 @@
 import Modal from "bootstrap/js/dist/modal";
 import {Settings} from "mudlet-map-renderer";
+import {roundMapZoom} from "./utils/roundMapZoom";
 
 const mapPositions = [
     'top-overlay',
@@ -35,7 +36,7 @@ const defaultSettings: UiSettings = {
     contentFontSize: 0.775,
     objectsFontSize: 0.6,
     buttonSize: 1,
-    mapScale: 0.30,
+    mapScale: roundMapZoom(0.30),
     showButtons: true,
     hapticFeedback: true,
     mapHeight: typeof window !== 'undefined' && window.innerWidth < 768 ? 25 : 30,
@@ -147,7 +148,7 @@ async function load(): Promise<UiSettings> {
         if (raw || Object.keys(parsed).length > 0) {
             const mapScale = (() => {
                 const value = Math.abs(parseFloat(parsed.mapScale));
-                return value > 0 ? value : defaultSettings.mapScale;
+                return value > 0 ? roundMapZoom(value) : roundMapZoom(defaultSettings.mapScale);
             })();
             const mapPosition = mapPositions.includes(parsed.mapPosition as MapPosition)
                 ? (parsed.mapPosition as MapPosition)
@@ -167,7 +168,7 @@ async function load(): Promise<UiSettings> {
 }
 
 function save(settings: UiSettings) {
-    storage.setItem('uiSettings', settings);
+    storage.setItem('uiSettings', { ...settings, mapScale: roundMapZoom(settings.mapScale) });
 }
 
 export default async function initUiSettings() {
@@ -197,7 +198,7 @@ export default async function initUiSettings() {
     contentInput.value = String(current.contentFontSize);
     objectsInput.value = String(current.objectsFontSize);
     buttonInput.value = String(current.buttonSize);
-    mapInput.value = String(current.mapScale);
+    mapInput.value = String(roundMapZoom(current.mapScale));
     mapHeightInput.value = String(current.mapHeight);
     mapPositionInput.value = current.mapPosition;
     explorationInput.checked = current.explorationMode;
@@ -222,7 +223,7 @@ export default async function initUiSettings() {
     function read(): UiSettings {
         const mapScale = (() => {
             const value = Math.abs(parseFloat(mapInput.value));
-            const scale = value > 0 ? value : defaultSettings.mapScale;
+            const scale = value > 0 ? roundMapZoom(value) : roundMapZoom(defaultSettings.mapScale);
             mapInput.value = String(scale);
             return scale;
         })();

--- a/web-client/src/utils/roundMapZoom.ts
+++ b/web-client/src/utils/roundMapZoom.ts
@@ -1,0 +1,15 @@
+const MAP_ZOOM_DECIMALS = 2;
+
+function roundToDecimals(value: number, decimals: number): number {
+    if (!Number.isFinite(value)) {
+        return 0;
+    }
+    const factor = Math.pow(10, decimals);
+    return Math.round(value * factor) / factor;
+}
+
+export function roundMapZoom(value: number): number {
+    return roundToDecimals(value, MAP_ZOOM_DECIMALS);
+}
+
+export { MAP_ZOOM_DECIMALS };


### PR DESCRIPTION
## Summary
- round map zoom values to two decimal places when loading and saving settings
- reuse a shared helper to consistently round zoom values across the embedded map and UI settings

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68e1d7ee2d4c832a9c2af64e7c8c441b