### PR TITLE
docs: document /list alias

### DIFF
--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -24,6 +24,7 @@ Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorze
 - **/przejrzyj [_co_]** - pokazuje zawartość skrzyń z kluczami i magicznymi przedmiotami lub podanego pojemnika (wykorzystuje komendę `ob`).
 - **/por [_skrot_]** - porównuje siłę, zręczność i wytrzymałość z podanym obiektem lub wszystkimi w pomieszczeniu.
 - **/chat** - wyświetla ostatnie 20 wiadomości z czatu GMCP.
+- **/list** - otwiera edytor pisania listów w kliencie.
 
 ## Menedżer pojemników
 - **/pojemnik** - uruchamia konfigurację menedżera pojemników.


### PR DESCRIPTION
## Summary
- document the /list command in the aliases reference

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68e2fffbd214832a9c21616ec66fdf32