### PR TITLE
Refactor recorder output to use ArkadiaClient hooks

### DIFF
--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -32,7 +32,8 @@ class ArkadiaClient implements ClientAdapter {
     private recorder = new Recorder({
         processIncomingData: (d) => this.processIncomingData(d),
         sendCommand: (cmd) => this.sendCommand(cmd),
-        emit: (ev, ...args) => this.emit(ev, ...args)
+        emit: (ev, ...args) => this.emit(ev, ...args),
+        output: (text, type) => this.output(text, type)
     });
 
     constructor() {

--- a/web-client/src/Recorder.ts
+++ b/web-client/src/Recorder.ts
@@ -4,6 +4,7 @@ export interface RecorderHooks {
     processIncomingData(data: string): void;
     sendCommand(command: string, echo?: boolean): void;
     emit(event: string, ...args: any[]): void;
+    output(text: string, type?: string): void;
 }
 
 export default class Recorder {
@@ -142,15 +143,15 @@ export default class Recorder {
         this.stopPlayback();
         this.isPlaying = true;
         this.hooks.emit('playback.start');
-        Output.send('== Playback start ==');
+        this.hooks.output('== Playback start ==');
         this.recordedMessages.forEach(ev => {
             if (ev.direction === 'in') {
                 this.hooks.processIncomingData(ev.message);
             } else {
-                Output.send('→ ' + ev.message);
+                this.hooks.output('→ ' + ev.message);
             }
         });
-        Output.send('== Playback end ==');
+        this.hooks.output('== Playback end ==');
         this.stopPlayback();
     }
 
@@ -161,7 +162,7 @@ export default class Recorder {
         this.paused = false;
         this.playbackIndex = 0;
         this.hooks.emit('playback.start', this.recordedMessages.length);
-        Output.send('== Playback start ==');
+        this.hooks.output('== Playback start ==');
         this.hooks.emit('playback.index', 0, this.recordedMessages.length);
         this.scheduleNext(0);
     }
@@ -170,7 +171,7 @@ export default class Recorder {
         if (ev.direction === 'in') {
             this.hooks.processIncomingData(ev.message);
         } else {
-            Output.send('→ ' + ev.message);
+            this.hooks.output('→ ' + ev.message);
             window.clientExtension.sendCommand(ev.message, false);
             this.hooks.sendCommand(ev.message, false);
         }
@@ -179,7 +180,7 @@ export default class Recorder {
     private executeCurrent() {
         const ev = this.recordedMessages[this.playbackIndex];
         if (!ev) {
-            Output.send('== Playback end ==');
+            this.hooks.output('== Playback end ==');
             this.stopPlayback();
             return;
         }
@@ -192,7 +193,7 @@ export default class Recorder {
         if (!this.isPlaying) return;
         const ev = this.recordedMessages[this.playbackIndex];
         if (!ev) {
-            Output.send('== Playback end ==');
+            this.hooks.output('== Playback end ==');
             this.stopPlayback();
             return;
         }

--- a/web-client/test/Recorder.test.ts
+++ b/web-client/test/Recorder.test.ts
@@ -6,16 +6,16 @@ describe('Recorder playback', () => {
       processIncomingData: jest.fn(),
       sendCommand: jest.fn(),
       emit: jest.fn(),
+      output: jest.fn(),
     };
     const recorder = new Recorder(hooks as any);
     (window as any).clientExtension = { sendCommand: jest.fn() };
-    (window as any).Output = { send: jest.fn() };
     recorder.setRecordedMessages([
       { message: 'look', timestamp: 0, direction: 'out' },
     ]);
     jest.useFakeTimers();
     recorder.replayRecordedMessagesTimed();
     jest.runAllTimers();
-    expect((window as any).Output.send).toHaveBeenCalledWith('→ look');
+    expect(hooks.output).toHaveBeenCalledWith('→ look');
   });
 });


### PR DESCRIPTION
## Summary
- route recorder playback output through the ArkadiaClient output hook instead of Output.send
- extend the recorder hooks and tests to cover the new output integration

## Testing
- yarn --cwd web-client test Recorder.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68eae4e5f8a4832aa03d5115b009b3d6