### PR TITLE
Highlight next attack queue target and document aliases

### DIFF
--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -110,6 +110,7 @@ export default class TeamManager {
         if (this.enemies.length === 0) {
             return;
         }
+        const previousQueue = this.enemies.join(",");
         let nums: string[] | null = null;
         if (Array.isArray(detail)) {
             nums = detail.map(String);
@@ -142,6 +143,9 @@ export default class TeamManager {
         });
 
         this.enemies = remaining;
+        if (previousQueue !== this.enemies.join(",")) {
+            this.notifyAttackQueueChange();
+        }
     }
 
     private handleRoomInfo(detail: any) {
@@ -313,6 +317,7 @@ export default class TeamManager {
         }
         this.enemies.push(normalized);
         this.missingEnemyCounts.delete(normalized);
+        this.notifyAttackQueueChange();
         return true;
     }
 
@@ -322,8 +327,20 @@ export default class TeamManager {
         if (index === -1) {
             return false;
         }
+        const wasFirst = index === 0;
         this.enemies.splice(index, 1);
         this.missingEnemyCounts.delete(normalized);
+        if (wasFirst) {
+            const nextId = this.enemies[0];
+            if (nextId) {
+                const description = this.accumulatedObjectsData[nextId]?.desc;
+                const displayName = description ?? `ob_${nextId}`;
+                this.client.println(
+                    `<span style="color:orange">/nn zeby zaatakowac nastepny cel: ${displayName}</span>`
+                );
+            }
+        }
+        this.notifyAttackQueueChange();
         return true;
     }
 
@@ -331,6 +348,7 @@ export default class TeamManager {
         const next = this.enemies.shift();
         if (next) {
             this.missingEnemyCounts.delete(next);
+            this.notifyAttackQueueChange();
         }
         return next;
     }
@@ -345,5 +363,12 @@ export default class TeamManager {
         }
         this.enemies = [];
         this.missingEnemyCounts.clear();
+        this.notifyAttackQueueChange();
+    }
+
+    private notifyAttackQueueChange() {
+        if (typeof this.client?.sendEvent === "function") {
+            this.client.sendEvent("attackQueueChange", this.getEnemyQueue());
+        }
     }
 }

--- a/client/test/TeamManager.test.ts
+++ b/client/test/TeamManager.test.ts
@@ -5,6 +5,7 @@ import { EventEmitter } from 'events';
 class FakeClient {
   private emitter = new EventEmitter();
   Triggers = new Triggers({} as any);
+  println = jest.fn();
   addEventListener(event: string, cb: any, _options?: any) {
     this.emitter.on(event, cb);
     return () => this.emitter.off(event, cb);
@@ -215,6 +216,29 @@ describe('TeamManager', () => {
     manager.addEnemyToQueue('8');
     client.sendEvent('gmcp.objects.data', { '8': { living: false } });
     expect(manager.getEnemyQueue()).toEqual([]);
+  });
+
+  test('notifies about next enemy in queue when the current one dies', () => {
+    manager.addEnemyToQueue('8');
+    manager.addEnemyToQueue('9');
+    client.sendEvent('gmcp.objects.data', {
+      '9': { desc: 'Drugi przeciwnik', living: true },
+    });
+    client.println.mockClear();
+    client.sendEvent('gmcp.objects.data', { '8': { living: false } });
+    expect(client.println).toHaveBeenCalledWith(
+      '<span style="color:orange">/nn zeby zaatakowac nastepny cel: Drugi przeciwnik</span>',
+    );
+  });
+
+  test('falls back to object id when description is missing', () => {
+    manager.addEnemyToQueue('8');
+    manager.addEnemyToQueue('10');
+    client.println.mockClear();
+    client.sendEvent('gmcp.objects.data', { '8': { living: false } });
+    expect(client.println).toHaveBeenCalledWith(
+      '<span style="color:orange">/nn zeby zaatakowac nastepny cel: ob_10</span>',
+    );
   });
 
 });

--- a/client/test/attackQueue.test.ts
+++ b/client/test/attackQueue.test.ts
@@ -10,6 +10,7 @@ class FakeClient {
   };
   println = jest.fn();
   sendCommand = jest.fn();
