### PR TITLE
Improve modal layouts for mobile devices

### DIFF
--- a/web-client/src/options/Aliases.tsx
+++ b/web-client/src/options/Aliases.tsx
@@ -135,18 +135,19 @@ function Aliases() {
 
     return (
         <div className="m-2 d-flex flex-column gap-2">
-            <div className="d-flex gap-2 align-items-center">
+            <div className="d-flex flex-column flex-md-row align-items-stretch align-items-md-center gap-2 w-100">
                 <Form.Control
                     type="text"
                     size="sm"
                     placeholder="Filtruj"
                     value={filter}
                     onChange={(e: ChangeEvent<HTMLInputElement>) => setFilter(e.target.value)}
-                    style={{width: '100%', maxWidth: '12rem'}}
+                    className="flex-grow-1"
+                    style={{ minWidth: 0 }}
                 />
-                <Button size="sm" onClick={openNew}>Dodaj alias</Button>
-                <Button size="sm" onClick={openArkadiaImport}>Importuj z klienta Arkadii</Button>
-                <Button size="sm" onClick={openImport}>Importuj z Blowtorch</Button>
+                <Button size="sm" className="w-100 w-md-auto" onClick={openNew}>Dodaj alias</Button>
+                <Button size="sm" className="w-100 w-md-auto" onClick={openArkadiaImport}>Importuj z klienta Arkadii</Button>
+                <Button size="sm" className="w-100 w-md-auto" onClick={openImport}>Importuj z Blowtorch</Button>
                 <input
                     ref={arkadiaInputRef}
                     type="file"

--- a/web-client/src/options/Aliases.tsx
+++ b/web-client/src/options/Aliases.tsx
@@ -145,9 +145,9 @@ function Aliases() {
                     className="flex-grow-1"
                     style={{ minWidth: 0 }}
                 />
-                <Button size="sm" className="w-100 w-md-auto" onClick={openNew}>Dodaj alias</Button>
-                <Button size="sm" className="w-100 w-md-auto" onClick={openArkadiaImport}>Importuj z klienta Arkadii</Button>
-                <Button size="sm" className="w-100 w-md-auto" onClick={openImport}>Importuj z Blowtorch</Button>
+                <Button size="sm" className="w-100 w-md-auto text-nowrap" onClick={openNew}>Dodaj alias</Button>
+                <Button size="sm" className="w-100 w-md-auto text-nowrap" onClick={openArkadiaImport}>Importuj z klienta Arkadii</Button>
+                <Button size="sm" className="w-100 w-md-auto text-nowrap" onClick={openImport}>Importuj z Blowtorch</Button>
                 <input
                     ref={arkadiaInputRef}
                     type="file"

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -308,11 +308,11 @@ function MobileButtons() {
     return (
         <div onClick={close} className="w-100 position-relative">
             <div className="d-flex flex-column flex-lg-row align-items-stretch align-items-lg-center gap-2 mb-2 w-100">
-                <div className="btn-group flex-wrap flex-lg-nowrap">
+                <div className="mobile-buttons-mode-toggle">
                     <Button
                         size="sm"
                         variant={view === 'solo' ? 'primary' : 'secondary'}
-                        className="text-nowrap w-100 w-lg-auto"
+                        className="text-nowrap"
                         onClick={() => changeView('solo')}
                     >
                         Bez drużyny
@@ -320,7 +320,7 @@ function MobileButtons() {
                     <Button
                         size="sm"
                         variant={view === 'team' ? 'primary' : 'secondary'}
-                        className="text-nowrap w-100 w-lg-auto"
+                        className="text-nowrap"
                         onClick={() => changeView('team')}
                     >
                         W drużynie
@@ -328,7 +328,7 @@ function MobileButtons() {
                     <Button
                         size="sm"
                         variant={view === 'leader' ? 'primary' : 'secondary'}
-                        className="text-nowrap w-100 w-lg-auto"
+                        className="text-nowrap"
                         onClick={() => changeView('leader')}
                     >
                         Prowadzący

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -585,7 +585,7 @@ function MobileButtons() {
                         Kopiuj
                     </Button>
                 </div>
-                <Button id="mobile-buttons-save" className="w-100 w-md-auto" onClick={save}>Zapisz</Button>
+                <Button id="mobile-buttons-save" className="w-100 w-md-auto text-nowrap" onClick={save}>Zapisz</Button>
             </div>
         </div>
     );

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -312,6 +312,7 @@ function MobileButtons() {
                     <Button
                         size="sm"
                         variant={view === 'solo' ? 'primary' : 'secondary'}
+                        className="text-nowrap w-100 w-lg-auto"
                         onClick={() => changeView('solo')}
                     >
                         Bez drużyny
@@ -319,6 +320,7 @@ function MobileButtons() {
                     <Button
                         size="sm"
                         variant={view === 'team' ? 'primary' : 'secondary'}
+                        className="text-nowrap w-100 w-lg-auto"
                         onClick={() => changeView('team')}
                     >
                         W drużynie
@@ -326,6 +328,7 @@ function MobileButtons() {
                     <Button
                         size="sm"
                         variant={view === 'leader' ? 'primary' : 'secondary'}
+                        className="text-nowrap w-100 w-lg-auto"
                         onClick={() => changeView('leader')}
                     >
                         Prowadzący

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -307,8 +307,8 @@ function MobileButtons() {
 
     return (
         <div onClick={close} className="w-100 position-relative">
-            <div className="d-flex align-items-center gap-2 mb-2">
-                <div className="btn-group">
+            <div className="d-flex flex-column flex-lg-row align-items-stretch align-items-lg-center gap-2 mb-2 w-100">
+                <div className="btn-group flex-wrap flex-lg-nowrap">
                     <Button
                         size="sm"
                         variant={view === 'solo' ? 'primary' : 'secondary'}
@@ -331,25 +331,30 @@ function MobileButtons() {
                         Prowadzący
                     </Button>
                 </div>
-                <Button size="sm" variant="secondary" onClick={() => restoreDefaults(view)}>
+                <Button
+                    size="sm"
+                    variant="secondary"
+                    className="w-100 w-lg-auto"
+                    onClick={() => restoreDefaults(view)}
+                >
                     Domyślne
                 </Button>
                 <Form.Check
                     id="mobile-buttons-lock"
                     type="checkbox"
-                    className="ms-auto user-select-none"
+                    className="user-select-none ms-lg-auto"
                     label="Zablokuj przyciski"
                     checked={settings.locked}
                     onChange={e => setSettings(prev => ({ ...prev, locked: e.target.checked }))}
                 />
             </div>
-            <div className="d-flex flex-column align-items-center mb-2">
+            <div className="d-flex flex-column align-items-center mb-2 w-100">
                 <div className="d-flex gap-1 mb-2">
                     <Button size="sm" variant="secondary" onClick={() => addRow('top')}>+R↑</Button>
                     <Button size="sm" variant="secondary" onClick={() => removeRow('top')}>-R↑</Button>
                 </div>
-                <div className="d-flex align-items-center">
-                    <div className="d-flex flex-column gap-1 me-2">
+                <div className="d-flex flex-column flex-lg-row align-items-center gap-2">
+                    <div className="d-flex flex-column gap-1 me-lg-2">
                         <Button size="sm" variant="secondary" onClick={() => addCol('left')}>+C←</Button>
                         <Button size="sm" variant="secondary" onClick={() => removeCol('left')}>-C←</Button>
                     </div>
@@ -367,7 +372,7 @@ function MobileButtons() {
                             />
                         ))}
                     </div>
-                    <div className="d-flex flex-column gap-1 ms-2">
+                    <div className="d-flex flex-column gap-1 ms-lg-2">
                         <Button size="sm" variant="secondary" onClick={() => addCol('right')}>+C→</Button>
                         <Button size="sm" variant="secondary" onClick={() => removeCol('right')}>-C→</Button>
                     </div>
@@ -404,8 +409,9 @@ function MobileButtons() {
                             });
                         }}
                     />
-                    <div className="d-flex align-items-center gap-2 flex-grow-1">
+                    <div className="d-flex align-items-center gap-2 flex-grow-1" style={{ minWidth: 0 }}>
                         <Form.Range
+                            className="flex-grow-1"
                             min={0}
                             max={100}
                             value={Math.round(backgroundAlpha * 100)}
@@ -562,18 +568,24 @@ function MobileButtons() {
                     )}
                 </div>
             )}
-            <div className="d-flex justify-content-between mt-2">
-                <div className="d-flex align-items-center gap-2">
-                    <Form.Select size="sm" value={copyFrom} onChange={e => setCopyFrom(e.target.value as Mode)}>
+            <div className="d-flex flex-column flex-md-row align-items-stretch align-items-md-center gap-2 mt-2">
+                <div className="d-flex flex-column flex-sm-row align-items-stretch align-items-sm-center gap-2 flex-grow-1">
+                    <Form.Select
+                        size="sm"
+                        value={copyFrom}
+                        onChange={e => setCopyFrom(e.target.value as Mode)}
+                        className="flex-grow-1"
+                        style={{ minWidth: 0 }}
+                    >
                         <option value="solo">Bez drużyny</option>
                         <option value="team">W drużynie</option>
                         <option value="leader">Prowadzący</option>
                     </Form.Select>
-                    <Button size="sm" variant="secondary" onClick={() => copyLayout(copyFrom)}>
+                    <Button size="sm" variant="secondary" className="w-100 w-sm-auto" onClick={() => copyLayout(copyFrom)}>
                         Kopiuj
                     </Button>
                 </div>
-                <Button id="mobile-buttons-save" onClick={save}>Zapisz</Button>
+                <Button id="mobile-buttons-save" className="w-100 w-md-auto" onClick={save}>Zapisz</Button>
             </div>
         </div>
     );

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -307,7 +307,7 @@ function MobileButtons() {
 
     return (
         <div onClick={close} className="w-100 position-relative">
-            <div className="d-flex flex-column flex-sm-row align-items-stretch align-items-sm-center gap-2 mb-2 w-100">
+            <div className="d-flex flex-column flex-sm-row flex-sm-wrap align-items-stretch align-items-sm-center gap-2 mb-2 w-100">
                 <div className="mobile-buttons-mode-toggle">
                     <Button
                         size="sm"

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -307,7 +307,7 @@ function MobileButtons() {
 
     return (
         <div onClick={close} className="w-100 position-relative">
-            <div className="d-flex flex-column flex-lg-row align-items-stretch align-items-lg-center gap-2 mb-2 w-100">
+            <div className="d-flex flex-column flex-sm-row align-items-stretch align-items-sm-center gap-2 mb-2 w-100">
                 <div className="mobile-buttons-mode-toggle">
                     <Button
                         size="sm"
@@ -337,7 +337,7 @@ function MobileButtons() {
                 <Button
                     size="sm"
                     variant="secondary"
-                    className="w-100 w-lg-auto"
+                    className="w-100 w-sm-auto"
                     onClick={() => restoreDefaults(view)}
                 >
                     Domyślne
@@ -345,7 +345,7 @@ function MobileButtons() {
                 <Form.Check
                     id="mobile-buttons-lock"
                     type="checkbox"
-                    className="user-select-none ms-lg-auto text-nowrap"
+                    className="user-select-none ms-sm-auto text-nowrap"
                     label="Zablokuj przyciski"
                     checked={settings.locked}
                     onChange={e => setSettings(prev => ({ ...prev, locked: e.target.checked }))}

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -345,7 +345,7 @@ function MobileButtons() {
                 <Form.Check
                     id="mobile-buttons-lock"
                     type="checkbox"
-                    className="user-select-none ms-lg-auto"
+                    className="user-select-none ms-lg-auto text-nowrap"
                     label="Zablokuj przyciski"
                     checked={settings.locked}
                     onChange={e => setSettings(prev => ({ ...prev, locked: e.target.checked }))}

--- a/web-client/src/options/UserTriggers.tsx
+++ b/web-client/src/options/UserTriggers.tsx
@@ -165,16 +165,17 @@ function UserTriggers() {
 
     return (
         <div className="m-2 d-flex flex-column gap-2">
-            <div className="d-flex gap-2 align-items-center">
+            <div className="d-flex flex-column flex-md-row align-items-stretch align-items-md-center gap-2 w-100">
                 <Form.Control
                     type="text"
                     size="sm"
                     placeholder="Filter"
                     value={filter}
                     onChange={(e: ChangeEvent<HTMLInputElement>) => setFilter(e.target.value)}
-                    style={{ width: '100%', maxWidth: '12rem' }}
+                    className="flex-grow-1"
+                    style={{ minWidth: 0 }}
                 />
-                <Button size="sm" onClick={openNew}>Add trigger</Button>
+                <Button size="sm" className="w-100 w-md-auto" onClick={openNew}>Add trigger</Button>
             </div>
             
             {showCreateForm && (

--- a/web-client/src/options/UserTriggers.tsx
+++ b/web-client/src/options/UserTriggers.tsx
@@ -175,7 +175,7 @@ function UserTriggers() {
                     className="flex-grow-1"
                     style={{ minWidth: 0 }}
                 />
-                <Button size="sm" className="w-100 w-md-auto" onClick={openNew}>Add trigger</Button>
+                <Button size="sm" className="w-100 w-md-auto text-nowrap" onClick={openNew}>Add trigger</Button>
             </div>
             
             {showCreateForm && (

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -240,7 +240,7 @@ input::placeholder {
   width: 100%;
 }
 
-@media (min-width: 992px) {
+@media (min-width: 576px) {
   .mobile-buttons-mode-toggle {
     display: inline-flex;
     flex-direction: row;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -211,6 +211,24 @@ input::placeholder {
   color: var(--text-primary);
 }
 
+@media (min-width: 576px) {
+  .w-sm-auto {
+    width: auto !important;
+  }
+}
+
+@media (min-width: 768px) {
+  .w-md-auto {
+    width: auto !important;
+  }
+}
+
+@media (min-width: 992px) {
+  .w-lg-auto {
+    width: auto !important;
+  }
+}
+
 h1 {
   font-size: 1.5rem;
   line-height: 1.1;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -229,6 +229,35 @@ input::placeholder {
   }
 }
 
+.mobile-buttons-mode-toggle {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.mobile-buttons-mode-toggle .btn {
+  width: 100%;
+}
+
+@media (min-width: 992px) {
+  .mobile-buttons-mode-toggle {
+    display: inline-flex;
+    flex-direction: row;
+    width: auto;
+    gap: 0;
+  }
+
+  .mobile-buttons-mode-toggle .btn {
+    width: auto;
+    flex-grow: 0;
+  }
+
+  .mobile-buttons-mode-toggle .btn + .btn {
+    margin-left: -1px;
+  }
+}
+
 h1 {
   font-size: 1.5rem;
   line-height: 1.1;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -242,15 +242,30 @@ input::placeholder {
 
 @media (min-width: 576px) {
   .mobile-buttons-mode-toggle {
-    display: inline-flex;
     flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.5rem;
     width: auto;
+  }
+
+  .mobile-buttons-mode-toggle .btn {
+    flex: 1 1 auto;
+    width: auto;
+  }
+
+  .mobile-buttons-mode-toggle .btn + .btn {
+    margin-left: 0;
+  }
+}
+
+@media (min-width: 768px) {
+  .mobile-buttons-mode-toggle {
+    flex-wrap: nowrap;
     gap: 0;
   }
 
   .mobile-buttons-mode-toggle .btn {
-    width: auto;
-    flex-grow: 0;
+    flex: 0 0 auto;
   }
 
   .mobile-buttons-mode-toggle .btn + .btn {


### PR DESCRIPTION
## Summary
- allow alias and trigger modals to stack controls on narrow viewports
- reorganize the mobile buttons editor so actions stay within the modal at phone widths
- add responsive width utility helpers used by the updated modal layouts

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68e3e97473b4832a850885cd6fe2656d