### PR TITLE
Adjust move mode for non-leader mobile buttons

### DIFF
--- a/client/src/scripts/moveMode.ts
+++ b/client/src/scripts/moveMode.ts
@@ -3,6 +3,28 @@ import Client from "../Client";
 const LABELS = ["zwykly", "prz", "prz dr"];
 const TITLES = ["zwykly", "przemknij", "przemknij z druzyna"];
 
+function getAvailableModes(client: Client) {
+    const total = LABELS.length;
+    if (client.TeamManager.isLeader?.()) {
+        return total;
+    }
+    return Math.max(1, total - 1);
+}
+
+function clampMoveMode(client: Client) {
+    const available = getAvailableModes(client);
+    const maxIndex = Math.max(0, available - 1);
+    if (client.moveMode > maxIndex) {
+        client.moveMode = maxIndex;
+        return true;
+    }
+    if (client.moveMode < 0) {
+        client.moveMode = 0;
+        return true;
+    }
+    return false;
+}
+
 export default function initMoveMode(client: Client) {
     const button = client.createButton(`Ruch: ${LABELS[0]}`, () => toggle(false));
     button.title = `Ruch: ${TITLES[0]}`;
@@ -10,6 +32,7 @@ export default function initMoveMode(client: Client) {
     let playerNum: string | undefined;
 
     function update() {
+        clampMoveMode(client);
         const mode = client.moveMode;
         const valueLabel = `Ruch: ${LABELS[mode]}`;
         const valueTitle = `Ruch: ${TITLES[mode]}`;
@@ -45,7 +68,8 @@ export default function initMoveMode(client: Client) {
 
     function toggle(notify = false) {
         if (client.carriageMode) return;
-        client.moveMode = (client.moveMode + 1) % LABELS.length;
+        const available = getAvailableModes(client) || 1;
+        client.moveMode = (client.moveMode + 1) % available;
         update();
         emitChange();
         if (notify) {
@@ -88,5 +112,14 @@ export default function initMoveMode(client: Client) {
         playerNum = undefined;
     });
 
+    client.addEventListener('teamChange', () => {
+        const changed = clampMoveMode(client);
+        update();
+        if (changed) {
+            emitChange();
+        }
+    });
+
+    update();
     emitChange();
 }

--- a/client/test/moveMode.test.ts
+++ b/client/test/moveMode.test.ts
@@ -7,6 +7,10 @@ class FakeClient extends EventTarget {
   moveModeBind = { key: 'Backquote' } as { key: string; ctrl?: boolean; alt?: boolean; shift?: boolean };
   println = jest.fn();
   sendEvent = jest.fn();
+  leader = false;
+  TeamManager = {
+    isLeader: () => this.leader,
+  };
   createButton(_name: string, callback: () => void) {
     const btn = document.createElement('input');
     btn.type = 'button';
@@ -56,8 +60,45 @@ describe('move mode default bind', () => {
     expect(client.println).not.toHaveBeenCalled();
   });
 
+  test('move mode button skips team sneak when not leader', () => {
+    const client = new FakeClient();
+    initMoveMode((client as unknown) as any);
+    client.moveModeButton!.click();
+    expect(client.moveMode).toBe(1);
+    client.moveModeButton!.click();
+    expect(client.moveMode).toBe(0);
+  });
+
+  test('leader can cycle through team sneak mode', () => {
+    const client = new FakeClient();
+    client.leader = true;
+    initMoveMode((client as unknown) as any);
+    client.moveModeButton!.click();
+    expect(client.moveMode).toBe(1);
+    client.moveModeButton!.click();
+    expect(client.moveMode).toBe(2);
+  });
+
+  test('losing leadership resets team sneak mode', () => {
+    const client = new FakeClient();
+    client.leader = true;
+    initMoveMode((client as unknown) as any);
+    client.moveModeButton!.click();
+    client.moveModeButton!.click();
+    expect(client.moveMode).toBe(2);
+    client.sendEvent.mockClear();
+
+    client.leader = false;
+    client.dispatchEvent(new Event('teamChange'));
+
+    expect(client.moveMode).toBe(1);
+    expect(client.moveModeButton!.value).toBe('Ruch: prz');
+    expect(client.sendEvent).toHaveBeenLastCalledWith('moveModeChanged', 1);
+  });
+
   test('combat gmcp resets move mode to normal', () => {
     const client = new FakeClient();
+    client.leader = true;
     initMoveMode((client as unknown) as any);
     client.moveModeButton!.click();
     client.moveModeButton!.click();
@@ -77,6 +118,7 @@ describe('move mode default bind', () => {
 
   test('combat gmcp resets move mode mobile button label', () => {
     const client = new FakeClient();
+    client.leader = true;
     initMoveMode((client as unknown) as any);
     const mobileButton = document.createElement('button');
     mobileButton.dataset.moveModeLabel = 'Tryb ruchu';

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -794,7 +794,8 @@ export default class MobileDirectionButtons {
                     break;
                 case 'moveMode':
                     if (this.client.carriageMode) break;
-                    this.client.moveMode = (this.client.moveMode + 1) % MOVE_MODE_LABELS.length;
+                    const options = this.getMoveModeOptionsCount() || 1;
+                    this.client.moveMode = (this.client.moveMode + 1) % options;
                     this.updateMoveModeButton(newBtn);
                     this.client.sendEvent('moveModeChanged', this.client.moveMode);
                     break;
@@ -831,10 +832,21 @@ export default class MobileDirectionButtons {
         }
     }
 
+    private getMoveModeOptionsCount() {
+        return this.leaderMode ? MOVE_MODE_LABELS.length : Math.max(1, MOVE_MODE_LABELS.length - 1);
+    }
+
     private updateMoveModeButton(button: HTMLButtonElement, mode: number = this.client.moveMode) {
+        const options = this.getMoveModeOptionsCount();
+        const maxIndex = Math.max(0, options - 1);
+        const safeMode = Math.max(0, Math.min(mode, maxIndex));
+        if (safeMode !== this.client.moveMode) {
+            this.client.moveMode = safeMode;
+            this.client.sendEvent('moveModeChanged', this.client.moveMode);
+        }
         const prefix = button.dataset.moveModeLabel ?? '';
-        const label = prefix ? `${prefix} ${MOVE_MODE_LABELS[mode]}` : MOVE_MODE_LABELS[mode];
-        const title = prefix ? `${prefix} ${MOVE_MODE_TITLES[mode]}` : MOVE_MODE_TITLES[mode];
+        const label = prefix ? `${prefix} ${MOVE_MODE_LABELS[safeMode]}` : MOVE_MODE_LABELS[safeMode];
+        const title = prefix ? `${prefix} ${MOVE_MODE_TITLES[safeMode]}` : MOVE_MODE_TITLES[safeMode];
         button.textContent = label;
         button.title = title;
     }


### PR DESCRIPTION
## Summary
- restrict the mobile move mode button from offering the team sneak option when the player is not the leader
- clamp move mode to available options on leadership changes and reuse the same logic for the core move mode button
- extend move mode tests to cover leadership transitions and cycling behaviour

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68e932f49700832ab4a2b8755072ab54