### PR TITLE
Synchronize UI settings map zoom with storage updates

### DIFF
--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -220,6 +220,29 @@ export default async function initUiSettings() {
     highlightCurrentRoomInput.checked = current.highlightCurrentRoom;
     apply(current);
 
+    const updateMapScale = (scale: number) => {
+        const rounded = roundMapZoom(scale);
+        mapInput.value = String(rounded);
+        current = { ...current, mapScale: rounded };
+    };
+
+    const handleStorageChange = (changes: { [key: string]: { oldValue: any; newValue: any } }) => {
+        const uiSettingsChange = changes.uiSettings;
+        if (!uiSettingsChange || !uiSettingsChange.newValue) {
+            return;
+        }
+        const newValue = uiSettingsChange.newValue;
+        const scaleValue = typeof newValue.mapScale === 'number'
+            ? newValue.mapScale
+            : parseFloat(newValue.mapScale);
+        const normalizedScale = Number.isFinite(scaleValue) && scaleValue > 0
+            ? scaleValue
+            : defaultSettings.mapScale;
+        updateMapScale(normalizedScale);
+    };
+
+    storage.onChanged?.addListener(handleStorageChange);
+
     function refreshExplorationStats() {
         const map = (window as any).embedded;
         if (map?.getVisitedCount && map?.getRoomCount && explorationStats) {


### PR DESCRIPTION
## Summary
- update the UI settings modal to keep the map scale input in sync with storage changes
- normalize and persist the latest zoom level when the map is adjusted outside the modal

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68e25a1b0c24832ab65eefe0b83e39a1