### PR TITLE
Add letter composer templates

### DIFF
--- a/client/src/eventBus.ts
+++ b/client/src/eventBus.ts
@@ -1,3 +1,5 @@
+import type { LetterSubmitPayload } from "./types/letter";
+
 export interface KnownEvents {
     'command': string;
     'port-connected': void;
@@ -17,7 +19,8 @@ export interface KnownEvents {
     'enterLocation': { id: number; room: any };
     'multibinds': { list: { index: number; action: string; label: string }[] };
     'letterComposer': { open: boolean };
-    'letterComposer.submit': { to: string; cc: string; subject: string; content: string };
+    'letterComposer.submit': LetterSubmitPayload;
+    'letterComposer.preview': LetterSubmitPayload;
     'npc': any;
     'zaskTimer': { seconds: number; ok: boolean } | null;
     'moveModeChanged': number;

--- a/client/src/scripts/letter.ts
+++ b/client/src/scripts/letter.ts
@@ -153,171 +153,160 @@ function formatContent(content: string, width: number) {
     return result;
 }
 
-function createPlainHeader(width: number) {
-    const dashes = "-".repeat(width);
-    const spaces = " ".repeat(width);
-    return [
-        ` +--${dashes}--+ `,
-        ` |  ${spaces}  | `,
-        ` |  ${spaces}  | `,
-    ];
+interface LetterTemplateRenderer {
+    createHeader(width: number): string[];
+    createFooter(width: number): string[];
+    formatLine(line: string, width: number): string;
 }
 
-function createPlainFooter(width: number) {
-    const dashes = "-".repeat(width);
-    const spaces = " ".repeat(width);
-    return [
-        ` |  ${spaces}  | `,
-        ` |  ${spaces}  | `,
-        ` +--${dashes}--+ `,
-    ];
+abstract class BaseLetterTemplate implements LetterTemplateRenderer {
+    protected constructor(private readonly bodyPrefix: string, private readonly bodySuffix: string) {}
+
+    abstract createHeader(width: number): string[];
+
+    abstract createFooter(width: number): string[];
+
+    formatLine(line: string, width: number): string {
+        const alignRight = line.startsWith(">");
+        const content = alignRight ? line.slice(1) : line;
+        const trimmed = content.length > width ? content.slice(0, width) : content;
+        const padded = alignRight ? trimmed.padStart(width, " ") : trimmed.padEnd(width, " ");
+        return `${this.bodyPrefix}${padded}${this.bodySuffix}`;
+    }
 }
 
-function createPlainBodyLine(line: string, width: number) {
-    const alignRight = line.startsWith(">");
-    const content = alignRight ? line.slice(1) : line;
-    const trimmed = content.length > width ? content.slice(0, width) : content;
-    const padded = alignRight ? trimmed.padStart(width, " ") : trimmed.padEnd(width, " ");
-    return ` |  ${padded}  | `;
+class PlainTemplate extends BaseLetterTemplate {
+    constructor() {
+        super(" |  ", "  | ");
+    }
+
+    createHeader(width: number) {
+        const dashes = "-".repeat(width);
+        const spaces = " ".repeat(width);
+        return [
+            ` +--${dashes}--+ `,
+            ` |  ${spaces}  | `,
+            ` |  ${spaces}  | `,
+        ];
+    }
+
+    createFooter(width: number) {
+        const dashes = "-".repeat(width);
+        const spaces = " ".repeat(width);
+        return [
+            ` |  ${spaces}  | `,
+            ` |  ${spaces}  | `,
+            ` +--${dashes}--+ `,
+        ];
+    }
 }
 
-function createParchmentHeader(width: number) {
-    const underscores = "_".repeat(width);
-    const spaces = " ".repeat(width);
-    return [
-        `  ____${underscores}___  `,
-        `/ \\   ${spaces}   \\.`,
-        `|  |  ${spaces}   |.`,
-        `\\_ |  ${spaces}   |.`,
-        `   |  ${spaces}   |.`,
-    ];
+class ParchmentTemplate extends BaseLetterTemplate {
+    constructor() {
+        super("   |   ", "  |.");
+    }
+
+    createHeader(width: number) {
+        const underscores = "_".repeat(width);
+        const spaces = " ".repeat(width);
+        return [
+            `  ____${underscores}___  `,
+            `/ \\   ${spaces}   \\.`,
+            `|  |  ${spaces}   |.`,
+            `\\_ |  ${spaces}   |.`,
+            `   |  ${spaces}   |.`,
+        ];
+    }
+
+    createFooter(width: number) {
+        const underscores = "_".repeat(width);
+        const spaces = " ".repeat(width);
+        return [
+            `   |  ${spaces}   |.   `,
+            `   |   ${underscores}__|___ `,
+            `   |  /${spaces}     /.`,
+            `   \\_/_${underscores}____/. `,
+        ];
+    }
 }
 
-function createParchmentFooter(width: number) {
-    const underscores = "_".repeat(width);
-    const spaces = " ".repeat(width);
-    return [
-        `   |  ${spaces}   |.   `,
-        `   |   ${underscores}__|___ `,
-        `   |  /${spaces}     /.`,
-        `   \\_/_${underscores}____/. `,
-    ];
+class Parchment2Template extends BaseLetterTemplate {
+    constructor() {
+        super(" |    ", " |   ");
+    }
+
+    createHeader(width: number) {
+        const underscores = "_".repeat(width);
+        const spaces = " ".repeat(width);
+        return [
+            ` ______${underscores}_____  `,
+            `/ _\\  ${spaces}     \\`,
+            `|/ >|  ${spaces}     | `,
+            `|\\_/__${underscores}______/`,
+            `\\.    ${spaces}   ./  `,
+            ` |     ${spaces}   |   `,
+        ];
+    }
+
+    createFooter(width: number) {
+        const underscores = "_".repeat(width);
+        const spaces = " ".repeat(width);
+        return [
+            ` |  ___${underscores}___|    `,
+            ` |/\\  ${spaces}     \\ `,
+            ` \\_|${spaces}       |`,
+            `  \\_/_${underscores}_____/  `,
+        ];
+    }
 }
 
-function createParchmentBodyLine(line: string, width: number) {
-    const alignRight = line.startsWith(">");
-    const content = alignRight ? line.slice(1) : line;
-    const trimmed = content.length > width ? content.slice(0, width) : content;
-    const padded = alignRight ? trimmed.padStart(width, " ") : trimmed.padEnd(width, " ");
-    return `   |   ${padded}  |.`;
+class Parchment3Template extends BaseLetterTemplate {
+    constructor() {
+        super(" |       |   ", "        | ");
+    }
+
+    createHeader(width: number) {
+        const spaces = " ".repeat(width);
+        const dashes = "-".repeat(width);
+        return [
+            `             ${spaces}  .---.   `,
+            `             ${spaces} /  .  \\ `,
+            `             ${spaces}|\\_/|   |`,
+            `             ${spaces}|   |  /| `,
+            String.raw`   .---------${dashes}------\' |`,
+            `  /  .-.     ${spaces}        | `,
+            ` |  /   \\   ${spaces}         |`,
+            ` | |\\_.  |  ${spaces}         |`,
+            ` |\\|  | /|  ${spaces}         |`,
+            String.raw` | \`---\' |  ${spaces}        | `,
+        ];
+    }
+
+    createFooter(width: number) {
+        const spaces = " ".repeat(width);
+        const dashes = "-".repeat(width);
+        return [
+            ` |       |   ${spaces}        /   `,
+            ` |       |---${dashes}--------\\'  `,
+            ` \\       |  ${spaces}            `,
+            ` \\.___./    ${spaces}            `,
+        ];
+    }
 }
 
-function createParchment2Header(width: number) {
-    const underscores = "_".repeat(width);
-    const spaces = " ".repeat(width);
-    return [
-        ` ______${underscores}_____  `,
-        `/ _\\  ${spaces}     \\`,
-        `|/ >|  ${spaces}     | `,
-        `|\\_/__${underscores}______/`,
-        `\\.    ${spaces}   ./  `,
-        ` |     ${spaces}   |   `,
-    ];
-}
-
-function createParchment2Footer(width: number) {
-    const underscores = "_".repeat(width);
-    const spaces = " ".repeat(width);
-    return [
-        ` |  ___${underscores}___|    `,
-        ` |/\\  ${spaces}     \\ `,
-        ` \\_|${spaces}       |`,
-        `  \\_/_${underscores}_____/  `,
-    ];
-}
-
-function createParchment2BodyLine(line: string, width: number) {
-    const alignRight = line.startsWith(">");
-    const content = alignRight ? line.slice(1) : line;
-    const trimmed = content.length > width ? content.slice(0, width) : content;
-    const padded = alignRight ? trimmed.padStart(width, " ") : trimmed.padEnd(width, " ");
-    return ` |    ${padded} |   `;
-}
-
-function createParchment3Header(width: number) {
-    const spaces = " ".repeat(width);
-    const dashes = "-".repeat(width);
-    return [
-        `             ${spaces}  .---.   `,
-        `             ${spaces} /  .  \\ `,
-        `             ${spaces}|\\_/|   |`,
-        `             ${spaces}|   |  /| `,
-        String.raw`   .---------${dashes}------\' |`,
-        `  /  .-.     ${spaces}        | `,
-        ` |  /   \\   ${spaces}         |`,
-        ` | |\\_.  |  ${spaces}         |`,
-        ` |\\|  | /|  ${spaces}         |`,
-        String.raw` | \`---\' |  ${spaces}        | `,
-    ];
-}
-
-function createParchment3Footer(width: number) {
-    const spaces = " ".repeat(width);
-    const dashes = "-".repeat(width);
-    return [
-        ` |       |   ${spaces}        /   `,
-        ` |       |---${dashes}--------\\'  `,
-        ` \\       |  ${spaces}            `,
-        ` \\.___./    ${spaces}            `,
-    ];
-}
-
-function createParchment3BodyLine(line: string, width: number) {
-    const alignRight = line.startsWith(">");
-    const content = alignRight ? line.slice(1) : line;
-    const trimmed = content.length > width ? content.slice(0, width) : content;
-    const padded = alignRight ? trimmed.padStart(width, " ") : trimmed.padEnd(width, " ");
-    return ` |       |   ${padded}        | `;
-}
-
-interface TemplateRenderer {
-    header: (width: number) => string[];
-    footer: (width: number) => string[];
-    bodyLine: (line: string, width: number) => string;
-}
-
-const TEMPLATE_RENDERERS: Record<LetterTemplate, TemplateRenderer | null> = {
-    plain: {
-        header: createPlainHeader,
-        footer: createPlainFooter,
-        bodyLine: createPlainBodyLine,
-    },
-    parchment: {
-        header: createParchmentHeader,
-        footer: createParchmentFooter,
-        bodyLine: createParchmentBodyLine,
-    },
-    parchment2: {
-        header: createParchment2Header,
-        footer: createParchment2Footer,
-        bodyLine: createParchment2BodyLine,
-    },
-    parchment3: {
-        header: createParchment3Header,
-        footer: createParchment3Footer,
-        bodyLine: createParchment3BodyLine,
-    },
+const TEMPLATE_RENDERERS: Record<LetterTemplate, LetterTemplateRenderer> = {
+    plain: new PlainTemplate(),
+    parchment: new ParchmentTemplate(),
+    parchment2: new Parchment2Template(),
+    parchment3: new Parchment3Template(),
 };
 
 function applyTemplate(lines: string[], width: number, template: LetterTemplate) {
     const renderer = TEMPLATE_RENDERERS[template];
-    if (!renderer) {
-        return lines;
-    }
-    const header = renderer.header(width);
-    const footer = renderer.footer(width);
+    const header = renderer.createHeader(width);
+    const footer = renderer.createFooter(width);
     const bodySource = lines.length ? lines : [""];
-    const body = bodySource.map(line => renderer.bodyLine(line, width));
+    const body = bodySource.map(line => renderer.formatLine(line, width));
     return [...header, ...body, ...footer];
 }
 

--- a/client/src/scripts/letter.ts
+++ b/client/src/scripts/letter.ts
@@ -160,6 +160,32 @@ interface LetterTemplateRenderer {
     getBodyWidth(totalWidth: number): number;
 }
 
+class NoneTemplate implements LetterTemplateRenderer {
+    createHeader(): string[] {
+        return [];
+    }
+
+    createFooter(): string[] {
+        return [];
+    }
+
+    getBodyWidth(totalWidth: number): number {
+        return totalWidth;
+    }
+
+    formatLine(line: string, width: number): string {
+        if (!line) {
+            return "";
+        }
+        if (line.startsWith(">")) {
+            const content = line.slice(1);
+            const trimmed = content.length > width ? content.slice(0, width) : content;
+            return trimmed.padStart(width, " ");
+        }
+        return line.length > width ? line.slice(0, width) : line;
+    }
+}
+
 abstract class BaseLetterTemplate implements LetterTemplateRenderer {
     private readonly prefixLength: number;
     private readonly suffixLength: number;
@@ -308,6 +334,7 @@ class Parchment3Template extends BaseLetterTemplate {
 }
 
 const TEMPLATE_RENDERERS: Record<LetterTemplate, LetterTemplateRenderer> = {
+    none: new NoneTemplate(),
     plain: new PlainTemplate(),
     parchment: new ParchmentTemplate(),
     parchment2: new Parchment2Template(),

--- a/client/src/scripts/letter.ts
+++ b/client/src/scripts/letter.ts
@@ -1,7 +1,7 @@
 import Client from "../Client";
 import { defaultSettings } from "../defaultSettings";
 import type { LetterSubmitPayload, LetterTemplate } from "../types/letter";
-import { isLetterTemplate } from "../types/letter";
+import { LETTER_TEMPLATE_PREVIEW_LABELS, isLetterTemplate } from "../types/letter";
 
 const PROMPT_PATTERN = /Wpisz ~\?, zeby uzyskac pomoc, lub \*\*, by zakonczyc edycje\./;
 const TRIGGER_TAG = "letter-composer";
@@ -245,7 +245,7 @@ class ParchmentTemplate extends BaseLetterTemplate {
 
 class Parchment2Template extends BaseLetterTemplate {
     constructor() {
-        super(" |     ", "     | ");
+        super(" |     ", "   |   ");
     }
 
     createHeader(width: number) {
@@ -331,15 +331,8 @@ function renderLetter(content: string, template: LetterTemplate) {
     return { lines, hasContent };
 }
 
-const TEMPLATE_LABELS: Record<LetterTemplate, string> = {
-    plain: "zwykly",
-    parchment: "pergamin",
-    parchment2: "pergamin 2",
-    parchment3: "pergamin 3",
-};
-
 function printPreview(client: Client, lines: string[], template: LetterTemplate, hasContent: boolean) {
-    const templateLabel = TEMPLATE_LABELS[template] ?? template;
+    const templateLabel = LETTER_TEMPLATE_PREVIEW_LABELS[template] ?? template;
     const header = `Podglad listu (szerokosc ${lineWidth}, szablon ${templateLabel})`;
     if (!hasContent) {
         client.println(`${header}\n(brak tresci)`);

--- a/client/src/scripts/letter.ts
+++ b/client/src/scripts/letter.ts
@@ -153,6 +153,34 @@ function formatContent(content: string, width: number) {
     return result;
 }
 
+function createPlainHeader(width: number) {
+    const dashes = "-".repeat(width);
+    const spaces = " ".repeat(width);
+    return [
+        ` +--${dashes}--+ `,
+        ` |  ${spaces}  | `,
+        ` |  ${spaces}  | `,
+    ];
+}
+
+function createPlainFooter(width: number) {
+    const dashes = "-".repeat(width);
+    const spaces = " ".repeat(width);
+    return [
+        ` |  ${spaces}  | `,
+        ` |  ${spaces}  | `,
+        ` +--${dashes}--+ `,
+    ];
+}
+
+function createPlainBodyLine(line: string, width: number) {
+    const alignRight = line.startsWith(">");
+    const content = alignRight ? line.slice(1) : line;
+    const trimmed = content.length > width ? content.slice(0, width) : content;
+    const padded = alignRight ? trimmed.padStart(width, " ") : trimmed.padEnd(width, " ");
+    return ` |  ${padded}  | `;
+}
+
 function createParchmentHeader(width: number) {
     const underscores = "_".repeat(width);
     const spaces = " ".repeat(width);
@@ -184,19 +212,124 @@ function createParchmentBodyLine(line: string, width: number) {
     return `   |   ${padded}  |.`;
 }
 
-function applyTemplate(lines: string[], width: number, template: LetterTemplate) {
-    if (template === "parchment") {
-        const header = createParchmentHeader(width);
-        const footer = createParchmentFooter(width);
-        const bodySource = lines.length ? lines : [""];
-        const body = bodySource.map(line => createParchmentBodyLine(line, width));
-        return [...header, ...body, ...footer];
-    }
-    return lines;
+function createParchment2Header(width: number) {
+    const underscores = "_".repeat(width);
+    const spaces = " ".repeat(width);
+    return [
+        ` ______${underscores}_____  `,
+        `/ _\\  ${spaces}     \\`,
+        `|/ >|  ${spaces}     | `,
+        `|\\_/__${underscores}______/`,
+        `\\.    ${spaces}   ./  `,
+        ` |     ${spaces}   |   `,
+    ];
 }
 
+function createParchment2Footer(width: number) {
+    const underscores = "_".repeat(width);
+    const spaces = " ".repeat(width);
+    return [
+        ` |  ___${underscores}___|    `,
+        ` |/\\  ${spaces}     \\ `,
+        ` \\_|${spaces}       |`,
+        `  \\_/_${underscores}_____/  `,
+    ];
+}
+
+function createParchment2BodyLine(line: string, width: number) {
+    const alignRight = line.startsWith(">");
+    const content = alignRight ? line.slice(1) : line;
+    const trimmed = content.length > width ? content.slice(0, width) : content;
+    const padded = alignRight ? trimmed.padStart(width, " ") : trimmed.padEnd(width, " ");
+    return ` |    ${padded} |   `;
+}
+
+function createParchment3Header(width: number) {
+    const spaces = " ".repeat(width);
+    const dashes = "-".repeat(width);
+    return [
+        `             ${spaces}  .---.   `,
+        `             ${spaces} /  .  \\ `,
+        `             ${spaces}|\\_/|   |`,
+        `             ${spaces}|   |  /| `,
+        String.raw`   .---------${dashes}------\' |`,
+        `  /  .-.     ${spaces}        | `,
+        ` |  /   \\   ${spaces}         |`,
+        ` | |\\_.  |  ${spaces}         |`,
+        ` |\\|  | /|  ${spaces}         |`,
+        String.raw` | \`---\' |  ${spaces}        | `,
+    ];
+}
+
+function createParchment3Footer(width: number) {
+    const spaces = " ".repeat(width);
+    const dashes = "-".repeat(width);
+    return [
+        ` |       |   ${spaces}        /   `,
+        ` |       |---${dashes}--------\\'  `,
+        ` \\       |  ${spaces}            `,
+        ` \\.___./    ${spaces}            `,
+    ];
+}
+
+function createParchment3BodyLine(line: string, width: number) {
+    const alignRight = line.startsWith(">");
+    const content = alignRight ? line.slice(1) : line;
+    const trimmed = content.length > width ? content.slice(0, width) : content;
+    const padded = alignRight ? trimmed.padStart(width, " ") : trimmed.padEnd(width, " ");
+    return ` |       |   ${padded}        | `;
+}
+
+interface TemplateRenderer {
+    header: (width: number) => string[];
+    footer: (width: number) => string[];
+    bodyLine: (line: string, width: number) => string;
+}
+
+const TEMPLATE_RENDERERS: Record<LetterTemplate, TemplateRenderer | null> = {
+    plain: {
+        header: createPlainHeader,
+        footer: createPlainFooter,
+        bodyLine: createPlainBodyLine,
+    },
+    parchment: {
+        header: createParchmentHeader,
+        footer: createParchmentFooter,
+        bodyLine: createParchmentBodyLine,
+    },
+    parchment2: {
+        header: createParchment2Header,
+        footer: createParchment2Footer,
+        bodyLine: createParchment2BodyLine,
+    },
+    parchment3: {
+        header: createParchment3Header,
+        footer: createParchment3Footer,
+        bodyLine: createParchment3BodyLine,
+    },
+};
+
+function applyTemplate(lines: string[], width: number, template: LetterTemplate) {
+    const renderer = TEMPLATE_RENDERERS[template];
+    if (!renderer) {
+        return lines;
+    }
+    const header = renderer.header(width);
+    const footer = renderer.footer(width);
+    const bodySource = lines.length ? lines : [""];
+    const body = bodySource.map(line => renderer.bodyLine(line, width));
+    return [...header, ...body, ...footer];
+}
+
+const TEMPLATE_LABELS: Record<LetterTemplate, string> = {
+    plain: "zwykly",
+    parchment: "pergamin",
+    parchment2: "pergamin 2",
+    parchment3: "pergamin 3",
+};
+
 function printPreview(client: Client, lines: string[], template: LetterTemplate) {
-    const templateLabel = template === "parchment" ? "pergamin" : "zwykly";
+    const templateLabel = TEMPLATE_LABELS[template] ?? template;
     const header = `Podglad listu (szerokosc ${lineWidth}, szablon ${templateLabel})`;
     if (!lines.length) {
         client.println(`${header}\n(brak tresci)`);

--- a/client/src/scripts/letter.ts
+++ b/client/src/scripts/letter.ts
@@ -245,7 +245,7 @@ class ParchmentTemplate extends BaseLetterTemplate {
 
 class Parchment2Template extends BaseLetterTemplate {
     constructor() {
-        super(" |    ", " |   ");
+        super(" |     ", "     | ");
     }
 
     createHeader(width: number) {
@@ -253,10 +253,10 @@ class Parchment2Template extends BaseLetterTemplate {
         const spaces = " ".repeat(width);
         return [
             ` ______${underscores}_____  `,
-            `/ _\\  ${spaces}     \\`,
+            String.raw` / _\  ${spaces}     \ `,
             `|/ >|  ${spaces}     | `,
-            `|\\_/__${underscores}______/`,
-            `\\.    ${spaces}   ./  `,
+            String.raw` |\_/__${underscores}______/`,
+            String.raw` \.    ${spaces}   ./  `,
             ` |     ${spaces}   |   `,
         ];
     }
@@ -265,10 +265,10 @@ class Parchment2Template extends BaseLetterTemplate {
         const underscores = "_".repeat(width);
         const spaces = " ".repeat(width);
         return [
-            ` |  ___${underscores}___|    `,
-            ` |/\\  ${spaces}     \\ `,
-            ` \\_|${spaces}       |`,
-            `  \\_/_${underscores}_____/  `,
+            ` |  ___${underscores}___|   `,
+            String.raw` |/\   ${spaces}     \ `,
+            String.raw` \_|   ${spaces}      |`,
+            String.raw`  \_/_ ${underscores}_____/ `,
         ];
     }
 }
@@ -300,7 +300,7 @@ class Parchment3Template extends BaseLetterTemplate {
         const dashes = "-".repeat(width);
         return [
             ` |       |   ${spaces}        /   `,
-            ` |       |---${dashes}--------\\'  `,
+            String.raw` |       |---${dashes}--------\' `,
             ` \\       |  ${spaces}            `,
             ` \\.___./    ${spaces}            `,
         ];

--- a/client/src/scripts/letter.ts
+++ b/client/src/scripts/letter.ts
@@ -157,14 +157,27 @@ interface LetterTemplateRenderer {
     createHeader(width: number): string[];
     createFooter(width: number): string[];
     formatLine(line: string, width: number): string;
+    getBodyWidth(totalWidth: number): number;
 }
 
 abstract class BaseLetterTemplate implements LetterTemplateRenderer {
-    protected constructor(private readonly bodyPrefix: string, private readonly bodySuffix: string) {}
+    private readonly prefixLength: number;
+    private readonly suffixLength: number;
+
+    protected constructor(private readonly bodyPrefix: string, private readonly bodySuffix: string) {
+        this.prefixLength = bodyPrefix.length;
+        this.suffixLength = bodySuffix.length;
+    }
 
     abstract createHeader(width: number): string[];
 
     abstract createFooter(width: number): string[];
+
+    getBodyWidth(totalWidth: number): number {
+        const decorationWidth = this.prefixLength + this.suffixLength;
+        const bodyWidth = totalWidth - decorationWidth;
+        return Math.max(1, bodyWidth);
+    }
 
     formatLine(line: string, width: number): string {
         const alignRight = line.startsWith(">");
@@ -301,13 +314,21 @@ const TEMPLATE_RENDERERS: Record<LetterTemplate, LetterTemplateRenderer> = {
     parchment3: new Parchment3Template(),
 };
 
-function applyTemplate(lines: string[], width: number, template: LetterTemplate) {
-    const renderer = TEMPLATE_RENDERERS[template];
+function applyTemplate(lines: string[], width: number, renderer: LetterTemplateRenderer) {
     const header = renderer.createHeader(width);
     const footer = renderer.createFooter(width);
     const bodySource = lines.length ? lines : [""];
     const body = bodySource.map(line => renderer.formatLine(line, width));
     return [...header, ...body, ...footer];
+}
+
+function renderLetter(content: string, template: LetterTemplate) {
+    const renderer = TEMPLATE_RENDERERS[template];
+    const bodyWidth = renderer.getBodyWidth(lineWidth);
+    const baseLines = formatContent(content, bodyWidth);
+    const lines = applyTemplate(baseLines, bodyWidth, renderer);
+    const hasContent = baseLines.some(line => line.length > 0);
+    return { lines, hasContent };
 }
 
 const TEMPLATE_LABELS: Record<LetterTemplate, string> = {
@@ -317,10 +338,10 @@ const TEMPLATE_LABELS: Record<LetterTemplate, string> = {
     parchment3: "pergamin 3",
 };
 
-function printPreview(client: Client, lines: string[], template: LetterTemplate) {
+function printPreview(client: Client, lines: string[], template: LetterTemplate, hasContent: boolean) {
     const templateLabel = TEMPLATE_LABELS[template] ?? template;
     const header = `Podglad listu (szerokosc ${lineWidth}, szablon ${templateLabel})`;
-    if (!lines.length) {
+    if (!hasContent) {
         client.println(`${header}\n(brak tresci)`);
         return;
     }
@@ -347,8 +368,7 @@ export default function initLetter(client: Client, aliases?: { pattern: RegExp; 
         const carbonCopy = cc.trim();
         const subjectLine = subject.trim();
         const template = normalizeTemplate(rawTemplate);
-        const baseLines = formatContent(content, lineWidth);
-        const lines = applyTemplate(baseLines, lineWidth, template);
+        const { lines } = renderLetter(content, template);
 
         client.Triggers.removeByTag(TRIGGER_TAG);
         client.Triggers.registerOneTimeTrigger(
@@ -373,8 +393,7 @@ export default function initLetter(client: Client, aliases?: { pattern: RegExp; 
 
     client.addEventListener("letterComposer.preview", (event: CustomEvent<LetterSubmitPayload>) => {
         const template = normalizeTemplate(event.detail.template);
-        const baseLines = formatContent(event.detail.content, lineWidth);
-        const lines = applyTemplate(baseLines, lineWidth, template);
-        printPreview(client, lines, template);
+        const { lines, hasContent } = renderLetter(event.detail.content, template);
+        printPreview(client, lines, template, hasContent);
     });
 }

--- a/client/src/scripts/letter.ts
+++ b/client/src/scripts/letter.ts
@@ -1,17 +1,13 @@
 import Client from "../Client";
 import { defaultSettings } from "../defaultSettings";
+import type { LetterSubmitPayload, LetterTemplate } from "../types/letter";
+import { isLetterTemplate } from "../types/letter";
 
 const PROMPT_PATTERN = /Wpisz ~\?, zeby uzyskac pomoc, lub \*\*, by zakonczyc edycje\./;
 const TRIGGER_TAG = "letter-composer";
 const MIN_LINE_WIDTH = 20;
 const MAX_LINE_WIDTH = 120;
-
-interface LetterSubmitPayload {
-    to: string;
-    cc: string;
-    subject: string;
-    content: string;
-}
+const DEFAULT_TEMPLATE: LetterTemplate = "plain";
 
 let lineWidth = clampLineWidth(defaultSettings.letterLineWidth);
 
@@ -31,6 +27,13 @@ function updateLineWidth(value: unknown) {
             lineWidth = clampLineWidth(parsed);
         }
     }
+}
+
+function normalizeTemplate(value: unknown): LetterTemplate {
+    if (isLetterTemplate(value)) {
+        return value;
+    }
+    return DEFAULT_TEMPLATE;
 }
 
 function normalizeLine(line: string) {
@@ -150,8 +153,51 @@ function formatContent(content: string, width: number) {
     return result;
 }
 
-function printPreview(client: Client, lines: string[]) {
-    const header = `Podglad listu (szerokosc ${lineWidth})`;
+function createParchmentHeader(width: number) {
+    const underscores = "_".repeat(width);
+    const spaces = " ".repeat(width);
+    return [
+        `  ____${underscores}___  `,
+        `/ \\   ${spaces}   \\.`,
+        `|  |  ${spaces}   |.`,
+        `\\_ |  ${spaces}   |.`,
+        `   |  ${spaces}   |.`,
+    ];
+}
+
+function createParchmentFooter(width: number) {
+    const underscores = "_".repeat(width);
+    const spaces = " ".repeat(width);
+    return [
+        `   |  ${spaces}   |.   `,
+        `   |   ${underscores}__|___ `,
+        `   |  /${spaces}     /.`,
+        `   \\_/_${underscores}____/. `,
+    ];
+}
+
+function createParchmentBodyLine(line: string, width: number) {
+    const alignRight = line.startsWith(">");
+    const content = alignRight ? line.slice(1) : line;
+    const trimmed = content.length > width ? content.slice(0, width) : content;
+    const padded = alignRight ? trimmed.padStart(width, " ") : trimmed.padEnd(width, " ");
+    return `   |   ${padded}  |.`;
+}
+
+function applyTemplate(lines: string[], width: number, template: LetterTemplate) {
+    if (template === "parchment") {
+        const header = createParchmentHeader(width);
+        const footer = createParchmentFooter(width);
+        const bodySource = lines.length ? lines : [""];
+        const body = bodySource.map(line => createParchmentBodyLine(line, width));
+        return [...header, ...body, ...footer];
+    }
+    return lines;
+}
+
+function printPreview(client: Client, lines: string[], template: LetterTemplate) {
+    const templateLabel = template === "parchment" ? "pergamin" : "zwykly";
+    const header = `Podglad listu (szerokosc ${lineWidth}, szablon ${templateLabel})`;
     if (!lines.length) {
         client.println(`${header}\n(brak tresci)`);
         return;
@@ -174,11 +220,13 @@ export default function initLetter(client: Client, aliases?: { pattern: RegExp; 
     });
 
     client.addEventListener("letterComposer.submit", (event: CustomEvent<LetterSubmitPayload>) => {
-        const { to, cc, subject, content } = event.detail;
+        const { to, cc, subject, content, template: rawTemplate } = event.detail;
         const recipient = to.trim();
         const carbonCopy = cc.trim();
         const subjectLine = subject.trim();
-        const lines = formatContent(content, lineWidth);
+        const template = normalizeTemplate(rawTemplate);
+        const baseLines = formatContent(content, lineWidth);
+        const lines = applyTemplate(baseLines, lineWidth, template);
 
         client.Triggers.removeByTag(TRIGGER_TAG);
         client.Triggers.registerOneTimeTrigger(
@@ -202,7 +250,9 @@ export default function initLetter(client: Client, aliases?: { pattern: RegExp; 
     });
 
     client.addEventListener("letterComposer.preview", (event: CustomEvent<LetterSubmitPayload>) => {
-        const lines = formatContent(event.detail.content, lineWidth);
-        printPreview(client, lines);
+        const template = normalizeTemplate(event.detail.template);
+        const baseLines = formatContent(event.detail.content, lineWidth);
+        const lines = applyTemplate(baseLines, lineWidth, template);
+        printPreview(client, lines, template);
     });
 }

--- a/client/src/types/letter.ts
+++ b/client/src/types/letter.ts
@@ -12,14 +12,14 @@ export interface LetterTemplateDefinition {
 const LETTER_TEMPLATE_DEFINITION_MAP: Record<LetterTemplate, LetterTemplateDefinition> = {
     none: {
         value: "none",
-        displayLabel: "No template",
+        displayLabel: "Brak",
         previewLabel: "bez szablonu",
         supportsJustification: true,
     },
     plain: {
         value: "plain",
-        displayLabel: "Zwykly",
-        previewLabel: "zwykly",
+        displayLabel: "Ramka",
+        previewLabel: "Ramka",
         supportsJustification: true,
     },
     parchment: {

--- a/client/src/types/letter.ts
+++ b/client/src/types/letter.ts
@@ -2,6 +2,54 @@ export const LETTER_TEMPLATES = ["plain", "parchment", "parchment2", "parchment3
 
 export type LetterTemplate = (typeof LETTER_TEMPLATES)[number];
 
+export interface LetterTemplateDefinition {
+    readonly value: LetterTemplate;
+    readonly displayLabel: string;
+    readonly previewLabel: string;
+    readonly supportsJustification: boolean;
+}
+
+const LETTER_TEMPLATE_DEFINITION_MAP: Record<LetterTemplate, LetterTemplateDefinition> = {
+    plain: {
+        value: "plain",
+        displayLabel: "Zwykly",
+        previewLabel: "zwykly",
+        supportsJustification: true,
+    },
+    parchment: {
+        value: "parchment",
+        displayLabel: "Pergamin",
+        previewLabel: "pergamin",
+        supportsJustification: true,
+    },
+    parchment2: {
+        value: "parchment2",
+        displayLabel: "Pergamin II",
+        previewLabel: "pergamin 2",
+        supportsJustification: true,
+    },
+    parchment3: {
+        value: "parchment3",
+        displayLabel: "Pergamin III",
+        previewLabel: "pergamin 3",
+        supportsJustification: true,
+    },
+};
+
+export const LETTER_TEMPLATE_DEFINITIONS: Readonly<Record<LetterTemplate, LetterTemplateDefinition>> =
+    LETTER_TEMPLATE_DEFINITION_MAP;
+
+export const LETTER_TEMPLATE_CHOICES: readonly LetterTemplateDefinition[] =
+    LETTER_TEMPLATES
+        .map(template => LETTER_TEMPLATE_DEFINITION_MAP[template])
+        .filter(definition => definition.supportsJustification);
+
+export const LETTER_TEMPLATE_PREVIEW_LABELS: Readonly<Record<LetterTemplate, string>> =
+    LETTER_TEMPLATES.reduce<Record<LetterTemplate, string>>((accumulator, template) => {
+        accumulator[template] = LETTER_TEMPLATE_DEFINITION_MAP[template].previewLabel;
+        return accumulator;
+    }, {} as Record<LetterTemplate, string>);
+
 export interface LetterSubmitPayload {
     to: string;
     cc: string;

--- a/client/src/types/letter.ts
+++ b/client/src/types/letter.ts
@@ -1,0 +1,15 @@
+export const LETTER_TEMPLATES = ["plain", "parchment"] as const;
+
+export type LetterTemplate = (typeof LETTER_TEMPLATES)[number];
+
+export interface LetterSubmitPayload {
+    to: string;
+    cc: string;
+    subject: string;
+    content: string;
+    template: LetterTemplate;
+}
+
+export function isLetterTemplate(value: unknown): value is LetterTemplate {
+    return typeof value === "string" && (LETTER_TEMPLATES as readonly string[]).includes(value);
+}

--- a/client/src/types/letter.ts
+++ b/client/src/types/letter.ts
@@ -1,4 +1,4 @@
-export const LETTER_TEMPLATES = ["plain", "parchment", "parchment2", "parchment3"] as const;
+export const LETTER_TEMPLATES = ["none", "plain", "parchment", "parchment2", "parchment3"] as const;
 
 export type LetterTemplate = (typeof LETTER_TEMPLATES)[number];
 
@@ -10,6 +10,12 @@ export interface LetterTemplateDefinition {
 }
 
 const LETTER_TEMPLATE_DEFINITION_MAP: Record<LetterTemplate, LetterTemplateDefinition> = {
+    none: {
+        value: "none",
+        displayLabel: "No template",
+        previewLabel: "bez szablonu",
+        supportsJustification: true,
+    },
     plain: {
         value: "plain",
         displayLabel: "Zwykly",

--- a/client/src/types/letter.ts
+++ b/client/src/types/letter.ts
@@ -1,4 +1,4 @@
-export const LETTER_TEMPLATES = ["plain", "parchment"] as const;
+export const LETTER_TEMPLATES = ["plain", "parchment", "parchment2", "parchment3"] as const;
 
 export type LetterTemplate = (typeof LETTER_TEMPLATES)[number];
 

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -512,6 +512,13 @@
             <input id="letter-subject" name="letter-subject" class="form-control form-control-sm" type="text" autocomplete="off">
         </div>
         <div class="letter-composer-field">
+            <label for="letter-template" class="form-label">Szablon:</label>
+            <select id="letter-template" name="letter-template" class="form-select form-select-sm">
+                <option value="plain">Zwykly</option>
+                <option value="parchment">Pergamin</option>
+            </select>
+        </div>
+        <div class="letter-composer-field">
             <label for="letter-content" class="form-label">Treść:</label>
             <textarea id="letter-content" name="letter-content" class="form-control" rows="10"></textarea>
         </div>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -521,6 +521,8 @@
                 <select id="letter-template" name="letter-template" class="form-select form-select-sm letter-template-select">
                     <option value="plain">Zwykly</option>
                     <option value="parchment">Pergamin</option>
+                    <option value="parchment2">Pergamin II</option>
+                    <option value="parchment3">Pergamin III</option>
                 </select>
             </div>
             <button type="button" class="btn btn-secondary btn-sm" data-letter-preview>Podgląd</button>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -516,11 +516,13 @@
             <textarea id="letter-content" name="letter-content" class="form-control" rows="10"></textarea>
         </div>
         <div class="letter-composer-actions">
-            <label for="letter-template" class="form-label mb-0">Szablon:</label>
-            <select id="letter-template" name="letter-template" class="form-select form-select-sm letter-template-select">
-                <option value="plain">Zwykly</option>
-                <option value="parchment">Pergamin</option>
-            </select>
+            <div class="letter-template-group">
+                <label for="letter-template" class="form-label mb-0">Szablon:</label>
+                <select id="letter-template" name="letter-template" class="form-select form-select-sm letter-template-select">
+                    <option value="plain">Zwykly</option>
+                    <option value="parchment">Pergamin</option>
+                </select>
+            </div>
             <button type="button" class="btn btn-secondary btn-sm" data-letter-preview>Podgląd</button>
             <button type="submit" class="btn btn-primary btn-sm">Wyślij</button>
         </div>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -519,6 +519,7 @@
             <div class="letter-template-group">
                 <label for="letter-template" class="form-label mb-0">Szablon:</label>
                 <select id="letter-template" name="letter-template" class="form-select form-select-sm letter-template-select">
+                    <option value="none">No template</option>
                     <option value="plain">Zwykly</option>
                     <option value="parchment">Pergamin</option>
                     <option value="parchment2">Pergamin II</option>

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -512,17 +512,15 @@
             <input id="letter-subject" name="letter-subject" class="form-control form-control-sm" type="text" autocomplete="off">
         </div>
         <div class="letter-composer-field">
-            <label for="letter-template" class="form-label">Szablon:</label>
-            <select id="letter-template" name="letter-template" class="form-select form-select-sm">
-                <option value="plain">Zwykly</option>
-                <option value="parchment">Pergamin</option>
-            </select>
-        </div>
-        <div class="letter-composer-field">
             <label for="letter-content" class="form-label">Treść:</label>
             <textarea id="letter-content" name="letter-content" class="form-control" rows="10"></textarea>
         </div>
         <div class="letter-composer-actions">
+            <label for="letter-template" class="form-label mb-0">Szablon:</label>
+            <select id="letter-template" name="letter-template" class="form-select form-select-sm letter-template-select">
+                <option value="plain">Zwykly</option>
+                <option value="parchment">Pergamin</option>
+            </select>
             <button type="button" class="btn btn-secondary btn-sm" data-letter-preview>Podgląd</button>
             <button type="submit" class="btn btn-primary btn-sm">Wyślij</button>
         </div>

--- a/web-client/src/LetterComposer.ts
+++ b/web-client/src/LetterComposer.ts
@@ -1,5 +1,11 @@
 import ArkadiaClient from "./ArkadiaClient.ts";
-import { isLetterTemplate, type LetterSubmitPayload, type LetterTemplate } from "@client/src/types/letter";
+import {
+    LETTER_TEMPLATE_CHOICES,
+    LETTER_TEMPLATE_DEFINITIONS,
+    isLetterTemplate,
+    type LetterSubmitPayload,
+    type LetterTemplate,
+} from "@client/src/types/letter";
 
 interface LetterComposerState {
     hasCustomPosition: boolean;
@@ -36,6 +42,7 @@ export default class LetterComposer {
         this.closeButton = this.container?.querySelector<HTMLButtonElement>("[data-letter-close]");
         this.previewButton = this.container?.querySelector<HTMLButtonElement>("[data-letter-preview]");
         this.templateSelect = this.container?.querySelector<HTMLSelectElement>("[name='letter-template']");
+        this.rebuildTemplateOptions();
         this.templateSelection = this.loadTemplateSelection();
         this.applyTemplateSelection(this.templateSelection);
 
@@ -174,31 +181,59 @@ export default class LetterComposer {
         document.removeEventListener("pointerup", this.handlePointerUp);
     };
 
+    private isSelectableTemplate(value: unknown): value is LetterTemplate {
+        return isLetterTemplate(value) && Boolean(LETTER_TEMPLATE_DEFINITIONS[value]?.supportsJustification);
+    }
+
+    private rebuildTemplateOptions() {
+        if (!this.templateSelect) {
+            return;
+        }
+        const currentValue = this.templateSelect.value;
+        this.templateSelect.innerHTML = "";
+        LETTER_TEMPLATE_CHOICES.forEach(definition => {
+            const option = document.createElement("option");
+            option.value = definition.value;
+            option.textContent = definition.displayLabel;
+            this.templateSelect!.appendChild(option);
+        });
+
+        if (this.isSelectableTemplate(currentValue)) {
+            this.templateSelect.value = currentValue;
+        } else if (LETTER_TEMPLATE_CHOICES.length > 0) {
+            this.templateSelect.value = LETTER_TEMPLATE_CHOICES[0].value;
+        }
+    }
+
     private loadTemplateSelection(): LetterTemplate {
         try {
             const stored = localStorage.getItem(LetterComposer.TEMPLATE_STORAGE_KEY);
-            if (stored && isLetterTemplate(stored)) {
+            if (this.isSelectableTemplate(stored)) {
                 return stored;
             }
         } catch {
             // ignore storage errors
         }
-        if (this.templateSelect && isLetterTemplate(this.templateSelect.value)) {
+        if (this.templateSelect && this.isSelectableTemplate(this.templateSelect.value)) {
             return this.templateSelect.value;
         }
-        return "plain";
+        return LETTER_TEMPLATE_CHOICES[0]?.value ?? "plain";
     }
 
     private getCurrentTemplateSelection(): LetterTemplate {
-        if (this.templateSelect && isLetterTemplate(this.templateSelect.value)) {
+        if (this.templateSelect && this.isSelectableTemplate(this.templateSelect.value)) {
             return this.templateSelect.value;
         }
-        return "plain";
+        return LETTER_TEMPLATE_CHOICES[0]?.value ?? "plain";
     }
 
     private applyTemplateSelection(value: LetterTemplate) {
         if (this.templateSelect) {
-            this.templateSelect.value = value;
+            if (this.isSelectableTemplate(value)) {
+                this.templateSelect.value = value;
+            } else if (LETTER_TEMPLATE_CHOICES.length > 0) {
+                this.templateSelect.value = LETTER_TEMPLATE_CHOICES[0].value;
+            }
         }
     }
 

--- a/web-client/src/LetterComposer.ts
+++ b/web-client/src/LetterComposer.ts
@@ -1,17 +1,14 @@
 import ArkadiaClient from "./ArkadiaClient.ts";
+import { isLetterTemplate, type LetterSubmitPayload, type LetterTemplate } from "@client/src/types/letter";
 
 interface LetterComposerState {
     hasCustomPosition: boolean;
 }
 
-interface SubmitPayload {
-    to: string;
-    cc: string;
-    subject: string;
-    content: string;
-}
+type SubmitPayload = LetterSubmitPayload;
 
 export default class LetterComposer {
+    private static readonly TEMPLATE_STORAGE_KEY = "letter-composer-template";
     private container: HTMLElement | null;
     private header: HTMLElement | null;
     private form: HTMLFormElement | null;
@@ -21,10 +18,12 @@ export default class LetterComposer {
     private contentInput: HTMLTextAreaElement | null;
     private closeButton: HTMLButtonElement | null;
     private previewButton: HTMLButtonElement | null;
+    private templateSelect: HTMLSelectElement | null;
     private dragPointerId: number | null = null;
     private dragOffsetX = 0;
     private dragOffsetY = 0;
     private state: LetterComposerState = { hasCustomPosition: false };
+    private templateSelection: LetterTemplate = "plain";
 
     constructor(private client: typeof ArkadiaClient) {
         this.container = document.getElementById("letter-composer");
@@ -36,17 +35,24 @@ export default class LetterComposer {
         this.contentInput = this.container?.querySelector<HTMLTextAreaElement>("[name='letter-content']");
         this.closeButton = this.container?.querySelector<HTMLButtonElement>("[data-letter-close]");
         this.previewButton = this.container?.querySelector<HTMLButtonElement>("[data-letter-preview]");
+        this.templateSelect = this.container?.querySelector<HTMLSelectElement>("[name='letter-template']");
+        this.templateSelection = this.loadTemplateSelection();
+        this.applyTemplateSelection(this.templateSelection);
 
         this.attachListeners();
         this.client.on("letterComposer", () => this.show());
     }
 
     private getPayload(): SubmitPayload {
+        const template = this.getCurrentTemplateSelection();
+        this.templateSelection = template;
+        this.saveTemplateSelection(template);
         return {
             to: this.toInput?.value ?? "",
             cc: this.ccInput?.value ?? "",
             subject: this.subjectInput?.value ?? "",
             content: this.contentInput?.value ?? "",
+            template,
         };
     }
 
@@ -58,6 +64,7 @@ export default class LetterComposer {
                 this.client.emit("letterComposer.submit", payload);
                 this.hide();
                 this.form?.reset();
+                this.applyTemplateSelection(this.templateSelection);
             });
         }
 
@@ -73,6 +80,13 @@ export default class LetterComposer {
             });
         }
 
+        if (this.templateSelect) {
+            this.templateSelect.addEventListener("change", () => {
+                this.templateSelection = this.getCurrentTemplateSelection();
+                this.saveTemplateSelection(this.templateSelection);
+            });
+        }
+
         if (this.header && this.container) {
             this.header.addEventListener("pointerdown", ev => this.startDrag(ev));
         }
@@ -82,7 +96,9 @@ export default class LetterComposer {
         if (!this.container) {
             return;
         }
+        this.templateSelection = this.loadTemplateSelection();
         this.form?.reset();
+        this.applyTemplateSelection(this.templateSelection);
         this.container.hidden = false;
         requestAnimationFrame(() => {
             if (!this.state.hasCustomPosition) {
@@ -157,4 +173,40 @@ export default class LetterComposer {
         document.removeEventListener("pointermove", this.handlePointerMove);
         document.removeEventListener("pointerup", this.handlePointerUp);
     };
+
+    private loadTemplateSelection(): LetterTemplate {
+        try {
+            const stored = localStorage.getItem(LetterComposer.TEMPLATE_STORAGE_KEY);
+            if (stored && isLetterTemplate(stored)) {
+                return stored;
+            }
+        } catch {
+            // ignore storage errors
+        }
+        if (this.templateSelect && isLetterTemplate(this.templateSelect.value)) {
+            return this.templateSelect.value;
+        }
+        return "plain";
+    }
+
+    private getCurrentTemplateSelection(): LetterTemplate {
+        if (this.templateSelect && isLetterTemplate(this.templateSelect.value)) {
+            return this.templateSelect.value;
+        }
+        return "plain";
+    }
+
+    private applyTemplateSelection(value: LetterTemplate) {
+        if (this.templateSelect) {
+            this.templateSelect.value = value;
+        }
+    }
+
+    private saveTemplateSelection(value: LetterTemplate) {
+        try {
+            localStorage.setItem(LetterComposer.TEMPLATE_STORAGE_KEY, value);
+        } catch {
+            // ignore storage errors
+        }
+    }
 }

--- a/web-client/src/LetterComposer.ts
+++ b/web-client/src/LetterComposer.ts
@@ -29,7 +29,7 @@ export default class LetterComposer {
     private dragOffsetX = 0;
     private dragOffsetY = 0;
     private state: LetterComposerState = { hasCustomPosition: false };
-    private templateSelection: LetterTemplate = "plain";
+    private templateSelection: LetterTemplate = LETTER_TEMPLATE_CHOICES[0]?.value ?? "plain";
 
     constructor(private client: typeof ArkadiaClient) {
         this.container = document.getElementById("letter-composer");

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -1131,17 +1131,19 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
 .letter-composer-actions {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: flex-end;
   gap: 0.5rem;
   flex-wrap: wrap;
   margin-top: auto;
   padding-top: 0.5rem;
+  width: 100%;
 }
 
-.letter-composer-actions .form-label {
+.letter-template-group {
   display: flex;
   align-items: center;
   gap: 0.25rem;
+  margin-right: auto;
 }
 
 .letter-template-select {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -1130,10 +1130,23 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
 
 .letter-composer-actions {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: flex-start;
   gap: 0.5rem;
+  flex-wrap: wrap;
   margin-top: auto;
   padding-top: 0.5rem;
+}
+
+.letter-composer-actions .form-label {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.letter-template-select {
+  width: auto;
+  min-width: 9rem;
 }
 
 .docs-content {


### PR DESCRIPTION
## Summary
- add shared letter template types and update client to format parchment-styled letters
- expose template selection in the web letter composer and persist the last choice

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68e309f4fb60832a9eaacff0e37ef788