### PR TITLE
refactor: fetch core datasets from remote urls

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,75 +1,86 @@
-# Arkadia Map Extensions - Development Guidelines
+# Arkadia Web Client - Development Guidelines
 
 ## Build/Configuration Instructions
 
 ### Project Structure
-This is a **monorepo** managed by **Lerna** with the following workspaces:
+This repository uses Yarn workspaces to manage the following primary packages:
 
-| Package     | Description                                                       |
-|-------------|-------------------------------------------------------------------|
-| `extension` | Ready-to-use extension                                            |
-| `client`    | Content script, contains client modifications and scripts        |
-| `map`       | Map iframe                                                        |
-| `options`   | Extension options page                                            |
-| `scripts`   | Helper scripts for generating data files                          |
-| `sandbox`   | Development sandbox (not part of published extension)            |
+- `client`: Legacy runtime that powers the classic Arkadia browser client bundle.
+- `web-client`: Modern React-based interface and supporting utilities.
+- `scripts`: Helper scripts for data preparation and tooling.
+
+Additional directories such as `docs/` and `data/` provide documentation and reference assets.
 
 ### Prerequisites
-- **Node.js** (compatible with Yarn 1.22.22)
-- **Yarn 1.22.22** (specified as packageManager)
+- **Node.js** compatible with Yarn 1.22.22.
+- **Yarn 1.22.22** (declared via the root `packageManager`).
 
 ### Build Process
-1. **Install dependencies**: `yarn install` (installs for all workspaces)
-2. **Development build**: `yarn watch` (runs Lerna watch across all workspaces)
-3. **Production build**: `yarn build` (builds all workspaces and creates extension zip)
+1. **Install dependencies**: `yarn install`.
+2. **Client build**: `yarn --cwd client build`.
+3. **Web client build**: `yarn --cwd web-client build`.
+4. **Development servers**: run `yarn --cwd web-client dev` for the React app or `yarn --cwd client watch` for the legacy runtime bundle.
 
 ### Workspace-Specific Commands
-You can also run scripts for individual workspaces:
-```bash
-# Build specific workspace
-yarn workspace client build
-yarn workspace map build
-yarn workspace options build
+Use the workspace-specific scripts when iterating on a particular surface area:
 
-# Run tests for client workspace
-yarn workspace client test
+```bash
+# Build the client bundle
+$ yarn --cwd client build
+
+# Build the React web client
+$ yarn --cwd web-client build
+
+# Run tests for the client workspace
+$ yarn --cwd client test
+
+# Run tests for the React web client
+$ yarn --cwd web-client test
 ```
 
 ### Client Workspace Specifics
-- **Entry point**: `client/src/main.ts`
-- **Output**: `extension/dist/main.js`
-- **Build tool**: Webpack with ts-loader
-- **TypeScript config**: Targets ES2021, CommonJS modules
-- **Development mode**: Includes inline source maps
+- **Entry point**: `client/src/main.ts`.
+- **Output**: `client/dist/main.js`.
+- **Build tool**: Webpack with `ts-loader`.
+- **TypeScript config**: Targets ES2021 with CommonJS modules.
+- **Development mode**: Includes inline source maps.
+
+### Web Client Workspace Specifics
+- **Entry point**: `web-client/src/main.tsx`.
+- **Build tool**: Vite with React and TypeScript support.
+- **TypeScript config**: ES2022 modules.
+- **Development mode**: `yarn --cwd web-client dev` starts a local development server with hot module replacement.
 
 ## Testing Information
 
 ### Test Framework
-- **Jest** with TypeScript support (`ts-jest`)
-- **Environment**: JSDOM for DOM testing
-- **Configuration**: `client/jest.config.js`
+- **Jest** with TypeScript support (`ts-jest`).
+- **Environment**: JSDOM for DOM testing.
+- **Configuration**: Workspace-specific Jest configs.
 
 ### Running Tests
 ```bash
 # Run all tests
-yarn --cwd client test
+$ yarn --cwd client test
+$ yarn --cwd web-client test
 
-# Run specific test file
-yarn --cwd client test filename.test.ts
+# Run specific test file in the client workspace
+$ yarn --cwd client test filename.test.ts
 
 # Run tests in watch mode
