### PR TITLE
Add UI toggle for map room highlight

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -290,6 +290,10 @@
                                     <label class="form-check-label" for="ui-instant-move">Natychmiastowe przechodzenie po mapie</label>
                                 </div>
                                 <div class="form-check">
+                                    <input id="ui-highlight-current-room" type="checkbox" class="form-check-input" />
+                                    <label class="form-check-label" for="ui-highlight-current-room">Podświetl bieżące pomieszczenie</label>
+                                </div>
+                                <div class="form-check">
                                     <input id="ui-exploration-mode" type="checkbox" class="form-check-input" />
                                     <label class="form-check-label" for="ui-exploration-mode">
                                         Tryb eksploracji mapy <span id="ui-exploration-stats" class="ms-1 text-muted"></span>

--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -280,6 +280,10 @@
                                     <label class="form-check-label" for="ui-instant-move">Natychmiastowe przechodzenie po mapie</label>
                                 </div>
                                 <div class="form-check">
+                                    <input id="ui-highlight-current-room" type="checkbox" class="form-check-input" />
+                                    <label class="form-check-label" for="ui-highlight-current-room">Podświetl bieżące pomieszczenie</label>
+                                </div>
+                                <div class="form-check">
                                     <input id="ui-exploration-mode" type="checkbox" class="form-check-input" />
                                     <label class="form-check-label" for="ui-exploration-mode">
                                         Tryb eksploracji mapy <span id="ui-exploration-stats" class="ms-1 text-muted"></span>

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -67,6 +67,7 @@ export class EmbeddedMap {
     private highlights: number[] = []
     private zoom: number;
     private explorationMode = false;
+    private highlightCurrentRoom = true;
     private visited = new Set<number>();
     private totalRooms: number;
 
@@ -94,6 +95,7 @@ export class EmbeddedMap {
         let zoom = 0.30;
         let explorationMode = false;
         let instantMove = false;
+        let highlightCurrentRoom = true;
         let initialRoom = startId ?? 1;
         try {
             const data = getItemSync('uiSettings');
@@ -107,6 +109,9 @@ export class EmbeddedMap {
                 }
                 if (typeof parsed.instantMove === 'boolean') {
                     instantMove = parsed.instantMove;
+                }
+                if (typeof parsed.highlightCurrentRoom === 'boolean') {
+                    highlightCurrentRoom = parsed.highlightCurrentRoom;
                 }
             }
         } catch {
@@ -124,6 +129,7 @@ export class EmbeddedMap {
         this.renderer = new Renderer(this.map, this.reader);
         this.setExplorationMode(explorationMode);
         this.setInstantMove(instantMove);
+        this.setHighlightCurrentRoom(highlightCurrentRoom);
 
         window.addEventListener('enterLocation', async (ev: any) => {
             const id = ev.detail.id;
@@ -194,6 +200,9 @@ export class EmbeddedMap {
 
     renderRoom(roomId: number) {
         this.renderer.setPosition(roomId)
+        if (!this.highlightCurrentRoom) {
+            this.renderer.clearPosition();
+        }
         this.renderer.setZoom(this.zoom);
         const area = this.renderer.getCurrentArea()
         this.currentRoom = roomId;
@@ -262,6 +271,22 @@ export class EmbeddedMap {
 
     setInstantMove(on: boolean) {
         Settings.instantMapMove = on;
+    }
+
+    setHighlightCurrentRoom(on: boolean) {
+        this.highlightCurrentRoom = on;
+        Settings.highlightCurrentRoom = on;
+        if (!on) {
+            this.renderer.clearPosition();
+            return;
+        }
+        if (typeof this.currentRoom === 'number') {
+            try {
+                this.renderer.renderPosition(this.currentRoom);
+            } catch {
+                // ignore rendering errors when room is not ready yet
+            }
+        }
     }
 
     leadTo(id?: string) {

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -30,6 +30,7 @@ interface UiSettings {
     footerMode: number;
     explorationMode: boolean;
     instantMove: boolean;
+    highlightCurrentRoom: boolean;
 }
 
 const defaultSettings: UiSettings = {
@@ -47,6 +48,7 @@ const defaultSettings: UiSettings = {
     footerMode: 0,
     explorationMode: false,
     instantMove: false,
+    highlightCurrentRoom: true,
 };
 
 function apply(settings: UiSettings) {
@@ -116,6 +118,8 @@ function apply(settings: UiSettings) {
     }
     Settings.instantMove = settings.instantMove;
     (window as any).embedded?.setInstantMove?.(settings.instantMove);
+    Settings.highlightCurrentRoom = settings.highlightCurrentRoom;
+    (window as any).embedded?.setHighlightCurrentRoom?.(settings.highlightCurrentRoom);
     if ((window as any).clientExtension?.eventTarget) {
         (window as any).clientExtension.eventTarget.dispatchEvent(
             new CustomEvent('uiSettings', {
@@ -159,7 +163,10 @@ async function load(): Promise<UiSettings> {
             const fightTitleIcon = typeof parsed.fightTitleIcon === 'boolean' ? parsed.fightTitleIcon : defaultSettings.fightTitleIcon;
             const hapticFeedback = typeof parsed.hapticFeedback === 'boolean' ? parsed.hapticFeedback : defaultSettings.hapticFeedback;
             const instantMove = typeof parsed.instantMove === 'boolean' ? parsed.instantMove : defaultSettings.instantMove;
-            return { ...defaultSettings, ...parsed, mapScale, mapPosition, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode, fightTitleIcon, hapticFeedback, instantMove };
+            const highlightCurrentRoom = typeof parsed.highlightCurrentRoom === 'boolean'
+                ? parsed.highlightCurrentRoom
+                : defaultSettings.highlightCurrentRoom;
+            return { ...defaultSettings, ...parsed, mapScale, mapPosition, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode, fightTitleIcon, hapticFeedback, instantMove, highlightCurrentRoom };
         }
     } catch {
         // ignore malformed data
@@ -192,6 +199,7 @@ export default async function initUiSettings() {
     const xtermPaletteInput = modalEl.querySelector('#ui-xterm-palette') as HTMLSelectElement;
     const footerModeInput = modalEl.querySelector('#ui-footer-mode') as HTMLSelectElement;
     const instantMoveInput = modalEl.querySelector('#ui-instant-move') as HTMLInputElement;
+    const highlightCurrentRoomInput = modalEl.querySelector('#ui-highlight-current-room') as HTMLInputElement;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
 
     let current = await load();
@@ -209,6 +217,7 @@ export default async function initUiSettings() {
     xtermPaletteInput.value = current.xtermPalette;
     footerModeInput.value = String(current.footerMode);
     instantMoveInput.checked = current.instantMove;
+    highlightCurrentRoomInput.checked = current.highlightCurrentRoom;
     apply(current);
 
     function refreshExplorationStats() {
@@ -243,6 +252,7 @@ export default async function initUiSettings() {
             footerMode: parseInt(footerModeInput.value) || defaultSettings.footerMode,
             explorationMode: explorationInput.checked,
             instantMove: instantMoveInput.checked,
+            highlightCurrentRoom: highlightCurrentRoomInput.checked,
         };
     }
 


### PR DESCRIPTION
## Summary
- add a "highlight current room" toggle to the map settings UI with a default on state
- persist the new preference and propagate it to the embedded map renderer
- update the embedded map logic so the current room highlight can be turned on and off at runtime

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build *(fails: PathFinder is not exported by mudlet-map-renderer)*

------
https://chatgpt.com/codex/tasks/task_e_68e24c5e9794832ab0e2ec5980cb0987