### PR TITLE
Add runtime settings service shim

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -22,6 +22,9 @@ import {SKIP_LINE} from "./ControlConstants";
 import {stripPolishCharacters} from "./stripPolishCharacters";
 import eventBus from "./eventBus";
 import { openMapContextMenu } from "./contextMenus";
+import services from "./runtime/service-registry";
+import type { SettingsSnapshot } from "./runtime/settings/settings-service";
+import { settingsEventHub } from "./runtime/settings/settings-service";
 
 export interface ClientAdapter {
     send(text: string, echo?: boolean): void;
@@ -95,6 +98,8 @@ export default class Client {
     moveMode = 0;
     carriageMode = false;
     moveModeButton?: HTMLInputElement | HTMLButtonElement;
+
+    private readonly settingsService = services.settings;
 
 
     constructor(clientAdapter: ClientAdapter, port: any) {
@@ -233,13 +238,28 @@ export default class Client {
             }
         }
 
-        this.addEventListener('settings', (ev: CustomEvent) => {
-            applyBinds(ev.detail?.binds)
-        })
-
         this.addEventListener('binds', (ev: CustomEvent) => {
             applyBinds(ev.detail)
         })
+
+        let awaitingInitialDispatch = true;
+        this.settingsService.settings$.subscribe((settings: SettingsSnapshot) => {
+            const binds = (settings as any)?.binds;
+            if (binds) {
+                applyBinds(binds);
+            }
+            const dispatch = () => this.sendEvent('settings', settings);
+            if (awaitingInitialDispatch) {
+                awaitingInitialDispatch = false;
+                Promise.resolve().then(dispatch);
+            } else {
+                dispatch();
+            }
+        });
+
+        settingsEventHub.on('settings.error', (error) => {
+            console.error('Failed to update settings', error);
+        });
 
         this.addEventListener('uiSettings', (ev: CustomEvent) => {
             if (ev.detail?.xtermPalette) {

--- a/client/src/runtime/event-hub.ts
+++ b/client/src/runtime/event-hub.ts
@@ -1,0 +1,33 @@
+export interface EventHubSubscription {
+    unsubscribe(): void;
+}
+
+export class EventHub<Events extends Record<string, any>> {
+    private readonly target = new EventTarget();
+    private readonly wrappers = new Map<Function, EventListener>();
+
+    on<K extends keyof Events>(event: K, listener: (payload: Events[K]) => void): EventHubSubscription {
+        const wrapper: EventListener = (ev: Event) => {
+            const detail = (ev as CustomEvent).detail as Events[K];
+            listener(detail);
+        };
+        this.wrappers.set(listener, wrapper);
+        this.target.addEventListener(event as string, wrapper);
+        return {
+            unsubscribe: () => this.off(event, listener)
+        };
+    }
+
+    off<K extends keyof Events>(event: K, listener: (payload: Events[K]) => void) {
+        const wrapper = this.wrappers.get(listener);
+        if (!wrapper) {
+            return;
+        }
+        this.target.removeEventListener(event as string, wrapper);
+        this.wrappers.delete(listener);
+    }
+
+    emit<K extends keyof Events>(event: K, payload: Events[K]) {
+        this.target.dispatchEvent(new CustomEvent(event as string, { detail: payload }));
+    }
+}

--- a/client/src/runtime/service-registry.ts
+++ b/client/src/runtime/service-registry.ts
@@ -1,0 +1,11 @@
+import type { SettingsService } from './settings/settings-service';
+import { LocalStorageSettingsService } from './settings/local-storage-service';
+
+class ServiceRegistry {
+    readonly settings: SettingsService = new LocalStorageSettingsService();
+}
+
+const services = new ServiceRegistry();
+
+export default services;
+export type { ServiceRegistry };

--- a/client/src/runtime/settings/local-storage-service.ts
+++ b/client/src/runtime/settings/local-storage-service.ts
@@ -1,0 +1,117 @@
+import storage, { getItemSync } from '../../storage';
+import { defaultSettings } from '../../defaultSettings';
+import type { Observable, SettingsService, SettingsSnapshot } from './settings-service';
+import { settingsEventHub } from './settings-service';
+
+type StorageModule = typeof storage;
+
+type StorageChange = {
+    [key: string]: { oldValue: unknown; newValue: unknown };
+};
+
+class BehaviorSubject<T> implements Observable<T> {
+    private value: T;
+    private readonly listeners = new Set<(value: T) => void>();
+
+    constructor(initial: T) {
+        this.value = initial;
+    }
+
+    getValue(): T {
+        return this.value;
+    }
+
+    next(value: T) {
+        this.value = value;
+        this.listeners.forEach(listener => listener(value));
+    }
+
+    subscribe(listener: (value: T) => void) {
+        this.listeners.add(listener);
+        listener(this.value);
+        return {
+            unsubscribe: () => {
+                this.listeners.delete(listener);
+            },
+        };
+    }
+}
+
+function asError(error: unknown): Error {
+    if (error instanceof Error) {
+        return error;
+    }
+    return new Error(typeof error === 'string' ? error : 'Unknown error');
+}
+
+function normalizeSnapshot(snapshot: unknown): SettingsSnapshot {
+    const overrides = snapshot && typeof snapshot === 'object' ? snapshot as Record<string, unknown> : {};
+    return {
+        ...defaultSettings,
+        ...overrides,
+    } as SettingsSnapshot;
+}
+
+export class LocalStorageSettingsService implements SettingsService {
+    private readonly subject: BehaviorSubject<SettingsSnapshot>;
+    private readonly storage: StorageModule;
+    private readonly listener: ((changes: StorageChange) => void) | null;
+    private suppressNextChange = false;
+
+    readonly settings$: Observable<SettingsSnapshot>;
+
+    constructor(store: StorageModule = storage) {
+        this.storage = store;
+        const initial = normalizeSnapshot(getItemSync('settings')?.settings);
+        this.subject = new BehaviorSubject(initial);
+        this.settings$ = this.subject;
+        settingsEventHub.emit('settings.updated', initial);
+
+        const listener = (changes: StorageChange) => {
+            const change = changes['settings'];
+            if (!change) {
+                return;
+            }
+            if (this.suppressNextChange) {
+                this.suppressNextChange = false;
+                return;
+            }
+            const next = normalizeSnapshot(change.newValue);
+            this.applySnapshot(next);
+        };
+
+        if (this.storage.onChanged?.addListener) {
+            this.listener = listener;
+            this.storage.onChanged.addListener(listener);
+        } else {
+            this.listener = null;
+        }
+    }
+
+    async update(patch: Partial<SettingsSnapshot>): Promise<void> {
+        const current = this.subject.getValue();
+        const next = normalizeSnapshot({ ...current, ...patch });
+        try {
+            this.suppressNextChange = !!this.listener;
+            await this.storage.setItem('settings', next);
+            this.applySnapshot(next);
+        } catch (error) {
+            this.suppressNextChange = false;
+            const err = asError(error);
+            settingsEventHub.emit('settings.error', err);
+            throw err;
+        }
+    }
+
+    destroy() {
+        if (this.listener && this.storage.onChanged?.removeListener) {
+            this.storage.onChanged.removeListener(this.listener);
+        }
+    }
+
+    private applySnapshot(snapshot: SettingsSnapshot) {
+        this.subject.next(snapshot);
+        settingsEventHub.emit('settings.updated', snapshot);
+    }
+}
+

--- a/client/src/runtime/settings/settings-service.ts
+++ b/client/src/runtime/settings/settings-service.ts
@@ -1,0 +1,20 @@
+import { defaultSettings } from '../../defaultSettings';
+import { EventHub } from '../event-hub';
+
+export interface Observable<T> {
+    subscribe(listener: (value: T) => void): { unsubscribe(): void };
+}
+
+export type SettingsSnapshot = (typeof defaultSettings & Record<string, unknown>);
+
+export interface SettingsService {
+    readonly settings$: Observable<SettingsSnapshot>;
+    update(patch: Partial<SettingsSnapshot>): Promise<void>;
+}
+
+export interface SettingsEvents {
+    'settings.updated': SettingsSnapshot;
+    'settings.error': Error;
+}
+
+export const settingsEventHub = new EventHub<SettingsEvents>();

--- a/client/src/scripts/attackBeep.ts
+++ b/client/src/scripts/attackBeep.ts
@@ -1,6 +1,7 @@
 import Client from "../Client";
 import {colorString, findClosestColor} from "../Colors";
 import {loadPeople, type PersonEntry} from '../peopleLoader';
+import services from "../runtime/service-registry";
 
 const RED = findClosestColor("#ff0000");
 
@@ -74,11 +75,10 @@ export default function initAttackBeep(client: Client) {
         return highlightAttack(raw, upper);
     };
 
-    // Listen for settings changes
-    client.addEventListener('settings', (event: CustomEvent) => {
-        const settings = event.detail || {};
-        if (Array.isArray(settings.enemyGuilds)) {
-            enemyGuilds = [...settings.enemyGuilds];
+    services.settings.settings$.subscribe((settings) => {
+        const snapshot = settings as { enemyGuilds?: unknown };
+        if (Array.isArray(snapshot.enemyGuilds)) {
+            enemyGuilds = [...snapshot.enemyGuilds];
         }
         ensurePeopleLoaded().catch(() => undefined);
     });

--- a/client/test/attackBeep.test.ts
+++ b/client/test/attackBeep.test.ts
@@ -2,6 +2,8 @@ import initAttackBeep from '../src/scripts/attackBeep';
 import Triggers, {stripAnsiCodes} from '../src/Triggers';
 import {findClosestColor} from '../src/Colors';
 import {loadPeople} from '../src/peopleLoader';
+import services from '../src/runtime/service-registry';
+import { setCurrentCharacter } from '../src/storage';
 
 jest.mock('../src/peopleLoader', () => ({
   loadPeople: jest.fn(),
@@ -26,18 +28,21 @@ describe('attack beep triggers', () => {
 
   beforeEach(async () => {
     loadPeopleMock.mockReset().mockResolvedValue(MOCK_PEOPLE);
+    localStorage.clear();
+    setCurrentCharacter('');
+    await services.settings.update({ enemyGuilds: [] } as any);
     client = new FakeClient();
     initAttackBeep((client as unknown) as any);
     await loadPeopleMock.mock.results[0]?.value;
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
-    // initialize with enemy guilds so beeping is enabled only for configured guilds
-    const handler = client.addEventListener.mock.calls[0]?.[1];
-    if (handler) {
-      handler({ detail: { enemyGuilds: ['CKN'] } } as any);
-    }
+    await services.settings.update({ enemyGuilds: ['CKN'] } as any);
     const lastCall = loadPeopleMock.mock.results[loadPeopleMock.mock.results.length - 1];
     await lastCall?.value;
     jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await services.settings.update({ enemyGuilds: [] } as any);
   });
 
   test('beeps and highlights on attack', () => {

--- a/client/test/runtime/settings-service.test.ts
+++ b/client/test/runtime/settings-service.test.ts
@@ -1,0 +1,81 @@
+import { LocalStorageSettingsService } from '../../src/runtime/settings/local-storage-service';
+import { settingsEventHub, type SettingsSnapshot } from '../../src/runtime/settings/settings-service';
+import { setCurrentCharacter } from '../../src/storage';
+import { defaultSettings } from '../../src/defaultSettings';
+
+describe('LocalStorageSettingsService', () => {
+    let service: LocalStorageSettingsService | null = null;
+
+    beforeEach(() => {
+        localStorage.clear();
+        setCurrentCharacter('');
+    });
+
+    afterEach(() => {
+        service?.destroy();
+        service = null;
+        localStorage.clear();
+        setCurrentCharacter('');
+    });
+
+    function createService() {
+        service?.destroy();
+        service = new LocalStorageSettingsService();
+        return service;
+    }
+
+    test('persists updates to storage', async () => {
+        const svc = createService();
+        await svc.update({ language: 'elficki' } as Partial<SettingsSnapshot>);
+        const raw = localStorage.getItem('settings');
+        expect(raw).not.toBeNull();
+        const stored = JSON.parse(raw as string);
+        expect(stored.language).toBe('elficki');
+        expect(stored.packageHelper).toBe(defaultSettings.packageHelper);
+    });
+
+    test('emits reactive updates and notifies the event hub', async () => {
+        const svc = createService();
+        const observed: string[] = [];
+        const subscription = svc.settings$.subscribe(snapshot => {
+            observed.push(String(snapshot.language));
+        });
+        const hubUpdates: SettingsSnapshot[] = [];
+        const hubSubscription = settingsEventHub.on('settings.updated', (snapshot) => {
+            hubUpdates.push(snapshot);
+        });
+
+        await svc.update({ language: 'elficki' } as Partial<SettingsSnapshot>);
+        await svc.update({ language: 'khazalid' } as Partial<SettingsSnapshot>);
+
+        expect(observed.slice(-2)).toEqual(['elficki', 'khazalid']);
+        expect(hubUpdates.slice(-2).map(s => s.language)).toEqual(['elficki', 'khazalid']);
+
+        subscription.unsubscribe();
+        hubSubscription.unsubscribe();
+    });
+
+    test('reloads scoped settings when the active character changes', async () => {
+        setCurrentCharacter('Alice');
+        const svc = createService();
+        const snapshots: SettingsSnapshot[] = [];
+        const subscription = svc.settings$.subscribe(snapshot => {
+            snapshots.push(snapshot);
+        });
+
+        await svc.update({ language: 'elficki' } as Partial<SettingsSnapshot>);
+        const aliceRaw = localStorage.getItem('Alice:settings');
+        expect(aliceRaw).not.toBeNull();
+
+        localStorage.setItem('Bob:settings', JSON.stringify({
+            ...defaultSettings,
+            language: 'khazalid',
+        }));
+
+        setCurrentCharacter('Bob');
+        await Promise.resolve();
+
+        expect(snapshots.at(-1)?.language).toBe('khazalid');
+        subscription.unsubscribe();
+    });
+});


### PR DESCRIPTION
## Summary
- introduce a typed runtime settings service backed by local storage and an event hub
- wire the client and attack beep script to consume the new settings stream while re-emitting legacy events
- cover persistence, reactivity, and character switching with new Jest specifications

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68eaff293514832a817afb74793511bb