### PR TITLE
Refactor transport to WebSocket adapter and router

### DIFF
--- a/client/src/runtime/transport/message-router.ts
+++ b/client/src/runtime/transport/message-router.ts
@@ -1,0 +1,163 @@
+import eventBus from "../../eventBus";
+import type {
+    TransportAdapter,
+    TransportIn,
+    TransportObservable,
+    TransportSubscription,
+} from "./types";
+
+const GMCP_COMMAND_CODE = 201;
+const TELNET_OPTION_REGEX = /\u00FF\u00FA.*?\u00FF\u00F0|\u00FF.[^\u00FF]/g;
+
+export interface MessageRouterOptions {
+    parseAnsiPatterns: (text: string) => string;
+    transformLine?: (text: string, type: string) => string;
+}
+
+const defaultTransformLine = (text: string, type: string) => {
+    const extension = (window as any).clientExtension;
+    if (extension && typeof extension.onLine === "function") {
+        return extension.onLine(text, type);
+    }
+    return text;
+};
+
+export default class MessageRouter {
+    private subscription?: TransportSubscription;
+    private messageBuffer: { text: string; type: string }[] = [];
+    private receivedFirstGmcp = false;
+    private readonly parseAnsiPatterns: (text: string) => string;
+    private readonly transformLine: (text: string, type: string) => string;
+
+    constructor(private transport: TransportAdapter, options: MessageRouterOptions) {
+        this.parseAnsiPatterns = options.parseAnsiPatterns;
+        this.transformLine = options.transformLine ?? defaultTransformLine;
+        this.subscribe(transport.messages$);
+    }
+
+    private subscribe(observable: TransportObservable<TransportIn>) {
+        this.subscription = observable.subscribe((message) => {
+            if (message.type === "data") {
+                this.processIncomingData(message.payload);
+            }
+        });
+    }
+
+    attach(transport: TransportAdapter) {
+        this.dispose();
+        this.transport = transport;
+        this.subscribe(transport.messages$);
+    }
+
+    dispose() {
+        this.subscription?.unsubscribe();
+        this.subscription = undefined;
+    }
+
+    reset() {
+        this.receivedFirstGmcp = false;
+        this.messageBuffer = [];
+    }
+
+    get hasReceivedFirstGmcp() {
+        return this.receivedFirstGmcp;
+    }
+
+    processFrame(data: string) {
+        this.processIncomingData(data);
+    }
+
+    flushMessageBuffer() {
+        if (!this.messageBuffer.length) {
+            return;
+        }
+
+        const merged: { text: string; type: string }[] = [];
+        for (const entry of this.messageBuffer) {
+            const last = merged[merged.length - 1];
+            if (last && last.type === entry.type) {
+                last.text += entry.text;
+            } else {
+                merged.push({...entry});
+            }
+        }
+
+        merged.forEach((message, index) => this.sendLine(message.text, message.type, index));
+        eventBus.emit("output-sent", merged.length);
+        this.messageBuffer = [];
+    }
+
+    private processIncomingData(data: string) {
+        const withoutOptions = data.replace(TELNET_OPTION_REGEX, this.parseTelnetOption);
+        const sanitized = withoutOptions.replace(/[ÿù]/g, "");
+        if (sanitized.trim().length > 0) {
+            eventBus.emit("message", sanitized);
+        }
+        this.flushMessageBuffer();
+    }
+
+    private parseTelnetOption = (optionData: string): string => {
+        if (optionData.length >= 5) {
+            this.parseTelnetSubnegotiation(optionData.substring(2, optionData.length - 2));
+        }
+        return "";
+    };
+
+    private parseTelnetSubnegotiation(data: string) {
+        if (!data.length) {
+            return;
+        }
+
+        const firstChar = data.charCodeAt(0);
+        if (firstChar !== GMCP_COMMAND_CODE) {
+            return;
+        }
+
+        const gmcpData = data.substring(1);
+        if (!gmcpData.length) {
+            return;
+        }
+
+        const spaceIndex = gmcpData.indexOf(" ");
+        if (spaceIndex === -1) {
+            return;
+        }
+
+        const type = gmcpData.substring(0, spaceIndex).toLowerCase();
+        let payload = gmcpData.substring(spaceIndex + 1);
+
+        if (type === "gmcp_msgs") {
+            payload = payload.replace(/g/g, "\\u001B");
+        }
+
+        try {
+            const parsed = JSON.parse(payload);
+            if (type === "gmcp_msgs") {
+                const text = atob(parsed.text);
+                this.messageBuffer.push({ text, type: parsed.type });
+                return;
+            }
+
+            if (type === "char.info") {
+                this.receivedFirstGmcp = true;
+            }
+
+            eventBus.emit(`gmcp.${type}` as `gmcp.${string}`, parsed);
+            eventBus.emit("gmcp", { path: type, value: parsed });
+        } catch (error) {
+            console.error("Error parsing GMCP JSON:", (error as Error).message);
+        }
+    }
+
+    private sendLine(text: string, type: string, index: number) {
+        const transformed = this.transformLine(text, type);
+        eventBus.on("output-sent", () => {
+            eventBus.emit(`gmcp_msg.${type}` as `gmcp_msg.${string}`, transformed);
+        }, { once: true });
+
+        if (typeof (window as any).Output?.send === "function") {
+            (window as any).Output.send(this.parseAnsiPatterns(transformed), type);
+        }
+        eventBus.emit("line-sent");
+    }
+}

