### PR TITLE
Exclude more character storage keys from export

### DIFF
--- a/web-client/src/options/ExportImport.tsx
+++ b/web-client/src/options/ExportImport.tsx
@@ -126,9 +126,14 @@ interface ExportPayload {
 const EXCLUDED_LOCAL_STORAGE_KEYS = new Set([
     "cachedMapData",
     "cachedColors",
+    "deposits",
+    "improve_counter",
+    "kill_counter",
     "magics",
     "magic_keys",
     "herbs_data",
+    "mapperRoomId",
+    "object_num",
 ]);
 
 const EXCLUDED_LOCAL_STORAGE_PREFIXES = ["http://", "https://"];


### PR DESCRIPTION
## Summary
- add missing character-scoped storage keys to the export exclusion list so they no longer appear as character entries

## Testing
- yarn --cwd web-client test
- yarn --cwd client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68e689f96054832ab1699c31af3f0627