### PR TITLE
Add map label rendering options to UI settings

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -298,6 +298,13 @@
                                         <option value="left">Lewa</option>
                                     </select>
                                 </div>
+                                <div>
+                                    <label class="form-label" for="ui-label-render-mode">Tryb renderowania etykiet</label>
+                                    <select id="ui-label-render-mode" class="form-select">
+                                        <option value="image">Obraz</option>
+                                        <option value="data">Dane</option>
+                                    </select>
+                                </div>
                                 <div class="form-check">
                                     <input id="ui-instant-move" type="checkbox" class="form-check-input" />
                                     <label class="form-check-label" for="ui-instant-move">Natychmiastowe przechodzenie po mapie</label>
@@ -311,6 +318,10 @@
                                     <label class="form-check-label" for="ui-exploration-mode">
                                         Tryb eksploracji mapy <span id="ui-exploration-stats" class="ms-1 text-muted"></span>
                                     </label>
+                                </div>
+                                <div class="form-check">
+                                    <input id="ui-transparent-labels" type="checkbox" class="form-check-input" />
+                                    <label class="form-check-label" for="ui-transparent-labels">Przezroczyste etykiety (wymusza tryb danych)</label>
                                 </div>
                             </div>
                         </section>

--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -272,6 +272,13 @@
                                         <option value="left">Lewa</option>
                                     </select>
                                 </div>
+                                <div>
+                                    <label class="form-label" for="ui-label-render-mode">Tryb renderowania etykiet</label>
+                                    <select id="ui-label-render-mode" class="form-select">
+                                        <option value="image">Obraz</option>
+                                        <option value="data">Dane</option>
+                                    </select>
+                                </div>
                                 <div class="form-check">
                                     <input id="ui-instant-move" type="checkbox" class="form-check-input" />
                                     <label class="form-check-label" for="ui-instant-move">Natychmiastowe przechodzenie po mapie</label>
@@ -285,6 +292,10 @@
                                     <label class="form-check-label" for="ui-exploration-mode">
                                         Tryb eksploracji mapy <span id="ui-exploration-stats" class="ms-1 text-muted"></span>
                                     </label>
+                                </div>
+                                <div class="form-check">
+                                    <input id="ui-transparent-labels" type="checkbox" class="form-check-input" />
+                                    <label class="form-check-label" for="ui-transparent-labels">Przezroczyste etykiety (wymusza tryb danych)</label>
                                 </div>
                             </div>
                         </section>

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -1,4 +1,4 @@
-import {MapReader, Renderer, PathFinder, Settings, RoomContextMenuEventDetail} from "mudlet-map-renderer";
+import {MapReader, Renderer, PathFinder, Settings, RoomContextMenuEventDetail, LabelRenderMode} from "mudlet-map-renderer";
 import {getCurrentCharacter, getItemSync, setItemSync} from "@client/src/storage";
 
 const STORAGE_KEY = 'mapperRoomId';