--- a/client/src/runtime/transport/types.ts
+++ b/client/src/runtime/transport/types.ts
@@ -1,0 +1,32 @@
+export interface TransportSubscription {
+    unsubscribe(): void;
+}
+
+export interface TransportObservable<T> {
+    subscribe(listener: (value: T) => void): TransportSubscription;
+}
+
+export interface TransportConnectOptions {
+    manual?: boolean;
+}
+
+export type TransportIn =
+    | { type: 'open'; event: Event }
+    | { type: 'close'; event: CloseEvent }
+    | { type: 'error'; event: Event }
+    | { type: 'data'; payload: string };
+
+export type TransportOut =
+    | { kind: 'text'; payload: string }
+    | { kind: 'gmcp'; path: string; payload?: unknown }
+    | { kind: 'raw'; payload: string };
+
+export interface TransportAdapter {
+    readonly messages$: TransportObservable<TransportIn>;
+
+    connect(options?: TransportConnectOptions): void;
+
+    disconnect(): void;
+
+    send(message: TransportOut): void;
+}

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -3,205 +3,161 @@ import {RecordedEvent} from './recordingStorage';
 import Recorder from './Recorder';
 import {ClientAdapter} from "@client/src/Client.ts";
 import eventBus, {ClientEvents} from "@client/src/eventBus.ts";
-import TelnetOptionNegotiation from "./TelnetOptionNegotiation.ts";
 import {md5} from 'js-md5';
-import {uncompress} from "./compression.ts";
+import type {
+    TransportAdapter,
+    TransportConnectOptions,
+    TransportIn,
+    TransportSubscription,
+} from "@client/src/runtime/transport/types";
+import MessageRouter from "@client/src/runtime/transport/message-router";
+import WebSocketTransportAdapter from "./transport/websocket-adapter";
 
 type Params<T> = T extends void ? [] : T extends any[] ? T : [T];
 type EventListener<K extends keyof ClientEvents> = (...args: Params<ClientEvents[K]>) => void;
 
-// WebSocket configuration
-const WEBSOCKET_URL = 'wss://arkadia.rpg.pl/wss';
-const GMCP_COMMAND_CODE = 201;
-const MCCP_COMMAND_CODE = 86;
-const TELNET_OPTION_REGEX = /\u00FF\u00FA.*?\u00FF\u00F0|\u00FF.[^\u00FF]/g;
+export interface ArkadiaClientDependencies {
+    transport: TransportAdapter;
+    router: MessageRouter;
+}
 
+function createRouter(transport: TransportAdapter) {
+    return new MessageRouter(transport, { parseAnsiPatterns });
+}
 
 class ArkadiaClient implements ClientAdapter {
-    private socket!: WebSocket;
-    private telnetNegotiator = new TelnetOptionNegotiation(this)
-    private mccp = false;
-    // @ts-ignore
-    private readInflator = new pako.Inflate()
-    private receivedFirstGmcp: boolean = false;
+    private transport: TransportAdapter;
+    private router: MessageRouter;
+    private transportSubscription?: TransportSubscription;
+    private socketOpen = false;
+    private lastConnectManual = true;
     private userCommand: string | null = null;
     private passwordCommand: string | null = null;
-    private lastConnectManual = true;
-    private pingTimer: number | null = null;
-    private messageBuffer: { text: string, type: string }[] = []
-    private recorder = new Recorder({
-        processIncomingData: (d) => this.processIncomingData(d),
-        sendCommand: (cmd) => this.sendCommand(cmd),
-        emit: (ev, ...args) => this.emit(ev, ...args)
-    });
+    private recorder: Recorder;
 
-    constructor() {
+    constructor(deps: ArkadiaClientDependencies) {
+        this.transport = deps.transport;
+        this.router = deps.router;
+        this.router.attach(this.transport);
+        this.transportSubscription = this.transport.messages$.subscribe(this.handleTransportMessage);
+        this.recorder = new Recorder({
+            processIncomingData: (data) => this.router.processFrame(data),
+            sendCommand: (command, echo = true) => this.send(command, echo),
+            emit: (event, ...args) => this.emit(event as keyof ClientEvents, ...(args as any)),
+        });
+
         addEventListener("beforeunload", (event) => {
-            if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+            if (this.socketOpen) {
                 event.preventDefault();
             }
-        })
+        });
     }
 
