### PR TITLE
Apply imported settings immediately and clamp mobile positions

### DIFF
--- a/web-client/src/options/ExportImport.tsx
+++ b/web-client/src/options/ExportImport.tsx
@@ -3,6 +3,11 @@ import {Alert, Button, Form, Spinner} from "react-bootstrap";
 import storage from "@client/src/storage";
 import type {StoredMultibindRecord} from "../multibindStorage";
 import {readMultibinds, replaceMultibinds} from "../multibindStorage";
+import {applyUiSettings, loadUiSettings} from "../uiSettings";
+import {
+    applySettings as applyMobileButtonSettings,
+    loadSettings as loadMobileButtonSettings,
+} from "../mobileButtonSettings";
 import type {RecordedEvent} from "./recordingStorage";
 import {getRecording, getRecordingNames} from "./recordingStorage";
 
@@ -129,6 +134,11 @@ const EXCLUDED_LOCAL_STORAGE_KEYS = new Set([
     "magics",
     "magic_keys",
     "herbs_data"
+]);
+
+const IMPORT_EXCLUDED_KEYS = new Set([
+    "mobileButtonsPosition",
+    "objectsListPosition",
 ]);
 
 const EXCLUDED_LOCAL_STORAGE_PREFIXES = ["http://", "https://"];
@@ -383,6 +393,7 @@ function applyLocalStorageImport(data: ExportedLocalStorage) {
     Object.entries(data.global ?? {}).forEach(([key, raw]) => {
         if (typeof raw !== "string") return;
         if (isExcludedLocalStorageKey(key)) return;
+        if (IMPORT_EXCLUDED_KEYS.has(key)) return;
         localStorage.setItem(key, raw);
     });
     Object.entries(data.characters ?? {}).forEach(([character, entries]) => {
@@ -393,9 +404,118 @@ function applyLocalStorageImport(data: ExportedLocalStorage) {
             const baseIdx = storageKey.lastIndexOf(":");
             const baseKey = baseIdx > -1 ? storageKey.slice(baseIdx + 1) : storageKey;
             if (isExcludedLocalStorageKey(baseKey)) return;
+            if (IMPORT_EXCLUDED_KEYS.has(baseKey)) return;
             localStorage.setItem(storageKey, raw);
         });
     });
