### PR TITLE
Apply imported settings immediately and clamp UI positions

### DIFF
--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -101,9 +101,10 @@ export default class ObjectList {
         const deltaY = e.clientY - this.startY;
         const newLeft = this.offsetLeft + deltaX;
         const newTop = this.offsetTop + deltaY;
-        const maxLeft = window.innerWidth - this.container.offsetWidth;
+        const maxLeft = Math.max(0, window.innerWidth - this.container.offsetWidth);
+        const maxTop = Math.max(0, window.innerHeight - this.container.offsetHeight);
         const clampedLeft = Math.min(maxLeft, Math.max(0, newLeft));
-        const clampedTop = Math.max(0, newTop);
+        const clampedTop = Math.min(maxTop, Math.max(0, newTop));
         this.container.style.left = `${clampedLeft}px`;
         this.container.style.top = `${clampedTop}px`;
     };
@@ -112,13 +113,15 @@ export default class ObjectList {
         if (!this.isDragging || !this.container || e.pointerId !== this.pointerId) return;
         this.isDragging = false;
         this.container.releasePointerCapture(this.pointerId);
+        this.clampToViewport();
         const rect = this.container.getBoundingClientRect();
+        const maxLeft = Math.max(0, window.innerWidth - this.container.offsetWidth);
+        const maxTop = Math.max(0, window.innerHeight - this.container.offsetHeight);
         const position = {
-            left: rect.left,
-            top: rect.top,
+            left: Math.min(Math.max(0, rect.left), maxLeft),
+            top: Math.min(Math.max(0, rect.top), maxTop),
         };
         setItemSync("objectsListPosition", position);
-        this.clampToViewport();
     };
 
     private clampToViewport = () => {
@@ -128,7 +131,8 @@ export default class ObjectList {
         let newLeft = parseFloat(styles.left || "0");
         let newTop = parseFloat(styles.top || "0");
 
-        const maxLeft = window.innerWidth - this.container.offsetWidth;
+        const maxLeft = Math.max(0, window.innerWidth - this.container.offsetWidth);
+        const maxTop = Math.max(0, window.innerHeight - this.container.offsetHeight);
 
         if (rect.right > window.innerWidth) {
             newLeft = maxLeft;
@@ -137,15 +141,19 @@ export default class ObjectList {
         }
 
         if (rect.bottom > window.innerHeight) {
-            newTop = window.innerHeight - this.container.offsetHeight;
+            newTop = maxTop;
         } else if (rect.top < 0) {
             newTop = 0;
         }
 
         newLeft = Math.min(maxLeft, Math.max(0, newLeft));
-        newTop = Math.max(0, newTop);
+        newTop = Math.min(maxTop, Math.max(0, newTop));
+        const changed = Math.abs(newLeft - rect.left) > 0.5 || Math.abs(newTop - rect.top) > 0.5;
         this.container.style.left = `${newLeft}px`;
         this.container.style.top = `${newTop}px`;
+        if (changed) {
+            setItemSync("objectsListPosition", { left: newLeft, top: newTop });
+        }
     };
 
     private isMobileBrowser() {

--- a/web-client/src/options/ExportImport.tsx
+++ b/web-client/src/options/ExportImport.tsx
@@ -1,6 +1,8 @@
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, Button, Form, Spinner } from "react-bootstrap";
 import storage from "@client/src/storage";
+import { loadSettings as loadMobileButtonSettings, applySettings as applyMobileButtonSettings } from "../mobileButtonSettings";
+import { applyUiSettings, loadUiSettings } from "../uiSettings";
 import type { StoredMultibindRecord } from "../multibindStorage";
 import { readMultibinds, replaceMultibinds } from "../multibindStorage";
 import type { RecordedEvent } from "./recordingStorage";
@@ -385,12 +387,58 @@ async function buildExport(selectedCharacters: string[]): Promise<ExportPayload>
     };
 }
 
