### PR TITLE
Add temp bind trigger for blocked idz paths

### DIFF
--- a/client/src/scripts/idz.ts
+++ b/client/src/scripts/idz.ts
@@ -33,6 +33,31 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
         }
     };
 
+    const getNextStep = () => {
+        if (index >= path.length - 1) {
+            return null;
+        }
+
+        const current = client.Map.getRoomById(path[index]);
+        if (!current) {
+            return null;
+        }
+
+        const nextId = path[index + 1];
+        const exits = Object.assign({}, current.exits ?? {}, current.specialExits ?? {});
+        const dir = Object.keys(exits).find(d => exits[d] === nextId);
+        if (!dir) {
+            return null;
+        }
+
+        const command = longToShort[dir] ?? dir;
+        if (typeof command !== 'string' || command.length === 0) {
+            return null;
+        }
+
+        return { command };
+    };
+
     const scheduleStep = () => {
         if (paused || index >= path.length - 1) {
             clearTimer();
@@ -48,17 +73,8 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
             return;
         }
 
-        const current = client.Map.getRoomById(path[index]);
-        if (!current) {
-            clearTimer();
-            path = [];
-            client.sendEvent('leadTo');
-            return;
-        }
-        const nextId = path[index + 1];
-        const exits = Object.assign({}, current.exits ?? {}, current.specialExits ?? {});
-        const dir = Object.keys(exits).find(d => exits[d] === nextId);
-        if (!dir) {
+        const nextStep = getNextStep();
+        if (!nextStep) {
             clearTimer();
             path = [];
             client.sendEvent('leadTo');
@@ -70,7 +86,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
             timer = null;
             if (paused) return;
             client.suppressMapMoveEvent = true;
-            client.sendCommand(longToShort[dir] ?? dir);
+            client.sendCommand(nextStep.command);
             index += 1;
             scheduleStep();
         }, time);
@@ -226,5 +242,21 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
             client.sendEvent('notify', { text: `[WALK] delay ${lastDelay.toFixed(2)}s` });
         }
     });
+
+    if (client.Triggers?.registerTrigger) {
+        client.Triggers.registerTrigger(
+            /^Nie wiesz, w ktorym kierunku masz ruszyc\.\.\.$/,
+            () => {
+                const step = getNextStep();
+                if (!step) {
+                    return undefined;
+                }
+
+                client.setTempBind?.(0, step.command);
+                return undefined;
+            },
+            'idzWalker'
+        );
+    }
 }
 

--- a/client/src/scripts/tempBinds.ts
+++ b/client/src/scripts/tempBinds.ts
@@ -1,5 +1,4 @@
 import Client from "../Client";
