### PR TITLE
Align mobile buttons positioning with left origin

### DIFF
--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -260,19 +260,19 @@ export default class MobileDirectionButtons {
 
     private clampToView() {
         const rect = this.container.getBoundingClientRect();
-        let right = parseInt(this.container.style.right, 10);
+        let left = parseInt(this.container.style.left, 10);
         let top = parseInt(this.container.style.top, 10);
-        if (isNaN(right)) {
-            right = window.innerWidth - rect.right;
+        if (isNaN(left)) {
+            left = rect.left;
         }
         if (isNaN(top)) {
             top = rect.top;
         }
-        const maxRight = window.innerWidth - this.container.offsetWidth - 5;
+        const maxLeft = Math.max(5, window.innerWidth - this.container.offsetWidth - 5);
         const maxTop = window.innerHeight - this.container.offsetHeight - 5;
-        const clampedRight = Math.min(Math.max(5, right), maxRight);
+        const clampedLeft = Math.min(Math.max(5, left), maxLeft);
         const clampedTop = Math.min(Math.max(5, top), maxTop);
-        this.container.style.right = `${clampedRight}px`;
+        this.container.style.left = `${clampedLeft}px`;
         this.container.style.top = `${clampedTop}px`;
     }
 
@@ -309,13 +309,30 @@ export default class MobileDirectionButtons {
         this.container.addEventListener('contextmenu', (e) => e.preventDefault());
 
         // Set initial position from storage if available
+        this.container.style.removeProperty('right');
+
         const savedData = getItemSync('mobileButtonsPosition');
         const savedPosition = savedData?.mobileButtonsPosition;
         if (savedPosition) {
             try {
-                const { x, y } = savedPosition as any;
-                this.container.style.right = `${x}px`;
-                this.container.style.top = `${y}px`;
+                const { x, y, origin } = savedPosition as any;
+                const rect = this.container.getBoundingClientRect();
+                const width = rect.width || this.container.offsetWidth;
+                const safeWidth = Number.isFinite(width) ? width : 0;
+                if (typeof x === 'number' && !Number.isNaN(x)) {
+                    if (origin === 'left') {
+                        this.container.style.left = `${x}px`;
+                    } else {
+                        const fromLeft = window.innerWidth - safeWidth - x;
+                        if (Number.isFinite(fromLeft)) {
+                            this.container.style.left = `${fromLeft}px`;
+                        }
+                    }
+                }
+                if (typeof y === 'number' && !Number.isNaN(y)) {
+                    this.container.style.top = `${y}px`;
+                }
+                this.container.style.removeProperty('right');
                 requestAnimationFrame(() => this.clampToView());
             } catch (e) {
                 console.error('Error parsing saved position:', e);
@@ -381,7 +398,7 @@ export default class MobileDirectionButtons {
             this.container.classList.add('dragging');
 
             const rect = this.container.getBoundingClientRect();
-            this.offsetX = window.innerWidth - rect.right;
+            this.offsetX = rect.left;
             this.offsetY = rect.top;
 
             this.container.style.opacity = '0.8';
@@ -399,17 +416,17 @@ export default class MobileDirectionButtons {
         this.currentX = x;
         this.currentY = y;
 
-        const deltaX = this.initialX - this.currentX;
+        const deltaX = this.currentX - this.initialX;
         const deltaY = this.currentY - this.initialY;
 
-        const newRight = this.offsetX + deltaX;
+        const newLeft = this.offsetX + deltaX;
         const newTop = this.offsetY + deltaY;
 
-        const maxRight = window.innerWidth - this.container.offsetWidth - 5;
-        const clampedRight = Math.min(maxRight, Math.max(5, newRight));
+        const maxLeft = Math.max(5, window.innerWidth - this.container.offsetWidth - 5);
+        const clampedLeft = Math.min(maxLeft, Math.max(5, newLeft));
         const clampedTop = Math.max(5, newTop);
 
-        this.container.style.right = `${clampedRight}px`;
+        this.container.style.left = `${clampedLeft}px`;
         this.container.style.top = `${clampedTop}px`;
     }
 
@@ -422,8 +439,9 @@ export default class MobileDirectionButtons {
         if (this.isDragging && this.container) {
             const rect = this.container.getBoundingClientRect();
             const position = {
-                x: window.innerWidth - rect.right,
+                x: rect.left,
                 y: rect.top,
+                origin: 'left' as const,
             };
             setItemSync('mobileButtonsPosition', position);
 

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -994,7 +994,7 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
 /* Direction Buttons (visible on both mobile and desktop) */
 .mobile-direction-buttons {
   position: fixed;
-  right: 5px;
+  left: 5px;
   top: 160px; /* Position relative to top */
   z-index: 1000;
   gap: 10px;


### PR DESCRIPTION
## Summary
- anchor the draggable mobile button layout to the left edge and migrate stored positions accordingly
- update the default styles to position the mobile button grid from the left

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68e9275e89f4832aba126f563fd29c27