### PR TITLE
Refactor runtime messaging to event hub

### DIFF
--- a/client/src/runtime/event-hub.ts
+++ b/client/src/runtime/event-hub.ts
@@ -1,3 +1,5 @@
+import eventBus from "../eventBus";
+
 export interface EventHubSubscription {
     unsubscribe(): void;
 }
@@ -31,3 +33,52 @@ export class EventHub<Events extends Record<string, any>> {
         this.target.dispatchEvent(new CustomEvent(event as string, { detail: payload }));
     }
 }
+
+export interface RuntimeEvents {
+    message: string;
+    command: string;
+    gmcp: { path: string; value: unknown };
+    gmcpMessage: { type: string; text: string };
+    outputLine: { text: string; rawText: string; type: string; index: number };
+    outputFlushed: { count: number };
+    lineSent: { type: string };
+}
+
+export const runtimeEventHub = new EventHub<RuntimeEvents>();
+
+export function bridgeRuntimeEventsToLegacyEventBus(
+    eventHub: EventHub<RuntimeEvents>,
+): () => void {
+    const subscriptions: EventHubSubscription[] = [];
+
+    subscriptions.push(eventHub.on("message", (text) => {
+        eventBus.emit("message", text);
+    }));
+
+    subscriptions.push(eventHub.on("gmcp", ({ path, value }) => {
+        eventBus.emit(`gmcp.${path}` as `gmcp.${string}`, value);
+        eventBus.emit("gmcp", { path, value });
+    }));
+
+    subscriptions.push(eventHub.on("gmcpMessage", ({ type, text }) => {
+        eventBus.emit(`gmcp_msg.${type}` as `gmcp_msg.${string}`, text);
+    }));
+
+    subscriptions.push(eventHub.on("outputFlushed", ({ count }) => {
+        eventBus.emit("output-sent", count);
+    }));
+
+    subscriptions.push(eventHub.on("lineSent", () => {
+        eventBus.emit("line-sent");
+    }));
+
+    subscriptions.push(eventHub.on("command", (command) => {
+        eventBus.emit("command", command);
+    }));
+
+    return () => {
+        subscriptions.forEach((subscription) => subscription.unsubscribe());
+    };
+}
+
+bridgeRuntimeEventsToLegacyEventBus(runtimeEventHub);

--- a/client/src/runtime/transport/message-router.ts
+++ b/client/src/runtime/transport/message-router.ts
@@ -1,10 +1,10 @@
-import eventBus from "../../eventBus";
 import type {
     TransportAdapter,
     TransportIn,
     TransportObservable,
     TransportSubscription,
 } from "./types";
+import type { EventHub, RuntimeEvents } from "../event-hub";
 
 const GMCP_COMMAND_CODE = 201;
 const TELNET_OPTION_REGEX = /\u00FF\u00FA.*?\u00FF\u00F0|\u00FF.[^\u00FF]/g;
@@ -22,16 +22,29 @@ const defaultTransformLine = (text: string, type: string) => {
     return text;
 };
 