+  sendEvent = jest.fn();
 }
 
 describe('attack queue aliases', () => {

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -77,9 +77,11 @@ Możliwe jest także tworzenie własnych aliasów w ustawieniach klienta. Wzorze
 
 ## Walka
 - **/z _skrot_** - wykonuje polecenie `zabij` na obiekcie o podanym skrócie.
+- **/q _skrot_ lub ob_id_** - dodaje przeciwnika do kolejki ataku; przyjmuje skróty z listy obiektów lub identyfikatory w formie `ob_id`.
 - **/zas _skrot_** - zasłania obiekt o podanym skrócie; jeśli nie jest w drużynie używa komendy `zaslon przed`.
 - **/za _skrot_** - to samo co `/zas _skrot_`.
 - **/z** - atakuje cel oznaczony jako cel ataku.
+- **/nn** - atakuje następny cel z kolejki ataku.
 - **/zas** - zasłania cel oznaczony jako cel obrony lub `zaslon przed`, gdy cel nie jest w drużynie.
 - **/za** - to samo co `/zas`.
 - **/za2 _skrot_** - zasłania obiekt z poziomem krycia 2.

--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -30,6 +30,7 @@ export default class ObjectList {
             this.container?.addEventListener("click", this.onClick);
         }
         window.addEventListener("resize", this.clampToViewport);
+        this.client.addEventListener("attackQueueChange", () => this.render());
         this.client.addEventListener("gmcp.objects.nums", () => this.render());
         this.client.addEventListener("gmcp.objects.data", () => this.render());
         this.client.addEventListener("gmcp.char.state", () => this.render());
@@ -210,6 +211,8 @@ export default class ObjectList {
         const objects = manager.getObjectsOnLocation();
         const descWidth = Math.max(0, ...objects.map((o: any) => (o.desc || "").length));
         const tm = this.client.TeamManager;
+        const nextQueuedId = tm?.getEnemyQueue?.()?.[0];
+        const nextQueuedIdString = typeof nextQueuedId === "undefined" ? undefined : String(nextQueuedId);
         const teamAttacking = objects.some((o: any) => {
             return tm?.isInTeam?.(o.desc) && o.attack_num !== false && o.attack_num !== undefined;
         });
@@ -226,9 +229,19 @@ export default class ObjectList {
             } else if (obj.defense_target) {
                 prefix = `<span style="color:greenyellow">>></span>`;
             }
+            const isNextQueued =
+                !isPlayer &&
+                nextQueuedIdString !== undefined &&
+                typeof obj.num !== "undefined" &&
+                nextQueuedIdString === String(obj.num);
+            const numClasses = ["object-num"];
+            if (isNextQueued) {
+                numClasses.push("object-num-next-target");
+            }
+            const numStyle = isNextQueued ? " style=\"color:#ffd700\"" : "";
             const numLabel = isPlayer
                 ? `${prefix}${num}`
-                : `${prefix}<span class="object-num" data-object-id="${obj.num}" data-object-num="${num}">${num}</span>`;
+                : `${prefix}<span class="${numClasses.join(" ")}" data-object-id="${obj.num}" data-object-num="${num}"${numStyle}>${num}</span>`;
             const rawDesc = obj.desc || "";
             let coloredDesc = rawDesc;
             if (!isPlayer) {

--- a/web-client/test/ObjectList.test.ts
+++ b/web-client/test/ObjectList.test.ts
@@ -10,7 +10,7 @@ jest.mock('@client/src/storage', () => ({
 
 class MockClient {
   ObjectManager = { getObjectsOnLocation: () => [] as any[] };
-  TeamManager = { isInTeam: (_d: string) => false };
+  TeamManager = { isInTeam: (_d: string) => false, getEnemyQueue: () => [] as string[] };
   addEventListener() {}
   sendCommand = jest.fn();
 }
@@ -159,6 +159,25 @@ describe('ObjectList', () => {
     const desc = document.querySelector('.object-desc[data-object-num="1"]') as HTMLElement;
     desc.click();
     expect(client.sendCommand).toHaveBeenCalledWith('/za 1');
+  });
+
+  test('highlights next queued enemy number in gold', () => {
+    document.body.innerHTML = '<div id="objects-list"></div>';
+    const client = new MockClient();
+    client.TeamManager.getEnemyQueue = () => ['123'];
+    const objectList = new ObjectList(client as any);
+    const objects = [
+      { shortcut: '1', desc: 'Ork', num: 123 },
+      { shortcut: '2', desc: 'Goblin', num: 456 },
+    ];
+    client.ObjectManager.getObjectsOnLocation = () => objects;
+    (objectList as any).render();
+    const highlighted = document.querySelector(
+      '.object-num[data-object-id="123"]',
+    ) as HTMLElement;
+    expect(highlighted).toBeTruthy();
+    expect(highlighted.outerHTML).toContain('color:#ffd700');
+    expect(highlighted.classList.contains('object-num-next-target')).toBe(true);
   });
 
   test('player object is not clickable', () => {


### PR DESCRIPTION
## Summary
- highlight the upcoming attack queue target in the objects list and refresh it on queue updates
- notify when the current target dies so the next queued enemy can be attacked and document the queue aliases
- cover the new behaviours with unit tests on both the client and web client packages

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68e2ff6b6944832a93b6c80305b567ab