### PR TITLE
Ensure people worker runs as module locally

### DIFF
--- a/client/src/peopleLoader.ts
+++ b/client/src/peopleLoader.ts
@@ -35,7 +35,9 @@ async function loadFromCache(): Promise<PersonEntry[] | null> {
 
 function ensureWorker(): Worker {
     if (!workerInstance) {
-        workerInstance = new Worker(new URL('./peopleWorker.ts', import.meta.url));
+        workerInstance = new Worker(new URL('./peopleWorker.ts', import.meta.url), {
+            type: 'module',
+        });
         workerInstance.onmessage = (event: MessageEvent<WorkerMessage>) => {
             const { data } = event;
             const pending = pendingWorkerRequests.get(data.id);


### PR DESCRIPTION
## Summary
- ensure the people worker is instantiated as an ES module so it can use import syntax

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68e382cc8968832a9cdcafd0b09d35b8