### PR TITLE
Reset move mode to normal on combat start

### DIFF
--- a/client/src/scripts/moveMode.ts
+++ b/client/src/scripts/moveMode.ts
@@ -10,8 +10,26 @@ export default function initMoveMode(client: Client) {
     let playerNum: string | undefined;
 
     function update() {
-        button.value = `Ruch: ${LABELS[client.moveMode]}`;
-        button.title = `Ruch: ${TITLES[client.moveMode]}`;
+        const mode = client.moveMode;
+        const valueLabel = `Ruch: ${LABELS[mode]}`;
+        const valueTitle = `Ruch: ${TITLES[mode]}`;
+
+        button.value = valueLabel;
+        button.title = valueTitle;
+
+        const assignedButton = client.moveModeButton;
+        if (assignedButton && assignedButton !== button) {
+            if (assignedButton instanceof HTMLInputElement) {
+                assignedButton.value = valueLabel;
+                assignedButton.title = valueTitle;
+            } else {
+                const prefix = assignedButton.dataset.moveModeLabel;
+                const textLabel = prefix ? `${prefix} ${LABELS[mode]}` : valueLabel;
+                const textTitle = prefix ? `${prefix} ${TITLES[mode]}` : valueTitle;
+                assignedButton.textContent = textLabel;
+                assignedButton.title = textTitle;
+            }
+        }
     }
 
     function emitChange() {

--- a/client/test/moveMode.test.ts
+++ b/client/test/moveMode.test.ts
@@ -3,7 +3,7 @@ import initMoveMode from '../src/scripts/moveMode';
 class FakeClient extends EventTarget {
   moveMode = 0;
   carriageMode = false;
-  moveModeButton?: HTMLInputElement;
+  moveModeButton?: HTMLInputElement | HTMLButtonElement;
   moveModeBind = { key: 'Backquote' } as { key: string; ctrl?: boolean; alt?: boolean; shift?: boolean };
   println = jest.fn();
   sendEvent = jest.fn();
@@ -73,5 +73,23 @@ describe('move mode default bind', () => {
     expect(client.moveModeButton!.value).toBe('Ruch: zwykly');
     expect(client.sendEvent).toHaveBeenLastCalledWith('moveModeChanged', 0);
     expect(client.println).not.toHaveBeenCalled();
+  });
+
+  test('combat gmcp resets move mode mobile button label', () => {
+    const client = new FakeClient();
+    initMoveMode((client as unknown) as any);
+    const mobileButton = document.createElement('button');
+    mobileButton.dataset.moveModeLabel = 'Tryb ruchu';
+    mobileButton.textContent = 'Tryb ruchu prz dr';
+    mobileButton.title = 'Tryb ruchu przemknij z druzyna';
+    client.moveModeButton = mobileButton;
+    client.moveMode = 2;
+    client.dispatchEvent(new CustomEvent('gmcp.char.info', { detail: { object_num: 7 } }));
+
+    client.dispatchEvent(new CustomEvent('gmcp.objects.data', { detail: { '7': { attack_num: true } } }));
+
+    expect(client.moveMode).toBe(0);
+    expect(mobileButton.textContent).toBe('Tryb ruchu zwykly');
+    expect(mobileButton.title).toBe('Tryb ruchu zwykly');
   });
 });

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -776,8 +776,7 @@ export default class MobileDirectionButtons {
                 case 'moveMode':
                     if (this.client.carriageMode) break;
                     this.client.moveMode = (this.client.moveMode + 1) % MOVE_MODE_LABELS.length;
-                    newBtn.textContent = `${cfg.label} ${MOVE_MODE_LABELS[this.client.moveMode]}`;
-                    newBtn.title = `${cfg.label} ${MOVE_MODE_TITLES[this.client.moveMode]}`;
+                    this.updateMoveModeButton(newBtn);
                     this.client.sendEvent('moveModeChanged', this.client.moveMode);
                     break;
                 case 'specialExit':
@@ -793,8 +792,8 @@ export default class MobileDirectionButtons {
 
         if (cfg.macro === 'moveMode') {
             this.client.moveModeButton = newBtn;
-            newBtn.textContent = `${cfg.label} ${MOVE_MODE_LABELS[this.client.moveMode]}`;
-            newBtn.title = `${cfg.label} ${MOVE_MODE_TITLES[this.client.moveMode]}`;
+            newBtn.dataset.moveModeLabel = cfg.label || '';
+            this.updateMoveModeButton(newBtn);
             newBtn.disabled = this.client.carriageMode;
         } else if (cfg.macro === 'specialExit') {
             const updateLabel = () => {
@@ -811,6 +810,14 @@ export default class MobileDirectionButtons {
             this.client.addEventListener('enterLocation', updateLabel as EventListener);
             updateLabel();
         }
+    }
+
+    private updateMoveModeButton(button: HTMLButtonElement, mode: number = this.client.moveMode) {
+        const prefix = button.dataset.moveModeLabel ?? '';
+        const label = prefix ? `${prefix} ${MOVE_MODE_LABELS[mode]}` : MOVE_MODE_LABELS[mode];
+        const title = prefix ? `${prefix} ${MOVE_MODE_TITLES[mode]}` : MOVE_MODE_TITLES[mode];
+        button.textContent = label;
+        button.title = title;
     }
 
 }


### PR DESCRIPTION
## Summary
- reset the client move mode to normal when GMCP combat data indicates fighting and keep the UI in sync
- extend the move mode tests with GMCP combat coverage using an EventTarget-backed fake client

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd client test moveMode

------
https://chatgpt.com/codex/tasks/task_e_68e92a3c2704832a87f4a635814c31d3