### PR TITLE
Default transparent label rendering

### DIFF
--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -95,8 +95,8 @@ export class EmbeddedMap {
         let explorationMode = false;
         let instantMove = true;
         let highlightCurrentRoom = true;
-        let labelRenderMode: LabelRenderMode = 'image';
-        let transparentLabels = false;
+        let labelRenderMode: LabelRenderMode = 'data';
+        let transparentLabels = true;
         let initialRoom = startId ?? 1;
         try {
             const data = getItemSync('uiSettings');
@@ -114,8 +114,8 @@ export class EmbeddedMap {
                 if (typeof parsed.highlightCurrentRoom === 'boolean') {
                     highlightCurrentRoom = parsed.highlightCurrentRoom;
                 }
-                if (parsed.labelRenderMode === 'data') {
-                    labelRenderMode = 'data';
+                if (parsed.labelRenderMode === 'image' || parsed.labelRenderMode === 'data') {
+                    labelRenderMode = parsed.labelRenderMode;
                 }
                 if (typeof parsed.transparentLabels === 'boolean') {
                     transparentLabels = parsed.transparentLabels;

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -50,8 +50,8 @@ const defaultSettings: UiSettings = {
     explorationMode: false,
     instantMove: true,
     highlightCurrentRoom: true,
-    labelRenderMode: 'image',
-    transparentLabels: false,
+    labelRenderMode: 'data',
+    transparentLabels: true,
 };
 
 function apply(settings: UiSettings) {
@@ -165,8 +165,12 @@ async function load(): Promise<UiSettings> {
             const mapPosition = mapPositions.includes(parsed.mapPosition as MapPosition)
                 ? (parsed.mapPosition as MapPosition)
                 : defaultSettings.mapPosition;
-            const transparentLabels = !!parsed.transparentLabels;
-            const labelRenderMode = parsed.labelRenderMode === 'data' ? 'data' : defaultSettings.labelRenderMode;
+            const transparentLabels = typeof parsed.transparentLabels === 'boolean'
+                ? parsed.transparentLabels
+                : defaultSettings.transparentLabels;
+            const labelRenderMode = parsed.labelRenderMode === 'image' || parsed.labelRenderMode === 'data'
+                ? parsed.labelRenderMode
+                : defaultSettings.labelRenderMode;
             const effectiveLabelRenderMode = transparentLabels ? 'data' : labelRenderMode;
             const xtermPalette = parsed.xtermPalette === 'proper' ? 'proper' : defaultSettings.xtermPalette;
             const footerMode = typeof parsed.footerMode === 'number' ? parsed.footerMode : defaultSettings.footerMode;


### PR DESCRIPTION
## Summary
- default UI settings to transparent labels with data-based rendering
- ensure stored label render preferences only override when explicitly set
- align embedded map initialization with new defaults

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68e689c0a8cc832a8188199d2bebb556