+}
+
+function clampNumber(value: unknown, min: number, max: number) {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+        return min;
+    }
+    if (max < min) {
+        return min;
+    }
+    return Math.min(Math.max(value, min), max);
+}
+
+function adjustMobileButtonsPosition() {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+        return;
+    }
+    try {
+        const raw = localStorage.getItem("mobileButtonsPosition");
+        if (!raw) return;
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== "object") return;
+        const container = document.getElementById("mobile-direction-buttons") as HTMLDivElement | null;
+        const width = container?.offsetWidth ?? 0;
+        const height = container?.offsetHeight ?? 0;
+        const rightCandidate = (parsed as any).x ?? (parsed as any).right ?? (parsed as any).left ?? 5;
+        const topCandidate = (parsed as any).y ?? (parsed as any).top ?? 5;
+        const rightValue = typeof rightCandidate === "number" ? rightCandidate : Number(rightCandidate);
+        const topValue = typeof topCandidate === "number" ? topCandidate : Number(topCandidate);
+        const maxRight = Math.max(5, window.innerWidth - width - 5);
+        const maxTop = Math.max(5, window.innerHeight - height - 5);
+        const clampedRight = clampNumber(rightValue, 5, maxRight);
+        const clampedTop = clampNumber(topValue, 5, maxTop);
+        if (container) {
+            container.style.right = `${clampedRight}px`;
+            container.style.top = `${clampedTop}px`;
+        }
+        if (clampedRight !== rightValue || clampedTop !== topValue) {
+            localStorage.setItem("mobileButtonsPosition", JSON.stringify({x: clampedRight, y: clampedTop}));
+        }
+    } catch (err) {
+        console.error("Failed to adjust mobile buttons position", err);
+    }
+}
+
+function adjustObjectsListPosition() {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+        return;
+    }
+    try {
+        const raw = localStorage.getItem("objectsListPosition");
+        if (!raw) return;
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== "object") return;
+        const container = document.getElementById("objects-list");
+        const width = container instanceof HTMLElement ? container.offsetWidth : 0;
+        const height = container instanceof HTMLElement ? container.offsetHeight : 0;
+        const leftCandidate = (parsed as any).left ?? (parsed as any).x ?? 0;
+        const topCandidate = (parsed as any).top ?? (parsed as any).y ?? 0;
+        const leftValue = typeof leftCandidate === "number" ? leftCandidate : Number(leftCandidate);
+        const topValue = typeof topCandidate === "number" ? topCandidate : Number(topCandidate);
+        const maxLeft = Math.max(0, window.innerWidth - width);
+        const maxTop = Math.max(0, window.innerHeight - height);
+        const clampedLeft = clampNumber(leftValue, 0, maxLeft);
+        const clampedTop = clampNumber(topValue, 0, maxTop);
+        if (container instanceof HTMLElement) {
+            container.style.left = `${clampedLeft}px`;
+            container.style.top = `${clampedTop}px`;
+        }
+        if (clampedLeft !== leftValue || clampedTop !== topValue) {
+            localStorage.setItem("objectsListPosition", JSON.stringify({left: clampedLeft, top: clampedTop}));
+        }
+    } catch (err) {
+        console.error("Failed to adjust objects list position", err);
+    }
+}
+
+async function applyImportedUiSettings() {
+    if (typeof window === "undefined") {
+        return;
+    }
+    try {
+        const settings = await loadUiSettings();
+        applyUiSettings(settings);
+    } catch (err) {
+        console.error("Failed to apply UI settings after import", err);
+    }
+}
+
+async function applyImportedMobileButtonSettings() {
+    if (typeof window === "undefined") {
+        return;
+    }
+    try {
+        const settings = await loadMobileButtonSettings();
+        const teamManager = (window as any).clientExtension?.TeamManager;
+        const inTeam = !!teamManager?.isInAnyTeam?.();
+        const isLeader = !!teamManager?.isLeader?.();
+        applyMobileButtonSettings(settings, inTeam, isLeader);
+    } catch (err) {
+        console.error("Failed to apply mobile button settings after import", err);
+    }
+}
+
+async function applyImportedSettingsImmediately() {
+    await applyImportedUiSettings();
+    await applyImportedMobileButtonSettings();
+    adjustObjectsListPosition();
+    adjustMobileButtonsPosition();
 }
 
 function validatePayload(input: unknown): input is ExportPayload {
@@ -665,6 +785,7 @@ function ExportImport() {
 
     const applyImportedData = useCallback(async (payload: ExportPayload) => {
         applyLocalStorageImport(payload.localStorage);
+        await applyImportedSettingsImmediately();
         if (typeof indexedDB !== "undefined") {
             await replaceMultibinds(payload.indexedDB.multibinds ?? []);
         }

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -14,7 +14,7 @@ const mapPositions = [
 
 type MapPosition = (typeof mapPositions)[number];
 
-interface UiSettings {
+export interface UiSettings {
     contentFontSize: number;
     objectsFontSize: number;
     buttonSize: number;
@@ -34,7 +34,7 @@ interface UiSettings {
     transparentLabels: boolean;
 }
 
-const defaultSettings: UiSettings = {
+export const defaultSettings: UiSettings = {
     contentFontSize: 0.775,
     objectsFontSize: 0.6,
     buttonSize: 1,
@@ -54,7 +54,7 @@ const defaultSettings: UiSettings = {
     transparentLabels: true,
 };
 
-function apply(settings: UiSettings) {
+export function applyUiSettings(settings: UiSettings) {
     const contentArea = document.getElementById('content-area');
     if (contentArea) {
         contentArea.style.setProperty('--map-size', settings.mapHeight + 'vh');
@@ -149,7 +149,7 @@ function apply(settings: UiSettings) {
 
 import storage from "@client/src/storage";
 
-async function load(): Promise<UiSettings> {
+export async function loadUiSettings(): Promise<UiSettings> {
     try {
         const uiData = await storage.getItem('uiSettings');
         let raw = uiData?.uiSettings;
@@ -234,7 +234,7 @@ export default async function initUiSettings() {
     const transparentLabelsInput = modalEl.querySelector('#ui-transparent-labels') as HTMLInputElement;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
 
-    let current = await load();
+    let current = await loadUiSettings();
     contentInput.value = String(current.contentFontSize);
     objectsInput.value = String(current.objectsFontSize);
     buttonInput.value = String(current.buttonSize);
@@ -261,7 +261,7 @@ export default async function initUiSettings() {
         }
     };
     updateLabelRenderModeState();
-    apply(current);
+    applyUiSettings(current);
 
     transparentLabelsInput.addEventListener('change', updateLabelRenderModeState);
 
@@ -331,7 +331,7 @@ export default async function initUiSettings() {
             current = { ...current, labelRenderMode: 'data' };
         }
         save(current);
-        apply(current);
+        applyUiSettings(current);
         modal.hide();
     });
 


### PR DESCRIPTION
## Summary
- apply imported local storage data while skipping mobile buttons and objects list position keys
- reuse shared helpers to reapply UI and mobile button settings after import and clamp stored positions to the viewport
- expose uiSettings helpers so the importer can trigger immediate UI refresh

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68e693514048832a827b9af541f53de8