-import { longToShort } from "../MapHelper";
 
 function registerTempBind(
     client: Client,
@@ -20,57 +19,4 @@ export default function initTempBinds(client: Client, aliases: { pattern: RegExp
     registerTempBind(client, aliases, /^\/tbind1(?:\s+(.*))?$/, 0);
     registerTempBind(client, aliases, /^\/tbind2(?:\s+(.*))?$/, 1);
 
-    client.Triggers.registerTrigger(/^Nie wiesz, w ktorym kierunku masz ruszyc\.\.\.$/, () => {
-        const embedded = (window as any).embedded;
-        const destinations = Array.isArray(embedded?.destinations) ? embedded.destinations : [];
-        if (destinations.length === 0) {
-            return undefined;
-        }
-
-        const currentRoom: any = client.Map?.currentRoom;
-        if (!currentRoom?.id) {
-            return undefined;
-        }
-
-        const destId = parseInt(String(destinations[0]), 10);
-        if (Number.isNaN(destId)) {
-            return undefined;
-        }
-
-        const findPath = client.Map?.findPath?.bind(client.Map);
-        if (!findPath) {
-            return undefined;
-        }
-
-        let path: Array<string | number> | null = null;
-        try {
-            path = findPath(currentRoom.id, destId) ?? null;
-        } catch (e) {
-            path = null;
-        }
-
-        if (!path || path.length < 2) {
-            return undefined;
-        }
-
-        const nextId = parseInt(String(path[1]), 10);
-        if (Number.isNaN(nextId)) {
-            return undefined;
-        }
-
-        const exits = Object.assign({}, currentRoom.exits ?? {}, currentRoom.specialExits ?? {});
-        const nextEntry = Object.entries(exits).find(([_, value]) => parseInt(String(value), 10) === nextId);
-        if (!nextEntry) {
-            return undefined;
-        }
-
-        const dir = nextEntry[0];
-        const command = (longToShort as Record<string, string | undefined>)[dir] ?? dir;
-        if (typeof command !== 'string' || command.trim() === '') {
-            return undefined;
-        }
-
-        client.setTempBind(0, command);
-        return undefined;
-    }, 'tempBinds');
 }

--- a/client/test/idz.test.ts
+++ b/client/test/idz.test.ts
@@ -11,24 +11,45 @@ describe('idz walking', () => {
     jest.useRealTimers();
   });
 
-  function setup() {
+  function setup({
+    map: mapOverrides,
+    client: clientOverrides,
+  }: {
+    map?: Partial<{
+      currentRoom: any;
+      findPath: jest.Mock;
+      getRoomById: jest.Mock;
+      tryGetMapReader: jest.Mock;
+      locationHistory: unknown[];
+    }>;
+    client?: Partial<any>;
+  } = {}) {
     const aliases: { pattern: RegExp; callback: Function }[] = [];
+    const baseMap = {
+      currentRoom: { id: 1, exits: { north: 2 }, specialExits: {} },
+      findPath: jest.fn(() => ['1', '2']),
+      getRoomById: jest.fn(() => null),
+      tryGetMapReader: jest.fn(() => ({ getRooms: jest.fn(() => []) })),
+      locationHistory: [],
+    };
+
+    const map = { ...baseMap, ...(mapOverrides ?? {}) };
+
+    const registerTrigger = jest.fn();
     const client: any = {
-      Map: {
-        currentRoom: { id: 1, exits: { north: 2 }, specialExits: {} },
-        findPath: jest.fn(() => ['1', '2']),
-        getRoomById: jest.fn(() => null),
-        tryGetMapReader: jest.fn(() => ({ getRooms: jest.fn(() => []) })),
-      },
+      Map: map,
+      Triggers: { registerTrigger },
       addEventListener: jest.fn(() => () => {}),
       sendEvent: jest.fn(),
       sendCommand: jest.fn(),
       port: { postMessage: jest.fn() },
       suppressMapMoveEvent: false,
+      setTempBind: jest.fn(),
+      ...(clientOverrides ?? {}),
     };
 
     initIdz(client, aliases);
-    return { client, aliases };
+    return { client, aliases, registerTrigger };
   }
 
   test('aborts scheduled walk when room lookup fails', () => {
@@ -46,5 +67,49 @@ describe('idz walking', () => {
     expect(client.sendCommand).not.toHaveBeenCalled();
     expect(client.sendEvent).toHaveBeenCalledWith('leadTo', 2);
     expect(client.sendEvent).toHaveBeenCalledWith('leadTo');
+  });
+
+  test('blocked direction trigger populates temp bind while walking', () => {
+    const getRoomById = jest.fn((id: number) => {
+      if (id === 1) {
+        return { id: 1, exits: { north: 2 }, specialExits: {} };
+      }
+      return null;
+    });
+
+    const { client, aliases, registerTrigger } = setup({
+      map: { getRoomById },
+    });
+
+    const alias = aliases.find(a => a.pattern.test('/idz 2'));
+    expect(alias).toBeDefined();
+    const match = '/idz 2'.match(alias!.pattern) as RegExpMatchArray;
+    alias!.callback(match);
+
+    const triggerCall = registerTrigger.mock.calls.find(([pattern]) =>
+      pattern instanceof RegExp && pattern.test('Nie wiesz, w ktorym kierunku masz ruszyc...'),
+    );
+    expect(triggerCall).toBeDefined();
+
+    const trigger = triggerCall![1] as Function;
+    client.setTempBind.mockClear();
+
+    trigger('raw', 'raw', [] as unknown as RegExpMatchArray, '');
+
+    expect(client.setTempBind).toHaveBeenCalledWith(0, 'n');
+  });
+
+  test('blocked direction trigger ignores when no active path', () => {
+    const { client, registerTrigger } = setup();
+
+    const triggerCall = registerTrigger.mock.calls.find(([pattern]) =>
+      pattern instanceof RegExp && pattern.test('Nie wiesz, w ktorym kierunku masz ruszyc...'),
+    );
+    expect(triggerCall).toBeDefined();
+
+    const trigger = triggerCall![1] as Function;
+    trigger('raw', 'raw', [] as unknown as RegExpMatchArray, '');
+
+    expect(client.setTempBind).not.toHaveBeenCalled();
   });
 });

--- a/client/test/tempBinds.test.ts
+++ b/client/test/tempBinds.test.ts
@@ -79,37 +79,4 @@ describe('temp binds', () => {
     expect(typoAlias).toBeUndefined();
   });
 
-  test('blocked movement message populates first temp bind for active destination path', () => {
-    const registerTrigger = jest.fn();
-    const findPath = jest.fn(() => ['1', '2']);
-    const client = {
-      Map: {
-        currentRoom: { id: 1, exits: { north: 2 }, specialExits: {} },
-        findPath,
-      },
-      Triggers: { registerTrigger },
-      setTempBind: jest.fn(),
-    } as unknown as Client;
-    const aliases: { pattern: RegExp; callback: Function }[] = [];
-
-    initTempBinds(client, aliases);
-
-    const triggerCall = registerTrigger.mock.calls.find(([pattern]) =>
-      pattern instanceof RegExp && pattern.test('Nie wiesz, w ktorym kierunku masz ruszyc...'),
-    );
-    expect(triggerCall).toBeDefined();
-    const trigger = triggerCall![1] as Function;
-
-    (window as any).embedded = { destinations: [] };
-    trigger('raw', 'raw', [] as unknown as RegExpMatchArray, '');
-    expect(client.setTempBind).not.toHaveBeenCalled();
-
-    (window as any).embedded = { destinations: [2] };
-    trigger('raw', 'raw', [] as unknown as RegExpMatchArray, '');
-
-    expect(findPath).toHaveBeenCalledWith(1, 2);
-    expect(client.setTempBind).toHaveBeenCalledWith(0, 'n');
-
-    delete (window as any).embedded;
-  });
 });


### PR DESCRIPTION
## Summary
- share next-step calculation in the idz walker to reuse it for movement commands
- register a trigger for "Nie wiesz, w ktorym kierunku masz ruszyc..." that sets a temp bind when walking
- extend idz tests to cover the new trigger behaviour

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ea1d0a30c4832a8ceacdff913ed9d3