+interface BufferedMessage {
+    text: string;
+    type: string;
+    gmcp?: boolean;
+}
+
 export default class MessageRouter {
     private subscription?: TransportSubscription;
-    private messageBuffer: { text: string; type: string }[] = [];
+    private messageBuffer: BufferedMessage[] = [];
+    private pendingGmcpMessages: { type: string; text: string }[] = [];
     private receivedFirstGmcp = false;
     private readonly parseAnsiPatterns: (text: string) => string;
     private readonly transformLine: (text: string, type: string) => string;
+    private readonly eventHub: EventHub<RuntimeEvents>;
 
-    constructor(private transport: TransportAdapter, options: MessageRouterOptions) {
+    constructor(
+        transport: TransportAdapter,
+        eventHub: EventHub<RuntimeEvents>,
+        options: MessageRouterOptions,
+    ) {
         this.parseAnsiPatterns = options.parseAnsiPatterns;
         this.transformLine = options.transformLine ?? defaultTransformLine;
+        this.eventHub = eventHub;
         this.subscribe(transport.messages$);
     }
 
@@ -45,7 +58,6 @@ export default class MessageRouter {
 
     attach(transport: TransportAdapter) {
         this.dispose();
-        this.transport = transport;
         this.subscribe(transport.messages$);
     }
 
@@ -57,6 +69,7 @@ export default class MessageRouter {
     reset() {
         this.receivedFirstGmcp = false;
         this.messageBuffer = [];
+        this.pendingGmcpMessages = [];
     }
 
     get hasReceivedFirstGmcp() {
@@ -72,18 +85,24 @@ export default class MessageRouter {
             return;
         }
 
-        const merged: { text: string; type: string }[] = [];
+        const merged: BufferedMessage[] = [];
         for (const entry of this.messageBuffer) {
             const last = merged[merged.length - 1];
-            if (last && last.type === entry.type) {
+            if (last && last.type === entry.type && last.gmcp === entry.gmcp) {
                 last.text += entry.text;
             } else {
-                merged.push({...entry});
+                merged.push({ ...entry });
             }
         }
 
-        merged.forEach((message, index) => this.sendLine(message.text, message.type, index));
-        eventBus.emit("output-sent", merged.length);
+        merged.forEach((message, index) => this.sendLine(message, index));
+        this.eventHub.emit("outputFlushed", { count: merged.length });
+        if (this.pendingGmcpMessages.length) {
+            for (const gmcpMessage of this.pendingGmcpMessages) {
+                this.eventHub.emit("gmcpMessage", gmcpMessage);
+            }
+            this.pendingGmcpMessages = [];
+        }
         this.messageBuffer = [];
     }
 
@@ -91,7 +110,7 @@ export default class MessageRouter {
         const withoutOptions = data.replace(TELNET_OPTION_REGEX, this.parseTelnetOption);
         const sanitized = withoutOptions.replace(/[ÿù]/g, "");
         if (sanitized.trim().length > 0) {
-            eventBus.emit("message", sanitized);
+            this.eventHub.emit("message", sanitized);
         }
         this.flushMessageBuffer();
     }
@@ -134,7 +153,7 @@ export default class MessageRouter {
             const parsed = JSON.parse(payload);
             if (type === "gmcp_msgs") {
                 const text = atob(parsed.text);
-                this.messageBuffer.push({ text, type: parsed.type });
+                this.messageBuffer.push({ text, type: parsed.type, gmcp: true });
                 return;
             }
 
@@ -142,22 +161,27 @@ export default class MessageRouter {
                 this.receivedFirstGmcp = true;
             }
 
-            eventBus.emit(`gmcp.${type}` as `gmcp.${string}`, parsed);
-            eventBus.emit("gmcp", { path: type, value: parsed });
+            this.eventHub.emit("gmcp", { path: type, value: parsed });
         } catch (error) {
             console.error("Error parsing GMCP JSON:", (error as Error).message);
         }
     }
 
-    private sendLine(text: string, type: string, index: number) {
-        const transformed = this.transformLine(text, type);
-        eventBus.on("output-sent", () => {
-            eventBus.emit(`gmcp_msg.${type}` as `gmcp_msg.${string}`, transformed);
-        }, { once: true });
+    private sendLine(message: BufferedMessage, index: number) {
+        const transformed = this.transformLine(message.text, message.type);
+        this.eventHub.emit("outputLine", {
+            text: transformed,
+            rawText: message.text,
+            type: message.type,
+            index,
+        });
+        if (message.gmcp) {
+            this.pendingGmcpMessages.push({ type: message.type, text: transformed });
+        }
 
         if (typeof (window as any).Output?.send === "function") {
-            (window as any).Output.send(this.parseAnsiPatterns(transformed), type);
+            (window as any).Output.send(this.parseAnsiPatterns(transformed), message.type);
         }
-        eventBus.emit("line-sent");
+        this.eventHub.emit("lineSent", { type: message.type });
     }
 }

--- a/client/test/runtime/message-router.test.ts
+++ b/client/test/runtime/message-router.test.ts
@@ -1,0 +1,134 @@
+import MessageRouter from "../../src/runtime/transport/message-router";
+import type {
+    TransportAdapter,
+    TransportConnectOptions,
+    TransportOut,
+    TransportSubscription,
+} from "../../src/runtime/transport/types";
+import { EventHub, bridgeRuntimeEventsToLegacyEventBus, type RuntimeEvents } from "../../src/runtime/event-hub";
+import eventBus from "../../src/eventBus";
+
+describe("MessageRouter runtime event hub integration", () => {
+    class DummyTransport implements TransportAdapter {
+        readonly messages$ = {
+            subscribe: () => ({ unsubscribe() {} }) as TransportSubscription,
+        };
+
+        connect(_options?: TransportConnectOptions | undefined): void {}
+        disconnect(): void {}
+        send(_message: TransportOut): void {}
+    }
+
+    let eventHub: EventHub<RuntimeEvents>;
+    let router: MessageRouter;
+    let teardownBridge: (() => void) | null = null;
+
+    beforeEach(() => {
+        eventHub = new EventHub<RuntimeEvents>();
+        teardownBridge = bridgeRuntimeEventsToLegacyEventBus(eventHub);
+        router = new MessageRouter(new DummyTransport(), eventHub, {
+            parseAnsiPatterns: (text) => text,
+            transformLine: (text) => text,
+        });
+    });
+
+    afterEach(() => {
+        router.dispose();
+        if (teardownBridge) {
+            teardownBridge();
+            teardownBridge = null;
+        }
+    });
+
+    function processFrame(frame: string) {
+        router.processFrame(frame);
+    }
+
+    function createGmcpFrame(path: string, payload: unknown) {
+        const gmcpPayload = `${path} ${JSON.stringify(payload)}`;
+        const gmcpData = String.fromCharCode(201) + gmcpPayload;
+        return `\u00FF\u00FA${gmcpData}\u00FF\u00F0`;
+    }
+
+    function createGmcpMessageFrame(type: string, text: string) {
+        const gmcpPayload = JSON.stringify({ type, text: Buffer.from(text, "utf8").toString("base64") });
+        const gmcpData = String.fromCharCode(201) + `gmcp_msgs ${gmcpPayload}`;
+        return `\u00FF\u00FA${gmcpData}\u00FF\u00F0`;
+    }
+
+    test("forwards GMCP updates through the event hub and legacy event bus", () => {
+        const gmcpUpdates: { path: string; value: unknown }[] = [];
+        const subscription = eventHub.on("gmcp", (payload) => {
+            gmcpUpdates.push(payload);
+        });
+        const busListener = jest.fn();
+        eventBus.on("gmcp.char.info", busListener);
+
+        processFrame(createGmcpFrame("char.info", { foo: "bar" }));
+
+        expect(gmcpUpdates).toEqual([{ path: "char.info", value: { foo: "bar" } }]);
+        expect(busListener).toHaveBeenCalledWith({ foo: "bar" });
+
+        subscription.unsubscribe();
+        eventBus.off("gmcp.char.info", busListener);
+    });
+
+    test("flushes buffered GMCP messages as output and gmcp_msg events", () => {
+        const outputLines: RuntimeEvents["outputLine"][] = [];
+        const gmcpMessages: RuntimeEvents["gmcpMessage"][] = [];
+        const outputSubscription = eventHub.on("outputLine", (payload) => {
+            outputLines.push(payload);
+        });
+        const gmcpSubscription = eventHub.on("gmcpMessage", (payload) => {
+            gmcpMessages.push(payload);
+        });
+        const gmcpMsgListener = jest.fn();
+        const outputSentListener = jest.fn();
+        eventBus.on("gmcp_msg.room.info", gmcpMsgListener);
+        eventBus.on("output-sent", outputSentListener);
+
+        processFrame(createGmcpMessageFrame("room.info", "Look around"));
+
+        expect(outputLines).toEqual([
+            {
+                text: "Look around",
+                rawText: "Look around",
+                type: "room.info",
+                index: 0,
+            },
+        ]);
+        expect(gmcpMessages).toEqual([
+            {
+                type: "room.info",
+                text: "Look around",
+            },
+        ]);
+        expect(outputSentListener).toHaveBeenCalledWith(1);
+        expect(gmcpMsgListener).toHaveBeenCalledWith("Look around");
+        const outputOrder = outputSentListener.mock.invocationCallOrder[0];
+        const gmcpOrder = gmcpMsgListener.mock.invocationCallOrder[0];
+        expect(outputOrder).toBeLessThan(gmcpOrder);
+
+        outputSubscription.unsubscribe();
+        gmcpSubscription.unsubscribe();
+        eventBus.off("gmcp_msg.room.info", gmcpMsgListener);
+        eventBus.off("output-sent", outputSentListener);
+    });
+
+    test("emits sanitized text messages", () => {
+        const messages: string[] = [];
+        const subscription = eventHub.on("message", (payload) => {
+            messages.push(payload);
+        });
+        const busListener = jest.fn();
+        eventBus.on("message", busListener);
+
+        processFrame("Hello adventurer!\n");
+
+        expect(messages.at(-1)).toBe("Hello adventurer!\n");
+        expect(busListener).toHaveBeenCalledWith("Hello adventurer!\n");
+
+        subscription.unsubscribe();
+        eventBus.off("message", busListener);
+    });
+});

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -11,6 +11,7 @@ import type {
     TransportSubscription,
 } from "@client/src/runtime/transport/types";
 import MessageRouter from "@client/src/runtime/transport/message-router";
+import { runtimeEventHub } from "@client/src/runtime/event-hub";
 import WebSocketTransportAdapter from "./transport/websocket-adapter";
 
 type Params<T> = T extends void ? [] : T extends any[] ? T : [T];
@@ -22,7 +23,7 @@ export interface ArkadiaClientDependencies {
 }
 
 function createRouter(transport: TransportAdapter) {
-    return new MessageRouter(transport, { parseAnsiPatterns });
+    return new MessageRouter(transport, runtimeEventHub, { parseAnsiPatterns });
 }
 
 class ArkadiaClient implements ClientAdapter {

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -44,11 +44,12 @@ import {
 import "./triggerTester"
 import "./triggerFinder"
 import MessageRouter from "@client/src/runtime/transport/message-router";
+import { runtimeEventHub } from "@client/src/runtime/event-hub";
 import WebSocketTransportAdapter from "./transport/websocket-adapter";
 import {parseAnsiPatterns} from "./ansiParser";
 
 const transport = new WebSocketTransportAdapter();
-const router = new MessageRouter(transport, { parseAnsiPatterns });
+const router = new MessageRouter(transport, runtimeEventHub, { parseAnsiPatterns });
 configureArkadiaClient({ transport, router });
 
 initSessionLogger(arkadiaClient).catch(err => console.error('Logger init failed', err));


### PR DESCRIPTION
## Summary
- define a RuntimeEvents contract and bridge that mirrors events onto the legacy event bus
- refactor the runtime message router to emit structured runtime events while keeping buffered GMCP output intact
- wire the shared runtime event hub into the web client and cover GMCP/message forwarding with unit tests

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68eb05e5527c832aac525c128b7951e3