### PR TITLE
Adjust full HP notification trigger

### DIFF
--- a/client/src/scripts/fullHpTimer.ts
+++ b/client/src/scripts/fullHpTimer.ts
@@ -7,6 +7,7 @@ export default function initFullHpTimer(client: Client) {
     let timer: number | null = null;
     let enabled = false;
     let playerNum: string | undefined;
+    let previousHp: number | null = null;
 
     function clearTimer() {
         if (timer !== null) {
@@ -37,12 +38,18 @@ export default function initFullHpTimer(client: Client) {
 
     client.addEventListener("gmcp.char.state", (ev: CustomEvent) => {
         const hp = ev.detail?.hp;
-        if (typeof hp !== "number") return;
+        if (typeof hp !== "number") {
+            previousHp = null;
+            return;
+        }
         if (hp === FULL_HP) {
-            startTimer();
+            if (previousHp !== null && previousHp > 0 && previousHp < FULL_HP) {
+                startTimer();
+            }
         } else {
             clearTimer();
         }
+        previousHp = hp;
     });
 
     client.addEventListener("gmcp.char.info", (ev: CustomEvent) => {
@@ -64,6 +71,7 @@ export default function initFullHpTimer(client: Client) {
     client.addEventListener("client.disconnect", () => {
         playerNum = undefined;
         clearTimer();
+        previousHp = null;
     });
 }
 

--- a/client/test/fullHpTimer.test.ts
+++ b/client/test/fullHpTimer.test.ts
@@ -27,16 +27,38 @@ describe('full hp timer', () => {
     client.sendEvent('settings', { fullHpMessage: true });
   }
 
-  test('prints message after three minutes at full hp', () => {
+  test('prints message after three minutes when recovering to full hp', () => {
     const client = new FakeClient();
     initFullHpTimer((client as unknown) as any);
     enable(client);
+    client.sendEvent('gmcp.char.state', { hp: 5 });
     client.sendEvent('gmcp.char.state', { hp: 6 });
     jest.advanceTimersByTime(180000);
     const color = findClosestColor('#00ff7f');
     const msg = colorString('Jestes w pelni zdrowia.', color);
     expect(client.println).toHaveBeenCalledWith(`\n${msg}\n`);
     expect(client.notify).toHaveBeenCalledWith('Jestes w pelni zdrowia.');
+  });
+
+  test('does not print message when reaching full hp from zero', () => {
+    const client = new FakeClient();
+    initFullHpTimer((client as unknown) as any);
+    enable(client);
+    client.sendEvent('gmcp.char.state', { hp: 0 });
+    client.sendEvent('gmcp.char.state', { hp: 6 });
+    jest.advanceTimersByTime(180000);
+    expect(client.println).not.toHaveBeenCalled();
+    expect(client.notify).not.toHaveBeenCalled();
+  });
+
+  test('does not print message when full hp is the first state update', () => {
+    const client = new FakeClient();
+    initFullHpTimer((client as unknown) as any);
+    enable(client);
+    client.sendEvent('gmcp.char.state', { hp: 6 });
+    jest.advanceTimersByTime(180000);
+    expect(client.println).not.toHaveBeenCalled();
+    expect(client.notify).not.toHaveBeenCalled();
   });
 
     test('timer is cancelled on combat', () => {


### PR DESCRIPTION
## Summary
- track previous hit point values before starting the full HP reminder
- prevent the notification when health jumps directly from zero or unknown to full
- expand the unit tests to cover the new scenarios

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68e682c815b8832aaabb9dd723358a13