+function dispatchStorageEvent(key: string, oldValue: string | null, newValue: string) {
+    if (typeof window === "undefined" || typeof window.dispatchEvent !== "function") {
+        return;
+    }
+    try {
+        const event = new StorageEvent("storage", {
+            key,
+            oldValue,
+            newValue,
+            storageArea: typeof localStorage !== "undefined" ? localStorage : undefined,
+            url: window.location.href,
+        });
+        window.dispatchEvent(event);
+    } catch (err) {
+        if (typeof document === "undefined" || typeof document.createEvent !== "function") {
+            console.error("Failed to dispatch storage event", err);
+            return;
+        }
+        try {
+            const legacyEvent = document.createEvent("StorageEvent") as StorageEvent;
+            (legacyEvent as unknown as { initStorageEvent: (...args: unknown[]) => void }).initStorageEvent(
+                "storage",
+                false,
+                false,
+                key,
+                oldValue,
+                newValue,
+                window.location.href,
+                typeof localStorage !== "undefined" ? localStorage : null
+            );
+            window.dispatchEvent(legacyEvent);
+        } catch (legacyErr) {
+            console.error("Failed to dispatch storage event", legacyErr);
+        }
+    }
+}
+
+function setLocalStorageValue(key: string, value: string) {
+    if (typeof localStorage === "undefined") {
+        return;
+    }
+    const previous = localStorage.getItem(key);
+    localStorage.setItem(key, value);
+    dispatchStorageEvent(key, previous, value);
+}
+
 function applyLocalStorageImport(data: ExportedLocalStorage) {
     if (!data) return;
     Object.entries(data.global ?? {}).forEach(([key, raw]) => {
         if (typeof raw !== "string") return;
         if (isExcludedLocalStorageKey(key)) return;
-        localStorage.setItem(key, raw);
+        setLocalStorageValue(key, raw);
     });
     Object.entries(data.characters ?? {}).forEach(([character, entries]) => {
         if (!entries || typeof entries !== "object") return;
@@ -400,7 +448,7 @@ function applyLocalStorageImport(data: ExportedLocalStorage) {
             const baseIdx = storageKey.lastIndexOf(":");
             const baseKey = baseIdx > -1 ? storageKey.slice(baseIdx + 1) : storageKey;
             if (isExcludedLocalStorageKey(baseKey)) return;
-            localStorage.setItem(storageKey, raw);
+            setLocalStorageValue(storageKey, raw);
         });
     });
 }
@@ -451,7 +499,7 @@ function ExportImport() {
         } else {
             clearStoredDriveToken();
         }
