### PR TITLE
Remove guild settings button from popup menu

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -213,9 +213,6 @@
                     <button class="w-100 p-1" id="npc-button">Odbiorcy paczek</button>
                 </li>
                 <li>
-                    <button class="w-100 p-1" id="guilds-button">Gildie</button>
-                </li>
-                <li>
                     <button class="w-100 p-1" id="scripts-button">Skrypty</button>
                 </li>
                 <li>

--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -206,9 +206,6 @@
                     <button class="w-100 p-1" id="npc-button">Odbiorcy paczek</button>
                 </li>
                 <li>
-                    <button class="w-100 p-1" id="guilds-button">Gildie</button>
-                </li>
-                <li>
                     <button class="w-100 p-1" id="scripts-button">Skrypty</button>
                 </li>
                 <li>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -458,7 +458,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const optionsSave = document.getElementById('options-save') as HTMLButtonElement | null;
     const bindsButton = document.getElementById('binds-button') as HTMLButtonElement | null;
     const npcButton = document.getElementById('npc-button') as HTMLButtonElement | null;
-    const guildsButton = document.getElementById('guilds-button') as HTMLButtonElement | null;
     const scriptsButton = document.getElementById('scripts-button') as HTMLButtonElement | null;
     const aliasesButton = document.getElementById('aliases-button') as HTMLButtonElement | null;
     const triggersButton = document.getElementById('triggers-button') as HTMLButtonElement | null;
@@ -617,13 +616,6 @@ document.addEventListener('DOMContentLoaded', () => {
     if (npcButton && npcModal) {
         npcButton.addEventListener('click', () => {
             npcModal.show();
-        });
-    }
-
-    if (guildsButton && optionsModal) {
-        guildsButton.addEventListener('click', () => {
-            window.dispatchEvent(new Event('show-guild-settings'));
-            optionsModal.show();
         });
     }
 


### PR DESCRIPTION
## Summary
- remove the Guilds shortcut from the popup menu in index and sandbox markup
- delete the associated event binding in the main script so the button is no longer referenced

## Testing
- yarn --cwd web-client test --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e3e845bc6c832aa550686d428a318e