+    configure(deps: Partial<ArkadiaClientDependencies>) {
+        let shouldResubscribe = false;
 
-    /**
-     * Register an event listener
-     */
-    on<K extends keyof ClientEvents>(event: K, listener: EventListener<K>): void {
-        eventBus.on(event, listener);
+        if (deps.transport && deps.transport !== this.transport) {
+            this.transportSubscription?.unsubscribe();
+            this.transport = deps.transport;
+            shouldResubscribe = true;
+        }
+
+        if (deps.router && deps.router !== this.router) {
+            this.router.dispose();
+            this.router = deps.router;
+            shouldResubscribe = true;
+        }
+
+        if (shouldResubscribe) {
+            this.router.attach(this.transport);
+            this.transportSubscription = this.transport.messages$.subscribe(this.handleTransportMessage);
+        }
     }
 
-    /**
-     * Remove an event listener
-     */
-    off<K extends keyof ClientEvents>(event: K, listener: EventListener<K>): void {
-        eventBus.off(event, listener);
-    }
-
-    /**
-     * Emit an event to all registered listeners
-     */
-    emit<K extends keyof ClientEvents>(event: K, ...args: Params<ClientEvents[K]>): void {
-        eventBus.emit(event, ...args);
-    }
-
-    /**
-     * Connect to the WebSocket server
-     */
-    connect(manual: boolean = true): void {
-        try {
-            // Reset the flag when connecting
-            this.receivedFirstGmcp = false;
-            this.lastConnectManual = manual;
-            this.socket = new WebSocket(WEBSOCKET_URL, []);
-            this.socket.onmessage = (event: MessageEvent<string>) => {
-                try {
-                    const decodedData = this.inflate(atob(event.data));
-                    this.recorder.handleIncoming(decodedData);
-                    this.processIncomingData(decodedData);
-                } catch (error) {
-                    console.error('Error processing incoming message:', error);
-                }
-            };
-
-            this.socket.onerror = (error: Event) => {
-                this.emit('error', error);
-            };
-
-            this.socket.onclose = (event: CloseEvent) => {
-                this.emit('close', event);
-                this.emit('client.disconnect');
-                this.stopPing();
-
-                // @ts-ignore
-                this.readInflator = new pako.Inflate()
-            };
-
-            this.socket.onopen = (event: Event) => {
-                this.emit('open', event);
-                this.emit('client.connect');
-                this.mccp = false;
-                this.startPing();
+    private handleTransportMessage = (message: TransportIn) => {
+        switch (message.type) {
+            case "open":
+                this.socketOpen = true;
+                this.router.reset();
+                this.emit("open", message.event);
+                this.emit("client.connect");
                 if (!this.lastConnectManual && this.userCommand && this.passwordCommand) {
                     this.send(this.userCommand, false);
                     if (this.passwordCommand !== this.userCommand) {
                         this.send(this.passwordCommand, false);
                     }
                 }
-            };
-        } catch (error) {
-            this.emit('error', error);
+                break;
+            case "close":
+                this.socketOpen = false;
+                this.emit("close", message.event);
+                this.emit("client.disconnect");
+                this.router.reset();
+                break;
+            case "error":
+                this.emit("error", message.event);
+                break;
+            case "data":
+                this.recorder.handleIncoming(message.payload);
+                break;
         }
+    };
+
+    on<K extends keyof ClientEvents>(event: K, listener: EventListener<K>): void {
+        eventBus.on(event, listener);
     }
 
-    private inflate(decodedData: string) {
-        if (this.mccp) {
-            try {
-                const byteArray = decodedData.split("").map(function (char) {
-                    return char.charCodeAt(0);
-                });
-                this.readInflator.push(byteArray, 2);
-                if (this.readInflator.err) {
-                    console.error("MCCP decompression error: " + this.readInflator.msg);
-                    return decodedData;
-                }
-                const decompressed = new Uint16Array(this.readInflator.result);
-                const length = decompressed.length;
-                decodedData = "";
-                for (let i = 0; i < length; i++) {
-                    decodedData += String.fromCharCode(decompressed[i]);
-                }
-                this.readInflator.chunks = []
-                this.readInflator.ended = false;
-            } catch (error) {
-                console.log("MCCP decompression error: " + error.message);
-            }
-        }
-        return decodedData;
+    off<K extends keyof ClientEvents>(event: K, listener: EventListener<K>): void {
+        eventBus.off(event, listener);
     }
 
-    /**
-     * Disconnect from the WebSocket server
-     */
+    emit<K extends keyof ClientEvents>(event: K, ...args: Params<ClientEvents[K]>): void {
+        eventBus.emit(event, ...args);
+    }
+
+    connect(options?: TransportConnectOptions | boolean): void {
+        const manual = typeof options === "boolean" ? options : options?.manual ?? true;
+        this.lastConnectManual = manual;
+        this.router.reset();
+        this.transport.connect({ manual });
+    }
+
     disconnect(): void {
-        if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-            this.socket.close();
-        }
-        this.mccp = false;
-        this.stopPing();
+        this.transport.disconnect();
+        this.router.reset();
     }
 
-    /**
-     * Check if the WebSocket is currently open
-     */
     isSocketOpen(): boolean {
-        return !!this.socket && this.socket.readyState === WebSocket.OPEN;
+        return this.socketOpen;
     }
 
-    /**
-     * Check if the first GMCP event has been received
-     */
     hasReceivedFirstGmcp(): boolean {
-        return this.receivedFirstGmcp;
+        return this.router.hasReceivedFirstGmcp;
     }
 
-    /**
-     * Manually set the stored password for automatic credential sending
-     */
     setStoredPassword(password: string | null): void {
         this.passwordCommand = password;
     }
 
-    /**
-     * Manually set the stored character for automatic credential sending
-     */
     setStoredCharacter(character: string | null): void {
         this.userCommand = character;
     }
 
     sendRaw(message: string): void {
-        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
-            console.error('WebSocket is not connected');
+        if (!this.socketOpen) {
+            console.error("WebSocket is not connected");
             return;
         }
-        try {
-            this.socket.send(message);
-        } catch (error) {
-            console.error('Error sending message:', error);
-            this.emit('error', error);
-        }
+        this.transport.send({ kind: "raw", payload: message });
     }
 
-    /**
-     * Send a message through the WebSocket
-     */
     send(message: string, echo: boolean = true): void {
-        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
-            console.error('WebSocket is not connected');
+        if (!this.socketOpen) {
+            console.error("WebSocket is not connected");
             return;
         }
 
-        if (!this.receivedFirstGmcp) {
+        if (!this.router.hasReceivedFirstGmcp) {
             if (!this.userCommand) {
                 this.userCommand = message;
             }
@@ -210,162 +166,57 @@ class ArkadiaClient implements ClientAdapter {
 
         try {
             this.recorder.handleOutgoing(message);
-            this.socket.send(btoa(message + "\r\n"));
-            // Only echo commands if requested and we've received the first GMCP event
-            if (echo && this.receivedFirstGmcp && message) {
-                this.output("→ " + message, 'command');
+            this.transport.send({ kind: "text", payload: message });
+            if (echo && this.router.hasReceivedFirstGmcp && message) {
+                this.output("→ " + message, "command");
             }
         } catch (error) {
-            console.error('Error sending message:', error);
-            this.emit('error', error);
+            console.error("Error sending message:", error);
+            const synthetic = new Event("error");
+            (synthetic as any).detail = error;
+            this.emit("error", synthetic);
         }
     }
 
     sendGmcp(path: string, payload: any = {}): void {
-        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+        if (!this.socketOpen) {
             return;
         }
         try {
-            const data = typeof payload === 'string' ? payload : JSON.stringify(payload);
-            const gmcpMessage = `\xFF\xFA${String.fromCharCode(GMCP_COMMAND_CODE)}${path} ${data}\xFF\xF0`;
-            this.socket.send(btoa(gmcpMessage));
+            this.transport.send({ kind: "gmcp", path, payload });
         } catch (error) {
-            console.error('Error sending GMCP message:', error);
-            this.emit('error', error);
+            console.error("Error sending GMCP message:", error);
+            const synthetic = new Event("error");
+            (synthetic as any).detail = error;
+            this.emit("error", synthetic);
         }
     }
 
     setConfig(payload: any, filename: string) {
-        const serialized = JSON.stringify(payload)
+        const serialized = JSON.stringify(payload);
         const data = {
             data: payload,
             md5: md5(serialized),
             compressed: false,
             filename: filename,
-        }
-        this.sendGmcp('client.conf.set', data)
+        };
+        this.sendGmcp('client.conf.set', data);
     }
 
-    private startPing() {
-        this.stopPing();
-        this.sendGmcp('core.ping');
-        this.pingTimer = window.setInterval(() => this.sendGmcp('core.ping'), 30000);
-    }
-
-    private stopPing() {
-        if (this.pingTimer !== null) {
-            clearInterval(this.pingTimer);
-            this.pingTimer = null;
-        }
-    }
-
-    /**
-     * Compatibility wrapper matching old client API
-     */
     sendCommand(command: string, echo: boolean = true): void {
         this.send(command, echo);
     }
 
     output(text?: string, type?: string) {
-        this.emit('message', text, type)
+        this.emit('message', text, type);
     }
 
-    //Should be done on all ouput
     parseAnsiPatterns(text: string) {
-        return parseAnsiPatterns(text)
-    }
-
-    /**
-     * Process incoming WebSocket data by removing telnet options
-     */
-    private processIncomingData(data: string) {
-        const leftOver = data.replace(TELNET_OPTION_REGEX, this.parseTelnetOption.bind(this)).trim();
-        const sanitized = leftOver.replace(/[ÿù]/g, "");
-        if (sanitized.length > 0) {
-            this.emit('message', sanitized)
-        }
-        this.flushMessageBuffer()
-    }
-
-    /**
-     * Parse telnet option from incoming data
-     */
-    private parseTelnetOption(optionData: string): string {
-        if (optionData.length === 3) {
-            //this.telnetNegotiator.parseOptionNegotiation(optionData)
-        } else {
-            this.parseTelnetSubnegotiation(optionData.substring(2, optionData.length - 2));
-        }
-        return "";
-    }
-
-    /**
-     * Parse telnet subnegotiation, specifically GMCP (Generic MUD Communication Protocol)
-     */
-    private parseTelnetSubnegotiation(data: string): void {
-        if (data.length === 0) return;
-
-        const firstChar = data.charCodeAt(0);
-        if (firstChar === MCCP_COMMAND_CODE) {
-            this.mccp = true;
-            console.log("MCCP enabled")
-        }
-
-        if (firstChar === GMCP_COMMAND_CODE) {
-            const gmcpData = data.substring(1);
-            if (!gmcpData.length) return;
-
-            const spaceIndex = gmcpData.indexOf(" ");
-            if (spaceIndex === -1) return;
-
-            const type = gmcpData.substring(0, spaceIndex).toLowerCase();
-            let payload = gmcpData.substring(spaceIndex + 1);
-
-            // Handle special case for gmcp_msgs
-            if (type === "gmcp_msgs") {
-                payload = payload.replace(//g, "\\u001B");
-            }
-
-            try {
-                const gmcp = JSON.parse(payload);
-                this.receivedFirstGmcp = this.receivedFirstGmcp || type === "char.info";
-                if (type === "gmcp_msgs") {
-                    let text = atob(gmcp.text)
-                    this.messageBuffer.push({text, type: gmcp.type})
-                } else if (type === "client.conf.get") {
-                    const data = JSON.parse(uncompress(gmcp.data))
-                    const filename = gmcp.filename
-                } else {
-                    this.emit(`gmcp.${type}`, gmcp);
-                    this.emit('gmcp', {path: type, value: gmcp});
-                }
-            } catch (error) {
-                console.error('Error parsing GMCP JSON:', error);
-            }
-        }
+        return parseAnsiPatterns(text);
     }
 
     flushMessageBuffer() {
-        let processed = [];
-        this.messageBuffer.forEach((message, i) => {
-            if (processed[processed.length - 1]?.type === message.type) {
-                processed[processed.length - 1].text += message.text
-            } else {
-                processed.push(message)
-            }
-        })
-        processed.forEach((message, i) => {
-            this.sendLine(message.text, message.type, i)
-        })
-        this.emit('output-sent', processed.length)
-        this.messageBuffer = []
-    }
-
-    private sendLine(text: string, type: string, i: number) {
-        text = window.clientExtension.onLine(text, type)
-        eventBus.on('output-sent', () => this.emit(`gmcp_msg.${type}`, text), {once: true})
-        Output.send(parseAnsiPatterns(text), type);
-        this.emit('line-sent')
+        this.router.flushMessageBuffer();
     }
 
     startRecording(name: string) {
@@ -427,7 +278,26 @@ class ArkadiaClient implements ClientAdapter {
     replayRecordedMessagesTimed() {
         this.recorder.replayRecordedMessagesTimed();
     }
-
 }
 
-export default new ArkadiaClient();
+const defaultTransport = new WebSocketTransportAdapter();
+const defaultRouter = createRouter(defaultTransport);
+const legacyClient = new ArkadiaClient({ transport: defaultTransport, router: defaultRouter });
+
+export function configureArkadiaClient(deps: Partial<ArkadiaClientDependencies>) {
+    if (deps.transport || deps.router) {
+        const transport = deps.transport ?? defaultTransport;
+        const router = deps.router ?? createRouter(transport);
+        legacyClient.configure({ transport, router });
+    }
+    return legacyClient;
+}
+
+export function createArkadiaClient(deps?: Partial<ArkadiaClientDependencies>) {
+    const transport = deps?.transport ?? new WebSocketTransportAdapter();
+    const router = deps?.router ?? createRouter(transport);
+    return new ArkadiaClient({ transport, router });
+}
+
+export { ArkadiaClient };
+export default legacyClient;

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -1,6 +1,6 @@
 import 'bootswatch/dist/darkly/bootstrap.min.css';
 import './style.css'
-import arkadiaClient from "./ArkadiaClient.ts";
+import arkadiaClient, {configureArkadiaClient} from "./ArkadiaClient.ts";
 import "./plugin.ts"
 import {Modal, Dropdown} from 'bootstrap';
 import CharState from "./CharState";
@@ -43,6 +43,13 @@ import {
 } from "./mobileButtonSettings"
 import "./triggerTester"
 import "./triggerFinder"
+import MessageRouter from "@client/src/runtime/transport/message-router";
+import WebSocketTransportAdapter from "./transport/websocket-adapter";
+import {parseAnsiPatterns} from "./ansiParser";
+
+const transport = new WebSocketTransportAdapter();
+const router = new MessageRouter(transport, { parseAnsiPatterns });
+configureArkadiaClient({ transport, router });
 
 initSessionLogger(arkadiaClient).catch(err => console.error('Logger init failed', err));
 

--- a/web-client/src/transport/websocket-adapter.ts
+++ b/web-client/src/transport/websocket-adapter.ts
@@ -1,0 +1,179 @@
+import type {
+    TransportAdapter,
+    TransportConnectOptions,
+    TransportIn,
+    TransportObservable,
+    TransportOut,
+    TransportSubscription,
+} from "@client/src/runtime/transport/types";
+
+const WEBSOCKET_URL = "wss://arkadia.rpg.pl/wss";
+const GMCP_COMMAND_CODE = 201;
+const MCCP_COMMAND_CODE = 86;
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - pako is provided globally by the client bootstrap
+declare const pako: any;
+
+class Subject<T> implements TransportObservable<T> {
+    private listeners = new Set<(value: T) => void>();
+
+    subscribe(listener: (value: T) => void): TransportSubscription {
+        this.listeners.add(listener);
+        return {
+            unsubscribe: () => {
+                this.listeners.delete(listener);
+            },
+        };
+    }
+
+    next(value: T) {
+        for (const listener of this.listeners) {
+            listener(value);
+        }
+    }
+}
+
+export default class WebSocketTransportAdapter implements TransportAdapter {
+    private socket: WebSocket | null = null;
+    private readonly subject = new Subject<TransportIn>();
+    readonly messages$: TransportObservable<TransportIn> = this.subject;
+    private mccp = false;
+    private readInflator: any = new pako.Inflate();
+    private pingTimer: number | null = null;
+    private url: string;
+
+    constructor(url: string = WEBSOCKET_URL) {
+        this.url = url;
+    }
+
+    connect(_options?: TransportConnectOptions): void {
+        this.disconnect();
+        this.mccp = false;
+        this.resetInflator();
+
+        try {
+            this.socket = new WebSocket(this.url, []);
+            this.socket.onopen = (event: Event) => {
+                this.subject.next({ type: "open", event });
+                this.startPing();
+            };
+            this.socket.onerror = (event: Event) => {
+                this.subject.next({ type: "error", event });
+            };
+            this.socket.onclose = (event: CloseEvent) => {
+                this.stopPing();
+                this.subject.next({ type: "close", event });
+                this.resetInflator();
+                this.socket = null;
+            };
+            this.socket.onmessage = (event: MessageEvent<string>) => {
+                try {
+                    const decoded = this.handleIncoming(event.data);
+                    this.subject.next({ type: "data", payload: decoded });
+                } catch (error) {
+                    const synthetic = new Event("error");
+                    (synthetic as any).detail = error;
+                    this.subject.next({ type: "error", event: synthetic });
+                }
+            };
+        } catch (error) {
+            const synthetic = new Event("error");
+            (synthetic as any).detail = error;
+            this.subject.next({ type: "error", event: synthetic });
+        }
+    }
+
+    disconnect(): void {
+        if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+            this.socket.close();
+        }
+        this.stopPing();
+    }
+
+    send(message: TransportOut): void {
+        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+            return;
+        }
+
+        try {
+            if (message.kind === "text") {
+                this.socket.send(btoa(`${message.payload}\r\n`));
+            } else if (message.kind === "gmcp") {
+                const data = typeof message.payload === "string"
+                    ? message.payload
+                    : JSON.stringify(message.payload ?? {});
+                const gmcpMessage = `\xFF\xFA${String.fromCharCode(GMCP_COMMAND_CODE)}${message.path} ${data}\xFF\xF0`;
+                this.socket.send(btoa(gmcpMessage));
+            } else if (message.kind === "raw") {
+                this.socket.send(message.payload);
+            }
+        } catch (error) {
+            const synthetic = new Event("error");
+            (synthetic as any).detail = error;
+            this.subject.next({ type: "error", event: synthetic });
+        }
+    }
+
+    private handleIncoming(payload: string): string {
+        const decodedData = atob(payload);
+        const inflated = this.inflate(decodedData);
+        this.detectCompressionStart(inflated);
+        return inflated;
+    }
+
+    private inflate(decodedData: string): string {
+        if (!this.mccp) {
+            return decodedData;
+        }
+
+        try {
+            const byteArray = decodedData.split("").map((char) => char.charCodeAt(0));
+            this.readInflator.push(byteArray, 2);
+            if (this.readInflator.err) {
+                console.error("MCCP decompression error:", this.readInflator.msg);
+                return decodedData;
+            }
+            const decompressed = new Uint16Array(this.readInflator.result);
+            let result = "";
+            for (let i = 0; i < decompressed.length; i++) {
+                result += String.fromCharCode(decompressed[i]);
+            }
+            this.readInflator.chunks = [];
+            this.readInflator.ended = false;
+            return result;
+        } catch (error) {
+            console.error("MCCP decompression error:", (error as Error).message);
+            return decodedData;
+        }
+    }
+
+    private detectCompressionStart(data: string) {
+        if (this.mccp) {
+            return;
+        }
+        const prefix = `\xFF\xFA${String.fromCharCode(MCCP_COMMAND_CODE)}`;
+        if (data.includes(prefix)) {
+            this.mccp = true;
+        }
+    }
+
+    private startPing() {
+        this.stopPing();
+        this.send({ kind: "gmcp", path: "core.ping" });
+        this.pingTimer = window.setInterval(() => {
+            this.send({ kind: "gmcp", path: "core.ping" });
+        }, 30000);
+    }
+
+    private stopPing() {
+        if (this.pingTimer !== null) {
+            clearInterval(this.pingTimer);
+            this.pingTimer = null;
+        }
+    }
+
+    private resetInflator() {
+        this.readInflator = new pako.Inflate();
+    }
+}

--- a/web-client/test/transport/websocket-adapter.test.ts
+++ b/web-client/test/transport/websocket-adapter.test.ts
@@ -1,0 +1,184 @@
+import WebSocketTransportAdapter from "../../src/transport/websocket-adapter";
+import type {TransportIn} from "@client/src/runtime/transport/types";
+
+const globalAny = globalThis as any;
+
+class MockWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSED = 3;
+    static instances: MockWebSocket[] = [];
+
+    onopen: ((event: Event) => void) | null = null;
+    onclose: ((event: CloseEvent) => void) | null = null;
+    onerror: ((event: Event) => void) | null = null;
+    onmessage: ((event: MessageEvent<string>) => void) | null = null;
+    readyState = MockWebSocket.CONNECTING;
+    sent: string[] = [];
+    closed = false;
+
+    constructor(public url: string) {
+        MockWebSocket.instances.push(this);
+    }
+
+    send(data: string) {
+        this.sent.push(data);
+    }
+
+    close() {
+        this.closed = true;
+        this.readyState = MockWebSocket.CLOSED;
+        this.onclose?.({ type: "close" } as CloseEvent);
+    }
+
+    triggerOpen() {
+        this.readyState = MockWebSocket.OPEN;
+        this.onopen?.(new Event("open"));
+    }
+
+    triggerClose() {
+        this.readyState = MockWebSocket.CLOSED;
+        this.onclose?.({ type: "close" } as CloseEvent);
+    }
+
+    triggerError(error?: any) {
+        const event = new Event("error");
+        (event as any).detail = error;
+        this.onerror?.(event);
+    }
+
+    triggerMessage(payload: string) {
+        const data = btoa(payload);
+        this.onmessage?.({ data } as MessageEvent<string>);
+    }
+}
+
+describe("WebSocketTransportAdapter", () => {
+    const originalWebSocket = globalAny.WebSocket;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        MockWebSocket.instances = [];
+        globalAny.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+        globalAny.pako = {
+            Inflate: jest.fn(() => ({
+                err: 0,
+                msg: "",
+                result: new Uint16Array(),
+                chunks: [],
+                ended: false,
+                push: jest.fn(),
+            })),
+        };
+    });
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+        globalAny.WebSocket = originalWebSocket;
+        delete globalAny.pako;
+    });
+
+    const collectEvents = (adapter: WebSocketTransportAdapter) => {
+        const events: TransportIn[] = [];
+        const subscription = adapter.messages$.subscribe((event) => events.push(event));
+        return { events, subscription };
+    };
+
+    it("emits lifecycle events and sends pings", () => {
+        const adapter = new WebSocketTransportAdapter("ws://example");
+        const { events, subscription } = collectEvents(adapter);
+
+        adapter.connect();
+        const socket = MockWebSocket.instances[0];
+        expect(socket).toBeDefined();
+
+        socket.triggerOpen();
+        expect(events[0]?.type).toBe("open");
+        expect(socket.sent).toHaveLength(1);
+        expect(atob(socket.sent[0])).toContain("core.ping");
+
+        jest.advanceTimersByTime(30000);
+        expect(socket.sent).toHaveLength(2);
+
+        socket.triggerClose();
+        expect(events.some((event) => event.type === "close")).toBe(true);
+
+        jest.advanceTimersByTime(30000);
+        expect(socket.sent).toHaveLength(2);
+
+        subscription.unsubscribe();
+    });
+
+    it("decodes text frames", () => {
+        const adapter = new WebSocketTransportAdapter("ws://example");
+        const frames: string[] = [];
+        const subscription = adapter.messages$.subscribe((event) => {
+            if (event.type === "data") {
+                frames.push(event.payload);
+            }
+        });
+
+        adapter.connect();
+        const socket = MockWebSocket.instances[0];
+        socket.triggerOpen();
+        socket.triggerMessage("hello world");
+
+        expect(frames).toContain("hello world");
+        subscription.unsubscribe();
+    });
+
+    it("inflates MCCP payloads after negotiation", () => {
+        const inflateResult = new Uint16Array(Array.from("decoded").map((char) => char.charCodeAt(0)));
+        const inflateMock = {
+            err: 0,
+            msg: "",
+            result: inflateResult,
+            chunks: [] as unknown[],
+            ended: false,
+            push: jest.fn(),
+        };
+        globalAny.pako = { Inflate: jest.fn(() => inflateMock) };
+
+        const adapter = new WebSocketTransportAdapter("ws://example");
+        const frames: string[] = [];
+        const subscription = adapter.messages$.subscribe((event) => {
+            if (event.type === "data") {
+                frames.push(event.payload);
+            }
+        });
+
+        adapter.connect();
+        const socket = MockWebSocket.instances[0];
+        socket.triggerOpen();
+        socket.triggerMessage(`\xFF\xFA${String.fromCharCode(86)}foo\xFF\xF0`);
+        socket.triggerMessage("ignored");
+
+        expect(inflateMock.push).toHaveBeenCalled();
+        expect(frames.pop()).toBe("decoded");
+        subscription.unsubscribe();
+    });
+
+    it("closes the socket on disconnect", () => {
+        const adapter = new WebSocketTransportAdapter("ws://example");
+        adapter.connect();
+        const socket = MockWebSocket.instances[0];
+        socket.triggerOpen();
+
+        adapter.disconnect();
+        expect(socket.closed).toBe(true);
+    });
+
+    it("emits error events", () => {
+        const adapter = new WebSocketTransportAdapter("ws://example");
+        const { events, subscription } = collectEvents(adapter);
+
+        adapter.connect();
+        const socket = MockWebSocket.instances[0];
+        const error = new Error("boom");
+        socket.triggerError(error);
+
+        expect(events.some((event) => event.type === "error")).toBe(true);
+        subscription.unsubscribe();
+    });
+});


### PR DESCRIPTION
## Summary
- add typed transport interfaces and a runtime message router for normalising GMCP and text frames
- extract the WebSocket networking code into a reusable transport adapter and update the legacy Arkadia client to compose it
- wire the new adapter and router into the bootstrap and cover the adapter with Jest unit tests

## Testing
- yarn --cwd web-client test
- yarn --cwd client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68eaff489cdc832a89b91e32fc2612e1