-    }, []);
+    }, [applyUiSettings, loadUiSettings, loadMobileButtonSettings, applyMobileButtonSettings]);
 
     useEffect(() => {
         if (window.google?.accounts?.oauth2) {
@@ -678,6 +726,28 @@ function ExportImport() {
         await importVisitedRooms(payload.indexedDB.visitedRooms ?? []);
     }, []);
 
+    const applyImportedSettings = useCallback(async () => {
+        try {
+            const uiSettings = await loadUiSettings();
+            applyUiSettings(uiSettings);
+        } catch (err) {
+            console.error("Failed to apply UI settings after import", err);
+        }
+        try {
+            if (typeof window !== "undefined") {
+                const client = (window as any)?.clientExtension;
+                if (client) {
+                    const settings = await loadMobileButtonSettings();
+                    const inTeam = !!client.TeamManager?.isInAnyTeam?.();
+                    const isLeader = !!client.TeamManager?.isLeader?.();
+                    applyMobileButtonSettings(settings, inTeam, isLeader);
+                }
+            }
+        } catch (err) {
+            console.error("Failed to apply mobile button settings after import", err);
+        }
+    }, [applyUiSettings, loadUiSettings, loadMobileButtonSettings, applyMobileButtonSettings]);
+
     const handleExport = async () => {
         setError(null);
         setStatus(null);
@@ -723,7 +793,8 @@ function ExportImport() {
                 throw new Error("invalid");
             }
             await applyImportedData(parsed);
-            setStatus("Import zakończony sukcesem. Niektóre ustawienia mogą wymagać odświeżenia strony.");
+            await applyImportedSettings();
+            setStatus("Import zakończony sukcesem. Ustawienia zostały zastosowane.");
             refreshCharacters();
         } catch (err) {
             console.error("Failed to import settings", err);

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -268,12 +268,21 @@ export default class MobileDirectionButtons {
         if (isNaN(top)) {
             top = rect.top;
         }
-        const maxRight = window.innerWidth - this.container.offsetWidth - 5;
-        const maxTop = window.innerHeight - this.container.offsetHeight - 5;
+        const maxRight = Math.max(5, window.innerWidth - this.container.offsetWidth - 5);
+        const maxTop = Math.max(5, window.innerHeight - this.container.offsetHeight - 5);
         const clampedRight = Math.min(Math.max(5, right), maxRight);
         const clampedTop = Math.min(Math.max(5, top), maxTop);
+        const changed = clampedRight !== right || clampedTop !== top;
         this.container.style.right = `${clampedRight}px`;
         this.container.style.top = `${clampedTop}px`;
+        if (changed) {
+            const updatedRect = this.container.getBoundingClientRect();
+            const position = {
+                x: Math.min(Math.max(5, window.innerWidth - updatedRect.right), maxRight),
+                y: Math.min(Math.max(5, updatedRect.top), maxTop),
+            };
+            setItemSync('mobileButtonsPosition', position);
+        }
     }
 
     private setupKeyboardHandlers() {
@@ -405,9 +414,10 @@ export default class MobileDirectionButtons {
         const newRight = this.offsetX + deltaX;
         const newTop = this.offsetY + deltaY;
 
-        const maxRight = window.innerWidth - this.container.offsetWidth - 5;
+        const maxRight = Math.max(5, window.innerWidth - this.container.offsetWidth - 5);
+        const maxTop = Math.max(5, window.innerHeight - this.container.offsetHeight - 5);
         const clampedRight = Math.min(maxRight, Math.max(5, newRight));
-        const clampedTop = Math.max(5, newTop);
+        const clampedTop = Math.min(maxTop, Math.max(5, newTop));
 
         this.container.style.right = `${clampedRight}px`;
         this.container.style.top = `${clampedTop}px`;
@@ -420,10 +430,13 @@ export default class MobileDirectionButtons {
         }
 
         if (this.isDragging && this.container) {
+            this.clampToView();
             const rect = this.container.getBoundingClientRect();
+            const maxRight = Math.max(5, window.innerWidth - this.container.offsetWidth - 5);
+            const maxTop = Math.max(5, window.innerHeight - this.container.offsetHeight - 5);
             const position = {
-                x: window.innerWidth - rect.right,
-                y: rect.top,
+                x: Math.min(Math.max(5, window.innerWidth - rect.right), maxRight),
+                y: Math.min(Math.max(5, rect.top), maxTop),
             };
             setItemSync('mobileButtonsPosition', position);
 

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -14,7 +14,7 @@ const mapPositions = [
 
 type MapPosition = (typeof mapPositions)[number];
 
-interface UiSettings {
+export interface UiSettings {
     contentFontSize: number;
     objectsFontSize: number;
     buttonSize: number;
@@ -54,7 +54,7 @@ const defaultSettings: UiSettings = {
     transparentLabels: false,
 };
 
-function apply(settings: UiSettings) {
+export function applyUiSettings(settings: UiSettings) {
     const contentArea = document.getElementById('content-area');
     if (contentArea) {
         contentArea.style.setProperty('--map-size', settings.mapHeight + 'vh');
@@ -149,7 +149,7 @@ function apply(settings: UiSettings) {
 
 import storage from "@client/src/storage";
 
-async function load(): Promise<UiSettings> {
+export async function loadUiSettings(): Promise<UiSettings> {
     try {
         const uiData = await storage.getItem('uiSettings');
         let raw = uiData?.uiSettings;
@@ -230,7 +230,7 @@ export default async function initUiSettings() {
     const transparentLabelsInput = modalEl.querySelector('#ui-transparent-labels') as HTMLInputElement;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
 
-    let current = await load();
+    let current = await loadUiSettings();
     contentInput.value = String(current.contentFontSize);
     objectsInput.value = String(current.objectsFontSize);
     buttonInput.value = String(current.buttonSize);
@@ -257,7 +257,7 @@ export default async function initUiSettings() {
         }
     };
     updateLabelRenderModeState();
-    apply(current);
+    applyUiSettings(current);
 
     transparentLabelsInput.addEventListener('change', updateLabelRenderModeState);
 
@@ -327,7 +327,7 @@ export default async function initUiSettings() {
             current = { ...current, labelRenderMode: 'data' };
         }
         save(current);
-        apply(current);
+        applyUiSettings(current);
         modal.hide();
     });
 


### PR DESCRIPTION
## Summary
- dispatch storage change events when importing settings and reapply UI/mobile layouts immediately
- clamp mobile button and objects list positions to the viewport and persist corrected values
- expose reusable UI settings helpers for post-import application

## Testing
- yarn --cwd web-client test --watch=false
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68e68b360854832aa3d0fa711db1df8b