### PR TITLE
Ensure context menus stay within the viewport

### DIFF
--- a/client/src/OutputHandler.ts
+++ b/client/src/OutputHandler.ts
@@ -23,6 +23,7 @@ export default class OutputHandler {
         if (this.contextMenu) {
             this.contextMenu.classList.remove('show')
             this.contextMenu.innerHTML = ''
+            this.contextMenu.style.visibility = ''
         }
     }
 
@@ -53,9 +54,30 @@ export default class OutputHandler {
             }
             this.contextMenu!.appendChild(btn)
         })
-        this.contextMenu.style.left = `${x}px`
-        this.contextMenu.style.top = `${y}px`
-        this.contextMenu.classList.add('show')
+        const menu = this.contextMenu
+        menu.style.left = `0px`
+        menu.style.top = `0px`
+        menu.style.visibility = 'hidden'
+        menu.classList.add('show')
+
+        const rect = menu.getBoundingClientRect()
+        const viewportWidth = document.documentElement?.clientWidth ?? window.innerWidth ?? 0
+        const viewportHeight = document.documentElement?.clientHeight ?? window.innerHeight ?? 0
+
+        let left = x
+        let top = y
+
+        if (left + rect.width > viewportWidth) {
+            left = Math.max(0, viewportWidth - rect.width)
+        }
+
+        if (top + rect.height > viewportHeight) {
+            top = Math.max(0, viewportHeight - rect.height)
+        }
+
+        menu.style.left = `${left}px`
+        menu.style.top = `${top}px`
+        menu.style.visibility = ''
     }
 
     private decorateClickable(span: HTMLElement, cbIndex: number, title?: string) {

--- a/client/test/OutputHandler.test.ts
+++ b/client/test/OutputHandler.test.ts
@@ -131,3 +131,76 @@ describe('OutputHandler clickable text', () => {
     expect(cb).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('OutputHandler context menu positioning', () => {
+  test('repositions context menu to stay within viewport', () => {
+    document.body.innerHTML =
+      '<div id="main_text_output_msg_wrapper"><div id="split-bottom"></div></div><div id="context-menu"></div>';
+    const client = new FakeClient();
+    const handler = new OutputHandler((client as unknown) as any);
+    const menu = document.getElementById('context-menu') as HTMLElement;
+
+    const originalWidthDescriptor = Object.getOwnPropertyDescriptor(
+      document.documentElement,
+      'clientWidth'
+    );
+    const originalHeightDescriptor = Object.getOwnPropertyDescriptor(
+      document.documentElement,
+      'clientHeight'
+    );
+
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(document.documentElement, 'clientHeight', {
+      configurable: true,
+      value: 800,
+    });
+
+    const rect = {
+      width: 250,
+      height: 150,
+      top: 0,
+      left: 0,
+      right: 250,
+      bottom: 150,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect;
+    const getBoundingClientRectSpy = jest
+      .spyOn(menu, 'getBoundingClientRect')
+      .mockReturnValue(rect);
+
+    handler.showContextMenu(
+      [
+        {
+          label: 'Action',
+          action: jest.fn(),
+        },
+      ],
+      900,
+      700
+    );
+
+    expect(menu.style.left).toBe('750px');
+    expect(menu.style.top).toBe('650px');
+    expect(menu.classList.contains('show')).toBe(true);
+    expect(menu.style.visibility).toBe('');
+
+    if (originalWidthDescriptor) {
+      Object.defineProperty(document.documentElement, 'clientWidth', originalWidthDescriptor);
+    } else {
+      delete (document.documentElement as any).clientWidth;
+    }
+
+    if (originalHeightDescriptor) {
+      Object.defineProperty(document.documentElement, 'clientHeight', originalHeightDescriptor);
+    } else {
+      delete (document.documentElement as any).clientHeight;
+    }
+
+    getBoundingClientRectSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- adjust context menu rendering to clamp its position within the viewport
- cover the positioning behaviour with a dedicated unit test

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68e2a176f4f0832a910379a47a0eb543