### PR TITLE
Add commands to highlight visited locations

### DIFF
--- a/client/src/eventBus.ts
+++ b/client/src/eventBus.ts
@@ -17,6 +17,7 @@ export interface KnownEvents {
     'attackMode': string;
     'contentWidth': number;
     'enterLocation': { id: number; room: any };
+    'highlights': number[];
     'multibinds': { list: { index: number; action: string; label: string }[] };
     'letterComposer': { open: boolean };
     'letterComposer.submit': LetterSubmitPayload;

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -79,6 +79,7 @@ import initIdleFullHp from './scripts/idleFullHp'
 import initFullHpTimer from './scripts/fullHpTimer'
 import initNoExitHighlight from './scripts/noExitHighlight'
 import initLetter from './scripts/letter'
+import initZaznaczaj from './scripts/zaznaczaj'
 import Client from "./Client";
 
 
@@ -93,6 +94,7 @@ export function registerScripts(client: Client) {
         }
     })
     initMapAliases(client, aliases)
+    initZaznaczaj(client, aliases)
 
     blockers.forEach(blocker => {
         let blockerPattern = blocker.type === "0" ? blocker.pattern : new RegExp(blocker.pattern)

--- a/client/src/scripts/zaznaczaj.ts
+++ b/client/src/scripts/zaznaczaj.ts
@@ -1,0 +1,52 @@
+import Client from "../Client";
+
+export default function initZaznaczaj(
+    client: Client,
+    aliases: { pattern: RegExp; callback: Function }[],
+) {
+    let active = false;
+    const highlights = new Set<number>();
+
+    const sendHighlights = () => {
+        client.sendEvent('highlights', Array.from(highlights));
+    };
+
+    client.addEventListener('enterLocation', (ev: CustomEvent<{ id: number }>) => {
+        if (!active) {
+            return;
+        }
+        const id = ev.detail?.id;
+        if (typeof id !== 'number') {
+            return;
+        }
+        if (highlights.has(id)) {
+            return;
+        }
+        highlights.add(id);
+        sendHighlights();
+    });
+
+    aliases.push({
+        pattern: /^\/zaznaczaj$/,
+        callback: () => {
+            active = true;
+            highlights.clear();
+            const currentId = client.Map.currentRoom?.id;
+            if (typeof currentId === 'number') {
+                highlights.add(currentId);
+            }
+            sendHighlights();
+            client.println('Zaznaczanie lokalizacji wlaczone.');
+        },
+    });
+
+    aliases.push({
+        pattern: /^\/zaznaczaj-$/,
+        callback: () => {
+            active = false;
+            highlights.clear();
+            sendHighlights();
+            client.println('Zaznaczanie lokalizacji wylaczone.');
+        },
+    });
+}


### PR DESCRIPTION
## Summary
- add /zaznaczaj alias that starts tracking visited rooms and highlights them on the map
- add /zaznaczaj- alias to clear the tracked highlights and stop marking rooms

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68e7e3672f64832ab1f7151bd3b513af