### PR TITLE
Limit objects list width to viewport

### DIFF
--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -504,6 +504,9 @@ body {
 }
 #objects-list-pip {
     white-space: pre;
+    box-sizing: border-box;
+    max-width: 100vw;
+    overflow-x: hidden;
 }
 #objects-list-pip .object-num,
 #objects-list-pip .object-desc {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -536,6 +536,9 @@ h1 {
   touch-action: none;
   z-index: 10;
   min-width: 350px;
+  box-sizing: border-box;
+  max-width: 100vw;
+  overflow-x: hidden;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -591,6 +594,7 @@ h1 {
 
 #objects-list .objects-list-content {
   white-space: pre;
+  overflow-x: hidden;
 }
 
 #objects-list .object-num,


### PR DESCRIPTION
## Summary
- limit the draggable objects list to the viewport width and hide horizontal overflow
- mirror the overflow and sizing safeguards in the Picture-in-Picture stylesheet

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68e963e91220832ab6e162929554045e