### PR TITLE
Introduce runtime event hub abstraction for client and web client

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -21,6 +21,7 @@ import {color, Colors} from "./Colors";
 import {SKIP_LINE} from "./ControlConstants";
 import {stripPolishCharacters} from "./stripPolishCharacters";
 import eventBus from "./eventBus";
+import type { EventHub, EventKey } from "./runtime/event-hub";
 import { openMapContextMenu } from "./contextMenus";
 
 export interface ClientAdapter {
@@ -38,17 +39,18 @@ export interface ClientAdapter {
 export default class Client {
     clientAdapter: ClientAdapter;
     port?: any;
-    eventTarget = eventBus;
+    readonly events: EventHub;
+    eventTarget: EventTarget = eventBus;
     Colors = Colors;
-    FunctionalBind = new FunctionalBind(this);
-    Triggers = new Triggers(this);
-    packageHelper = new PackageHelper(this);
-    Map = new MapHelper(this);
-    Pausers = new Pausers(this);
-    OutputHandler = new OutputHandler(this);
-    TeamManager = new TeamManager(this);
-    ObjectManager = new ObjectManager(this);
-    inlineCompassRose = new InlineCompassRose(this);
+    FunctionalBind: FunctionalBind;
+    Triggers: Triggers;
+    packageHelper: PackageHelper;
+    Map: MapHelper;
+    Pausers: Pausers;
+    OutputHandler: OutputHandler;
+    TeamManager: TeamManager;
+    ObjectManager: ObjectManager;
+    inlineCompassRose: InlineCompassRose;
     panel = document.getElementById("panel_buttons_bottom");
     contentWidth = 0;
     sounds: Record<string, Howl> = {
@@ -97,14 +99,26 @@ export default class Client {
     moveModeButton?: HTMLInputElement | HTMLButtonElement;
 
 
-    constructor(clientAdapter: ClientAdapter, port: any) {
+    constructor(clientAdapter: ClientAdapter, port: any, eventHub: EventHub) {
         this.clientAdapter = clientAdapter
+        this.events = eventHub
+        this.eventTarget = eventHub.target
+        this.FunctionalBind = new FunctionalBind(this);
+        this.Triggers = new Triggers(this);
+        this.packageHelper = new PackageHelper(this);
+        this.Map = new MapHelper(this);
+        this.Pausers = new Pausers(this);
+        this.OutputHandler = new OutputHandler(this);
+        this.TeamManager = new TeamManager(this);
+        this.ObjectManager = new ObjectManager(this);
+        this.inlineCompassRose = new InlineCompassRose(this);
+
         attachGmcpListener(this);
 
         window.addEventListener('extension-message', (ev: Event) => {
             const data: any = (ev as CustomEvent).detail;
             if (data && data.data !== undefined) {
-                this.eventTarget.dispatchEvent(new CustomEvent(data.type, {detail: data.data}))
+                this.events.publish(data.type as EventKey, data.data)
             }
         })
 
@@ -311,7 +325,7 @@ export default class Client {
             port.postMessage({type: 'GET_STORAGE', key: 'scripts'})
         }
         this.port = port
-        this.eventTarget.dispatchEvent(new CustomEvent('port-connected'))
+        this.events.publish('port-connected')
         console.log("Client connected to background service.")
     }
 
@@ -349,7 +363,7 @@ export default class Client {
         if (command) {
             command = stripPolishCharacters(command)
         }
-        this.eventTarget.dispatchEvent(new CustomEvent('command', {detail: command}))
+        this.events.publish('command', command)
 
         let preparse = command
         command = this.Map.parseCommand(command)
@@ -416,7 +430,7 @@ export default class Client {
 
     onLine(line: string, type: string) {
         this.inLineProcess = true
-        this.eventTarget.dispatchEvent(new CustomEvent(LINE_START_EVENT))
+        this.events.publish(LINE_START_EVENT as EventKey)
         const ansiRegex = /\x1b\[[0-9;]*m/g
 
         line = this.Triggers.parseMultiline(line, type)
@@ -459,8 +473,12 @@ export default class Client {
     }
 
     sendEvent(type: string, payload?: any) {
-        this.eventTarget.dispatchEvent(new CustomEvent(type, {detail: payload}))
-        window.dispatchEvent(new CustomEvent(type, {detail: payload}))
+        const eventType = type as EventKey;
+        if (payload !== undefined) {
+            this.events.publish(eventType, payload)
+        } else {
+            this.events.publish(eventType)
+        }
     }
 
     openMapContextMenu(roomId: number, x: number, y: number) {

--- a/client/src/eventBus.ts
+++ b/client/src/eventBus.ts
@@ -1,40 +1,9 @@
-import type { LetterSubmitPayload } from "./types/letter";
+import type { ClientEventMap, EventHandler, EventParams } from "./runtime/event-hub";
 
-export interface KnownEvents {
-    'command': string;
-    'port-connected': void;
-    'output-sent': number;
-    'buffer-sent': number;
-    'mapMove': void;
-    'stepBack': void;
-    'leadTo': number;
-    'notify': { text: string };
-    'lampTimer': number | null;
-    'coverTimer': number | null;
-    'breakItem': { text: string; command?: string };
-    'packageStatus': { recipient: string; seconds?: number } | null;
-    'releaseGuard': boolean;
-    'attackMode': string;
-    'contentWidth': number;
-    'enterLocation': { id: number; room: any };
-    'highlights': number[];
-    'multibinds': { list: { index: number; action: string; label: string }[] };
-    'letterComposer': { open: boolean };
-    'letterComposer.submit': LetterSubmitPayload;
-    'letterComposer.preview': LetterSubmitPayload;
-    'npc': any;
-    'zaskTimer': { seconds: number; ok: boolean } | null;
-    'moveModeChanged': number;
-}
+export type ClientEvents = ClientEventMap;
 
-export type ClientEvents = KnownEvents & {
-    [key: `gmcp.${string}`]: any;
-    [key: `gmcp_msg.${string}`]: string;
-    [key: string]: any;
-};
-
-type Params<T> = T extends void ? [] : T extends any[] ? T : [T];
-type Handler<T> = (...args: Params<T>) => void;
+type Params<T> = EventParams<T>;
+type Handler<T> = EventHandler<T>;
 
 class EventBus<Events extends Record<string, any>> extends EventTarget {
     private wrappers = new WeakMap<Handler<any>, EventListener>();

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -82,9 +82,10 @@ import initLetter from './scripts/letter'
 import initTeamBlockers from './scripts/teamBlockers'
 import initZaznaczaj from './scripts/zaznaczaj'
 import Client from "./Client";
+import type { EventHub } from "./runtime/event-hub";
 
 
-export function registerScripts(client: Client) {
+export function registerScripts(client: Client, _eventHub: EventHub = client.events) {
     const aliases = client.aliases
     aliases.push({
         pattern: /\/fake (.*)/,

--- a/client/src/runtime/event-hub.ts
+++ b/client/src/runtime/event-hub.ts
@@ -1,0 +1,67 @@
+import type { LetterSubmitPayload } from "../types/letter";
+
+export interface KnownEvents {
+    'command': string;
+    'port-connected': void;
+    'output-sent': number;
+    'buffer-sent': number;
+    'mapMove': void;
+    'stepBack': void;
+    'leadTo': number;
+    'notify': { text: string };
+    'lampTimer': number | null;
+    'coverTimer': number | null;
+    'breakItem': { text: string; command?: string };
+    'packageStatus': { recipient: string; seconds?: number } | null;
+    'releaseGuard': boolean;
+    'attackMode': string;
+    'contentWidth': number;
+    'enterLocation': { id: number; room: any };
+    'highlights': number[];
+    'multibinds': { list: { index: number; action: string; label: string }[] };
+    'letterComposer': { open: boolean };
+    'letterComposer.submit': LetterSubmitPayload;
+    'letterComposer.preview': LetterSubmitPayload;
+    'npc': any;
+    'zaskTimer': { seconds: number; ok: boolean } | null;
+    'moveModeChanged': number;
+    'line-start': void;
+}
+
+export type ClientEventMap = KnownEvents & {
+    [key: `gmcp.${string}`]: any;
+    [key: `gmcp_msg.${string}`]: string;
+    [key: string]: any;
+};
+
+export type EventParams<T> = T extends void ? [] : T extends any[] ? T : [T];
+export type EventHandler<T> = (...args: EventParams<T>) => void;
+
+export type EventKey = Extract<keyof ClientEventMap, string>;
+
+export interface EventTopic<K extends EventKey> {
+    readonly key: K;
+}
+
+export type TopicInput<K extends EventKey> = K | EventTopic<K>;
+
+export interface EventHub {
+    readonly target: EventTarget;
+    subscribe<K extends EventKey>(
+        topic: TopicInput<K>,
+        handler: EventHandler<ClientEventMap[K]>,
+        options?: AddEventListenerOptions | boolean,
+    ): () => void;
+    publish<K extends EventKey>(topic: TopicInput<K>, ...args: EventParams<ClientEventMap[K]>): void;
+    topic<K extends EventKey>(key: K): EventTopic<K>;
+}
+
+export function resolveTopic<K extends EventKey>(topic: TopicInput<K>): K {
+    if (typeof topic === 'string') {
+        return topic;
+    }
+    if (topic && typeof topic === 'object' && 'key' in topic) {
+        return topic.key;
+    }
+    return String(topic) as K;
+}

--- a/client/src/runtime/event-hub/legacy.ts
+++ b/client/src/runtime/event-hub/legacy.ts
@@ -1,0 +1,48 @@
+import eventBus from "../../eventBus";
+import type {
+    ClientEventMap,
+    EventHandler,
+    EventHub,
+    EventKey,
+    EventParams,
+    EventTopic,
+    TopicInput,
+} from "../event-hub";
+import { resolveTopic } from "../event-hub";
+
+function createDetail(args: unknown[]): unknown {
+    if (args.length === 0) {
+        return undefined;
+    }
+    if (args.length === 1) {
+        return args[0];
+    }
+    return args;
+}
+
+export default class LegacyEventHub implements EventHub {
+    readonly target = eventBus;
+
+    topic<K extends EventKey>(key: K): EventTopic<K> {
+        return { key };
+    }
+
+    subscribe<K extends EventKey>(
+        topic: TopicInput<K>,
+        handler: EventHandler<ClientEventMap[K]>,
+        options?: AddEventListenerOptions | boolean,
+    ): () => void {
+        const key = resolveTopic(topic);
+        eventBus.on(key, handler as EventHandler<any>, options);
+        return () => {
+            eventBus.off(key, handler as EventHandler<any>);
+        };
+    }
+
+    publish<K extends EventKey>(topic: TopicInput<K>, ...args: EventParams<ClientEventMap[K]>): void {
+        const key = resolveTopic(topic);
+        eventBus.emit(key, ...args);
+        const detail = createDetail(args as unknown[]);
+        window.dispatchEvent(new CustomEvent(String(key), { detail }));
+    }
+}

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -17,6 +17,7 @@ jest.mock('../src/main', () => ({
 }));
 
 import Client from '../src/Client';
+import LegacyEventHub from '../src/runtime/event-hub/legacy';
 import { mudletColorLine } from '../src/Colors';
 import { Howl } from 'howler';
 
@@ -71,7 +72,7 @@ beforeEach(() => {
 
 test('requests notification permission on demand', () => {
   (global as any).Notification = { permission: 'default', requestPermission: jest.fn() };
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   client.enableNotifications();
   expect((global as any).Notification.requestPermission).toHaveBeenCalledTimes(1);
   delete (global as any).Notification;
@@ -79,7 +80,7 @@ test('requests notification permission on demand', () => {
 
 test('does not request notification permission when already decided', () => {
   (global as any).Notification = { permission: 'granted', requestPermission: jest.fn() };
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   client.enableNotifications();
   expect((global as any).Notification.requestPermission).not.toHaveBeenCalled();
   delete (global as any).Notification;
@@ -89,7 +90,7 @@ test('registers service worker if available', () => {
   (global as any).Notification = { permission: 'granted', requestPermission: jest.fn() };
   const original = (navigator as any).serviceWorker;
   (navigator as any).serviceWorker = { register: jest.fn().mockResolvedValue(undefined) };
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   client.enableNotifications();
   expect((navigator as any).serviceWorker.register).toHaveBeenCalledWith('sw.js');
   const calledPath = (navigator as any).serviceWorker.register.mock.calls[0][0];
@@ -103,7 +104,7 @@ test('registers service worker using base path', () => {
   document.head.innerHTML = '<base href="/test/">';
   const original = (navigator as any).serviceWorker;
   (navigator as any).serviceWorker = { register: jest.fn().mockResolvedValue(undefined) };
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   client.enableNotifications();
   expect((navigator as any).serviceWorker.register).toHaveBeenCalledWith('sw.js');
   const calledPath = (navigator as any).serviceWorker.register.mock.calls[0][0];
@@ -114,7 +115,7 @@ test('registers service worker using base path', () => {
 });
 
 test('port messages trigger window events', () => {
-  new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   const listener = (global as any).portMock.onMessage.addListener.mock.calls[0][0];
   const detail = [{ name: 'Foo', loc: 1 }];
   listener({ npc: detail });
@@ -124,12 +125,12 @@ test('port messages trigger window events', () => {
 });
 
 test('createEvent returns object with type and data', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   expect(client.createEvent('t', 123)).toEqual({ type: 't', data: 123 });
 });
 
 test('addEventListener allows removal', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   const handler = jest.fn();
   const remove = client.addEventListener('foo', handler);
   client.eventTarget.dispatchEvent(new CustomEvent('foo', { detail: 'bar' }));
@@ -140,7 +141,7 @@ test('addEventListener allows removal', () => {
 });
 
 test('println uses print with newline', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   const spy = jest.spyOn(client, 'print').mockImplementation();
   client.println('hi');
   expect(spy).toHaveBeenNthCalledWith(1, '\n');
@@ -149,7 +150,7 @@ test('println uses print with newline', () => {
 });
 
 test('createButton creates button attached to panel', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   const cb = jest.fn();
   const button = client.createButton('name', cb);
   expect(button.value).toBe('name');
@@ -160,7 +161,7 @@ test('createButton creates button attached to panel', () => {
 });
 
 test('sendCommand dispatches event and splits commands', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   client.sendCommand('foo#bar');
   expect(parseCommand).toHaveBeenCalledWith('foo#bar');
   expect(parseCommand).toHaveBeenCalledWith('parsed:foo');
@@ -170,7 +171,7 @@ test('sendCommand dispatches event and splits commands', () => {
 });
 
 test('sendCommand allows empty command', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   client.sendCommand('');
   expect(parseCommand).toHaveBeenCalledWith('');
   expect((global as any).clientAdapterMock.send).toHaveBeenCalledWith('parsed:', true);
@@ -178,7 +179,7 @@ test('sendCommand allows empty command', () => {
 
 test('sendCommand splits commands returned by parseCommand', () => {
   parseCommand.mockImplementationOnce(() => 'foo;bar');
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   client.sendCommand('e');
   expect(parseCommand).toHaveBeenCalledWith('e');
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(1, 'parsed:foo', true);
@@ -187,7 +188,7 @@ test('sendCommand splits commands returned by parseCommand', () => {
 
 test('sendCommand prints echo commands locally', () => {
   parseCommand.mockImplementationOnce((cmd: string) => cmd);
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   const printSpy = jest.spyOn(client, 'print').mockImplementation();
   client.sendCommand('echo <red> text');
   expect(printSpy).toHaveBeenCalledWith(mudletColorLine('<red> text'));
@@ -195,7 +196,7 @@ test('sendCommand prints echo commands locally', () => {
 });
 
 test('onLine sends printed messages after line and restores Output.send', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   const originalOutputSend = (window as any).Output.send;
 
   client.Triggers.parseLine = jest.fn(() => {
@@ -218,7 +219,7 @@ test('onLine sends printed messages after line and restores Output.send', () => 
 });
 
 test('onLine replaces reset sequences with preceding ANSI code', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   const line = '\x1b[22;38;5;1mRED\x1b[0m text \x1b[22;38;5;2mGREEN\x1b[0m';
 
   const result = client.onLine(line, '');
@@ -229,7 +230,7 @@ test('onLine replaces reset sequences with preceding ANSI code', () => {
 });
 
 test('onLine keeps trailing resets without preceding color', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   const line = '\x1b[22;38;5;1mred\x1b[0m\x1b[0m';
 
   const result = client.onLine(line, '');
@@ -239,7 +240,7 @@ test('onLine keeps trailing resets without preceding color', () => {
 });
 
 test('onLine restores color after inserting enclosed color', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   const gray = '\x1b[22;38;5;8m';
   const yellow = '\x1b[22;38;5;11m';
   const orange = '\x1b[22;38;5;215m';
@@ -273,7 +274,7 @@ test('onLine restores color after inserting enclosed color', () => {
 });
 
 test('onLine preserves final reset at line end', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   const gray = '\x1b[22;38;5;8m';
   const line = gray + 'gray text' + '\x1b[0m';
 
@@ -283,7 +284,7 @@ test('onLine preserves final reset at line end', () => {
 });
 
 test('playSound restarts sound when called twice', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   const sound = (Howl as jest.Mock).mock.results[0].value;
 
   client.playSound('beep');
@@ -302,13 +303,13 @@ test('updateContentWidth measures characters per line', () => {
   Object.defineProperty(wrapper, 'clientWidth', { value: 100, configurable: true });
   const measure = document.getElementById('content-width-measure')!;
   (measure as any).getBoundingClientRect = jest.fn(() => ({ width: 10 }));
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   client.updateContentWidth();
   expect(client.contentWidth).toBe(10);
 });
 
 test('support sends commands to support leader', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   jest.spyOn(client, 'sendCommand');
   jest.spyOn(client.TeamManager, 'getLeaderId').mockReturnValue('5');
   client.support();
@@ -317,7 +318,7 @@ test('support sends commands to support leader', () => {
 });
 
 test('sendCommand expands object shortcuts', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   jest.spyOn(client.ObjectManager, 'getObjectsOnLocation').mockReturnValue([
     { num: 5, shortcut: '1' },
     { num: 7, shortcut: 'A' },

--- a/client/test/objectNumReset.test.ts
+++ b/client/test/objectNumReset.test.ts
@@ -1,4 +1,5 @@
 import Client from '../src/Client';
+import LegacyEventHub from '../src/runtime/event-hub/legacy';
 import { getItemSync } from '../src/storage';
 
 (window as any).Input = { send: jest.fn() };
@@ -62,7 +63,7 @@ describe('object_num persistence and reset event', () => {
     (window as any).dispatchEvent = jest.fn();
     (global as any).portMock = { onMessage: { addListener: jest.fn() }, postMessage: jest.fn() };
     (global as any).clientAdapterMock = { send: jest.fn(), stop: jest.fn(), connect: jest.fn(), output: jest.fn(), sendGmcp: jest.fn() };
-    client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+    client = new Client((global as any).clientAdapterMock as any, (global as any).portMock, new LegacyEventHub());
   });
 
   test('stores object_num and emits reset when changed', () => {

--- a/client/test/runtime/event-hub.test.ts
+++ b/client/test/runtime/event-hub.test.ts
@@ -1,0 +1,43 @@
+import eventBus from "../../src/eventBus";
+import LegacyEventHub from "../../src/runtime/event-hub/legacy";
+
+describe('LegacyEventHub', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('publishes events to both eventBus subscribers and native listeners', () => {
+        const hub = new LegacyEventHub();
+        const payload = { text: 'hello' };
+        const busListener = jest.fn();
+        const nativeListener = jest.fn();
+
+        eventBus.on('notify', busListener);
+        window.addEventListener('notify', nativeListener as EventListener);
+
+        try {
+            hub.publish('notify', payload);
+
+            expect(busListener).toHaveBeenCalledTimes(1);
+            expect(busListener).toHaveBeenCalledWith(payload);
+
+            expect(nativeListener).toHaveBeenCalledTimes(1);
+            const event = nativeListener.mock.calls[0][0] as CustomEvent;
+            expect(event.detail).toEqual(payload);
+        } finally {
+            eventBus.off('notify', busListener);
+            window.removeEventListener('notify', nativeListener as EventListener);
+        }
+    });
+
+    it('unsubscribes handlers when cleanup is invoked', () => {
+        const hub = new LegacyEventHub();
+        const handler = jest.fn();
+
+        const unsubscribe = hub.subscribe('notify', handler);
+        unsubscribe();
+
+        hub.publish('notify', { text: 'bye' });
+        expect(handler).not.toHaveBeenCalled();
+    });
+});

--- a/client/test/tempBinds.test.ts
+++ b/client/test/tempBinds.test.ts
@@ -10,6 +10,7 @@ jest.mock('howler', () => ({
 }));
 
 import Client from '../src/Client';
+import LegacyEventHub from '../src/runtime/event-hub/legacy';
 import initTempBinds from '../src/scripts/tempBinds';
 
 describe('temp binds', () => {
@@ -26,7 +27,7 @@ describe('temp binds', () => {
       postMessage: jest.fn(),
       onMessage: { addListener: jest.fn() },
     } as any;
-    const client = new Client(adapter, port);
+    const client = new Client(adapter, port, new LegacyEventHub());
     (client as any).println = jest.fn();
     return client;
   }

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -2,13 +2,13 @@ import {parseAnsiPatterns} from './ansiParser';
 import {RecordedEvent} from './recordingStorage';
 import Recorder from './Recorder';
 import {ClientAdapter} from "@client/src/Client.ts";
-import eventBus, {ClientEvents} from "@client/src/eventBus.ts";
+import LegacyEventHub from "@client/src/runtime/event-hub/legacy.ts";
+import type { ClientEventMap, EventHub, EventKey, EventParams } from "@client/src/runtime/event-hub.ts";
 import TelnetOptionNegotiation from "./TelnetOptionNegotiation.ts";
 import {md5} from 'js-md5';
 import {uncompress} from "./compression.ts";
 
-type Params<T> = T extends void ? [] : T extends any[] ? T : [T];
-type EventListener<K extends keyof ClientEvents> = (...args: Params<ClientEvents[K]>) => void;
+type EventListener<K extends EventKey> = (...args: EventParams<ClientEventMap[K]>) => void;
 
 // WebSocket configuration
 const WEBSOCKET_URL = 'wss://arkadia.rpg.pl/wss';
@@ -29,6 +29,8 @@ class ArkadiaClient implements ClientAdapter {
     private lastConnectManual = true;
     private pingTimer: number | null = null;
     private messageBuffer: { text: string, type: string }[] = []
+    private eventHub: EventHub = new LegacyEventHub();
+    private subscriptions = new Map<EventKey, Map<EventListener<any>, () => void>>();
     private recorder = new Recorder({
         processIncomingData: (d) => this.processIncomingData(d),
         sendCommand: (cmd) => this.sendCommand(cmd),
@@ -44,25 +46,55 @@ class ArkadiaClient implements ClientAdapter {
     }
 
 
+    setEventHub(eventHub: EventHub) {
+        const current = this.subscriptions;
+        current.forEach((listeners) => {
+            listeners.forEach((unsubscribe) => unsubscribe());
+        });
+        this.subscriptions = new Map();
+        this.eventHub = eventHub;
+        current.forEach((listeners, event) => {
+            listeners.forEach((_unsubscribe, listener) => {
+                this.on(event as EventKey, listener as EventListener<any>);
+            });
+        });
+    }
+
+
+
     /**
      * Register an event listener
      */
-    on<K extends keyof ClientEvents>(event: K, listener: EventListener<K>): void {
-        eventBus.on(event, listener);
+    on<K extends EventKey>(event: K, listener: EventListener<K>): void {
+        const unsubscribe = this.eventHub.subscribe(event, listener);
+        let listeners = this.subscriptions.get(event);
+        if (!listeners) {
+            listeners = new Map();
+            this.subscriptions.set(event, listeners);
+        }
+        listeners.set(listener as EventListener<any>, unsubscribe);
     }
 
     /**
      * Remove an event listener
      */
-    off<K extends keyof ClientEvents>(event: K, listener: EventListener<K>): void {
-        eventBus.off(event, listener);
+    off<K extends EventKey>(event: K, listener: EventListener<K>): void {
+        const listeners = this.subscriptions.get(event);
+        const unsubscribe = listeners?.get(listener as EventListener<any>);
+        if (unsubscribe) {
+            unsubscribe();
+            listeners!.delete(listener as EventListener<any>);
+            if (listeners!.size === 0) {
+                this.subscriptions.delete(event);
+            }
+        }
     }
 
     /**
      * Emit an event to all registered listeners
      */
-    emit<K extends keyof ClientEvents>(event: K, ...args: Params<ClientEvents[K]>): void {
-        eventBus.emit(event, ...args);
+    emit<K extends EventKey>(event: K, ...args: EventParams<ClientEventMap[K]>): void {
+        this.eventHub.publish(event, ...args);
     }
 
     /**
@@ -363,7 +395,7 @@ class ArkadiaClient implements ClientAdapter {
 
     private sendLine(text: string, type: string, i: number) {
         text = window.clientExtension.onLine(text, type)
-        eventBus.on('output-sent', () => this.emit(`gmcp_msg.${type}`, text), {once: true})
+        this.eventHub.subscribe('output-sent', () => this.emit(`gmcp_msg.${type}` as EventKey, text), {once: true})
         Output.send(parseAnsiPatterns(text), type);
         this.emit('line-sent')
     }
@@ -430,4 +462,11 @@ class ArkadiaClient implements ClientAdapter {
 
 }
 
-export default new ArkadiaClient();
+const arkadiaClient = new ArkadiaClient();
+
+export function configureArkadiaClientEventHub(eventHub: EventHub) {
+    arkadiaClient.setEventHub(eventHub);
+    return arkadiaClient;
+}
+
+export default arkadiaClient;

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -1,6 +1,6 @@
 import 'bootswatch/dist/darkly/bootstrap.min.css';
 import './style.css'
-import arkadiaClient from "./ArkadiaClient.ts";
+import arkadiaClient, { configureArkadiaClientEventHub } from "./ArkadiaClient.ts";
 import "./plugin.ts"
 import {Modal, Dropdown} from 'bootstrap';
 import CharState from "./CharState";
@@ -20,6 +20,7 @@ import initSessionLogger from "./sessionLogger";
 import LetterComposer from "./LetterComposer";
 
 import "@client/src/main.ts"
+import LegacyEventHub from "@client/src/runtime/event-hub/legacy.ts";
 import MockPort from "./MockPort.ts";
 import NoSleep from 'nosleep.js';
 import {loadMapData, loadColors} from "./mapDataLoader.ts";
@@ -46,9 +47,12 @@ import "./triggerFinder"
 
 initSessionLogger(arkadiaClient).catch(err => console.error('Logger init failed', err));
 
-const client = new Client(arkadiaClient, new MockPort())
+const eventHub = new LegacyEventHub();
+configureArkadiaClientEventHub(eventHub);
+
+const client = new Client(arkadiaClient, new MockPort(), eventHub)
 window.clientExtension = client;
-registerScripts(client)
+registerScripts(client, eventHub)
 client.connect(client.port, true)
 
 


### PR DESCRIPTION
## Summary
- add a runtime event hub contract and legacy implementation bridging the existing event bus and DOM events
- inject the event hub into the browser client, shared client bootstrap, and tests while keeping event-target compatibility
- update web client to route ArkadiaClient events through the hub and cover the legacy bridge with new Jest tests

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68eafa50ade4832a91d3881e4d6915cd