### PR TITLE
Stop auto refreshing map on look commands

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -132,9 +132,6 @@ export default class MapHelper {
     }
 
     parseCommand(command: string): string | null {
-        if (command === "zerknij" || command === "spojrz" || command === "sp") {
-            this.refreshPosition = true;
-        }
         if (command.trim() === "idz") {
             this.refreshPosition = true;
             if (this.currentRoom) {


### PR DESCRIPTION
## Summary
- stop toggling map refresh for the `sp`, `spojrz`, and `zerknij` commands so they no longer move the map automatically

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68e3f4d46de4832aba7941c6a4740e9f