### PR TITLE
Add coverage for magic highlighting tests

### DIFF
--- a/client/test/magicKeys.test.ts
+++ b/client/test/magicKeys.test.ts
@@ -1,5 +1,5 @@
-import initMagicKeys from '../src/scripts/magicKeys';
-import { colorStringInLine, findClosestColor } from '../src/Colors';
+import initMagicKeys, { KEYS_COLOR } from '../src/scripts/magicKeys';
+import { colorTokenInLine } from '../src/Colors';
 
 describe('magic keys', () => {
     beforeEach(() => {
@@ -19,7 +19,10 @@ describe('magic keys', () => {
         const call = client.Triggers.registerTokenTrigger.mock.calls[0];
         const pattern = call[0];
         const callback = call[1];
-        const colored = colorStringInLine('alpha test', pattern, findClosestColor('#00ff7f'));
-        expect(callback('alpha test', 'alpha test', {} as any)).toBe(colored);
+        const sentence = 'to jest alpha w zdaniu';
+        expect(callback(sentence, sentence, {} as any)).toBe(colorTokenInLine(sentence, pattern, KEYS_COLOR));
+
+        const titleCase = 'Alpha pojawila sie w zdaniu';
+        expect(callback(titleCase, titleCase, {} as any)).toBe(colorTokenInLine(titleCase, pattern, KEYS_COLOR));
     });
 });

--- a/client/test/magics.test.ts
+++ b/client/test/magics.test.ts
@@ -1,5 +1,5 @@
 import initMagics, { MAGICS_COLOR } from '../src/scripts/magics';
-import { colorStringInLine } from '../src/Colors';
+import { colorTokenInLine } from '../src/Colors';
 
 describe('magics', () => {
     beforeEach(() => {
@@ -19,7 +19,10 @@ describe('magics', () => {
         const call = client.Triggers.registerTokenTrigger.mock.calls[0];
         const pattern = call[0];
         const callback = call[1];
-        const colored = colorStringInLine('alpha test', pattern, MAGICS_COLOR);
-        expect(callback('alpha test', 'alpha test', {} as any)).toBe(colored);
+        const sentence = 'to jest alpha w zdaniu';
+        expect(callback(sentence, sentence, {} as any)).toBe(colorTokenInLine(sentence, pattern, MAGICS_COLOR));
+
+        const titleCase = 'Alpha pojawila sie w zdaniu';
+        expect(callback(titleCase, titleCase, {} as any)).toBe(colorTokenInLine(titleCase, pattern, MAGICS_COLOR));
     });
 });


### PR DESCRIPTION
## Summary
- extend magic trigger tests to ensure highlighted tokens are colored when embedded in sentences
- verify that magic triggers also color tokens written in title case for both magics and magic keys

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68eadec9df80832aae140504ed516894