### PR TITLE
Refactor map loader to use data catalog

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -45,6 +45,9 @@ import "./triggerTester"
 import "./triggerFinder"
 import MessageRouter from "@client/src/runtime/transport/message-router";
 import { runtimeEventHub } from "@client/src/runtime/event-hub";
+import services from "@client/src/runtime/service-registry";
+import { COLORS_DATASET_KEY, MAP_DATASET_KEY } from "@client/src/runtime/data";
+import type { DataCatalogEntryStatus } from "@client/src/runtime/data";
 import WebSocketTransportAdapter from "./transport/websocket-adapter";
 import {parseAnsiPatterns} from "./ansiParser";
 import { bindUiStoreToClientEvents } from "./ui/store";
@@ -170,7 +173,46 @@ updateMapLayoutOffsets()
 const progressContainer = document.getElementById('map-progress-container')!;
 const progressBar = document.getElementById('map-progress-bar') as HTMLElement;
 
-progressContainer.style.display = 'none';
+const dataCatalog = services.dataCatalog;
+let mapStatus: DataCatalogEntryStatus = dataCatalog.metadataFor(MAP_DATASET_KEY)?.status ?? 'idle';
+let colorStatus: DataCatalogEntryStatus = dataCatalog.metadataFor(COLORS_DATASET_KEY)?.status ?? 'idle';
+let progressMessageOverride: string | null = null;
+
+function refreshProgressDisplay() {
+    if (mapStatus === 'ready' && colorStatus === 'ready') {
+        progressContainer.style.display = 'none';
+        progressBar.textContent = '';
+        progressBar.style.width = '100%';
+        return;
+    }
+
+    progressContainer.style.display = 'block';
+
+    const messages: string[] = [];
+    if (progressMessageOverride) {
+        messages.push(progressMessageOverride);
+    } else {
+        if (mapStatus === 'error') {
+            messages.push('Failed to load map data');
+        } else if (mapStatus !== 'ready') {
+            messages.push('Loading map data…');
+        }
+
+        if (colorStatus === 'error') {
+            messages.push('Failed to load map colors');
+        } else if (colorStatus !== 'ready') {
+            messages.push('Loading map colors…');
+        }
+    }
+
+    progressBar.textContent = messages.join(' ');
+
+    const loadingStates = [mapStatus, colorStatus].filter((status) => status === 'loading').length;
+    const percent = loadingStates > 0 ? 60 : 100;
+    progressBar.style.width = `${percent}%`;
+}
+
+refreshProgressDisplay();
 
 const outputWrapper = document.getElementById('main_text_output_msg_wrapper') as HTMLElement;
 const splitBottom = document.getElementById('split-bottom') as HTMLElement;