@@ -95,6 +95,8 @@ export class EmbeddedMap {
         let explorationMode = false;
         let instantMove = true;
         let highlightCurrentRoom = true;
+        let labelRenderMode: LabelRenderMode = 'image';
+        let transparentLabels = false;
         let initialRoom = startId ?? 1;
         try {
             const data = getItemSync('uiSettings');
@@ -112,6 +114,12 @@ export class EmbeddedMap {
                 if (typeof parsed.highlightCurrentRoom === 'boolean') {
                     highlightCurrentRoom = parsed.highlightCurrentRoom;
                 }
+                if (parsed.labelRenderMode === 'data') {
+                    labelRenderMode = 'data';
+                }
+                if (typeof parsed.transparentLabels === 'boolean') {
+                    transparentLabels = parsed.transparentLabels;
+                }
             }
         } catch {
             // ignore malformed data
@@ -125,6 +133,11 @@ export class EmbeddedMap {
         } catch {
         }
         this.zoom = zoom;
+        if (transparentLabels) {
+            labelRenderMode = 'data';
+        }
+        Settings.transparentLabels = transparentLabels;
+        Settings.labelRenderMode = labelRenderMode;
         this.renderer = new Renderer(this.map, this.reader);
         this.setExplorationMode(explorationMode);
         this.setInstantMove(instantMove);
@@ -266,6 +279,19 @@ export class EmbeddedMap {
         Settings.highlightCurrentRoom = on;
         this.renderer.setPosition(this.currentRoom);
 
+    }
+
+    setLabelRenderMode(mode: LabelRenderMode) {
+        Settings.labelRenderMode = Settings.transparentLabels ? 'data' : mode;
+        this.refresh();
+    }
+
+    setTransparentLabels(on: boolean) {
+        Settings.transparentLabels = on;
+        if (on) {
+            Settings.labelRenderMode = 'data';
+        }
+        this.refresh();
     }
 
     leadTo(id?: string) {

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -30,6 +30,8 @@ interface UiSettings {
     explorationMode: boolean;
     instantMove: boolean;
     highlightCurrentRoom: boolean;
+    labelRenderMode: 'image' | 'data';
+    transparentLabels: boolean;
 }
 
 const defaultSettings: UiSettings = {
@@ -48,6 +50,8 @@ const defaultSettings: UiSettings = {
     explorationMode: false,
     instantMove: true,
     highlightCurrentRoom: true,
+    labelRenderMode: 'image',
+    transparentLabels: false,
 };
 
 function apply(settings: UiSettings) {
@@ -115,6 +119,11 @@ function apply(settings: UiSettings) {
         (window as any).embedded.setExplorationMode?.(settings.explorationMode);
         (window as any).embedded.refresh();
     }
+    Settings.transparentLabels = settings.transparentLabels;
+    const labelRenderMode = settings.transparentLabels ? 'data' : settings.labelRenderMode;
+    Settings.labelRenderMode = labelRenderMode;
+    (window as any).embedded?.setTransparentLabels?.(settings.transparentLabels);
+    (window as any).embedded?.setLabelRenderMode?.(labelRenderMode);
     Settings.instantMapMove = settings.instantMove;
     (window as any).embedded?.setInstantMove?.(settings.instantMove);
     Settings.highlightCurrentRoom = settings.highlightCurrentRoom;
@@ -156,6 +165,9 @@ async function load(): Promise<UiSettings> {
             const mapPosition = mapPositions.includes(parsed.mapPosition as MapPosition)
                 ? (parsed.mapPosition as MapPosition)
                 : defaultSettings.mapPosition;
+            const transparentLabels = !!parsed.transparentLabels;
+            const labelRenderMode = parsed.labelRenderMode === 'data' ? 'data' : defaultSettings.labelRenderMode;
+            const effectiveLabelRenderMode = transparentLabels ? 'data' : labelRenderMode;
             const xtermPalette = parsed.xtermPalette === 'proper' ? 'proper' : defaultSettings.xtermPalette;
             const footerMode = typeof parsed.footerMode === 'number' ? parsed.footerMode : defaultSettings.footerMode;
             const explorationMode = !!parsed.explorationMode;
@@ -165,7 +177,22 @@ async function load(): Promise<UiSettings> {
             const highlightCurrentRoom = typeof parsed.highlightCurrentRoom === 'boolean'
                 ? parsed.highlightCurrentRoom
                 : defaultSettings.highlightCurrentRoom;
-            return { ...defaultSettings, ...parsed, mapScale, mapPosition, emojiLabels: !!parsed.emojiLabels, xtermPalette, footerMode, explorationMode, fightTitleIcon, hapticFeedback, instantMove, highlightCurrentRoom };
+            return {
+                ...defaultSettings,
+                ...parsed,
+                mapScale,
+                mapPosition,
+                emojiLabels: !!parsed.emojiLabels,
+                xtermPalette,
+                footerMode,
+                explorationMode,
+                fightTitleIcon,
+                hapticFeedback,
+                instantMove,
+                highlightCurrentRoom,
+                transparentLabels,
+                labelRenderMode: effectiveLabelRenderMode,
+            };
         }
     } catch {
         // ignore malformed data
@@ -199,6 +226,8 @@ export default async function initUiSettings() {
     const footerModeInput = modalEl.querySelector('#ui-footer-mode') as HTMLSelectElement;
     const instantMoveInput = modalEl.querySelector('#ui-instant-move') as HTMLInputElement;
     const highlightCurrentRoomInput = modalEl.querySelector('#ui-highlight-current-room') as HTMLInputElement;
+    const labelRenderModeInput = modalEl.querySelector('#ui-label-render-mode') as HTMLSelectElement;
+    const transparentLabelsInput = modalEl.querySelector('#ui-transparent-labels') as HTMLInputElement;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
 
     let current = await load();
@@ -217,7 +246,20 @@ export default async function initUiSettings() {
     footerModeInput.value = String(current.footerMode);
     instantMoveInput.checked = current.instantMove;
     highlightCurrentRoomInput.checked = current.highlightCurrentRoom;
+    labelRenderModeInput.value = current.labelRenderMode;
+    transparentLabelsInput.checked = current.transparentLabels;
+    const updateLabelRenderModeState = () => {
+        if (transparentLabelsInput.checked) {
+            labelRenderModeInput.value = 'data';
+            labelRenderModeInput.disabled = true;
+        } else {
+            labelRenderModeInput.disabled = false;
+        }
+    };
+    updateLabelRenderModeState();
     apply(current);
+
+    transparentLabelsInput.addEventListener('change', updateLabelRenderModeState);
 
     const updateMapScale = (scale: number) => {
         mapInput.value = String(scale);
@@ -274,11 +316,16 @@ export default async function initUiSettings() {
             explorationMode: explorationInput.checked,
             instantMove: instantMoveInput.checked,
             highlightCurrentRoom: highlightCurrentRoomInput.checked,
+            labelRenderMode: (labelRenderModeInput.value === 'data' ? 'data' : 'image'),
+            transparentLabels: transparentLabelsInput.checked,
         };
     }
 
     saveBtn.addEventListener('click', () => {
         current = read();
+        if (current.transparentLabels) {
+            current = { ...current, labelRenderMode: 'data' };
+        }
         save(current);
         apply(current);
         modal.hide();


### PR DESCRIPTION
## Summary
- add label rendering mode and transparent label controls to the map settings UI
- persist the new map label settings and ensure transparent labels force data mode
- update the embedded map to initialise and react to the new label preferences

## Testing
- yarn --cwd web-client test
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68e67eafb98c832a839ab625347c227d