### PR TITLE
Add letter composer width setting and preview

### DIFF
--- a/client/src/defaultSettings.ts
+++ b/client/src/defaultSettings.ts
@@ -14,6 +14,7 @@ export interface Settings {
     herbPostUseCommand: string;
     fullHpMessage: boolean;
     lowHpAlert: number;
+    letterLineWidth: number;
 }
 
 export const defaultSettings: Settings = {
@@ -32,4 +33,5 @@ export const defaultSettings: Settings = {
     herbPostUseCommand: '',
     fullHpMessage: false,
     lowHpAlert: 2,
+    letterLineWidth: 72,
 };

--- a/client/src/scripts/letter.ts
+++ b/client/src/scripts/letter.ts
@@ -1,7 +1,10 @@
 import Client from "../Client";
+import { defaultSettings } from "../defaultSettings";
 
 const PROMPT_PATTERN = /Wpisz ~\?, zeby uzyskac pomoc, lub \*\*, by zakonczyc edycje\./;
 const TRIGGER_TAG = "letter-composer";
+const MIN_LINE_WIDTH = 20;
+const MAX_LINE_WIDTH = 120;
 
 interface LetterSubmitPayload {
     to: string;
@@ -10,10 +13,150 @@ interface LetterSubmitPayload {
     content: string;
 }
 
-function justifyLine(line: string) {
-    return line
-        .replace(/\s+/g, " ")
-        .trim();
+let lineWidth = clampLineWidth(defaultSettings.letterLineWidth);
+
+function clampLineWidth(width: number) {
+    const rounded = Math.round(width);
+    return Math.min(MAX_LINE_WIDTH, Math.max(MIN_LINE_WIDTH, rounded));
+}
+
+function updateLineWidth(value: unknown) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        lineWidth = clampLineWidth(value);
+        return;
+    }
+    if (typeof value === "string") {
+        const parsed = parseInt(value, 10);
+        if (Number.isFinite(parsed)) {
+            lineWidth = clampLineWidth(parsed);
+        }
+    }
+}
+
+function normalizeLine(line: string) {
+    return line.replace(/\s+/g, " ").trim();
+}
+
+function splitLongWord(word: string, width: number) {
+    const parts: string[] = [];
+    for (let i = 0; i < word.length; i += width) {
+        parts.push(word.slice(i, i + width));
+    }
+    return parts;
+}
+
+function justifyWords(words: string[], lettersLength: number, width: number, isLastLine: boolean) {
+    if (words.length === 0) {
+        return "";
+    }
+    if (words.length === 1 || isLastLine) {
+        return words.join(" ");
+    }
+    const gaps = words.length - 1;
+    const totalSpaces = width - lettersLength;
+    const baseSpace = Math.max(1, Math.floor(totalSpaces / gaps));
+    let extra = totalSpaces - baseSpace * gaps;
+    let line = words[0];
+    for (let i = 1; i < words.length; i += 1) {
+        let spaces = baseSpace;
+        if (extra > 0) {
+            spaces += 1;
+            extra -= 1;
+        }
+        line += " ".repeat(spaces) + words[i];
+    }
+    return line;
+}
+
+function wrapLine(normalizedLine: string, width: number) {
+    if (!normalizedLine) {
+        return [];
+    }
+    const words = normalizedLine.split(" ");
+    const lines: string[] = [];
+    let currentWords: string[] = [];
+    let lettersLength = 0;
+
+    const flush = (isLastLine: boolean) => {
+        if (!currentWords.length) {
+            return;
+        }
+        lines.push(justifyWords(currentWords, lettersLength, width, isLastLine));
+        currentWords = [];
+        lettersLength = 0;
+    };
+
+    words.forEach(word => {
+        if (word.length > width) {
+            if (currentWords.length) {
+                flush(false);
+                currentWords = [];
+                lettersLength = 0;
+            }
+            const parts = splitLongWord(word, width);
+            const lastPart = parts.pop();
+            if (parts.length) {
+                lines.push(...parts);
+            }
+            if (lastPart) {
+                currentWords = [lastPart];
+                lettersLength = lastPart.length;
+            }
+            return;
+        }
+
+        const minimalSpaces = currentWords.length;
+        if (lettersLength + word.length + minimalSpaces > width && currentWords.length) {
+            flush(false);
+            currentWords = [word];
+            lettersLength = word.length;
+            return;
+        }
+
+        currentWords.push(word);
+        lettersLength += word.length;
+    });
+
+    flush(true);
+
+    return lines;
+}
+
+function formatContent(content: string, width: number) {
+    const rawLines = content.split(/\r?\n/);
+    const result: string[] = [];
+    let pendingBlankLine = false;
+    let hasContent = false;
+
+    rawLines.forEach(line => {
+        const normalized = normalizeLine(line);
+        if (!normalized) {
+            if (hasContent) {
+                pendingBlankLine = true;
+            }
+            return;
+        }
+
+        if (pendingBlankLine && result.length) {
+            result.push("");
+            pendingBlankLine = false;
+        }
+
+        const wrapped = wrapLine(normalized, width);
+        result.push(...wrapped);
+        hasContent = true;
+    });
+
+    return result;
+}
+
+function printPreview(client: Client, lines: string[]) {
+    const header = `Podglad listu (szerokosc ${lineWidth})`;
+    if (!lines.length) {
+        client.println(`${header}\n(brak tresci)`);
+        return;
+    }
+    client.println([header, ...lines].join("\n"));
 }
 
 export default function initLetter(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
@@ -26,23 +169,16 @@ export default function initLetter(client: Client, aliases?: { pattern: RegExp; 
         });
     }
 
+    client.addEventListener("settings", (event: CustomEvent<Partial<{ letterLineWidth?: number }>>) => {
+        updateLineWidth(event.detail?.letterLineWidth);
+    });
+
     client.addEventListener("letterComposer.submit", (event: CustomEvent<LetterSubmitPayload>) => {
         const { to, cc, subject, content } = event.detail;
         const recipient = to.trim();
         const carbonCopy = cc.trim();
         const subjectLine = subject.trim();
-        const lines = content
-            .split(/\r?\n/)
-            .map(line => justifyLine(line))
-            .filter((line, index, arr) => {
-                if (line.length > 0) {
-                    return true;
-                }
-                // Preserve intentional blank lines between non-empty content
-                const prev = index > 0 ? arr[index - 1] : "";
-                const next = index < arr.length - 1 ? arr[index + 1] : "";
-                return prev.length > 0 && next.length > 0;
-            });
+        const lines = formatContent(content, lineWidth);
 
         client.Triggers.removeByTag(TRIGGER_TAG);
         client.Triggers.registerOneTimeTrigger(
@@ -63,5 +199,10 @@ export default function initLetter(client: Client, aliases?: { pattern: RegExp; 
         client.sendCommand(recipient);
         client.sendCommand(subjectLine);
         client.sendCommand(carbonCopy);
+    });
+
+    client.addEventListener("letterComposer.preview", (event: CustomEvent<LetterSubmitPayload>) => {
+        const lines = formatContent(event.detail.content, lineWidth);
+        printPreview(client, lines);
     });
 }

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -516,6 +516,7 @@
             <textarea id="letter-content" name="letter-content" class="form-control" rows="10"></textarea>
         </div>
         <div class="letter-composer-actions">
+            <button type="button" class="btn btn-secondary btn-sm" data-letter-preview>Podgląd</button>
             <button type="submit" class="btn btn-primary btn-sm">Wyślij</button>
         </div>
     </form>

--- a/web-client/src/LetterComposer.ts
+++ b/web-client/src/LetterComposer.ts
@@ -20,6 +20,7 @@ export default class LetterComposer {
     private subjectInput: HTMLInputElement | null;
     private contentInput: HTMLTextAreaElement | null;
     private closeButton: HTMLButtonElement | null;
+    private previewButton: HTMLButtonElement | null;
     private dragPointerId: number | null = null;
     private dragOffsetX = 0;
     private dragOffsetY = 0;
@@ -34,21 +35,26 @@ export default class LetterComposer {
         this.subjectInput = this.container?.querySelector<HTMLInputElement>("[name='letter-subject']");
         this.contentInput = this.container?.querySelector<HTMLTextAreaElement>("[name='letter-content']");
         this.closeButton = this.container?.querySelector<HTMLButtonElement>("[data-letter-close]");
+        this.previewButton = this.container?.querySelector<HTMLButtonElement>("[data-letter-preview]");
 
         this.attachListeners();
         this.client.on("letterComposer", () => this.show());
+    }
+
+    private getPayload(): SubmitPayload {
+        return {
+            to: this.toInput?.value ?? "",
+            cc: this.ccInput?.value ?? "",
+            subject: this.subjectInput?.value ?? "",
+            content: this.contentInput?.value ?? "",
+        };
     }
 
     private attachListeners() {
         if (this.form) {
             this.form.addEventListener("submit", ev => {
                 ev.preventDefault();
-                const payload: SubmitPayload = {
-                    to: this.toInput?.value ?? "",
-                    cc: this.ccInput?.value ?? "",
-                    subject: this.subjectInput?.value ?? "",
-                    content: this.contentInput?.value ?? "",
-                };
+                const payload = this.getPayload();
                 this.client.emit("letterComposer.submit", payload);
                 this.hide();
                 this.form?.reset();
@@ -57,6 +63,14 @@ export default class LetterComposer {
 
         if (this.closeButton) {
             this.closeButton.addEventListener("click", () => this.hide());
+        }
+
+        if (this.previewButton) {
+            this.previewButton.addEventListener("click", ev => {
+                ev.preventDefault();
+                const payload = this.getPayload();
+                this.client.emit("letterComposer.preview", payload);
+            });
         }
 
         if (this.header && this.container) {

--- a/web-client/src/LetterComposer.ts
+++ b/web-client/src/LetterComposer.ts
@@ -82,6 +82,7 @@ export default class LetterComposer {
         if (!this.container) {
             return;
         }
+        this.form?.reset();
         this.container.hidden = false;
         requestAnimationFrame(() => {
             if (!this.state.hasCustomPosition) {

--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -55,6 +55,9 @@ const lowHpAlertOptions = [
     { value: 7, label: '7 - W swietnej kondycji' },
 ];
 
+const LETTER_LINE_WIDTH_MIN = 40;
+const LETTER_LINE_WIDTH_MAX = 120;
+
 function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void }) {
     const [settings, setSettings] = useState<FormSettings>({ ...defaultSettings });
 
@@ -149,6 +152,26 @@ function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void
                         onChange={e => onChangeSetting(s => s.fullHpMessage = e.target.checked)}
                         className="me-2"
                     />
+                    <Form.Group className="d-flex align-items-center me-2">
+                        <Form.Label className="me-1 mb-0" htmlFor="letterLineWidth">Szerokosc linii listu:</Form.Label>
+                        <Form.Control
+                            type="number"
+                            min={LETTER_LINE_WIDTH_MIN}
+                            max={LETTER_LINE_WIDTH_MAX}
+                            id="letterLineWidth"
+                            value={settings.letterLineWidth}
+                            onChange={ev => {
+                                const parsed = parseInt(ev.target.value, 10);
+                                const fallback = defaultSettings.letterLineWidth;
+                                const clamped = Math.min(
+                                    LETTER_LINE_WIDTH_MAX,
+                                    Math.max(LETTER_LINE_WIDTH_MIN, Number.isFinite(parsed) ? parsed : fallback)
+                                );
+                                onChangeSetting(s => s.letterLineWidth = clamped);
+                            }}
+                            style={{ width: '100%', maxWidth: '5rem' }}
+                        />
+                    </Form.Group>
                     <Form.Group className="d-flex align-items-center me-2">
                         <Form.Label className="me-1 mb-0" htmlFor="lowHpAlert">Alarm niskiego zdrowia:</Form.Label>
                         <Form.Select

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -994,6 +994,7 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
 .letter-composer-actions {
   display: flex;
   justify-content: flex-end;
+  gap: 0.5rem;
   margin-top: auto;
   padding-top: 0.5rem;
 }

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -915,8 +915,8 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   top: 4rem;
   left: 4rem;
   width: min(32rem, 90vw);
-  min-height: 22rem;
-  max-height: min(40rem, 90vh);
+  min-height: 23rem;
+  max-height: min(42rem, 90vh);
   background-color: rgba(17, 19, 23, 0.95);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 0.5rem;
@@ -988,7 +988,7 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
 
 .letter-composer textarea {
   resize: vertical;
-  min-height: 10rem;
+  min-height: 10.5rem;
 }
 
 .letter-composer-actions {


### PR DESCRIPTION
## Summary
- add a configurable maximum line width for the letter composer in character settings
- wrap and justify composed letters using the configured width and add a content preview action
- expose the preview control in the letter composer UI and adjust layout spacing

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68e303b4917c832aad3efd6044dda375