### PR TITLE
Refactor TeamManager to use runtime event hub

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -116,6 +116,7 @@ export default class Client {
         this.updateContentWidth()
         window.addEventListener('resize', () => this.updateContentWidth())
         this.addEventListener('uiSettings', () => this.updateContentWidth())
+        window.addEventListener('beforeunload', () => this.dispose())
 
         Object.values(this.sounds).forEach((sound) => sound.load())
 
@@ -591,5 +592,9 @@ export default class Client {
             this.contentWidth = Math.floor(width / charWidth)
             this.sendEvent('contentWidth', this.contentWidth)
         }
+    }
+
+    dispose() {
+        this.TeamManager.dispose?.()
     }
 }

--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -1,4 +1,5 @@
 import Client from "./Client";
+import { EventHub, EventHubSubscription, RuntimeEvents, runtimeEventHub } from "./runtime/event-hub";
 
 interface ObjectData {
     attack_num: boolean | number
@@ -33,6 +34,7 @@ interface AccumulatedObjectData {
 
 export default class TeamManager {
     private client: Client;
+    private subscriptions: EventHubSubscription[] = [];
     private members: Set<string> = new Set();
     private joined = false;
     private leader?: string;
@@ -48,23 +50,41 @@ export default class TeamManager {
     private missingEnemyCounts: Map<string, number> = new Map();
     private currentLocationSignature?: string;
 
-    constructor(client: Client) {
+    constructor(client: Client, eventHub: EventHub<RuntimeEvents> = runtimeEventHub) {
         this.client = client;
-        this.client.addEventListener('gmcp.objects.data', (e: CustomEvent) => {
-            this.handleObjectsData(e.detail);
-        });
-        this.client.addEventListener('gmcp.objects.nums', (e: CustomEvent) => {
-            this.handleObjectsNums(e.detail);
-        });
-        this.client.addEventListener('gmcp.char.info', (e: CustomEvent) => {
-            this.playerNum = String(e.detail.object_num);
-        });
-        this.client.addEventListener('gmcp.room.info', (e: CustomEvent) => {
-            this.handleRoomInfo(e.detail);
-        });
+
+        this.subscriptions.push(
+            eventHub.on('gmcp', ({ path, value }) => {
+                switch (path) {
+                    case 'objects.data':
+                        if (value && typeof value === 'object') {
+                            this.handleObjectsData(value as Record<string, AccumulatedObjectData>);
+                        }
+                        break;
+                    case 'objects.nums':
+                        this.handleObjectsNums(value);
+                        break;
+                    case 'char.info':
+                        if (value && typeof value === 'object' && 'object_num' in (value as any)) {
+                            this.playerNum = String((value as any).object_num);
+                        }
+                        break;
+                    case 'room.info':
+                        this.handleRoomInfo(value);
+                        break;
+                    default:
+                        break;
+                }
+            })
+        );
         if (typeof (this.client as any).Triggers?.registerTrigger === 'function') {
             this.registerTriggers();
         }
+    }
+
+    dispose() {
+        this.subscriptions.forEach(subscription => subscription.unsubscribe());
+        this.subscriptions = [];
     }
 
     private handleObjectsData(data: Record<string, AccumulatedObjectData>) {

--- a/client/test/TeamManager.test.ts
+++ b/client/test/TeamManager.test.ts
@@ -1,6 +1,7 @@
 import TeamManager from '../src/TeamManager';
 import Triggers from '../src/Triggers';
 import { EventEmitter } from 'events';
+import { EventHub, RuntimeEvents } from '../src/runtime/event-hub';
 
 class FakeClient {
   private emitter = new EventEmitter();
@@ -21,22 +22,32 @@ class FakeClient {
 describe('TeamManager', () => {
   let client: FakeClient;
   let manager: TeamManager;
+  let eventHub: EventHub<RuntimeEvents>;
+
+  const emitGmcp = (path: string, value: unknown) => {
+    eventHub.emit('gmcp', { path, value });
+  };
 
   beforeEach(() => {
     client = new FakeClient();
-    manager = new TeamManager((client as unknown) as any);
-    client.sendEvent('gmcp.char.info', { object_num: '99' });
+    eventHub = new EventHub<RuntimeEvents>();
+    manager = new TeamManager((client as unknown) as any, eventHub);
+    emitGmcp('char.info', { object_num: '99' });
+  });
+
+  afterEach(() => {
+    manager.dispose();
   });
 
   test('adds member from gmcp objects', () => {
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '1': { desc: 'Pablo', living: true, team: true },
     });
     expect(manager.isInTeam('Pablo')).toBe(true);
   });
 
   test('removes member on leave message', () => {
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '1': { desc: 'Vesper', living: true, team: true },
     });
     client.Triggers.parseLine('Vesper porzuca twoja druzyne.', '');
@@ -44,7 +55,7 @@ describe('TeamManager', () => {
   });
 
   test('clears team on clear message', () => {
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '1': { desc: 'Bob', living: true, team: true },
     });
     client.Triggers.parseLine('Nie jestes w zadnej druzynie.', '');
@@ -60,7 +71,7 @@ describe('TeamManager', () => {
   });
 
   test('returns leader id when available', () => {
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '5': { desc: 'Vesper', living: true, team: true, team_leader: true },
     });
     expect(manager.getLeaderId()).toBe('5');
@@ -69,7 +80,7 @@ describe('TeamManager', () => {
   test('emits event when leader attacks different target', () => {
     const callback = jest.fn();
     client.addEventListener('teamLeaderTargetNoAvatar', callback);
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '1': {
         desc: 'Eamon',
         living: true,
@@ -85,7 +96,7 @@ describe('TeamManager', () => {
   test('emits event when leader attacks and avatar does not', () => {
     const callback = jest.fn();
     client.addEventListener('teamLeaderTargetNoAvatar', callback);
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '1': {
         desc: 'Eamon',
         living: true,
@@ -103,7 +114,7 @@ describe('TeamManager', () => {
     const avatar = jest.fn();
     client.addEventListener('teamLeaderTargetNoAvatar', noAvatar);
     client.addEventListener('teamLeaderTargetAvatar', avatar);
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '1': {
         desc: 'Eamon',
         living: true,
@@ -128,23 +139,23 @@ describe('TeamManager', () => {
       attack_num: '3',
     };
     const player = { desc: 'You', living: true, team: true, attack_num: '2' };
-    client.sendEvent('gmcp.objects.data', { '1': data, '99': player });
-    client.sendEvent('gmcp.objects.data', { '1': data, '99': player });
+    emitGmcp('objects.data', { '1': data, '99': player });
+    emitGmcp('objects.data', { '1': data, '99': player });
     expect(callback).toHaveBeenCalledTimes(2);
   });
 
   test('emits event again after target changes', () => {
     const callback = jest.fn();
     client.addEventListener('teamLeaderTargetNoAvatar', callback);
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '1': { desc: 'Eamon', living: true, team: true, team_leader: true, attack_num: '3' },
       '99': { desc: 'You', living: true, team: true, attack_num: '2' },
     });
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '1': { desc: 'Eamon', living: true, team: true, team_leader: true, attack_num: '2' },
       '99': { desc: 'You', living: true, team: true, attack_num: '2' },
     });
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '1': { desc: 'Eamon', living: true, team: true, team_leader: true, attack_num: '3' },
       '99': { desc: 'You', living: true, team: true, attack_num: '2' },
     });
@@ -154,11 +165,11 @@ describe('TeamManager', () => {
   test('emits event again when leader number changes', () => {
     const callback = jest.fn();
     client.addEventListener('teamLeaderTargetNoAvatar', callback);
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '1': { desc: 'Eamon', living: true, team: true, team_leader: true, attack_num: '3' },
       '99': { desc: 'You', living: true, team: true, attack_num: '2' },
     });
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '2': { desc: 'Eamon', living: true, team: true, team_leader: true, attack_num: '3' },
       '99': { desc: 'You', living: true, team: true, attack_num: '2' },
     });
@@ -166,7 +177,7 @@ describe('TeamManager', () => {
   });
 
   test('stores attack and defense target ids', () => {
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '1': { desc: 'Bob', living: true, team: true, attack_target: true },
       '2': { desc: 'Alice', living: true, team: true, defense_target: true },
     });
@@ -175,7 +186,7 @@ describe('TeamManager', () => {
   });
 
   test('returns avatar attack target id', () => {
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '99': { desc: 'You', living: true, team: true, attack_num: '4' },
     });
     expect(manager.getAvatarAttackTargetId()).toBe('4');
@@ -192,40 +203,40 @@ describe('TeamManager', () => {
   test('removes enemies missing from gmcp objects nums after repeated updates', () => {
     manager.addEnemyToQueue('5');
     manager.addEnemyToQueue('6');
-    client.sendEvent('gmcp.objects.nums', { nums: ['6'] });
+    emitGmcp('objects.nums', { nums: ['6'] });
     expect(manager.getEnemyQueue()).toEqual(['5', '6']);
-    client.sendEvent('gmcp.objects.nums', { nums: ['6'] });
+    emitGmcp('objects.nums', { nums: ['6'] });
     expect(manager.getEnemyQueue()).toEqual(['6']);
   });
 
   test('restores pending removal when enemy reappears in gmcp objects nums', () => {
     manager.addEnemyToQueue('5');
     manager.addEnemyToQueue('6');
-    client.sendEvent('gmcp.objects.nums', { nums: ['6'] });
-    client.sendEvent('gmcp.objects.nums', { nums: ['5', '6'] });
+    emitGmcp('objects.nums', { nums: ['6'] });
+    emitGmcp('objects.nums', { nums: ['5', '6'] });
     expect(manager.getEnemyQueue()).toEqual(['5', '6']);
   });
 
   test('clears attack queue on new location', () => {
     manager.addEnemyToQueue('7');
-    client.sendEvent('gmcp.room.info', { num: 123 });
+    emitGmcp('room.info', { num: 123 });
     expect(manager.getEnemyQueue()).toEqual([]);
   });
 
   test('removes enemy from queue when marked as not living', () => {
     manager.addEnemyToQueue('8');
-    client.sendEvent('gmcp.objects.data', { '8': { living: false } });
+    emitGmcp('objects.data', { '8': { living: false } });
     expect(manager.getEnemyQueue()).toEqual([]);
   });
 
   test('notifies about next enemy in queue when the current one dies', () => {
     manager.addEnemyToQueue('8');
     manager.addEnemyToQueue('9');
-    client.sendEvent('gmcp.objects.data', {
+    emitGmcp('objects.data', {
       '9': { desc: 'Drugi przeciwnik', living: true },
     });
     client.println.mockClear();
-    client.sendEvent('gmcp.objects.data', { '8': { living: false } });
+    emitGmcp('objects.data', { '8': { living: false } });
     expect(client.println).toHaveBeenCalledWith(
       '<span style="color:orange">/nn zeby zaatakowac nastepny cel: Drugi przeciwnik</span>',
     );
@@ -235,10 +246,28 @@ describe('TeamManager', () => {
     manager.addEnemyToQueue('8');
     manager.addEnemyToQueue('10');
     client.println.mockClear();
-    client.sendEvent('gmcp.objects.data', { '8': { living: false } });
+    emitGmcp('objects.data', { '8': { living: false } });
     expect(client.println).toHaveBeenCalledWith(
       '<span style="color:orange">/nn zeby zaatakowac nastepny cel: ob_10</span>',
     );
+  });
+
+  test('dispose removes gmcp listeners', () => {
+    const callback = jest.fn();
+    client.addEventListener('teamChange', callback);
+
+    emitGmcp('objects.data', {
+      '1': { desc: 'Alice', living: true, team: true },
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    manager.dispose();
+    emitGmcp('objects.data', {
+      '2': { desc: 'Bob', living: true, team: true },
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
   });
 
 });


### PR DESCRIPTION
## Summary
- update TeamManager to consume GMCP updates through the runtime EventHub and track its subscriptions for cleanup
- add a dispose method that unsubscribes from the EventHub and call it from Client during shutdown
- adjust TeamManager tests to drive synthetic GMCP payloads through a stub EventHub and cover disposal behavior

## Testing
- `yarn --cwd client test`


------
https://chatgpt.com/codex/tasks/task_e_68eb13163438832aa68193068a3969d6