### PR TITLE
Add shared UI store and integration tests

### DIFF
--- a/web-client/package.json
+++ b/web-client/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "sql.js": "^1.13.0",
+    "zustand": "^5.0.3",
     "vite-tsconfig-paths": "^5.1.4"
   },
   "devDependencies": {

--- a/web-client/src/CharState.ts
+++ b/web-client/src/CharState.ts
@@ -1,5 +1,7 @@
-import ArkadiaClient from "./ArkadiaClient.ts";
+import type ArkadiaClient from "./ArkadiaClient.ts";
 import { COLOR_BAR_CLASS, COLOR_TEXT, getColorLevel } from "./colors.ts";
+import { uiStore } from "./ui/store";
+import { shallow } from "zustand/shallow";
 
 export interface CharStateData {
   hp: number;
@@ -69,7 +71,6 @@ const DEFAULT_CONFIG: Record<keyof CharStateData, CharStateConfig> = {
 };
 
 export default class CharState {
-  private client: typeof ArkadiaClient;
   private container: HTMLElement | null;
   private text: HTMLElement | null;
   private bars: HTMLElement | null;
@@ -80,6 +81,9 @@ export default class CharState {
   private mode = 0;
   private labelElements: Record<keyof CharStateData, HTMLSpanElement> =
     {} as any;
+  private unsubscribeCharState: (() => void) | null = null;
+  private unsubscribeOptions: (() => void) | null = null;
+  private unsubscribePreferences: (() => void) | null = null;
 
   private applyMode(mode: number) {
     if (typeof mode === "number" && mode >= 0 && mode <= 3) {
@@ -150,46 +154,77 @@ export default class CharState {
   }
 
   constructor(
-    client: typeof ArkadiaClient,
+    _client: typeof ArkadiaClient,
     overrides?: Partial<
       Record<keyof CharStateData, Partial<CharStateConfig>>
     >,
   ) {
-    this.client = client;
     this.config = { ...DEFAULT_CONFIG };
     this.applyOverrides(overrides);
     this.initDOM();
 
-    this.client.on('settings', (ev: any) => {
-      if (typeof ev.detail?.emojiLabels === 'boolean') {
-        this.applyLabelMode(ev.detail.emojiLabels);
-      }
-      if (typeof ev.detail?.footerMode === 'number') {
-        this.applyMode(ev.detail.footerMode);
-      }
-    });
-
-    const ext: any = (window as any).clientExtension;
-    if (ext?.addEventListener) {
-      ext.addEventListener('uiSettings', (ev: CustomEvent) => {
-        if (typeof ev.detail?.emojiLabels === 'boolean') {
-          this.applyLabelMode(ev.detail.emojiLabels);
-        }
-        if (typeof ev.detail?.footerMode === 'number') {
-          this.applyMode(ev.detail.footerMode);
-        }
-      });
+    const initialState = uiStore.getState();
+    if (initialState.charState && Object.keys(initialState.charState).length > 0) {
+      this.state = { ...this.state, ...initialState.charState };
     }
-
-    this.client.on(
-      "gmcp.char.state",
-      (state: Partial<CharStateData>) => this.update(state),
+    if (initialState.charOptions) {
+      this.options = { ...this.options, ...initialState.charOptions };
+    }
+    this.unsubscribeCharState = uiStore.subscribe(
+      (state) => state.charState,
+      (next) => {
+        if (next && Object.keys(next).length > 0) {
+          this.update(next);
+        }
+      },
     );
 
-    this.client.on('gmcp.char.options', (options: any) => {
-      this.options = { ...this.options, ...options };
+    this.unsubscribeOptions = uiStore.subscribe(
+      (state) => state.charOptions,
+      (options) => {
+        if (options && Object.keys(options).length > 0) {
+          this.options = { ...this.options, ...options };
+          this.update({});
+        }
+      },
+      { equalityFn: shallow },
+    );
+
+    this.unsubscribePreferences = uiStore.subscribe(
+      (state) => state.uiPreferences,
+      (preferences, previous) => {
+        if (
+          (!previous || preferences.emojiLabels !== previous.emojiLabels) &&
+          typeof preferences.emojiLabels === "boolean"
+        ) {
+          this.applyLabelMode(preferences.emojiLabels);
+        }
+        if (
+          (!previous || preferences.footerMode !== previous.footerMode) &&
+          typeof preferences.footerMode === "number"
+        ) {
+          this.applyMode(preferences.footerMode);
+        }
+      },
+      { equalityFn: shallow, fireImmediately: true },
+    );
+
+    if (
+      typeof initialState.uiPreferences.emojiLabels === "boolean" &&
+      initialState.uiPreferences.emojiLabels !== this.useEmoji
+    ) {
+      this.applyLabelMode(initialState.uiPreferences.emojiLabels);
+    }
+    if (
+      typeof initialState.uiPreferences.footerMode === "number" &&
+      initialState.uiPreferences.footerMode !== this.mode
+    ) {
+      this.applyMode(initialState.uiPreferences.footerMode);
+    }
+
+    if (initialState.charState && Object.keys(initialState.charState).length > 0) {
       this.update({});
-    });
+    }
   }
 
   private update(partialState: Partial<CharStateData>) {

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -47,6 +47,7 @@ import MessageRouter from "@client/src/runtime/transport/message-router";
 import { runtimeEventHub } from "@client/src/runtime/event-hub";
 import WebSocketTransportAdapter from "./transport/websocket-adapter";
 import {parseAnsiPatterns} from "./ansiParser";
+import { bindUiStoreToClientEvents } from "./ui/store";
 
 const transport = new WebSocketTransportAdapter();
 const router = new MessageRouter(transport, runtimeEventHub, { parseAnsiPatterns });
@@ -56,6 +57,7 @@ initSessionLogger(arkadiaClient).catch(err => console.error('Logger init failed'
 
 const client = new Client(arkadiaClient, new MockPort())
 window.clientExtension = client;
+bindUiStoreToClientEvents(client);
 registerScripts(client)
 client.connect(client.port, true)
 

--- a/web-client/src/options/GuildsSettings.tsx
+++ b/web-client/src/options/GuildsSettings.tsx
@@ -2,13 +2,17 @@ import { useEffect, useState, useMemo } from "react";
 import storage, { getCurrentCharacter } from "@client/src/storage";
 import GuildSection from "./GuildSection";
 import guilds from "./guilds";
-import { defaultSettings } from "./defaultSettings";
+import { useUiDispatch, useUiStore } from "../ui/store";
 
 function GuildsSettings({ registerSave }: { registerSave: (cb: () => void) => void }) {
     const [selected, setSelected] = useState<string[]>([]);
     const [enemySelected, setEnemySelected] = useState<string[]>([]);
     const [colors, setColors] = useState<Record<string, string | undefined>>({});
     const [locked, setLocked] = useState(!getCurrentCharacter());
+    const dispatch = useUiDispatch();
+    const settingsGuilds = useUiStore(state => state.settings.guilds as string[] | undefined);
+    const settingsEnemyGuilds = useUiStore(state => state.settings.enemyGuilds as string[] | undefined);
+    const settingsGuildColors = useUiStore(state => state.settings.guildColors as Record<string, string | undefined> | undefined);
     const defaultColors = useMemo(() => {
         const map: Record<string, string> = {};
         guilds.forEach(g => {
@@ -28,36 +32,16 @@ function GuildsSettings({ registerSave }: { registerSave: (cb: () => void) => vo
     }, []);
 
     useEffect(() => {
-        const load = () => {
-            storage.getItem("settings").then(res => {
-                if (res && res.settings) {
-                    setSelected(res.settings.guilds || []);
-                    setEnemySelected(res.settings.enemyGuilds || []);
-                    setColors(res.settings.guildColors || {});
-                } else {
-                    setSelected([]);
-                    setEnemySelected([]);
-                    setColors({});
-                }
-            });
-        };
+        setSelected(Array.isArray(settingsGuilds) ? [...settingsGuilds] : []);
+    }, [settingsGuilds]);
 
-        load();
+    useEffect(() => {
+        setEnemySelected(Array.isArray(settingsEnemyGuilds) ? [...settingsEnemyGuilds] : []);
+    }, [settingsEnemyGuilds]);
 
-        const listener = (changes: { [key: string]: { oldValue: any; newValue: any } }) => {
-            if (changes.settings) {
-                const s = changes.settings.newValue || {};
-                setSelected(s.guilds || []);
-                setEnemySelected(s.enemyGuilds || []);
-                setColors(s.guildColors || {});
-            }
-        };
-
-        storage.onChanged?.addListener(listener);
-        return () => {
-            storage.onChanged?.removeListener?.(listener);
-        };
-    }, []);
+    useEffect(() => {
+        setColors(settingsGuildColors ? { ...settingsGuildColors } : {});
+    }, [settingsGuildColors]);
 
     function onChange(guild: string, checked: boolean) {
         setSelected(prev => checked ? [...prev, guild] : prev.filter(g => g !== guild));
@@ -89,20 +73,16 @@ function GuildsSettings({ registerSave }: { registerSave: (cb: () => void) => vo
 
     useEffect(() => {
         registerSave(() =>
-            storage.getItem("settings").then(res => {
-                const base = res && res.settings
-                    ? { ...defaultSettings, ...res.settings }
-                    : { ...defaultSettings };
-                const settings = {
-                    ...base,
-                    guilds: selected,
-                    enemyGuilds: enemySelected,
-                    guildColors: colors,
-                };
-                return storage.setItem("settings", settings);
+            dispatch({
+                type: "settings/update",
+                patch: {
+                    guilds: [...selected],
+                    enemyGuilds: [...enemySelected],
+                    guildColors: { ...colors },
+                },
             })
         );
-    }, [registerSave, selected, enemySelected, colors]);
+    }, [registerSave, selected, enemySelected, colors, dispatch]);
 
     return (
         <div className="p-2">

--- a/web-client/src/ui/store.ts
+++ b/web-client/src/ui/store.ts
@@ -1,0 +1,208 @@
+import { createStore } from "zustand/vanilla";
+import { subscribeWithSelector } from "zustand/middleware";
+import { useStore } from "zustand";
+
+import { runtimeEventHub } from "@client/src/runtime/event-hub";
+import type { EventHubSubscription } from "@client/src/runtime/event-hub";
+import services from "@client/src/runtime/service-registry";
+import type { SettingsSnapshot } from "@client/src/runtime/settings/settings-service";
+import { defaultSettings } from "@client/src/defaultSettings";
+
+import type { CharStateData } from "../CharState";
+
+type ListenerCleanup = () => void;
+
+export interface UiPreferences {
+    emojiLabels: boolean | null;
+    footerMode: number | null;
+    fightTitleIcon: boolean | null;
+}
+
+export interface CharOptionsState {
+    form?: number;
+}
+
+export interface UiStoreState {
+    settings: SettingsSnapshot;
+    charState: Partial<CharStateData>;
+    charOptions: CharOptionsState;
+    uiPreferences: UiPreferences;
+    dispatch: (intent: UiIntent) => Promise<void>;
+}
+
+export type UiIntent =
+    | { type: "settings/update"; patch: Partial<SettingsSnapshot> };
+
+const defaultPreferences: UiPreferences = {
+    emojiLabels: null,
+    footerMode: null,
+    fightTitleIcon: null,
+};
+
+async function handleUiIntent(intent: UiIntent): Promise<void> {
+    if (intent.type === "settings/update") {
+        await services.settings.update(intent.patch);
+        return;
+    }
+    throw new Error(`Unhandled UI intent: ${JSON.stringify(intent)}`);
+}
+
+const baseState = {
+    settings: { ...defaultSettings } as SettingsSnapshot,
+    charState: {},
+    charOptions: {},
+    uiPreferences: { ...defaultPreferences },
+};
+
+const initialState: UiStoreState = {
+    ...baseState,
+    dispatch: handleUiIntent,
+};
+
+const store = createStore(
+    subscribeWithSelector<UiStoreState>(() => ({
+        ...baseState,
+        dispatch: handleUiIntent,
+    }))
+);
+
+function updatePreferencesFromSnapshot(snapshot: SettingsSnapshot) {
+    const next: Partial<UiPreferences> = {};
+    if (typeof (snapshot as any).emojiLabels === "boolean") {
+        next.emojiLabels = Boolean((snapshot as any).emojiLabels);
+    }
+    if (typeof (snapshot as any).footerMode === "number") {
+        next.footerMode = (snapshot as any).footerMode as number;
+    }
+    if (typeof (snapshot as any).fightTitleIcon === "boolean") {
+        next.fightTitleIcon = Boolean((snapshot as any).fightTitleIcon);
+    }
+    if (Object.keys(next).length > 0) {
+        store.setState((current) => ({
+            uiPreferences: { ...current.uiPreferences, ...next },
+        }));
+    }
+}
+
+let subscriptionsInitialised = false;
+let runtimeCleanup: ListenerCleanup | null = null;
+
+function subscribeToRuntime() {
+    if (subscriptionsInitialised) {
+        return;
+    }
+    subscriptionsInitialised = true;
+
+    const settingsSubscription = services.settings.settings$.subscribe((snapshot) => {
+        store.setState({ settings: snapshot });
+        updatePreferencesFromSnapshot(snapshot);
+    });
+
+    const gmcpSubscription: EventHubSubscription = runtimeEventHub.on("gmcp", ({ path, value }) => {
+        if (typeof path !== "string") {
+            return;
+        }
+        switch (path) {
+            case "char.state":
+                if (value && typeof value === "object") {
+                    store.setState((current) => ({
+                        charState: { ...current.charState, ...(value as Partial<CharStateData>) },
+                    }));
+                }
+                break;
+            case "char.options":
+                if (value && typeof value === "object") {
+                    store.setState((current) => ({
+                        charOptions: { ...current.charOptions, ...(value as CharOptionsState) },
+                    }));
+                }
+                break;
+            default:
+                break;
+        }
+    });
+
+    runtimeCleanup = () => {
+        settingsSubscription.unsubscribe();
+        gmcpSubscription.unsubscribe();
+        subscriptionsInitialised = false;
+    };
+}
+
+subscribeToRuntime();
+let uiSettingsCleanup: ListenerCleanup | null = null;
+let uiSettingsListener: EventListener | null = null;
+let lastClient: ClientLike | null = null;
+
+type ClientLike = {
+    addEventListener: (
+        event: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ) => void;
+    removeEventListener?: (
+        event: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+    ) => void;
+};
+
+export function bindUiStoreToClientEvents(client: ClientLike | null | undefined) {
+    if (!client || typeof client.addEventListener !== "function") {
+        return;
+    }
+
+    uiSettingsCleanup?.();
+
+    const listener: EventListener = (event: Event) => {
+        const detail = (event as CustomEvent).detail ?? {};
+        const next: Partial<UiPreferences> = {};
+        if (typeof detail.emojiLabels === "boolean") {
+            next.emojiLabels = Boolean(detail.emojiLabels);
+        }
+        if (typeof detail.footerMode === "number") {
+            next.footerMode = Number(detail.footerMode);
+        }
+        if (typeof detail.fightTitleIcon === "boolean") {
+            next.fightTitleIcon = Boolean(detail.fightTitleIcon);
+        }
+        if (Object.keys(next).length > 0) {
+            store.setState((current) => ({
+                uiPreferences: { ...current.uiPreferences, ...next },
+            }));
+        }
+    };
+
+    client.addEventListener("uiSettings", listener);
+    uiSettingsListener = listener;
+    lastClient = client;
+    uiSettingsCleanup = () => {
+        if (typeof client.removeEventListener === "function") {
+            client.removeEventListener("uiSettings", listener);
+        }
+        uiSettingsListener = null;
+        lastClient = null;
+    };
+}
+
+export const uiStore = store;
+
+export function resetUiStoreForTesting() {
+    uiSettingsCleanup?.();
+    uiSettingsCleanup = null;
+    uiSettingsListener = null;
+    lastClient = null;
+    runtimeCleanup?.();
+    runtimeCleanup = null;
+    store.setState({ ...baseState, dispatch: handleUiIntent });
+    subscribeToRuntime();
+}
+
+export function useUiStore<T>(selector: (state: UiStoreState) => T): T {
+    return useStore(store, selector);
+}
+
+export function useUiDispatch() {
+    return useStore(store, (state) => state.dispatch);
+}
+

--- a/web-client/test/CharState.test.ts
+++ b/web-client/test/CharState.test.ts
@@ -1,36 +1,26 @@
 import CharState from '../src/CharState';
-
-class MockClient {
-  private events: Record<string, Function[]> = {};
-  on(event: string, listener: Function) {
-    (this.events[event] ||= []).push(listener);
-  }
-  emit(event: string, ...args: any[]) {
-    (this.events[event] || []).forEach(fn => fn(...args));
-  }
-}
+import { runtimeEventHub } from '@client/src/runtime/event-hub';
+import { resetUiStoreForTesting } from '../src/ui/store';
 
 describe('CharState', () => {
-  let client: MockClient;
-
   beforeEach(() => {
     document.body.innerHTML = '<div id="char-state" data-footer-mode="3"><span id="char-state-text"></span><div id="char-state-bars"></div></div>';
-    client = new MockClient();
-    new CharState(client as any);
+    resetUiStoreForTesting();
+    new CharState({} as any);
   });
 
   test('progress values stay white in graphical mode', () => {
-    client.emit('gmcp.char.state', { hp: 5 });
+    runtimeEventHub.emit('gmcp', { path: 'char.state', value: { hp: 5 } });
     const valueSpan = document.querySelector('#char-state-bars .progress-value') as HTMLElement;
     expect(valueSpan).not.toBeNull();
     expect(valueSpan.style.color).toBe('white');
   });
 
   test('form is hidden when gmcp option disables form', () => {
-    client.emit('gmcp.char.state', { form: 0 });
+    runtimeEventHub.emit('gmcp', { path: 'char.state', value: { form: 0 } });
     let formBar = document.querySelector('#char-state-bars .char-state-bar[title="form"]');
     expect(formBar).not.toBeNull();
-    client.emit('gmcp.char.options', { form: 0 });
+    runtimeEventHub.emit('gmcp', { path: 'char.options', value: { form: 0 } });
     formBar = document.querySelector('#char-state-bars .char-state-bar[title="form"]');
     expect(formBar).toBeNull();
   });

--- a/web-client/test/uiStore.integration.test.tsx
+++ b/web-client/test/uiStore.integration.test.tsx
@@ -1,0 +1,101 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import type { Root } from "react-dom/client";
+
+import { runtimeEventHub } from "@client/src/runtime/event-hub";
+import services from "@client/src/runtime/service-registry";
+import { resetUiStoreForTesting } from "../src/ui/store";
+import CharState from "../src/CharState";
+import GuildsSettings from "../src/options/GuildsSettings";
+import guilds from "../src/options/guilds";
+import { setCurrentCharacter } from "@client/src/storage";
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("UI store integration", () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement | null = null;
+
+  beforeEach(() => {
+    localStorage.clear();
+    resetUiStoreForTesting();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root!.unmount();
+      });
+      root = null;
+    }
+    if (container && container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+    container = null;
+    jest.restoreAllMocks();
+    setCurrentCharacter("");
+  });
+
+  test("CharState reflects gmcp updates and settings changes", async () => {
+    document.body.innerHTML =
+      '<div id="char-state" data-footer-mode="0"><div id="char-state-text"></div><div id="char-state-bars"></div></div>';
+    new CharState({} as any);
+
+    await act(async () => {
+      runtimeEventHub.emit("gmcp", { path: "char.state", value: { hp: 3, mana: 5 } });
+    });
+
+    const hpSpan = document.querySelector("#char-state-text span");
+    expect(hpSpan).not.toBeNull();
+    expect(hpSpan!.innerHTML).toContain("HP");
+
+    await act(async () => {
+      await services.settings.update({ emojiLabels: true } as any);
+    });
+
+    expect(hpSpan!.innerHTML).toContain("❤");
+  });
+
+  test("GuildsSettings reads and writes through the store", async () => {
+    setCurrentCharacter("Tester");
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    let saveHandler: () => Promise<void> | void = () => {};
+
+    await act(async () => {
+      root = createRoot(container!);
+      root!.render(
+        <GuildsSettings
+          registerSave={(cb) => {
+            saveHandler = cb;
+          }}
+        />,
+      );
+    });
+
+    const allCheckbox = container!.querySelector("#guild-all") as HTMLInputElement;
+    expect(allCheckbox).not.toBeNull();
+    expect(allCheckbox.checked).toBe(false);
+
+    await act(async () => {
+      await services.settings.update({ guilds } as any);
+    });
+
+    expect(allCheckbox.checked).toBe(true);
+
+    const updateSpy = jest.spyOn(services.settings, "update");
+    await act(async () => {
+      await saveHandler();
+    });
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guilds: expect.arrayContaining(guilds),
+        enemyGuilds: expect.any(Array),
+        guildColors: expect.any(Object),
+      }),
+    );
+  });
+});
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -7681,3 +7681,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zustand@^5.0.3:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.8.tgz#b998a0c088c7027a20f2709141a91cb07ac57f8a"
+  integrity sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==


### PR DESCRIPTION
## Summary
- introduce a Zustand-based UI store that subscribes to the runtime event hub and settings service, plus binding hooks from the client
- refactor the CharState HUD and GuildsSettings panel to consume the shared store and dispatch typed settings updates
- add zustand as a dependency alongside new integration coverage for store-driven propagation and updated CharState tests

## Testing
- `yarn --cwd web-client test`


------
https://chatgpt.com/codex/tasks/task_e_68eb086fec48832aa45c2f17c06ce163