### PR TITLE
Adjust viewport clamping for draggable overlays

### DIFF
--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -125,25 +125,48 @@ export default class ObjectList {
         if (!this.container) return;
         const rect = this.container.getBoundingClientRect();
         const styles = window.getComputedStyle(this.container);
+        const viewportWidth = window.innerWidth;
+        const viewportHeight = window.innerHeight;
+        const containerWidth = this.container.offsetWidth;
+        const containerHeight = this.container.offsetHeight;
+        const fitsHorizontally = containerWidth <= viewportWidth;
+        const fitsVertically = containerHeight <= viewportHeight;
+
         let newLeft = parseFloat(styles.left || "0");
         let newTop = parseFloat(styles.top || "0");
 
-        const maxLeft = window.innerWidth - this.container.offsetWidth;
-
-        if (rect.right > window.innerWidth) {
-            newLeft = maxLeft;
-        } else if (rect.left < 0) {
-            newLeft = 0;
+        if (fitsHorizontally) {
+            const maxLeft = viewportWidth - containerWidth;
+            if (rect.right > viewportWidth) {
+                newLeft = maxLeft;
+            } else if (rect.left < 0) {
+                newLeft = 0;
+            }
+            newLeft = Math.min(maxLeft, Math.max(0, newLeft));
+        } else {
+            if (rect.left >= viewportWidth) {
+                newLeft = viewportWidth - containerWidth;
+            } else if (rect.right <= 0) {
+                newLeft = 0;
+            }
         }
 
-        if (rect.bottom > window.innerHeight) {
-            newTop = window.innerHeight - this.container.offsetHeight;
-        } else if (rect.top < 0) {
-            newTop = 0;
+        if (fitsVertically) {
+            const maxTop = viewportHeight - containerHeight;
+            if (rect.bottom > viewportHeight) {
+                newTop = maxTop;
+            } else if (rect.top < 0) {
+                newTop = 0;
+            }
+            newTop = Math.min(maxTop, Math.max(0, newTop));
+        } else {
+            if (rect.top >= viewportHeight) {
+                newTop = viewportHeight - containerHeight;
+            } else if (rect.bottom <= 0) {
+                newTop = 0;
+            }
         }
 
-        newLeft = Math.min(maxLeft, Math.max(0, newLeft));
-        newTop = Math.max(0, newTop);
         this.container.style.left = `${newLeft}px`;
         this.container.style.top = `${newTop}px`;
     };

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -255,20 +255,48 @@ export default class MobileDirectionButtons {
 
     private clampToView() {
         const rect = this.container.getBoundingClientRect();
+        const viewportWidth = window.innerWidth;
+        const viewportHeight = window.innerHeight;
+        const containerWidth = this.container.offsetWidth;
+        const containerHeight = this.container.offsetHeight;
+        const margin = 5;
+        const fitsHorizontally = containerWidth + margin * 2 <= viewportWidth;
+        const fitsVertically = containerHeight + margin * 2 <= viewportHeight;
+
         let right = parseInt(this.container.style.right, 10);
         let top = parseInt(this.container.style.top, 10);
-        if (isNaN(right)) {
-            right = window.innerWidth - rect.right;
+
+        if (Number.isNaN(right)) {
+            right = viewportWidth - rect.right;
         }
-        if (isNaN(top)) {
+        if (Number.isNaN(top)) {
             top = rect.top;
         }
-        const maxRight = window.innerWidth - this.container.offsetWidth - 5;
-        const maxTop = window.innerHeight - this.container.offsetHeight - 5;
-        const clampedRight = Math.min(Math.max(5, right), maxRight);
-        const clampedTop = Math.min(Math.max(5, top), maxTop);
-        this.container.style.right = `${clampedRight}px`;
-        this.container.style.top = `${clampedTop}px`;
+
+        if (fitsHorizontally) {
+            const maxRight = Math.max(margin, viewportWidth - containerWidth - margin);
+            right = Math.min(Math.max(margin, right), maxRight);
+        } else {
+            if (rect.left >= viewportWidth) {
+                right = margin;
+            } else if (rect.right <= 0) {
+                right = viewportWidth - containerWidth - margin;
+            }
+        }
+
+        if (fitsVertically) {
+            const maxTop = Math.max(margin, viewportHeight - containerHeight - margin);
+            top = Math.min(Math.max(margin, top), maxTop);
+        } else {
+            if (rect.top >= viewportHeight) {
+                top = viewportHeight - containerHeight - margin;
+            } else if (rect.bottom <= 0) {
+                top = margin;
+            }
+        }
+
+        this.container.style.right = `${right}px`;
+        this.container.style.top = `${top}px`;
     }
 
     private setupKeyboardHandlers() {


### PR DESCRIPTION
## Summary
- update the objects list viewport clamp to leave user positioning intact when the panel is larger than the viewport
- tweak mobile direction button clamping so oversized layouts only snap back when completely off-screen

## Testing
- `yarn --cwd web-client test`


------
https://chatgpt.com/codex/tasks/task_e_68e592d7075c832a94491ff274dfcf2d