### PR TITLE
Add attack queue support and aliases

### DIFF
--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -44,14 +44,22 @@ export default class TeamManager {
     private avatarAttackTargetId?: string
     private attackTargetId?: string
     private defenseTargetId?: string
+    private enemies: string[] = [];
+    private currentLocationSignature?: string;
 
     constructor(client: Client) {
         this.client = client;
         this.client.addEventListener('gmcp.objects.data', (e: CustomEvent) => {
             this.handleObjectsData(e.detail);
         });
+        this.client.addEventListener('gmcp.objects.nums', (e: CustomEvent) => {
+            this.handleObjectsNums(e.detail);
+        });
         this.client.addEventListener('gmcp.char.info', (e: CustomEvent) => {
             this.playerNum = String(e.detail.object_num);
+        });
+        this.client.addEventListener('gmcp.room.info', (e: CustomEvent) => {
+            this.handleRoomInfo(e.detail);
         });
         if (typeof (this.client as any).Triggers?.registerTrigger === 'function') {
             this.registerTriggers();
@@ -86,11 +94,45 @@ export default class TeamManager {
             if (id === this.playerNum && obj.attack_num !== undefined) {
                 this.avatarAttackTargetId = typeof obj.attack_num == "boolean" ? undefined : String(obj.attack_num)
             }
+            if (obj?.living === false) {
+                this.removeEnemyFromQueue(id);
+            }
         });
         if (this.leaderAttackTargetId && this.avatarAttackTargetId !== this.leaderAttackTargetId) {
             this.client.sendEvent('teamLeaderTargetNoAvatar', this.leaderAttackTargetId);
         } else  {
             this.client.sendEvent('teamLeaderTargetAvatar');
+        }
+    }
+
+    private handleObjectsNums(detail: any) {
+        if (this.enemies.length === 0) {
+            return;
+        }
+        let nums: string[] | null = null;
+        if (Array.isArray(detail)) {
+            nums = detail.map(String);
+        } else if (detail && Array.isArray(detail.nums)) {
+            nums = detail.nums.map(String);
+        } else if (detail && Array.isArray(detail.objects)) {
+            nums = detail.objects.map(String);
+        }
+        if (!nums) {
+            return;
+        }
+        const allowed = new Set(nums);
+        if (this.enemies.some(id => !allowed.has(id))) {
+            this.enemies = this.enemies.filter(id => allowed.has(id));
+        }
+    }
+
+    private handleRoomInfo(detail: any) {
+        const signature = typeof detail === 'object' && detail !== null
+            ? String(detail?.num ?? detail?.id ?? detail?.hash ?? JSON.stringify(detail))
+            : String(detail ?? '');
+        if (this.currentLocationSignature !== signature) {
+            this.currentLocationSignature = signature;
+            this.clearEnemyQueue();
         }
     }
 
@@ -224,6 +266,7 @@ export default class TeamManager {
         if (hadMembers) {
             this.client.sendEvent('teamChange');
         }
+        this.clearEnemyQueue();
     }
 
     getAccumulatedObjectsData() {
@@ -242,6 +285,40 @@ export default class TeamManager {
         return this.avatarAttackTargetId;
     }
 
+    addEnemyToQueue(id: string): boolean {
+        const normalized = String(id);
+        if (!normalized) {
+            return false;
+        }
+        if (this.enemies.includes(normalized)) {
+            return false;
+        }
+        this.enemies.push(normalized);
+        return true;
+    }
 
+    removeEnemyFromQueue(id: string): boolean {
+        const normalized = String(id);
+        const index = this.enemies.indexOf(normalized);
+        if (index === -1) {
+            return false;
+        }
+        this.enemies.splice(index, 1);
+        return true;
+    }
 
+    shiftEnemyFromQueue(): string | undefined {
+        return this.enemies.shift();
+    }
+
+    getEnemyQueue(): string[] {
+        return [...this.enemies];
+    }
+
+    private clearEnemyQueue() {
+        if (this.enemies.length === 0) {
+            return;
+        }
+        this.enemies = [];
+    }
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -8,6 +8,7 @@ import initBuses from './scripts/buses'
 import initGates from './scripts/gates'
 import initSeat from './scripts/seat'
 import initAttackBeep from './scripts/attackBeep'
+import initAttackQueue from './scripts/attackQueue'
 import initLamp from './scripts/lamp'
 import initCoverTimer from './scripts/coverTimer'
 import initZaskTimer from './scripts/zaskTimer'
@@ -137,6 +138,7 @@ export function registerScripts(client: Client) {
     initGates(client)
     initSeat(client)
     initAttackBeep(client)
+    initAttackQueue(client, aliases)
     initLamp(client)
     initCoverTimer(client)
     initZaskTimer(client)

--- a/client/src/scripts/attackQueue.ts
+++ b/client/src/scripts/attackQueue.ts
@@ -1,0 +1,56 @@
+import Client from "../Client";
+
+function normalizeId(input: string): string | null {
+    if (!input) {
+        return null;
+    }
+    const trimmed = input.trim();
+    if (trimmed === "") {
+        return null;
+    }
+    const withoutPrefix = trimmed.startsWith("ob_") ? trimmed.slice(3) : trimmed;
+    if (!/^[0-9]+$/.test(withoutPrefix)) {
+        return null;
+    }
+    return withoutPrefix;
+}
+
+export default function initAttackQueue(
+    client: Client,
+    aliases?: { pattern: RegExp; callback: Function }[]
+) {
+    const list = aliases ?? client.aliases;
+
+    const add = (matches: RegExpMatchArray) => {
+        const id = normalizeId(matches[1] ?? matches[0]);
+        if (!id) {
+            client.println("Niepoprawne id przeciwnika.");
+            return;
+        }
+        const added = client.TeamManager.addEnemyToQueue(id);
+        if (added) {
+            client.println(`Dodano ob_${id} do kolejki ataku.`);
+        } else {
+            client.println(`ob_${id} jest juz w kolejce ataku.`);
+        }
+    };
+
+    const killNext = () => {
+        const next = client.TeamManager.shiftEnemyFromQueue();
+        if (!next) {
+            client.println("Kolejka ataku jest pusta.");
+            return;
+        }
+        client.sendCommand(`zabij ob_${next}`);
+    };
+
+    list.push({
+        pattern: /^\/q\s+(?:ob_)?([0-9]+)$/,
+        callback: (matches: RegExpMatchArray) => add(matches),
+    });
+
+    list.push({
+        pattern: /^\/nn$/,
+        callback: killNext,
+    });
+}

--- a/client/test/TeamManager.test.ts
+++ b/client/test/TeamManager.test.ts
@@ -180,4 +180,31 @@ describe('TeamManager', () => {
     expect(manager.getAvatarAttackTargetId()).toBe('4');
   });
 
+  test('manages attack queue entries', () => {
+    expect(manager.addEnemyToQueue('5')).toBe(true);
+    expect(manager.addEnemyToQueue('5')).toBe(false);
+    expect(manager.getEnemyQueue()).toEqual(['5']);
+    expect(manager.shiftEnemyFromQueue()).toBe('5');
+    expect(manager.shiftEnemyFromQueue()).toBeUndefined();
+  });
+
+  test('removes enemies missing from gmcp objects nums', () => {
+    manager.addEnemyToQueue('5');
+    manager.addEnemyToQueue('6');
+    client.sendEvent('gmcp.objects.nums', { nums: ['6'] });
+    expect(manager.getEnemyQueue()).toEqual(['6']);
+  });
+
+  test('clears attack queue on new location', () => {
+    manager.addEnemyToQueue('7');
+    client.sendEvent('gmcp.room.info', { num: 123 });
+    expect(manager.getEnemyQueue()).toEqual([]);
+  });
+
+  test('removes enemy from queue when marked as not living', () => {
+    manager.addEnemyToQueue('8');
+    client.sendEvent('gmcp.objects.data', { '8': { living: false } });
+    expect(manager.getEnemyQueue()).toEqual([]);
+  });
+
 });

--- a/client/test/attackQueue.test.ts
+++ b/client/test/attackQueue.test.ts
@@ -1,0 +1,76 @@
+import initAttackQueue from '../src/scripts/attackQueue';
+
+class FakeClient {
+  TeamManager = {
+    addEnemyToQueue: jest.fn(),
+    shiftEnemyFromQueue: jest.fn(),
+  };
+  println = jest.fn();
+  sendCommand = jest.fn();
+}
+
+describe('attack queue aliases', () => {
+  let client: FakeClient;
+  let aliases: { pattern: RegExp; callback: (matches: RegExpMatchArray) => void }[];
+
+  beforeEach(() => {
+    client = new FakeClient();
+    aliases = [];
+    initAttackQueue((client as unknown) as any, aliases);
+    client.TeamManager.addEnemyToQueue.mockReset();
+    client.TeamManager.shiftEnemyFromQueue.mockReset();
+    client.println.mockClear();
+    client.sendCommand.mockClear();
+  });
+
+  const execAlias = (
+    alias: { pattern: RegExp; callback: (matches: RegExpMatchArray) => void },
+    input: string,
+  ) => {
+    const matches = input.match(alias.pattern);
+    if (!matches) {
+      throw new Error('Pattern did not match input');
+    }
+    alias.callback(matches);
+  };
+
+  test('adds enemy to queue and prints confirmation', () => {
+    const alias = aliases.find(a => a.pattern.test('/q 123'))!;
+    client.TeamManager.addEnemyToQueue.mockReturnValue(true);
+
+    execAlias(alias, '/q 123');
+
+    expect(client.TeamManager.addEnemyToQueue).toHaveBeenCalledWith('123');
+    expect(client.println).toHaveBeenCalledWith('Dodano ob_123 do kolejki ataku.');
+  });
+
+  test('normalizes ob_ prefix and warns on duplicates', () => {
+    const alias = aliases.find(a => a.pattern.test('/q ob_321'))!;
+    client.TeamManager.addEnemyToQueue.mockReturnValue(false);
+
+    execAlias(alias, '/q ob_321');
+
+    expect(client.TeamManager.addEnemyToQueue).toHaveBeenCalledWith('321');
+    expect(client.println).toHaveBeenCalledWith('ob_321 jest juz w kolejce ataku.');
+  });
+
+  test('kills next enemy from queue', () => {
+    const alias = aliases.find(a => a.pattern.test('/nn'))!;
+    client.TeamManager.shiftEnemyFromQueue.mockReturnValue('77');
+
+    execAlias(alias, '/nn');
+
+    expect(client.TeamManager.shiftEnemyFromQueue).toHaveBeenCalled();
+    expect(client.sendCommand).toHaveBeenCalledWith('zabij ob_77');
+  });
+
+  test('notifies when queue is empty', () => {
+    const alias = aliases.find(a => a.pattern.test('/nn'))!;
+    client.TeamManager.shiftEnemyFromQueue.mockReturnValue(undefined);
+
+    execAlias(alias, '/nn');
+
+    expect(client.sendCommand).not.toHaveBeenCalled();
+    expect(client.println).toHaveBeenCalledWith('Kolejka ataku jest pusta.');
+  });
+});


### PR DESCRIPTION
## Summary
- extend the team manager to maintain an attack queue that clears on new locations and removes missing enemies
- introduce an attack queue script exposing /q and /nn aliases to manage and execute the queue
- cover the new queue behaviour with unit tests for the manager and alias handling

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build *(fails: mudlet-map-renderer no longer exports PathFinder in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2da08f1d8832ab574a96573c05b78