### PR TITLE
Add headers to context menus for map and herb popups

### DIFF
--- a/client/src/OutputHandler.ts
+++ b/client/src/OutputHandler.ts
@@ -26,9 +26,24 @@ export default class OutputHandler {
         }
     }
 
-    showContextMenu(items: { label: string; action: () => void }[], x: number, y: number) {
+    showContextMenu(
+        items: { label: string; action: () => void }[],
+        x: number,
+        y: number,
+        options?: { header?: string; smallHeader?: boolean }
+    ) {
         if (!this.contextMenu) return
         this.hideContextMenu()
+        const header = options?.header
+        if (header) {
+            const headerEl = document.createElement('div')
+            headerEl.className = 'context-menu-header'
+            if (options?.smallHeader) {
+                headerEl.classList.add('context-menu-header-small')
+            }
+            headerEl.textContent = header
+            this.contextMenu!.appendChild(headerEl)
+        }
         items.forEach(item => {
             const btn = document.createElement('button')
             btn.textContent = item.label

--- a/client/src/contextMenus.ts
+++ b/client/src/contextMenus.ts
@@ -70,7 +70,10 @@ export function openHerbContextMenu(client: Client, options: HerbMenuOptions) {
         return;
     }
 
-    client.OutputHandler.showContextMenu(items, x, y);
+    client.OutputHandler.showContextMenu(items, x, y, {
+        header: `Ziolo: ${herbId}`,
+        smallHeader: true,
+    });
 }
 
 export function openMapContextMenu(client: Client, roomId: number, x: number, y: number) {
@@ -89,5 +92,8 @@ export function openMapContextMenu(client: Client, roomId: number, x: number, y:
         },
     ];
 
-    client.OutputHandler.showContextMenu(items, x, y);
+    client.OutputHandler.showContextMenu(items, x, y, {
+        header: `Lokacja: ${roomId}`,
+        smallHeader: true,
+    });
 }

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -1128,6 +1128,24 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   align-items: stretch;
 }
 
+.context-menu-header {
+  align-self: stretch;
+  background: #1f1f1f;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.85);
+  pointer-events: none;
+}
+
+.context-menu-header-small {
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+}
+
 .context-menu button {
   display: inline-flex;
   align-items: center;
@@ -1156,6 +1174,16 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   .context-menu {
     padding: 0.5rem 0.6rem;
     border-radius: 0.5rem;
+  }
+
+  .context-menu-header {
+    font-size: 0.95rem;
+    padding: 0.45rem 0.9rem;
+  }
+
+  .context-menu-header-small {
+    font-size: 0.85rem;
+    padding: 0.35rem 0.8rem;
   }
 
   .context-menu button {


### PR DESCRIPTION
## Summary
- add optional headers (with small variant) to the shared context-menu renderer
- display the current location id and herb identifier in map and herb popups
- style the new context-menu headers for both desktop and mobile layouts

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68e253524d08832a9bfd797469dd0877