### PR TITLE
Add Google Drive backup integration

### DIFF
--- a/web-client/src/options/ExportImport.tsx
+++ b/web-client/src/options/ExportImport.tsx
@@ -33,6 +33,92 @@ interface ExportPayload {
     };
 }
 
+const DRIVE_SCOPES = ["https://www.googleapis.com/auth/drive.appdata"];
+const CLIENT_ID = "717498712073-50tjdorsa6vk4mq0fj774u0rhqr5jkd4.apps.googleusercontent.com";
+const GOOGLE_SCRIPT_ID = "google-identity-services";
+const GOOGLE_SCRIPT_SRC = "https://accounts.google.com/gsi/client";
+const DRIVE_API_BASE = "https://www.googleapis.com/drive/v3";
+const DRIVE_UPLOAD_URL = "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart";
+
+declare global {
+    interface Window {
+        google?: {
+            accounts?: {
+                oauth2?: {
+                    initTokenClient?: (config: {
+                        client_id: string;
+                        scope: string;
+                        callback: (response: GoogleTokenResponse) => void;
+                    }) => GoogleTokenClient;
+                };
+            };
+        };
+    }
+}
+
+interface GoogleTokenResponse {
+    access_token?: string;
+    expires_in?: number | string;
+    error?: string;
+    error_description?: string;
+}
+
+interface GoogleTokenClient {
+    requestAccessToken: (options?: { prompt?: string }) => void;
+    callback?: (response: GoogleTokenResponse) => void;
+}
+
+interface DriveFileEntry {
+    id: string;
+    name: string;
+    createdTime?: string;
+    modifiedTime?: string;
+    size?: string;
+}
+
+function loadScript(id: string, src: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        if (document.getElementById(id)) {
+            resolve();
+            return;
+        }
+        const script = document.createElement("script");
+        script.id = id;
+        script.src = src;
+        script.async = true;
+        script.defer = true;
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error("Failed to load Google Identity Services"));
+        document.head.appendChild(script);
+    });
+}
+
+function formatDriveDate(value?: string): string {
+    if (!value) return "";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return "";
+    }
+    return date.toLocaleString();
+}
+
+function buildBackupFilename() {
+    const timestamp = new Date().toISOString().replace(/[:T]/g, "-").split(".")[0];
+    return `arkadia-backup-${timestamp}.json`;
+}
+
+function formatDriveSize(value?: string): string {
+    if (!value) return "";
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric <= 0) {
+        return "";
+    }
+    if (numeric >= 1024 * 1024) {
+        return `${(numeric / (1024 * 1024)).toFixed(1)} MB`;
+    }
+    return `${(numeric / 1024).toFixed(1)} KB`;
+}
+
 const EXCLUDED_LOCAL_STORAGE_KEYS = new Set([
     "cachedMapData",
     "cachedColors",
@@ -309,11 +395,37 @@ function ExportImport() {
     const [status, setStatus] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [isProcessing, setIsProcessing] = useState(false);
+    const [isDriveProcessing, setIsDriveProcessing] = useState(false);
+    const [isDriveLoading, setIsDriveLoading] = useState(false);
+    const [isConnectingDrive, setIsConnectingDrive] = useState(false);
+    const [googleReady, setGoogleReady] = useState(false);
+    const [driveFiles, setDriveFiles] = useState<DriveFileEntry[]>([]);
+    const [tokenInfo, setTokenInfo] = useState<{ token: string; expiresAt: number } | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const tokenClientRef = useRef<GoogleTokenClient | null>(null);
+    const tokenInfoRef = useRef<{ token: string; expiresAt: number } | null>(null);
+    const pendingTokenRequestsRef = useRef<
+        Array<{ resolve: (token: string) => void; reject: (error: Error) => void }>
+    >([]);
     const selectedCharacters = useMemo(
         () => characters.filter(name => selection[name]),
         [characters, selection]
     );
+    const isDriveConnected = useMemo(() => {
+        if (!tokenInfo) {
+            return false;
+        }
+        return Date.now() < tokenInfo.expiresAt;
+    }, [tokenInfo]);
+
+    const clearTokenInfo = useCallback(() => {
+        tokenInfoRef.current = null;
+        setTokenInfo(null);
+    }, []);
+
+    useEffect(() => {
+        tokenInfoRef.current = tokenInfo;
+    }, [tokenInfo]);
 
     const refreshCharacters = useCallback(() => {
         const list = collectCharacters();
@@ -329,6 +441,90 @@ function ExportImport() {
             return next;
         });
     }, []);
+
+    useEffect(() => {
+        let isCancelled = false;
+        const handleTokenResponse = (response: GoogleTokenResponse) => {
+            const pending = pendingTokenRequestsRef.current.splice(0);
+            if (response?.error) {
+                const error = new Error(response.error_description ?? response.error ?? "Token request failed");
+                (error as Error & { authError?: string }).authError = response.error ?? undefined;
+                pending.forEach(entry => entry.reject(error));
+                return;
+            }
+            const accessToken = typeof response?.access_token === "string" ? response.access_token : "";
+            if (!accessToken) {
+                const error = new Error("Brak tokena dostępu");
+                pending.forEach(entry => entry.reject(error));
+                return;
+            }
+            const expiresInSeconds = Number(response?.expires_in);
+            const expiresAt = Number.isFinite(expiresInSeconds)
+                ? Date.now() + expiresInSeconds * 1000
+                : Date.now() + 5 * 60 * 1000;
+            if (isCancelled) {
+                return;
+            }
+            const info = { token: accessToken, expiresAt };
+            tokenInfoRef.current = info;
+            setTokenInfo(info);
+            pending.forEach(entry => entry.resolve(accessToken));
+        };
+
+        const initialiseClient = () => {
+            if (isCancelled) {
+                return;
+            }
+            const initTokenClient = window.google?.accounts?.oauth2?.initTokenClient;
+            if (!initTokenClient) {
+                console.error("Google Identity Services not available");
+                return;
+            }
+            const client = initTokenClient({
+                client_id: CLIENT_ID,
+                scope: DRIVE_SCOPES.join(" "),
+                callback: handleTokenResponse,
+            });
+            tokenClientRef.current = client;
+            setGoogleReady(true);
+        };
+
+        if (window.google?.accounts?.oauth2?.initTokenClient) {
+            initialiseClient();
+        } else {
+            loadScript(GOOGLE_SCRIPT_ID, GOOGLE_SCRIPT_SRC)
+                .then(() => {
+                    initialiseClient();
+                })
+                .catch(err => {
+                    console.error("Failed to load Google Identity Services", err);
+                });
+        }
+
+        return () => {
+            isCancelled = true;
+            const pending = pendingTokenRequestsRef.current.splice(0);
+            if (pending.length > 0) {
+                const error = new Error("Token request cancelled");
+                pending.forEach(entry => entry.reject(error));
+            }
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!tokenInfo) {
+            return;
+        }
+        const remaining = tokenInfo.expiresAt - Date.now();
+        if (remaining <= 0) {
+            clearTokenInfo();
+            return;
+        }
+        const timeout = window.setTimeout(() => {
+            clearTokenInfo();
+        }, remaining);
+        return () => window.clearTimeout(timeout);
+    }, [tokenInfo, clearTokenInfo]);
 
     useEffect(() => {
         refreshCharacters();
@@ -370,6 +566,300 @@ function ExportImport() {
         await importVisitedRooms(payload.indexedDB.visitedRooms ?? []);
     }, []);
 
+    const ensureAccessToken = useCallback(
+        (prompt: "" | "consent" = "") => {
+            const info = tokenInfoRef.current;
+            if (info && Date.now() < info.expiresAt - 60_000) {
+                return Promise.resolve(info.token);
+            }
+            return new Promise<string>((resolve, reject) => {
+                const client = tokenClientRef.current;
+                if (!client) {
+                    reject(new Error("Google OAuth nie jest jeszcze gotowe."));
+                    return;
+                }
+                pendingTokenRequestsRef.current.push({ resolve, reject });
+                if (pendingTokenRequestsRef.current.length > 1) {
+                    return;
+                }
+                try {
+                    client.requestAccessToken({ prompt });
+                } catch (err) {
+                    const error = err instanceof Error ? err : new Error(String(err));
+                    const pending = pendingTokenRequestsRef.current.splice(0);
+                    pending.forEach(entry => entry.reject(error));
+                }
+            });
+        },
+        []
+    );
+
+    const runWithToken = useCallback(
+        async <T,>(
+            action: (token: string) => Promise<T>,
+            options?: { allowInteractive?: boolean }
+        ): Promise<T> => {
+            const allowInteractive = options?.allowInteractive ?? true;
+            const attempt = async (prompt: "" | "consent") => {
+                const token = await ensureAccessToken(prompt);
+                return action(token);
+            };
+            try {
+                return await attempt("");
+            } catch (err) {
+                const authError = (err as Error & { authError?: string }).authError;
+                if (
+                    allowInteractive &&
+                    (authError === "interaction_required" || authError === "consent_required")
+                ) {
+                    return await attempt("consent");
+                }
+                if ((err as Error & { shouldRetryWithNewToken?: boolean }).shouldRetryWithNewToken) {
+                    try {
+                        return await attempt("");
+                    } catch (retryErr) {
+                        const retryAuthError = (retryErr as Error & { authError?: string }).authError;
+                        if (
+                            allowInteractive &&
+                            (retryAuthError === "interaction_required" || retryAuthError === "consent_required")
+                        ) {
+                            return await attempt("consent");
+                        }
+                        throw retryErr;
+                    }
+                }
+                throw err;
+            }
+        },
+        [ensureAccessToken]
+    );
+
+    const driveFetch = useCallback(
+        async (token: string, input: RequestInfo | URL, init?: RequestInit) => {
+            const headers = new Headers(init?.headers ?? undefined);
+            headers.set("Authorization", `Bearer ${token}`);
+            const response = await fetch(input, { ...init, headers });
+            if (response.status === 401) {
+                clearTokenInfo();
+                const error = new Error("Unauthorized");
+                (error as Error & { shouldRetryWithNewToken?: boolean }).shouldRetryWithNewToken = true;
+                throw error;
+            }
+            return response;
+        },
+        [clearTokenInfo]
+    );
+
+    const loadDriveExports = useCallback(async (options?: { allowInteractive?: boolean }) => {
+        setIsDriveLoading(true);
+        try {
+            await runWithToken(async token => {
+                const response = await driveFetch(
+                    token,
+                    `${DRIVE_API_BASE}/files?spaces=appDataFolder&fields=files(id,name,createdTime,modifiedTime,size)&orderBy=createdTime%20desc`
+                );
+                if (!response.ok) {
+                    const message = await response.text().catch(() => "");
+                    throw new Error(message || "Nie udało się pobrać listy kopii zapasowych z Google Drive.");
+                }
+                const data = await response.json();
+                const files = Array.isArray(data?.files) ? data.files : [];
+                setDriveFiles(
+                    files
+                        .filter((entry: any) => typeof entry?.id === "string")
+                        .map((entry: any) => ({
+                            id: entry.id as string,
+                            name: typeof entry?.name === "string" ? entry.name : "",
+                            createdTime: typeof entry?.createdTime === "string" ? entry.createdTime : undefined,
+                            modifiedTime: typeof entry?.modifiedTime === "string" ? entry.modifiedTime : undefined,
+                            size: typeof entry?.size === "string" ? entry.size : undefined,
+                        }))
+                );
+            }, options);
+        } catch (err) {
+            console.error("Failed to list Google Drive exports", err);
+            throw err;
+        } finally {
+            setIsDriveLoading(false);
+        }
+    }, [driveFetch, runWithToken]);
+
+    useEffect(() => {
+        if (!googleReady) {
+            return;
+        }
+        let cancelled = false;
+        (async () => {
+            try {
+                await loadDriveExports({ allowInteractive: false });
+            } catch (err) {
+                const authError = (err as Error & { authError?: string }).authError;
+                if (authError === "interaction_required" || authError === "consent_required") {
+                    return;
+                }
+                if ((err as Error & { shouldRetryWithNewToken?: boolean }).shouldRetryWithNewToken) {
+                    return;
+                }
+                if (!cancelled) {
+                    console.error("Failed to synchronise Google Drive backups", err);
+                }
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [googleReady, loadDriveExports]);
+
+    const connectToDrive = useCallback(async () => {
+        if (!googleReady) {
+            return;
+        }
+        setError(null);
+        setStatus(null);
+        setIsConnectingDrive(true);
+        try {
+            await loadDriveExports();
+            setStatus("Połączono z Google Drive.");
+        } catch (err) {
+            console.error("Failed to connect to Google Drive", err);
+            const authError = (err as Error & { authError?: string }).authError;
+            if (authError === "access_denied") {
+                setError("Dostęp do Google Drive został odrzucony.");
+            } else {
+                setError("Nie udało się połączyć z Google Drive.");
+            }
+        } finally {
+            setIsConnectingDrive(false);
+        }
+    }, [googleReady, loadDriveExports]);
+
+    const handleDriveExport = useCallback(async () => {
+        setError(null);
+        setStatus(null);
+        setIsDriveProcessing(true);
+        try {
+            const payload = await buildExport(selectedCharacters);
+            await runWithToken(async token => {
+                const metadata = {
+                    name: buildBackupFilename(),
+                    parents: ["appDataFolder"],
+                    mimeType: "application/json",
+                };
+                const boundary = `boundary_${Math.random().toString(36).slice(2)}`;
+                const body = [
+                    `--${boundary}`,
+                    "Content-Type: application/json; charset=UTF-8",
+                    "",
+                    JSON.stringify(metadata),
+                    `--${boundary}`,
+                    "Content-Type: application/json",
+                    "",
+                    JSON.stringify(payload, null, 2),
+                    `--${boundary}--`,
+                    "",
+                ].join("\r\n");
+                const response = await driveFetch(token, DRIVE_UPLOAD_URL, {
+                    method: "POST",
+                    headers: { "Content-Type": `multipart/related; boundary=${boundary}` },
+                    body,
+                });
+                if (!response.ok) {
+                    const message = await response.text().catch(() => "");
+                    throw new Error(message || "Nie udało się zapisać kopii zapasowej w Google Drive.");
+                }
+            });
+            setStatus("Eksport zapisany w Google Drive.");
+            try {
+                await loadDriveExports({ allowInteractive: false });
+            } catch (err) {
+                console.error("Failed to refresh Google Drive exports", err);
+            }
+        } catch (err) {
+            console.error("Failed to export to Google Drive", err);
+            const authError = (err as Error & { authError?: string }).authError;
+            if (authError === "access_denied") {
+                setError("Dostęp do Google Drive został odrzucony.");
+            } else {
+                setError("Nie udało się zapisać eksportu na Google Drive.");
+            }
+        } finally {
+            setIsDriveProcessing(false);
+        }
+    }, [driveFetch, loadDriveExports, runWithToken, selectedCharacters]);
+
+    const handleDriveImport = useCallback(
+        async (file: DriveFileEntry) => {
+            setError(null);
+            setStatus(null);
+            setIsDriveProcessing(true);
+            try {
+                await runWithToken(async token => {
+                    const response = await driveFetch(
+                        token,
+                        `${DRIVE_API_BASE}/files/${encodeURIComponent(file.id)}?alt=media`
+                    );
+                    if (!response.ok) {
+                        const message = await response.text().catch(() => "");
+                        throw new Error(message || "Nie udało się pobrać kopii zapasowej z Google Drive.");
+                    }
+                    const text = await response.text();
+                    const parsed = JSON.parse(text);
+                    if (!validatePayload(parsed)) {
+                        throw new Error("invalid");
+                    }
+                    await applyImportedData(parsed);
+                });
+                setStatus(
+                    "Import z Google Drive zakończony sukcesem. Niektóre ustawienia mogą wymagać odświeżenia strony."
+                );
+                refreshCharacters();
+            } catch (err) {
+                console.error("Failed to import from Google Drive", err);
+                const authError = (err as Error & { authError?: string }).authError;
+                if (authError === "access_denied") {
+                    setError("Dostęp do Google Drive został odrzucony.");
+                } else {
+                    setError("Nie udało się zaimportować danych z Google Drive.");
+                }
+            } finally {
+                setIsDriveProcessing(false);
+            }
+        },
+        [applyImportedData, driveFetch, refreshCharacters, runWithToken]
+    );
+
+    const handleDriveDelete = useCallback(
+        async (file: DriveFileEntry) => {
+            setError(null);
+            setStatus(null);
+            setIsDriveProcessing(true);
+            try {
+                await runWithToken(async token => {
+                    const response = await driveFetch(token, `${DRIVE_API_BASE}/files/${encodeURIComponent(file.id)}`, {
+                        method: "DELETE",
+                    });
+                    if (!response.ok && response.status !== 204) {
+                        const message = await response.text().catch(() => "");
+                        throw new Error(message || "Nie udało się usunąć kopii zapasowej z Google Drive.");
+                    }
+                });
+                setStatus("Eksport został usunięty z Google Drive.");
+                setDriveFiles(prev => prev.filter(entry => entry.id !== file.id));
+            } catch (err) {
+                console.error("Failed to delete Google Drive export", err);
+                const authError = (err as Error & { authError?: string }).authError;
+                if (authError === "access_denied") {
+                    setError("Dostęp do Google Drive został odrzucony.");
+                } else {
+                    setError("Nie udało się usunąć eksportu z Google Drive.");
+                }
+            } finally {
+                setIsDriveProcessing(false);
+            }
+        },
+        [driveFetch, runWithToken]
+    );
+
     const handleExport = async () => {
         setError(null);
         setStatus(null);
@@ -378,8 +868,7 @@ function ExportImport() {
             const payload = await buildExport(selectedCharacters);
             const json = JSON.stringify(payload, null, 2);
             const blob = new Blob([json], { type: "application/json" });
-            const timestamp = new Date().toISOString().replace(/[:T]/g, "-").split(".")[0];
-            const filename = `arkadia-backup-${timestamp}.json`;
+            const filename = buildBackupFilename();
             const url = URL.createObjectURL(blob);
             const anchor = document.createElement("a");
             anchor.href = url;
@@ -474,10 +963,104 @@ function ExportImport() {
                     onChange={onFileChange}
                 />
             </div>
-            <div className="border-top pt-3">
-                <Alert variant="warning" className="mb-0">
-                    Integracja z Google Drive jest obecnie niedostępna. Użyj eksportu do pliku, aby tworzyć kopie zapasowe.
-                </Alert>
+            <div className="border-top pt-3 d-flex flex-column gap-3">
+                <div>
+                    <h2 className="h6 mb-1">Google Drive</h2>
+                    <p className="text-muted mb-0">
+                        Połącz konto Google, aby przechowywać kopie zapasowe w przestrzeni aplikacji Google Drive.
+                    </p>
+                </div>
+                <div className="d-flex flex-wrap gap-2 align-items-center">
+                    <Button
+                        variant="secondary"
+                        onClick={connectToDrive}
+                        disabled={!googleReady || isConnectingDrive || isDriveProcessing || isDriveLoading}
+                    >
+                        {isConnectingDrive ? (
+                            <span className="d-inline-flex align-items-center gap-2">
+                                <Spinner animation="border" size="sm" role="status" />
+                                <span>Łączenie…</span>
+                            </span>
+                        ) : isDriveConnected ? (
+                            "Odśwież połączenie z Google Drive"
+                        ) : (
+                            "Połącz z Google Drive"
+                        )}
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        onClick={handleDriveExport}
+                        disabled={!isDriveConnected || isDriveProcessing || isProcessing || isDriveLoading}
+                    >
+                        {isDriveProcessing ? (
+                            <span className="d-inline-flex align-items-center gap-2">
+                                <Spinner animation="border" size="sm" role="status" />
+                                <span>Przetwarzanie…</span>
+                            </span>
+                        ) : (
+                            "Eksportuj do Google Drive"
+                        )}
+                    </Button>
+                    {!googleReady && (
+                        <span className="text-muted small">Ładowanie obsługi Google…</span>
+                    )}
+                    {googleReady && isDriveConnected && !isConnectingDrive && !isDriveProcessing && !isDriveLoading && (
+                        <span className="text-success small">Połączono z Google Drive</span>
+                    )}
+                </div>
+                <div className="d-flex flex-column gap-2">
+                    {isDriveLoading ? (
+                        <div className="d-inline-flex align-items-center gap-2 text-muted">
+                            <Spinner animation="border" size="sm" role="status" />
+                            <span>Ładowanie kopii zapasowych…</span>
+                        </div>
+                    ) : isDriveConnected ? (
+                        driveFiles.length > 0 ? (
+                            <div className="d-flex flex-column gap-2">
+                                {driveFiles.map(file => {
+                                    const displayDate = formatDriveDate(file.modifiedTime ?? file.createdTime);
+                                    const sizeText = formatDriveSize(file.size);
+                                    return (
+                                        <div
+                                            key={file.id}
+                                            className="d-flex flex-column flex-lg-row align-items-lg-center gap-2 border rounded px-3 py-2"
+                                        >
+                                            <div className="flex-grow-1">
+                                                <div className="fw-semibold">{file.name || "arkadia-backup.json"}</div>
+                                                <div className="text-muted small">
+                                                    {displayDate || "Brak daty"}
+                                                    {sizeText ? ` · ${sizeText}` : ""}
+                                                </div>
+                                            </div>
+                                            <div className="d-flex gap-2">
+                                                <Button
+                                                    size="sm"
+                                                    variant="secondary"
+                                                    onClick={() => handleDriveImport(file)}
+                                                    disabled={isDriveProcessing}
+                                                >
+                                                    Importuj
+                                                </Button>
+                                                <Button
+                                                    size="sm"
+                                                    variant="danger"
+                                                    onClick={() => handleDriveDelete(file)}
+                                                    disabled={isDriveProcessing}
+                                                >
+                                                    Usuń
+                                                </Button>
+                                            </div>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        ) : (
+                            <p className="text-muted mb-0">Brak kopii zapasowych w Google Drive.</p>
+                        )
+                    ) : (
+                        <p className="text-muted mb-0">Połącz konto Google, aby wyświetlić kopie zapasowe.</p>
+                    )}
+                </div>
             </div>
             {status && (
                 <Alert variant="success" className="mb-0">


### PR DESCRIPTION
## Summary
- integrate Google Drive OAuth helpers into the export/import options so that short-lived tokens can be reused without repeated prompts
- add Google Drive controls that allow connecting, listing, uploading, importing, and deleting remote backups

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68e3db65ebd0832a9350e69a20dd4beb