### PR TITLE
Refresh Drive file list when opening export popup

### DIFF
--- a/web-client/src/options/ExportImport.tsx
+++ b/web-client/src/options/ExportImport.tsx
@@ -578,15 +578,23 @@ function ExportImport() {
     useEffect(() => {
         const handleShow = () => {
             refreshCharacters();
-            if (driveTokenRef.current && driveTokenExpiryRef.current && Date.now() < driveTokenExpiryRef.current) {
-                void refreshDriveFiles();
+            if (!tokenClientRef.current) {
+                return;
             }
+            void (async () => {
+                try {
+                    await ensureDriveToken();
+                    await refreshDriveFiles();
+                } catch (err) {
+                    console.error("Failed to refresh Google Drive files", err);
+                }
+            })();
         };
         window.addEventListener("show-export-import", handleShow);
         return () => {
             window.removeEventListener("show-export-import", handleShow);
         };
-    }, [refreshCharacters, refreshDriveFiles]);
+    }, [refreshCharacters, refreshDriveFiles, ensureDriveToken]);
 
     const handleToggleAll = (checked: boolean) => {
         setSelection(prev => {


### PR DESCRIPTION
## Summary
- refresh Google Drive backup list when the export/import popup is opened
- ensure access token retrieval is attempted before listing files and log failures

## Testing
- yarn --cwd web-client test --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e3bc940004832a82ebc3bbdb104ed7