### PR TITLE
Add movable /list letter composer alias

### DIFF
--- a/client/src/eventBus.ts
+++ b/client/src/eventBus.ts
@@ -17,7 +17,7 @@ export interface KnownEvents {
     'enterLocation': { id: number; room: any };
     'multibinds': { list: { index: number; action: string; label: string }[] };
     'letterComposer': { open: boolean };
-    'letterComposer.submit': { to: string; cc: string; content: string };
+    'letterComposer.submit': { to: string; cc: string; subject: string; content: string };
     'npc': any;
     'zaskTimer': { seconds: number; ok: boolean } | null;
     'moveModeChanged': number;

--- a/client/src/eventBus.ts
+++ b/client/src/eventBus.ts
@@ -16,6 +16,8 @@ export interface KnownEvents {
     'contentWidth': number;
     'enterLocation': { id: number; room: any };
     'multibinds': { list: { index: number; action: string; label: string }[] };
+    'letterComposer': { open: boolean };
+    'letterComposer.submit': { to: string; cc: string; content: string };
     'npc': any;
     'zaskTimer': { seconds: number; ok: boolean } | null;
     'moveModeChanged': number;

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -77,6 +77,7 @@ import initLanguage from './scripts/language'
 import initIdleFullHp from './scripts/idleFullHp'
 import initFullHpTimer from './scripts/fullHpTimer'
 import initNoExitHighlight from './scripts/noExitHighlight'
+import initLetter from './scripts/letter'
 import Client from "./Client";
 
 
@@ -202,6 +203,7 @@ export function registerScripts(client: Client) {
     initGuildPostfix(client)
     initLanguage(client, aliases)
     initShortcuts(client, aliases)
+    initLetter(client, aliases)
     initShortExits(client)
     initExternalScripts(client)
     initUserAliases(client, aliases)

--- a/client/src/scripts/letter.ts
+++ b/client/src/scripts/letter.ts
@@ -61,7 +61,7 @@ export default function initLetter(client: Client, aliases?: { pattern: RegExp; 
 
         client.sendCommand("napisz list");
         client.sendCommand(recipient);
-        client.sendCommand(carbonCopy);
         client.sendCommand(subjectLine);
+        client.sendCommand(carbonCopy);
     });
 }

--- a/client/src/scripts/letter.ts
+++ b/client/src/scripts/letter.ts
@@ -1,0 +1,68 @@
+import Client from "../Client";
+
+const PROMPT_PATTERN = /Wpisz ~\?, zeby uzyskac pomoc, lub \*\*, by zakonczyc edycje\./;
+const TRIGGER_TAG = "letter-composer";
+
+interface LetterSubmitPayload {
+    to: string;
+    cc: string;
+    content: string;
+}
+
+function justifyLine(line: string) {
+    return line
+        .replace(/\s+/g, " ")
+        .trim();
+}
+
+export default function initLetter(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
+    if (aliases) {
+        aliases.push({
+            pattern: /^\/list$/,
+            callback: () => {
+                client.sendEvent("letterComposer", { open: true });
+            }
+        });
+    }
+
+    client.addEventListener("letterComposer.submit", (event: CustomEvent<LetterSubmitPayload>) => {
+        const { to, cc, content } = event.detail;
+        const recipient = to.trim();
+        const carbonCopy = cc.trim();
+        const lines = content
+            .split(/\r?\n/)
+            .map(line => justifyLine(line))
+            .filter((line, index, arr) => {
+                if (line.length > 0) {
+                    return true;
+                }
+                // Preserve intentional blank lines between non-empty content
+                const prev = index > 0 ? arr[index - 1] : "";
+                const next = index < arr.length - 1 ? arr[index + 1] : "";
+                return prev.length > 0 && next.length > 0;
+            });
+
+        client.Triggers.removeByTag(TRIGGER_TAG);
+        client.Triggers.registerOneTimeTrigger(
+            PROMPT_PATTERN,
+            () => {
+                if (recipient) {
+                    client.sendCommand(`do ${recipient}`);
+                }
+                if (carbonCopy) {
+                    client.sendCommand(`cc ${carbonCopy}`);
+                }
+                lines.forEach(line => {
+                    if (line.length > 0) {
+                        client.sendCommand(line);
+                    }
+                });
+                client.sendCommand("**");
+                return undefined;
+            },
+            TRIGGER_TAG
+        );
+
+        client.sendCommand("napisz list");
+    });
+}

--- a/client/src/scripts/letter.ts
+++ b/client/src/scripts/letter.ts
@@ -6,6 +6,7 @@ const TRIGGER_TAG = "letter-composer";
 interface LetterSubmitPayload {
     to: string;
     cc: string;
+    subject: string;
     content: string;
 }
 
@@ -26,9 +27,10 @@ export default function initLetter(client: Client, aliases?: { pattern: RegExp; 
     }
 
     client.addEventListener("letterComposer.submit", (event: CustomEvent<LetterSubmitPayload>) => {
-        const { to, cc, content } = event.detail;
+        const { to, cc, subject, content } = event.detail;
         const recipient = to.trim();
         const carbonCopy = cc.trim();
+        const subjectLine = subject.trim();
         const lines = content
             .split(/\r?\n/)
             .map(line => justifyLine(line))
@@ -46,12 +48,6 @@ export default function initLetter(client: Client, aliases?: { pattern: RegExp; 
         client.Triggers.registerOneTimeTrigger(
             PROMPT_PATTERN,
             () => {
-                if (recipient) {
-                    client.sendCommand(`do ${recipient}`);
-                }
-                if (carbonCopy) {
-                    client.sendCommand(`cc ${carbonCopy}`);
-                }
                 lines.forEach(line => {
                     if (line.length > 0) {
                         client.sendCommand(line);
@@ -63,6 +59,15 @@ export default function initLetter(client: Client, aliases?: { pattern: RegExp; 
             TRIGGER_TAG
         );
 
+        if (recipient) {
+            client.sendCommand(`do ${recipient}`);
+        }
+        if (carbonCopy) {
+            client.sendCommand(`cc ${carbonCopy}`);
+        }
+        if (subjectLine) {
+            client.sendCommand(`temat ${subjectLine}`);
+        }
         client.sendCommand("napisz list");
     });
 }

--- a/client/src/scripts/letter.ts
+++ b/client/src/scripts/letter.ts
@@ -59,15 +59,9 @@ export default function initLetter(client: Client, aliases?: { pattern: RegExp; 
             TRIGGER_TAG
         );
 
-        if (recipient) {
-            client.sendCommand(`do ${recipient}`);
-        }
-        if (carbonCopy) {
-            client.sendCommand(`cc ${carbonCopy}`);
-        }
-        if (subjectLine) {
-            client.sendCommand(`temat ${subjectLine}`);
-        }
         client.sendCommand("napisz list");
+        client.sendCommand(recipient);
+        client.sendCommand(carbonCopy);
+        client.sendCommand(subjectLine);
     });
 }

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -513,7 +513,7 @@
         </div>
         <div class="letter-composer-field">
             <label for="letter-content" class="form-label">Treść:</label>
-            <textarea id="letter-content" name="letter-content" class="form-control" rows="12"></textarea>
+            <textarea id="letter-content" name="letter-content" class="form-control" rows="10"></textarea>
         </div>
         <div class="letter-composer-actions">
             <button type="submit" class="btn btn-primary btn-sm">Wyślij</button>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -493,6 +493,29 @@
         <div id="idz-buttons-list" class="mobile-idz-buttons"></div>
     </div>
 </div>
+<div id="letter-composer" class="letter-composer" hidden>
+    <div class="letter-composer-header">
+        <span>Nowy list</span>
+        <button type="button" class="btn-close btn-close-white" aria-label="Zamknij" data-letter-close></button>
+    </div>
+    <form class="letter-composer-form">
+        <div class="letter-composer-field">
+            <label for="letter-to" class="form-label">Do:</label>
+            <input id="letter-to" name="letter-to" class="form-control form-control-sm" type="text" autocomplete="off">
+        </div>
+        <div class="letter-composer-field">
+            <label for="letter-cc" class="form-label">CC:</label>
+            <input id="letter-cc" name="letter-cc" class="form-control form-control-sm" type="text" autocomplete="off">
+        </div>
+        <div class="letter-composer-field">
+            <label for="letter-content" class="form-label">Treść:</label>
+            <textarea id="letter-content" name="letter-content" class="form-control" rows="6"></textarea>
+        </div>
+        <div class="letter-composer-actions">
+            <button type="submit" class="btn btn-primary btn-sm">Wyślij</button>
+        </div>
+    </form>
+</div>
 <div id="context-menu" class="context-menu"></div>
 <script src="/pako.min.js"></script>
 <script type="module" src="/src/plugin.ts"></script>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -508,6 +508,10 @@
             <input id="letter-cc" name="letter-cc" class="form-control form-control-sm" type="text" autocomplete="off">
         </div>
         <div class="letter-composer-field">
+            <label for="letter-subject" class="form-label">Temat:</label>
+            <input id="letter-subject" name="letter-subject" class="form-control form-control-sm" type="text" autocomplete="off">
+        </div>
+        <div class="letter-composer-field">
             <label for="letter-content" class="form-label">Treść:</label>
             <textarea id="letter-content" name="letter-content" class="form-control" rows="6"></textarea>
         </div>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -513,7 +513,7 @@
         </div>
         <div class="letter-composer-field">
             <label for="letter-content" class="form-label">Treść:</label>
-            <textarea id="letter-content" name="letter-content" class="form-control" rows="6"></textarea>
+            <textarea id="letter-content" name="letter-content" class="form-control" rows="12"></textarea>
         </div>
         <div class="letter-composer-actions">
             <button type="submit" class="btn btn-primary btn-sm">Wyślij</button>

--- a/web-client/src/LetterComposer.ts
+++ b/web-client/src/LetterComposer.ts
@@ -99,6 +99,10 @@ export default class LetterComposer {
         if (event.button !== 0 && event.pointerType !== "touch" && event.pointerType !== "pen") {
             return;
         }
+        const target = event.target as HTMLElement | null;
+        if (target?.closest("[data-letter-close]")) {
+            return;
+        }
         this.dragPointerId = event.pointerId;
         const rect = this.container.getBoundingClientRect();
         this.dragOffsetX = event.clientX - rect.left;

--- a/web-client/src/LetterComposer.ts
+++ b/web-client/src/LetterComposer.ts
@@ -1,0 +1,137 @@
+import ArkadiaClient from "./ArkadiaClient.ts";
+
+interface LetterComposerState {
+    hasCustomPosition: boolean;
+}
+
+interface SubmitPayload {
+    to: string;
+    cc: string;
+    content: string;
+}
+
+export default class LetterComposer {
+    private container: HTMLElement | null;
+    private header: HTMLElement | null;
+    private form: HTMLFormElement | null;
+    private toInput: HTMLInputElement | null;
+    private ccInput: HTMLInputElement | null;
+    private contentInput: HTMLTextAreaElement | null;
+    private closeButton: HTMLButtonElement | null;
+    private dragPointerId: number | null = null;
+    private dragOffsetX = 0;
+    private dragOffsetY = 0;
+    private state: LetterComposerState = { hasCustomPosition: false };
+
+    constructor(private client: typeof ArkadiaClient) {
+        this.container = document.getElementById("letter-composer");
+        this.header = this.container?.querySelector<HTMLElement>(".letter-composer-header");
+        this.form = this.container?.querySelector<HTMLFormElement>("form");
+        this.toInput = this.container?.querySelector<HTMLInputElement>("[name='letter-to']");
+        this.ccInput = this.container?.querySelector<HTMLInputElement>("[name='letter-cc']");
+        this.contentInput = this.container?.querySelector<HTMLTextAreaElement>("[name='letter-content']");
+        this.closeButton = this.container?.querySelector<HTMLButtonElement>("[data-letter-close]");
+
+        this.attachListeners();
+        this.client.on("letterComposer", () => this.show());
+    }
+
+    private attachListeners() {
+        if (this.form) {
+            this.form.addEventListener("submit", ev => {
+                ev.preventDefault();
+                const payload: SubmitPayload = {
+                    to: this.toInput?.value ?? "",
+                    cc: this.ccInput?.value ?? "",
+                    content: this.contentInput?.value ?? "",
+                };
+                this.client.emit("letterComposer.submit", payload);
+                this.hide();
+                this.form?.reset();
+            });
+        }
+
+        if (this.closeButton) {
+            this.closeButton.addEventListener("click", () => this.hide());
+        }
+
+        if (this.header && this.container) {
+            this.header.addEventListener("pointerdown", ev => this.startDrag(ev));
+        }
+    }
+
+    private show() {
+        if (!this.container) {
+            return;
+        }
+        this.container.hidden = false;
+        requestAnimationFrame(() => {
+            if (!this.state.hasCustomPosition) {
+                this.center();
+            }
+            this.toInput?.focus();
+        });
+    }
+
+    private hide() {
+        if (!this.container) {
+            return;
+        }
+        this.container.hidden = true;
+    }
+
+    private center() {
+        if (!this.container) {
+            return;
+        }
+        const width = this.container.offsetWidth || 420;
+        const height = this.container.offsetHeight || 320;
+        const left = Math.max(16, (window.innerWidth - width) / 2);
+        const top = Math.max(16, (window.innerHeight - height) / 4);
+        this.container.style.left = `${left}px`;
+        this.container.style.top = `${top}px`;
+    }
+
+    private startDrag(event: PointerEvent) {
+        if (!this.container || !this.header) {
+            return;
+        }
+        if (event.button !== 0 && event.pointerType !== "touch" && event.pointerType !== "pen") {
+            return;
+        }
+        this.dragPointerId = event.pointerId;
+        const rect = this.container.getBoundingClientRect();
+        this.dragOffsetX = event.clientX - rect.left;
+        this.dragOffsetY = event.clientY - rect.top;
+        this.header.setPointerCapture(event.pointerId);
+        document.addEventListener("pointermove", this.handlePointerMove);
+        document.addEventListener("pointerup", this.handlePointerUp);
+    }
+
+    private handlePointerMove = (event: PointerEvent) => {
+        if (!this.container || this.dragPointerId !== event.pointerId) {
+            return;
+        }
+        const maxLeft = Math.max(0, window.innerWidth - this.container.offsetWidth);
+        const maxTop = Math.max(0, window.innerHeight - this.container.offsetHeight);
+        let left = event.clientX - this.dragOffsetX;
+        let top = event.clientY - this.dragOffsetY;
+        left = Math.min(Math.max(0, left), maxLeft);
+        top = Math.min(Math.max(0, top), maxTop);
+        this.container.style.left = `${left}px`;
+        this.container.style.top = `${top}px`;
+        this.state.hasCustomPosition = true;
+    };
+
+    private handlePointerUp = (event: PointerEvent) => {
+        if (this.dragPointerId !== event.pointerId) {
+            return;
+        }
+        this.dragPointerId = null;
+        if (this.header) {
+            this.header.releasePointerCapture(event.pointerId);
+        }
+        document.removeEventListener("pointermove", this.handlePointerMove);
+        document.removeEventListener("pointerup", this.handlePointerUp);
+    };
+}

--- a/web-client/src/LetterComposer.ts
+++ b/web-client/src/LetterComposer.ts
@@ -7,6 +7,7 @@ interface LetterComposerState {
 interface SubmitPayload {
     to: string;
     cc: string;
+    subject: string;
     content: string;
 }
 
@@ -16,6 +17,7 @@ export default class LetterComposer {
     private form: HTMLFormElement | null;
     private toInput: HTMLInputElement | null;
     private ccInput: HTMLInputElement | null;
+    private subjectInput: HTMLInputElement | null;
     private contentInput: HTMLTextAreaElement | null;
     private closeButton: HTMLButtonElement | null;
     private dragPointerId: number | null = null;
@@ -29,6 +31,7 @@ export default class LetterComposer {
         this.form = this.container?.querySelector<HTMLFormElement>("form");
         this.toInput = this.container?.querySelector<HTMLInputElement>("[name='letter-to']");
         this.ccInput = this.container?.querySelector<HTMLInputElement>("[name='letter-cc']");
+        this.subjectInput = this.container?.querySelector<HTMLInputElement>("[name='letter-subject']");
         this.contentInput = this.container?.querySelector<HTMLTextAreaElement>("[name='letter-content']");
         this.closeButton = this.container?.querySelector<HTMLButtonElement>("[data-letter-close]");
 
@@ -43,6 +46,7 @@ export default class LetterComposer {
                 const payload: SubmitPayload = {
                     to: this.toInput?.value ?? "",
                     cc: this.ccInput?.value ?? "",
+                    subject: this.subjectInput?.value ?? "",
                     content: this.contentInput?.value ?? "",
                 };
                 this.client.emit("letterComposer.submit", payload);

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -17,6 +17,7 @@ import AttackMode from "./AttackMode";
 import FightTitle from "./FightTitle";
 import HpTitle from "./HpTitle";
 import initSessionLogger from "./sessionLogger";
+import LetterComposer from "./LetterComposer";
 
 import "@client/src/main.ts"
 import MockPort from "./MockPort.ts";
@@ -947,6 +948,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const fightTitle = new FightTitle(arkadiaClient);
     new HpTitle(arkadiaClient, fightTitle);
     new ObjectList(client);
+    new LetterComposer(arkadiaClient);
 
     // Initialize mobile direction buttons
     new MobileDirectionButtons(client);

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -914,8 +914,9 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   position: fixed;
   top: 4rem;
   left: 4rem;
-  width: min(28rem, 90vw);
-  max-height: min(32rem, 90vh);
+  width: min(32rem, 90vw);
+  min-height: 22rem;
+  max-height: min(40rem, 90vh);
   background-color: rgba(17, 19, 23, 0.95);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 0.5rem;
@@ -923,6 +924,8 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   color: #f8f9fa;
   z-index: 1100;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .letter-composer[hidden] {
@@ -972,6 +975,9 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   flex-direction: column;
   gap: 0.75rem;
   padding: 0.75rem;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .letter-composer-field {
@@ -982,12 +988,14 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
 
 .letter-composer textarea {
   resize: vertical;
-  min-height: 8rem;
+  min-height: 12rem;
 }
 
 .letter-composer-actions {
   display: flex;
   justify-content: flex-end;
+  margin-top: auto;
+  padding-top: 0.5rem;
 }
 
 .docs-content {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -954,6 +954,7 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   background-position: center;
   background-repeat: no-repeat;
   background-size: 0.9rem;
+  filter: none;
   opacity: 0.9;
   background-color: rgba(255, 255, 255, 0.08);
   transition: opacity 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -949,16 +949,19 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   height: 1.75rem;
   border-radius: 999px;
   padding: 0;
-  filter: invert(1) brightness(1.6);
-  opacity: 0.85;
+  --letter-composer-close-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='%23ffffff' stroke-linecap='round' stroke-width='1.5' d='M3.75 3.75l8.5 8.5m0-8.5l-8.5 8.5'/%3E%3C/svg%3E");
+  background-image: var(--letter-composer-close-icon);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 0.9rem;
+  opacity: 0.9;
   background-color: rgba(255, 255, 255, 0.08);
-  transition: opacity 0.2s ease, background-color 0.2s ease;
+  transition: opacity 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .letter-composer .btn-close:hover,
 .letter-composer .btn-close:focus-visible {
   opacity: 1;
-  filter: invert(1) brightness(2);
   background-color: rgba(255, 255, 255, 0.2);
   box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.35);
 }

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -910,6 +910,63 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   pointer-events: none;
 }
 
+.letter-composer {
+  position: fixed;
+  top: 4rem;
+  left: 4rem;
+  width: min(28rem, 90vw);
+  max-height: min(32rem, 90vh);
+  background-color: rgba(17, 19, 23, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.5rem;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.5);
+  color: #f8f9fa;
+  z-index: 1100;
+  overflow: hidden;
+}
+
+.letter-composer[hidden] {
+  display: none !important;
+}
+
+.letter-composer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background-color: rgba(0, 0, 0, 0.35);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  cursor: move;
+}
+
+.letter-composer-header span {
+  font-weight: 600;
+}
+
+.letter-composer-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+.letter-composer-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.letter-composer textarea {
+  resize: vertical;
+  min-height: 8rem;
+}
+
+.letter-composer-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .docs-content {
   flex: 1;
   overflow-y: auto;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -988,7 +988,7 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
 
 .letter-composer textarea {
   resize: vertical;
-  min-height: 12rem;
+  min-height: 10rem;
 }
 
 .letter-composer-actions {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -944,6 +944,24 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   font-weight: 600;
 }
 
+.letter-composer .btn-close {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  padding: 0;
+  filter: invert(1);
+  opacity: 0.8;
+  background-color: rgba(255, 255, 255, 0.08);
+  transition: opacity 0.2s ease, background-color 0.2s ease;
+}
+
+.letter-composer .btn-close:hover,
+.letter-composer .btn-close:focus-visible {
+  opacity: 1;
+  background-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.35);
+}
+
 .letter-composer-form {
   display: flex;
   flex-direction: column;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -949,8 +949,8 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   height: 1.75rem;
   border-radius: 999px;
   padding: 0;
-  filter: invert(1);
-  opacity: 0.8;
+  filter: invert(1) brightness(1.6);
+  opacity: 0.85;
   background-color: rgba(255, 255, 255, 0.08);
   transition: opacity 0.2s ease, background-color 0.2s ease;
 }
@@ -958,6 +958,7 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
 .letter-composer .btn-close:hover,
 .letter-composer .btn-close:focus-visible {
   opacity: 1;
+  filter: invert(1) brightness(2);
   background-color: rgba(255, 255, 255, 0.2);
   box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.35);
 }


### PR DESCRIPTION
## Summary
- add a new /list alias that opens a letter composer and queues the proper commands when sending
- expose letter composer events on the shared bus and wire the popup into the web client
- build a draggable letter composer popup with styling and submission handling

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build *(fails: PathFinder is not exported by mudlet-map-renderer)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d859ebbc832aba9e2c7f40814145