@@ -228,32 +270,62 @@ outputWrapper.addEventListener('touchend', (e) => {
 
 outputWrapper.addEventListener('dblclick', closeHistoryScrollback);
 
-function updateProgress(p: number, loaded?: number, total?: number) {
-    progressContainer.style.display = 'block';
-    progressBar.style.width = `${p}%`;
-    if (loaded !== undefined && total !== undefined && total > 0) {
-        const loadedKb = Math.floor(loaded / 1024);
-        const totalKb = Math.ceil(total / 1024);
-        progressBar.textContent = `${loadedKb} / ${totalKb} KB`;
-    } else {
-        progressBar.textContent = `${Math.floor(p)}%`;
-    }
+if (mapStatus !== 'ready') {
+    mapStatus = 'loading';
 }
+if (colorStatus !== 'ready') {
+    colorStatus = 'loading';
+}
+refreshProgressDisplay();
 
-// Load map data and colors asynchronously
-let mapDataPromise = loadMapData(updateProgress);
-let colorsPromise = loadColors();
+const mapDataPromise = loadMapData()
+    .then((mapData) => {
+        mapStatus = 'ready';
+
+        const metadata = dataCatalog.metadataFor(MAP_DATASET_KEY);
+        if (metadata?.source) {
+            progressMessageOverride = metadata.source === 'cache'
+                ? 'Loaded map data from cache'
+                : 'Loaded map data';
+            refreshProgressDisplay();
+            progressMessageOverride = null;
+            refreshProgressDisplay();
+        } else {
+            refreshProgressDisplay();
+        }
+
+        return mapData;
+    })
+    .catch((error) => {
+        mapStatus = 'error';
+        progressMessageOverride = error instanceof Error ? error.message : String(error);
+        refreshProgressDisplay();
+        throw error;
+    });
+
+const colorsPromise = loadColors()
+    .then((colors) => {
+        colorStatus = 'ready';
+        refreshProgressDisplay();
+        return colors;
+    })
+    .catch((error) => {
+        colorStatus = 'error';
+        progressMessageOverride = error instanceof Error ? error.message : String(error);
+        refreshProgressDisplay();
+        throw error;
+    });
 
 // When both are loaded, dispatch events
 Promise.all([mapDataPromise, colorsPromise])
     .then(([mapData, colors]) => {
         console.log('Map data and colors loaded successfully');
-        progressContainer.style.display = 'none';
+        refreshProgressDisplay();
         const {startId, reader, pathFinder} = client.Map.initialize(mapData, colors);
         (window as any).embedded = new EmbeddedMap(reader, pathFinder, startId);
     })
     .catch(error => {
-        progressContainer.style.display = 'none';
+        refreshProgressDisplay();
         console.error('Failed to load map data or colors:', error);
     });
 

--- a/web-client/src/mapDataLoader.ts
+++ b/web-client/src/mapDataLoader.ts
@@ -1,22 +1,91 @@
-// This file provides a way to load map and colors data asynchronously.
-import { loadCachedJSON } from "@client/src/utils/dataCache.ts";
+import services from "@client/src/runtime/service-registry";
+import { COLORS_DATASET_KEY, MAP_DATASET_KEY } from "@client/src/runtime/data";
+import type { DataCatalogEntryMetadata } from "@client/src/runtime/data";
 
-const TTL = 24 * 60 * 60 * 1000; // 24h
+type LoaderResult<T> = {
+    readonly data: T;
+    readonly metadata: DataCatalogEntryMetadata;
+};
 
-export function loadMapData(onProgress?: (progress: number, loaded?: number, total?: number) => void): Promise<MapData.Map> {
-    return loadCachedJSON({
-        url: 'https://delwing.github.io/arkadia-mapa/data/mapExport.json',
-        localStorageKey: 'cachedMapData',
-        indexedDB: { dbName: 'ArkadiaMapDB', storeName: 'mapData', key: 'mapExport' },
-        ttl: TTL,
-        onProgress,
+const loadPromises = new Map<string, Promise<void>>();
+
+function ensureLoad(key: string): Promise<void> {
+    let pending = loadPromises.get(key);
+    if (!pending) {
+        pending = services.dataCatalog.load(key).finally(() => {
+            loadPromises.delete(key);
+        });
+        loadPromises.set(key, pending);
+    }
+    return pending;
+}
+
+async function getReadyData<T>(key: string): Promise<LoaderResult<T>> {
+    const metadata = services.dataCatalog.metadataFor(key);
+    const cached = services.dataCatalog.get<T>(key);
+
+    if (metadata?.status === 'ready' && typeof cached !== 'undefined') {
+        return { data: cached, metadata };
+    }
+
+    return new Promise<LoaderResult<T>>((resolve, reject) => {
+        let settled = false;
+
+        const cleanup = () => {
+            settled = true;
+            subscription.unsubscribe();
+        };
+
+        const subscription = services.dataCatalog.ready$<T>(key).subscribe({
+            next: (event) => {
+                if (settled) {
+                    return;
+                }
+
+                cleanup();
+                resolve({ data: event.data, metadata: event.metadata });
+            },
+            error: (error) => {
+                if (settled) {
+                    return;
+                }
+
+                cleanup();
+                reject(error);
+            },
+        });
+
+        ensureLoad(key)
+            .then(() => {
+                if (settled) {
+                    return;
+                }
+
+                const data = services.dataCatalog.get<T>(key);
+                const entryMetadata = services.dataCatalog.metadataFor(key);
+
+                if (typeof data !== 'undefined' && entryMetadata?.status === 'ready') {
+                    cleanup();
+                    resolve({ data, metadata: entryMetadata });
+                }
+            })
+            .catch((error) => {
+                if (settled) {
+                    return;
+                }
+
+                cleanup();
+                reject(error);
+            });
     });
 }
 
-export function loadColors(): Promise<MapData.Env[]> {
-    return loadCachedJSON({
-        url: 'https://delwing.github.io/arkadia-mapa/data/colors.json',
-        localStorageKey: 'cachedColors',
-        ttl: TTL,
-    });
+export async function loadMapData(): Promise<MapData.Map> {
+    const { data } = await getReadyData<MapData.Map>(MAP_DATASET_KEY);
+    return data;
+}
+
+export async function loadColors(): Promise<MapData.Env[]> {
+    const { data } = await getReadyData<MapData.Env[]>(COLORS_DATASET_KEY);
+    return data;
 }

--- a/web-client/test/mapDataLoader.test.ts
+++ b/web-client/test/mapDataLoader.test.ts
@@ -1,33 +1,152 @@
-import { loadMapData, loadColors } from '../src/mapDataLoader';
-import { loadCachedJSON } from '@client/src/utils/dataCache.ts';
-
-jest.mock('@client/src/utils/dataCache.ts', () => ({
-  loadCachedJSON: jest.fn()
-}));
+import { Subject } from 'rxjs';
+import type {
+  DataCatalog,
+  DataCatalogEntryMetadata,
+  DataCatalogReadyEvent,
+} from '@client/src/runtime/data';
+import { COLORS_DATASET_KEY, MAP_DATASET_KEY } from '@client/src/runtime/data';
 
 describe('mapDataLoader', () => {
+  let metadataByKey: Map<string, DataCatalogEntryMetadata | undefined>;
+  let dataByKey: Map<string, unknown>;
+  let readySubjects: Map<string, Subject<DataCatalogReadyEvent<unknown>>>;
+  let dataCatalogMock: jest.Mocked<DataCatalog>;
+
+  const requireLoader = async () => {
+    const module = await import('../src/mapDataLoader');
+    return module;
+  };
+
   beforeEach(() => {
-    (loadCachedJSON as jest.Mock).mockClear();
+    metadataByKey = new Map();
+    dataByKey = new Map();
+    readySubjects = new Map();
+
+    dataCatalogMock = {
+      register: jest.fn(),
+      load: jest.fn(),
+      loadAll: jest.fn(),
+      get: jest.fn((key: string) => dataByKey.get(key)),
+      metadataFor: jest.fn((key: string) => metadataByKey.get(key)),
+      ready$: jest.fn((key?: string) => {
+        if (!key) {
+          throw new Error('Global ready$ not supported in tests');
+        }
+        let subject = readySubjects.get(key);
+        if (!subject) {
+          subject = new Subject<DataCatalogReadyEvent<unknown>>();
+          readySubjects.set(key, subject);
+        }
+        return subject.asObservable();
+      }),
+    } as jest.Mocked<DataCatalog>;
+
+    jest.resetModules();
+    jest.doMock('@client/src/runtime/service-registry', () => ({
+      __esModule: true,
+      default: { dataCatalog: dataCatalogMock },
+    }));
   });
 
-  test('loadMapData passes correct options', () => {
-    const onProgress = jest.fn();
-    loadMapData(onProgress);
-    expect(loadCachedJSON).toHaveBeenCalledWith({
-      url: 'https://delwing.github.io/arkadia-mapa/data/mapExport.json',
-      localStorageKey: 'cachedMapData',
-      indexedDB: { dbName: 'ArkadiaMapDB', storeName: 'mapData', key: 'mapExport' },
-      ttl: 86400000,
-      onProgress
-    });
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  test('loadColors passes correct options', () => {
-    loadColors();
-    expect(loadCachedJSON).toHaveBeenCalledWith({
-      url: 'https://delwing.github.io/arkadia-mapa/data/colors.json',
-      localStorageKey: 'cachedColors',
-      ttl: 86400000
+  test('loadMapData triggers catalog load and resolves when ready data arrives', async () => {
+    const mapMetadata: DataCatalogEntryMetadata = { key: MAP_DATASET_KEY, status: 'idle' };
+    metadataByKey.set(MAP_DATASET_KEY, mapMetadata);
+
+    let resolveLoad: () => void = () => {};
+    dataCatalogMock.load.mockImplementation(() => new Promise<void>((resolve) => {
+      resolveLoad = resolve;
+    }));
+
+    const { loadMapData } = await requireLoader();
+
+    const resultPromise = loadMapData();
+
+    expect(dataCatalogMock.load).toHaveBeenCalledWith(MAP_DATASET_KEY);
+
+    const readySubject = readySubjects.get(MAP_DATASET_KEY);
+    expect(readySubject).toBeDefined();
+
+    const readyMetadata: DataCatalogEntryMetadata = {
+      key: MAP_DATASET_KEY,
+      status: 'ready',
+      source: 'loader',
+    };
+
+    const mapData = { rooms: [] } as unknown as MapData.Map;
+    dataByKey.set(MAP_DATASET_KEY, mapData);
+    metadataByKey.set(MAP_DATASET_KEY, readyMetadata);
+
+    readySubject!.next({ key: MAP_DATASET_KEY, data: mapData, metadata: readyMetadata });
+    resolveLoad();
+
+    await expect(resultPromise).resolves.toBe(mapData);
+  });
+
+  test('loadMapData returns cached data without reloading', async () => {
+    const cachedMetadata: DataCatalogEntryMetadata = {
+      key: MAP_DATASET_KEY,
+      status: 'ready',
+      source: 'cache',
+    };
+    const mapData = { rooms: [] } as unknown as MapData.Map;
+    metadataByKey.set(MAP_DATASET_KEY, cachedMetadata);
+    dataByKey.set(MAP_DATASET_KEY, mapData);
+
+    const { loadMapData } = await requireLoader();
+
+    await expect(loadMapData()).resolves.toBe(mapData);
+    expect(dataCatalogMock.load).not.toHaveBeenCalled();
+    expect(dataCatalogMock.ready$).not.toHaveBeenCalled();
+  });
+
+  test('loadMapData propagates load errors when data unavailable', async () => {
+    metadataByKey.set(MAP_DATASET_KEY, { key: MAP_DATASET_KEY, status: 'idle' });
+    const loadError = new Error('boom');
+    dataCatalogMock.load.mockRejectedValue(loadError);
+
+    const { loadMapData } = await requireLoader();
+
+    await expect(loadMapData()).rejects.toBe(loadError);
+    expect(dataCatalogMock.load).toHaveBeenCalledWith(MAP_DATASET_KEY);
+  });
+
+  test('loadColors uses the catalog just like map data', async () => {
+    metadataByKey.set(COLORS_DATASET_KEY, { key: COLORS_DATASET_KEY, status: 'idle' });
+
+    let resolveLoad: () => void = () => {};
+    dataCatalogMock.load.mockImplementation((key: string) => {
+      if (key !== COLORS_DATASET_KEY) {
+        return Promise.resolve();
+      }
+      return new Promise<void>((resolve) => {
+        resolveLoad = resolve;
+      });
     });
+
+    const { loadColors } = await requireLoader();
+
+    const resultPromise = loadColors();
+    expect(dataCatalogMock.load).toHaveBeenCalledWith(COLORS_DATASET_KEY);
+
+    const readySubject = readySubjects.get(COLORS_DATASET_KEY);
+    expect(readySubject).toBeDefined();
+
+    const readyMetadata: DataCatalogEntryMetadata = {
+      key: COLORS_DATASET_KEY,
+      status: 'ready',
+      source: 'loader',
+    };
+    const colorsData = [] as unknown as MapData.Env[];
+    dataByKey.set(COLORS_DATASET_KEY, colorsData);
+    metadataByKey.set(COLORS_DATASET_KEY, readyMetadata);
+
+    readySubject!.next({ key: COLORS_DATASET_KEY, data: colorsData, metadata: readyMetadata });
+    resolveLoad();
+
+    await expect(resultPromise).resolves.toBe(colorsData);
   });
 });

--- a/web-client/test/types/zustand.d.ts
+++ b/web-client/test/types/zustand.d.ts
@@ -1,0 +1,42 @@
+declare module 'zustand' {
+    export type StateCreator<TState, CustomSetState = any, CustomGetState = any, StoreApiType = any> = (
+        set: CustomSetState,
+        get: CustomGetState,
+        api: StoreApiType,
+    ) => TState;
+
+    export type StoreApi<TState> = {
+        getState: () => TState;
+        setState: (
+            partial: Partial<TState> | ((state: TState) => Partial<TState>),
+            replace?: boolean,
+        ) => void;
+        subscribe: (listener: (state: TState, previousState: TState) => void) => () => void;
+    };
+
+    export function useStore<TState, StateSlice = TState>(
+        store: StoreApi<TState>,
+        selector?: (state: TState) => StateSlice,
+        equalityFn?: (a: StateSlice, b: StateSlice) => boolean,
+    ): StateSlice;
+}
+
+declare module 'zustand/vanilla' {
+    import type { StateCreator, StoreApi } from 'zustand';
+
+    export function createStore<TState>(
+        initializer: StateCreator<TState, StoreApi<TState>['setState'], StoreApi<TState>['getState'], StoreApi<TState>>,
+    ): StoreApi<TState>;
+}
+
+declare module 'zustand/middleware' {
+    import type { StateCreator } from 'zustand';
+
+    export function subscribeWithSelector<TState>(
+        initializer: StateCreator<TState, any, any, any>,
+    ): StateCreator<TState, any, any, any>;
+}
+
+declare module 'zustand/shallow' {
+    export function shallow<T>(a: T, b: T): boolean;
+}


### PR DESCRIPTION
## Summary
- load map and color datasets through the shared DataCatalog and reuse in-flight requests
- update the main entrypoint to watch catalog metadata for the loading indicator instead of cache callbacks
- refresh the map data loader tests to mock the catalog and add lightweight zustand type stubs for Jest

## Testing
- yarn --cwd web-client test *(fails: jest cannot process certain TypeScript modules due to existing configuration issues)*

------
https://chatgpt.com/codex/tasks/task_e_68eb13174960832ab7fed1176193a992