### PR TITLE
Handle map follow after idz direction updates

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -73,6 +73,7 @@ import initShortcuts from './scripts/shortcuts'
 import initMultibinds from './scripts/multibinds'
 import initCompareAll from './scripts/compareAll'
 import initFollowSpecialExits from './scripts/followSpecialExits'
+import initFollow from './scripts/follow'
 import initMountain from './scripts/mountain'
 import initLanguage from './scripts/language'
 import initIdleFullHp from './scripts/idleFullHp'
@@ -105,31 +106,6 @@ export function registerScripts(client: Client) {
 
     initNoExitHighlight(client)
 
-    client.Triggers.registerTrigger(/^.*[pP]odazasz (|skradajac sie )za (.*)\.$/, (_, __, matches): undefined => {
-        const tokenized = matches[2].split(' ')
-        const direction = tokenized[tokenized.length - 1]
-        const result = client.Map.move(direction)
-        if (result.moved) {
-            return;
-        }
-        client.Map.followMove(matches[2])
-    }, 'follow')
-
-    client.Triggers.registerTrigger(/^Wraz z .* (?:jedziesz|zjezdzasz|wjezdzasz) .* (?:wozem|bryczka|dylizansem) (?:na )?(?<direction>.*?)(?:,.*)?\.$/, (_r, _l, matches: any): undefined => {
-        client.Map.followMove(matches.direction)
-    }, 'follow')
-
-    client.Triggers.registerTrigger([
-        /^Wykonuje komende 'idz /,
-        /^Ruszasz (?:niespiesznie|marszem|truchtem|biegiem|szybkim biegiem) w droge\./
-    ], (): undefined => {
-        client.sendEvent('refreshPositionWhenAble')
-    })
-
-    client.Triggers.registerTrigger(/^Wykonywanie komendy 'idz.*' zostaje przerwane\./, (): undefined => {
-        client.Map.refreshPosition = false
-    })
-
     client.Triggers.registerTrigger('ENTER by przejsc dalej', (): string => {
         client.sendCommand('')
         return ""
@@ -155,6 +131,7 @@ export function registerScripts(client: Client) {
     ;(client as any).killCounter = killCounter
     initImproveCounter(client, killCounter, aliases)
     initEscape(client)
+    initFollow(client)
     initGps(client)
     initLocalizers(client)
     initShipLocalizers(client)

--- a/client/src/scripts/follow.ts
+++ b/client/src/scripts/follow.ts
@@ -1,0 +1,44 @@
+import Client from "../Client";
+
+type FollowMatches = RegExpMatchArray & { groups?: { direction?: string } };
+
+const FOLLOW_TEAM_PATTERN = /^.*[pP]odazasz (|skradajac sie )za (.*)\.$/;
+const FOLLOW_VEHICLE_PATTERN = /^Wraz z .* (?:jedziesz|zjezdzasz|wjezdzasz) .* (?:wozem|bryczka|dylizansem) (?:na )?(?<direction>.*?)(?:,.*)?\.$/;
+const RUN_COMMAND_PATTERN = /^Wykonuje komende 'idz /;
+const RUNNING_PATTERN = /^Ruszasz (?:niespiesznie|marszem|truchtem|biegiem|szybkim biegiem) w droge\./;
+const RUN_DIRECTION_PATTERN = /^Ruszasz (.+?) na (?<direction>[A-Za-z ]+)\.$/i;
+
+export default function initFollow(client: Client) {
+    client.Triggers.registerTrigger(FOLLOW_TEAM_PATTERN, (_raw, _line, matches): undefined => {
+        const target = matches[2];
+        const tokens = target.split(" ");
+        const direction = tokens[tokens.length - 1];
+        const result = client.Map.move(direction);
+        if (result.moved) {
+            return;
+        }
+        client.Map.followMove(target);
+    }, "follow");
+
+    client.Triggers.registerTrigger(FOLLOW_VEHICLE_PATTERN, (_raw, _line, matches: FollowMatches): undefined => {
+        const direction = matches.groups?.direction;
+        if (direction) {
+            client.Map.followMove(direction);
+        }
+    }, "follow");
+
+    client.Triggers.registerTrigger([RUN_COMMAND_PATTERN, RUNNING_PATTERN], (): undefined => {
+        client.sendEvent("refreshPositionWhenAble");
+    });
+
+    client.Triggers.registerTrigger([RUN_COMMAND_PATTERN, RUNNING_PATTERN, RUN_DIRECTION_PATTERN], (_raw, _line, matches: FollowMatches): undefined => {
+        const direction = matches.groups?.direction?.trim() ?? matches[2]?.trim();
+        if (direction) {
+            client.Map.followMove(direction);
+        }
+    }, "follow");
+
+    client.Triggers.registerTrigger(/^Wykonywanie komendy 'idz.*' zostaje przerwane\./, (): undefined => {
+        client.Map.refreshPosition = false;
+    });
+}

--- a/client/test/follow.test.ts
+++ b/client/test/follow.test.ts
@@ -1,0 +1,41 @@
+import Triggers from '../src/Triggers';
+import initFollow from '../src/scripts/follow';
+
+describe('follow triggers', () => {
+  function createClient() {
+    const client: any = {
+      Map: {
+        move: jest.fn(() => ({ moved: false })),
+        followMove: jest.fn(),
+        refreshPosition: true,
+      },
+      sendEvent: jest.fn(),
+    };
+    client.Triggers = new Triggers(client);
+    return client;
+  }
+
+  function fireLine(client: any, line: string, type = 'game') {
+    client.Triggers.triggers.forEach(trigger => {
+      trigger.execute(line, type);
+    });
+  }
+
+  it('refreshes position when idz command starts', () => {
+    const client = createClient();
+    initFollow(client);
+
+    fireLine(client, "Wykonuje komende 'idz polnoc'");
+
+    expect(client.sendEvent).toHaveBeenCalledWith('refreshPositionWhenAble');
+  });
+
+  it('follows reported direction after idz movement line', () => {
+    const client = createClient();
+    initFollow(client);
+
+    fireLine(client, 'Ruszasz szybkim biegiem na polnoc.');
+
+    expect(client.Map.followMove).toHaveBeenCalledWith('polnoc');
+  });
+});


### PR DESCRIPTION
## Summary
- trigger map follow when the run command output includes a direction after refreshing the position
- move follow trigger registrations into their own script and exercise them with line-based tests

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68e81da64730832aa9eac20703540150