-yarn --cwd client test --watch
+$ yarn --cwd client test --watch
 ```
 
 ### Test Structure
-- **Test location**: `client/test/` directory
-- **Naming convention**: `*.test.ts`
-- **Test environment**: JSDOM (for DOM manipulation testing)
+- **Test location**: `client/test/` and `web-client/test/` directories.
+- **Naming convention**: `*.test.ts` / `*.test.tsx`.
+- **Test environment**: JSDOM (for DOM manipulation testing).
 
 ### Adding New Tests
-1. Create test file in `client/test/` with `.test.ts` extension
-2. Use Jest's `describe` and `test` functions
-3. Example test structure:
+1. Create a test file in the appropriate workspace directory with a `.test.ts`/`.test.tsx` extension.
+2. Use Jest's `describe`/`it` or `test` helpers.
+3. Example structure:
+
 ```typescript
 describe('Feature Name', () => {
     test('should test specific functionality', () => {
@@ -80,15 +91,15 @@ describe('Feature Name', () => {
 ```
 
 ### Example Test Execution
-The project includes comprehensive test coverage with 60+ tests across 16 test suites. Most tests pass consistently, with occasional mock-related issues in specific scenarios (e.g., `attackBeep.test.ts`).
+The project includes comprehensive test coverage with 60+ tests across multiple suites. Most tests pass consistently, with occasional mock-related issues in specific scenarios (e.g., `attackBeep.test.ts`).
 
 ## Additional Development Information
 
 ### Code Style Guidelines
 
 #### TypeScript Configuration
-- **Target**: ES2021
-- **Module system**: CommonJS
+- **Target**: ES2021 for the legacy client, ES2022 for the React app.
+- **Module systems**: CommonJS in `client`, ES modules in `web-client`.
 - **Strict mode**: Disabled, but specific linting rules enabled:
   - `noUnusedLocals: true`
   - `noUnusedParameters: true`
@@ -96,51 +107,37 @@ The project includes comprehensive test coverage with 60+ tests across 16 test s
   - `noUncheckedSideEffectImports: true`
 
 #### Naming Conventions
-- **Classes**: PascalCase (e.g., `Client`, `PackageHelper`)
-- **Methods/Functions**: camelCase (e.g., `addEventListener`, `sendCommand`)
-- **Properties**: camelCase (e.g., `eventTarget`, `packageHelper`)
-- **Files**: camelCase for TypeScript files (e.g., `attackBeep.ts`, `inlineCompassRose.ts`)
+- **Classes**: PascalCase (e.g., `Client`, `PackageHelper`).
+- **Methods/Functions**: camelCase (e.g., `addEventListener`, `sendCommand`).
+- **Properties**: camelCase (e.g., `eventTarget`, `packageHelper`).
+- **Files**: camelCase for TypeScript files (e.g., `attackBeep.ts`, `inlineCompassRose.ts`).
 
 #### Architecture Patterns
-- **Event-driven architecture**: Heavy use of `EventTarget` and `CustomEvent`
-- **Dependency injection**: Client class instantiates and manages helper classes
-- **Modular design**: Features separated into individual script files
-- **Chrome extension integration**: Uses `chrome.runtime.Port` for background communication
+- **Event-driven architecture**: Heavy use of `EventTarget` and `CustomEvent`.
+- **Dependency injection**: Client class instantiates and manages helper classes.
+- **Modular design**: Features separated into individual script files and React modules.
+- **Service registry**: Shared browser services (settings, data catalog, etc.) are resolved at runtime without Chrome-specific APIs.
 
 #### Regular Expressions
-**CRITICAL**: Never use Polish letters in regular expressions (as specified in AGENTS.md)
+**CRITICAL**: Never use Polish letters in regular expressions (as specified in AGENTS.md).
 
 #### File Organization
-- **Main client code**: `client/src/`
-- **Feature scripts**: `client/src/scripts/`
-- **Type definitions**: `client/src/types/`
-- **Tests**: `client/test/`
-- **Static data**: JSON files in `client/src/` (e.g., `blockers.json`, `people.json`)
+- **Main client code**: `client/src/`.
+- **Feature scripts**: `client/src/scripts/`.
+- **Type definitions**: `client/src/types/`.
+- **React components and hooks**: `web-client/src/`.
+- **Tests**: `client/test/` and `web-client/test/`.
+- **Static data**: JSON files in `client/src/` (e.g., `blockers.json`, `people.json`).
 
 ### Development Workflow
-1. Make changes in appropriate workspace
-2. Run tests to ensure no regressions: `yarn --cwd client test`
-3. Use watch mode for development: `yarn watch`
-4. Build final extension: `yarn build`
-
-### Sandbox Development
-The sandbox is a separate application useful for local testing without packaging the extension:
-
-```bash
-cd sandbox
-yarn install
-yarn vite build --mode development
-```
-
-Then open `http://localhost:5173` in your browser to test features locally.
+1. Make changes in the appropriate workspace.
+2. Run tests to ensure no regressions (`yarn --cwd client test` and/or `yarn --cwd web-client test`).
+3. Use watch mode for development: `yarn --cwd client watch` or `yarn --cwd web-client dev`.
+4. Build production artifacts with the workspace-specific build commands.
 
 ### Debugging
-- **Source maps**: Available in development mode
-- **Console logging**: Used throughout codebase for debugging
-- **Chrome DevTools**: Full support for extension debugging
-
-### Extension-Specific Notes
-- **Sound integration**: Uses Howler.js for audio playback
-- **DOM manipulation**: Direct DOM access for UI elements
-- **Game integration**: Interfaces with Arkadia MUD client
-- **Map rendering**: Uses `mudlet-map-renderer` package
+- **Source maps**: Available in development mode for both workspaces.
+- **Console logging**: Used throughout the codebase for diagnostics.
+- **Browser DevTools**: Recommended for inspecting network requests and runtime state.
+- **Game integration**: Interfaces with the Arkadia MUD backend via websocket/HTTP APIs.
+- **Map rendering**: Uses `mudlet-map-renderer` within both the legacy and modern clients.

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "howler": "^2.2.4",
     "lua-in-js": "^2.2.5",
     "mudlet-map-renderer": "^0.8.1-konva",
+    "rxjs": "^7.8.2",
     "sql.js": "^1.13.0"
   },
   "devDependencies": {

--- a/client/src/runtime/data/catalog.ts
+++ b/client/src/runtime/data/catalog.ts
@@ -1,0 +1,42 @@
+import type { Observable } from 'rxjs';
+import type { DataPersistenceAdapter } from './persistence/types';
+
+export type DataCatalogEntryStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface DataCatalogEntryMetadata {
+    readonly key: string;
+    readonly status: DataCatalogEntryStatus;
+    readonly updatedAt?: number;
+    readonly source?: 'loader' | 'cache';
+    readonly error?: string;
+}
+
+export interface DataLoaderContext<T> {
+    readonly cachedData?: T;
+    readonly metadata: Readonly<DataCatalogEntryMetadata>;
+    persist(data: T): Promise<void>;
+}
+
+export type DataLoader<T> = (context: DataLoaderContext<T>) => Promise<T | void>;
+
+export interface DataLoaderRegistration<T> {
+    readonly key: string;
+    readonly loader: DataLoader<T>;
+    readonly persistence?: DataPersistenceAdapter<T>;
+    readonly eager?: boolean;
+}
+
+export interface DataCatalogReadyEvent<T = unknown> {
+    readonly key: string;
+    readonly data: T;
+    readonly metadata: DataCatalogEntryMetadata;
+}
+
+export interface DataCatalog {
+    register<T>(registration: DataLoaderRegistration<T>): void;
+    load(key: string): Promise<void>;
+    loadAll(): Promise<void>;
+    get<T>(key: string): T | undefined;
+    metadataFor(key: string): DataCatalogEntryMetadata | undefined;
+    ready$<T = unknown>(key?: string): Observable<DataCatalogReadyEvent<T>>;
+}

--- a/client/src/runtime/data/core-loaders.ts
+++ b/client/src/runtime/data/core-loaders.ts
@@ -1,0 +1,81 @@
+import type { DataCatalog, DataLoader } from './catalog';
+import { DefaultDataCatalog } from './default-catalog';
+import type { DataPersistenceAdapter } from './persistence/types';
+import { IndexedDbPersistenceAdapter } from './persistence/indexeddb-adapter';
+import { LocalStoragePersistenceAdapter } from './persistence/local-storage-adapter';
+
+export const MAP_DATASET_KEY = 'maps';
+export const NPC_DATASET_KEY = 'npcs';
+export const COLORS_DATASET_KEY = 'colors';
+
+export type DataSource<T> = () => Promise<T>;
+
+export interface CoreLoaderOptions {
+    readonly mapSource?: DataSource<unknown>;
+    readonly npcSource?: DataSource<unknown>;
+    readonly colorSource?: DataSource<unknown>;
+    readonly mapPersistence?: DataPersistenceAdapter<unknown>;
+    readonly npcPersistence?: DataPersistenceAdapter<unknown>;
+    readonly colorPersistence?: DataPersistenceAdapter<unknown>;
+    readonly catalog?: DataCatalog;
+}
+
+export function createJsonLoader<T>(source: DataSource<T>): DataLoader<T> {
+    return async ({ persist }) => {
+        const data = await source();
+        await persist(data);
+        return data;
+    };
+}
+
+export function registerCoreLoaders(options: CoreLoaderOptions = {}): DataCatalog {
+    const catalog = options.catalog ?? new DefaultDataCatalog();
+    const mapPersistence = options.mapPersistence ?? new IndexedDbPersistenceAdapter(MAP_DATASET_KEY);
+    const npcPersistence = options.npcPersistence ?? new LocalStoragePersistenceAdapter(NPC_DATASET_KEY);
+    const colorPersistence = options.colorPersistence ?? new LocalStoragePersistenceAdapter(COLORS_DATASET_KEY);
+
+    const mapLoader = createJsonLoader(
+        options.mapSource ?? createFetchJsonSource('https://delwing.github.io/arkadia-mapa/data/mapExport.json'),
+    );
+    const npcLoader = createJsonLoader(
+        options.npcSource ?? createFetchJsonSource('https://delwing.github.io/arkadia-mapa/data/npc.json'),
+    );
+    const colorLoader = createJsonLoader(
+        options.colorSource ?? createFetchJsonSource('https://delwing.github.io/arkadia-mapa/data/colors.json'),
+    );
+
+    catalog.register({
+        key: MAP_DATASET_KEY,
+        loader: mapLoader,
+        persistence: mapPersistence,
+    });
+
+    catalog.register({
+        key: NPC_DATASET_KEY,
+        loader: npcLoader,
+        persistence: npcPersistence,
+    });
+
+    catalog.register({
+        key: COLORS_DATASET_KEY,
+        loader: colorLoader,
+        persistence: colorPersistence,
+    });
+
+    return catalog;
+}
+
+function createFetchJsonSource<T>(resourceUrl: string): DataSource<T> {
+    return async () => {
+        if (typeof fetch !== 'function') {
+            throw new Error('Fetch API is not available to load core dataset.');
+        }
+
+        const response = await fetch(resourceUrl);
+        if (!response.ok) {
+            throw new Error(`Failed to load dataset from ${resourceUrl}: ${response.status} ${response.statusText}`);
+        }
+
+        return (await response.json()) as T;
+    };
+}

--- a/client/src/runtime/data/default-catalog.ts
+++ b/client/src/runtime/data/default-catalog.ts
@@ -1,0 +1,173 @@
+import { Observable, ReplaySubject, Subject } from 'rxjs';
+import type {
+    DataCatalog,
+    DataCatalogEntryMetadata,
+    DataCatalogReadyEvent,
+    DataLoader,
+    DataLoaderContext,
+    DataLoaderRegistration,
+} from './catalog';
+import type { DataPersistenceAdapter } from './persistence/types';
+
+interface CatalogEntry<T> {
+    readonly key: string;
+    readonly loader: DataLoader<T>;
+    readonly persistence?: DataPersistenceAdapter<T>;
+    data?: T;
+    metadata: DataCatalogEntryMetadata;
+    readonly ready$: ReplaySubject<DataCatalogReadyEvent<T>>;
+}
+
+export class DefaultDataCatalog implements DataCatalog {
+    private readonly entries = new Map<string, CatalogEntry<unknown>>();
+
+    private readonly globalReady$ = new Subject<DataCatalogReadyEvent<unknown>>();
+
+    register<T>(registration: DataLoaderRegistration<T>): void {
+        if (this.entries.has(registration.key)) {
+            throw new Error(`Data loader with key \"${registration.key}\" already registered.`);
+        }
+
+        const metadata: DataCatalogEntryMetadata = {
+            key: registration.key,
+            status: 'idle',
+        };
+
+        const ready$ = new ReplaySubject<DataCatalogReadyEvent<T>>(1);
+        const entry: CatalogEntry<T> = {
+            key: registration.key,
+            loader: registration.loader,
+            persistence: registration.persistence,
+            metadata,
+            ready$,
+        };
+
+        this.entries.set(registration.key, entry as CatalogEntry<unknown>);
+
+        if (registration.persistence) {
+            void this.restoreFromPersistence(entry);
+        }
+
+        if (registration.eager) {
+            void this.load(registration.key);
+        }
+    }
+
+    async load<T>(key: string): Promise<void> {
+        const entry = this.getEntry<T>(key);
+
+        entry.metadata = { ...entry.metadata, status: 'loading' };
+
+        const persist = async (value: T): Promise<void> => {
+            entry.data = value;
+            if (entry.persistence) {
+                await entry.persistence.write(value);
+            }
+        };
+
+        const context: DataLoaderContext<T> = {
+            cachedData: entry.data,
+            metadata: entry.metadata,
+            persist,
+        };
+
+        try {
+            const result = await entry.loader(context);
+            if (typeof result !== 'undefined') {
+                await persist(result);
+            }
+
+            if (typeof entry.data === 'undefined') {
+                throw new Error(`Loader for \"${key}\" did not provide any data.`);
+            }
+
+            entry.metadata = {
+                key,
+                status: 'ready',
+                updatedAt: Date.now(),
+                source: 'loader',
+            };
+            this.emitReady(entry);
+        } catch (error) {
+            entry.metadata = {
+                key,
+                status: 'error',
+                updatedAt: Date.now(),
+                error: error instanceof Error ? error.message : String(error),
+            };
+            throw error;
+        }
+    }
+
+    async loadAll(): Promise<void> {
+        await Promise.all(Array.from(this.entries.keys()).map((key) => this.load(key)));
+    }
+
+    get<T>(key: string): T | undefined {
+        const entry = this.entries.get(key);
+        return entry?.data as T | undefined;
+    }
+
+    metadataFor(key: string): DataCatalogEntryMetadata | undefined {
+        return this.entries.get(key)?.metadata;
+    }
+
+    ready$<T = unknown>(key?: string): Observable<DataCatalogReadyEvent<T>> {
+        if (key) {
+            return this.ensureReadySubject<T>(key).asObservable();
+        }
+
+        return this.globalReady$.asObservable() as Observable<DataCatalogReadyEvent<T>>;
+    }
+
+    private ensureReadySubject<T>(key: string): ReplaySubject<DataCatalogReadyEvent<T>> {
+        const entry = this.getEntry(key);
+        return entry.ready$ as ReplaySubject<DataCatalogReadyEvent<T>>;
+    }
+
+    private emitReady<T>(entry: CatalogEntry<T>): void {
+        const event: DataCatalogReadyEvent<T> = {
+            key: entry.key,
+            data: entry.data as T,
+            metadata: entry.metadata,
+        };
+
+        entry.ready$.next(event);
+        this.globalReady$.next(event as DataCatalogReadyEvent<unknown>);
+    }
+
+    private async restoreFromPersistence<T>(entry: CatalogEntry<T>): Promise<void> {
+        if (!entry.persistence) {
+            return;
+        }
+
+        try {
+            const value = await entry.persistence.read();
+            if (typeof value !== 'undefined') {
+                entry.data = value;
+                entry.metadata = {
+                    key: entry.key,
+                    status: 'ready',
+                    updatedAt: Date.now(),
+                    source: 'cache',
+                };
+                this.emitReady(entry);
+            }
+        } catch (error) {
+            entry.metadata = {
+                key: entry.key,
+                status: 'error',
+                updatedAt: Date.now(),
+                error: error instanceof Error ? error.message : String(error),
+            };
+        }
+    }
+
+    private getEntry<T>(key: string): CatalogEntry<T> {
+        const entry = this.entries.get(key) as CatalogEntry<T> | undefined;
+        if (!entry) {
+            throw new Error(`Unknown data catalog key: ${key}`);
+        }
+        return entry;
+    }
+}

--- a/client/src/runtime/data/index.ts
+++ b/client/src/runtime/data/index.ts
@@ -1,0 +1,13 @@
+export * from './catalog';
+export { DefaultDataCatalog } from './default-catalog';
+export {
+    registerCoreLoaders,
+    MAP_DATASET_KEY,
+    NPC_DATASET_KEY,
+    COLORS_DATASET_KEY,
+    createJsonLoader,
+} from './core-loaders';
+export type { DataSource } from './core-loaders';
+export { IndexedDbPersistenceAdapter } from './persistence/indexeddb-adapter';
+export { LocalStoragePersistenceAdapter } from './persistence/local-storage-adapter';
+export type { DataPersistenceAdapter } from './persistence/types';

--- a/client/src/runtime/data/persistence/indexeddb-adapter.ts
+++ b/client/src/runtime/data/persistence/indexeddb-adapter.ts
@@ -1,0 +1,99 @@
+import type { DataPersistenceAdapter } from './types';
+
+interface IndexedDbAdapterConfig {
+    readonly databaseName?: string;
+    readonly storeName?: string;
+    readonly version?: number;
+}
+
+export class IndexedDbPersistenceAdapter<T> implements DataPersistenceAdapter<T> {
+    private readonly databaseName: string;
+    private readonly storeName: string;
+    private readonly version: number;
+
+    constructor(
+        private readonly key: string,
+        config: IndexedDbAdapterConfig = {},
+    ) {
+        this.databaseName = config.databaseName ?? 'arkadia-data';
+        this.storeName = config.storeName ?? 'catalog';
+        this.version = config.version ?? 1;
+    }
+
+    async read(): Promise<T | undefined> {
+        const db = await this.openDatabase();
+        try {
+            return await new Promise<T | undefined>((resolve, reject) => {
+                const transaction = db.transaction(this.storeName, 'readonly');
+                const store = transaction.objectStore(this.storeName);
+                const request = store.get(this.key);
+                request.onsuccess = () => {
+                    resolve(request.result as T | undefined);
+                };
+                request.onerror = () => {
+                    reject(request.error);
+                };
+            });
+        } finally {
+            db.close();
+        }
+    }
+
+    async write(value: T): Promise<void> {
+        const db = await this.openDatabase();
+        try {
+            await new Promise<void>((resolve, reject) => {
+                const transaction = db.transaction(this.storeName, 'readwrite');
+                const store = transaction.objectStore(this.storeName);
+                const request = store.put(value, this.key);
+                request.onsuccess = () => resolve();
+                request.onerror = () => reject(request.error);
+            });
+        } finally {
+            db.close();
+        }
+    }
+
+    async clear(): Promise<void> {
+        const db = await this.openDatabase();
+        try {
+            await new Promise<void>((resolve, reject) => {
+                const transaction = db.transaction(this.storeName, 'readwrite');
+                const store = transaction.objectStore(this.storeName);
+                const request = store.delete(this.key);
+                request.onsuccess = () => resolve();
+                request.onerror = () => reject(request.error);
+            });
+        } finally {
+            db.close();
+        }
+    }
+
+    private openDatabase(): Promise<IDBDatabase> {
+        const indexedDB = this.getIndexedDb();
+
+        return new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open(this.databaseName, this.version);
+            request.onupgradeneeded = () => {
+                const db = request.result;
+                if (!db.objectStoreNames.contains(this.storeName)) {
+                    db.createObjectStore(this.storeName);
+                }
+            };
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    private getIndexedDb(): IDBFactory {
+        const factory =
+            typeof window !== 'undefined'
+                ? window.indexedDB
+                : (globalThis as unknown as { indexedDB?: IDBFactory }).indexedDB;
+        if (!factory) {
+            throw new Error('IndexedDB is not available in this environment.');
+        }
+
+        return factory;
+    }
+}

--- a/client/src/runtime/data/persistence/local-storage-adapter.ts
+++ b/client/src/runtime/data/persistence/local-storage-adapter.ts
@@ -1,0 +1,38 @@
+import type { DataPersistenceAdapter } from './types';
+
+export class LocalStoragePersistenceAdapter<T> implements DataPersistenceAdapter<T> {
+    constructor(
+        private readonly key: string,
+        private readonly serialize: (value: T) => string = JSON.stringify,
+        private readonly deserialize: (value: string) => T = JSON.parse as (value: string) => T,
+    ) {}
+
+    async read(): Promise<T | undefined> {
+        const storage = this.getStorage();
+        const raw = storage.getItem(this.key);
+        if (raw === null) {
+            return undefined;
+        }
+
+        return this.deserialize(raw);
+    }
+
+    async write(value: T): Promise<void> {
+        const storage = this.getStorage();
+        storage.setItem(this.key, this.serialize(value));
+    }
+
+    async clear(): Promise<void> {
+        const storage = this.getStorage();
+        storage.removeItem(this.key);
+    }
+
+    private getStorage(): Storage {
+        const storage = typeof window !== 'undefined' ? window.localStorage : (globalThis as unknown as { localStorage?: Storage }).localStorage;
+        if (!storage) {
+            throw new Error('LocalStorage is not available in this environment.');
+        }
+
+        return storage;
+    }
+}

--- a/client/src/runtime/data/persistence/types.ts
+++ b/client/src/runtime/data/persistence/types.ts
@@ -1,0 +1,5 @@
+export interface DataPersistenceAdapter<T> {
+    read(): Promise<T | undefined>;
+    write(value: T): Promise<void>;
+    clear(): Promise<void>;
+}

--- a/client/src/runtime/service-registry.ts
+++ b/client/src/runtime/service-registry.ts
@@ -1,8 +1,16 @@
+import type { DataCatalog } from './data';
+import { DefaultDataCatalog, registerCoreLoaders } from './data';
 import type { SettingsService } from './settings/settings-service';
 import { LocalStorageSettingsService } from './settings/local-storage-service';
 
 class ServiceRegistry {
-    readonly settings: SettingsService = new LocalStorageSettingsService();
+    readonly settings: SettingsService;
+    readonly dataCatalog: DataCatalog;
+
+    constructor() {
+        this.settings = new LocalStorageSettingsService();
+        this.dataCatalog = registerCoreLoaders({ catalog: new DefaultDataCatalog() });
+    }
 }
 
 const services = new ServiceRegistry();

--- a/client/test/runtime/data/catalog.test.ts
+++ b/client/test/runtime/data/catalog.test.ts
@@ -1,0 +1,155 @@
+import 'fake-indexeddb/auto';
+import { firstValueFrom } from 'rxjs';
+import { timeout } from 'rxjs/operators';
+import { DefaultDataCatalog } from '../../../src/runtime/data/default-catalog';
+import type { DataCatalogReadyEvent } from '../../../src/runtime/data';
+import {
+    COLORS_DATASET_KEY,
+    MAP_DATASET_KEY,
+    NPC_DATASET_KEY,
+    registerCoreLoaders,
+} from '../../../src/runtime/data/core-loaders';
+import type { DataPersistenceAdapter } from '../../../src/runtime/data/persistence/types';
+
+describe('DefaultDataCatalog', () => {
+    class MemoryAdapter<T> implements DataPersistenceAdapter<T> {
+        constructor(private value?: T) {}
+
+        async read(): Promise<T | undefined> {
+            return this.value;
+        }
+
+        async write(value: T): Promise<void> {
+            this.value = value;
+        }
+
+        async clear(): Promise<void> {
+            this.value = undefined;
+        }
+    }
+
+    it('allows registering loaders and retrieving data', async () => {
+        const catalog = new DefaultDataCatalog();
+        const adapter = new MemoryAdapter<{ value: number }>();
+
+        catalog.register({
+            key: 'test',
+            loader: async ({ persist }) => {
+                const payload = { value: 42 };
+                await persist(payload);
+                return payload;
+            },
+            persistence: adapter,
+        });
+
+        await catalog.load('test');
+
+        expect(catalog.get('test')).toEqual({ value: 42 });
+        expect(catalog.metadataFor('test')?.status).toBe('ready');
+        expect(await adapter.read()).toEqual({ value: 42 });
+    });
+
+    it('emits ready events when loaders finish', async () => {
+        const catalog = new DefaultDataCatalog();
+        catalog.register({
+            key: 'ready-test',
+            loader: async ({ persist }) => {
+                const payload = { another: 'value' };
+                await persist(payload);
+                return payload;
+            },
+        });
+
+        const eventPromise = firstValueFrom(
+            catalog
+                .ready$('ready-test')
+                .pipe(timeout({ each: 1000 })),
+        ) as Promise<DataCatalogReadyEvent<{ another: string }>>;
+
+        await catalog.load('ready-test');
+
+        const event = await eventPromise;
+        expect(event.key).toBe('ready-test');
+        expect(event.data).toEqual({ another: 'value' });
+        expect(event.metadata.status).toBe('ready');
+    });
+
+    it('restores cached data and emits ready event on registration', async () => {
+        const adapter = new MemoryAdapter({ cached: true });
+        const catalog = new DefaultDataCatalog();
+
+        catalog.register({
+            key: 'cached',
+            loader: async ({ cachedData }) => cachedData ?? { cached: false },
+            persistence: adapter,
+        });
+
+        const event = await firstValueFrom(
+            catalog
+                .ready$('cached')
+                .pipe(timeout({ each: 1000 })),
+        );
+
+        expect(event.data).toEqual({ cached: true });
+        expect(event.metadata.source).toBe('cache');
+        expect(catalog.get('cached')).toEqual({ cached: true });
+    });
+});
+
+describe('core data loaders', () => {
+    class MemoryAdapter<T> implements DataPersistenceAdapter<T> {
+        constructor(private value?: T) {}
+
+        async read(): Promise<T | undefined> {
+            return this.value;
+        }
+
+        async write(value: T): Promise<void> {
+            this.value = value;
+        }
+
+        async clear(): Promise<void> {
+            this.value = undefined;
+        }
+    }
+
+    it('registers loaders for core datasets and marks readiness', async () => {
+        const mapAdapter = new MemoryAdapter<unknown>();
+        const npcAdapter = new MemoryAdapter<unknown>();
+        const colorAdapter = new MemoryAdapter<unknown>();
+        const catalog = registerCoreLoaders({
+            catalog: new DefaultDataCatalog(),
+            mapPersistence: mapAdapter,
+            npcPersistence: npcAdapter,
+            colorPersistence: colorAdapter,
+            mapSource: async () => ({ zones: [] }),
+            npcSource: async () => ({ npcs: [] }),
+            colorSource: async () => ({ palette: [] }),
+        });
+
+        const mapReady = firstValueFrom(
+            catalog
+                .ready$(MAP_DATASET_KEY)
+                .pipe(timeout({ each: 1000 })),
+        );
+        const npcReady = firstValueFrom(
+            catalog
+                .ready$(NPC_DATASET_KEY)
+                .pipe(timeout({ each: 1000 })),
+        );
+        const colorReady = firstValueFrom(
+            catalog
+                .ready$(COLORS_DATASET_KEY)
+                .pipe(timeout({ each: 1000 })),
+        );
+
+        await catalog.loadAll();
+
+        await expect(mapReady).resolves.toMatchObject({ key: MAP_DATASET_KEY });
+        await expect(npcReady).resolves.toMatchObject({ key: NPC_DATASET_KEY });
+        await expect(colorReady).resolves.toMatchObject({ key: COLORS_DATASET_KEY });
+        expect(await mapAdapter.read()).toEqual({ zones: [] });
+        expect(await npcAdapter.read()).toEqual({ npcs: [] });
+        expect(await colorAdapter.read()).toEqual({ palette: [] });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6486,7 +6486,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^7.5.5:
+rxjs@^7.5.5, rxjs@^7.8.2:
   version "7.8.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
   integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==


### PR DESCRIPTION
## Summary
- define a runtime DataCatalog interface and default implementation with metadata and readiness observables
- add persistence adapters and register core map/NPC loaders, exposing the catalog via the service registry
- cover loader registration, caching, and readiness notifications with new unit tests
- update the core loader defaults to fetch map, NPC, and color datasets from their hosted URLs without Chrome-specific helpers and refresh the development guidelines to describe the standalone web client workflow

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68eb086686b8832aa8fb5b57cc2d74e4