### PR TITLE
Use data catalog for NPC data loading

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -122,9 +122,16 @@ function disableTabSleepPrevention() {
     updateWakeLockButton();
 }
 
-loadNpcData().then(npc => {
-    client.sendEvent("npc", npc)
-})
+const initializeNpcData = async () => {
+    try {
+        const npc = await loadNpcData();
+        client.sendEvent("npc", npc);
+    } catch (error) {
+        console.error('Failed to load NPC data:', error);
+    }
+};
+
+void initializeNpcData();
 
 arkadiaClient.on('settings', (detail: any) => {
     if (detail?.binds?.directions) {

--- a/web-client/src/npcDataLoader.ts
+++ b/web-client/src/npcDataLoader.ts
@@ -1,12 +1,22 @@
-// Loader for NPC data sharing cache logic with map loader.
-import { loadCachedJSON } from "@client/src/utils/dataCache.ts";
+import services from "@client/src/runtime/service-registry";
+import { NPC_DATASET_KEY } from "@client/src/runtime/data";
 
-const TTL = 24 * 60 * 60 * 1000; // 24h
+async function loadCatalogDataset<T>(key: string): Promise<T> {
+    const cached = services.dataCatalog.get<T>(key);
+    if (cached !== undefined) {
+        return cached;
+    }
 
-export function loadNpcData() {
-    return loadCachedJSON({
-        url: 'https://delwing.github.io/arkadia-mapa/data/npc.json',
-        indexedDB: { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' },
-        ttl: TTL,
-    });
+    await services.dataCatalog.load(key);
+
+    const loaded = services.dataCatalog.get<T>(key);
+    if (loaded === undefined) {
+        throw new Error(`Dataset "${key}" was not available after loading.`);
+    }
+
+    return loaded;
+}
+
+export function loadNpcData<T = unknown>() {
+    return loadCatalogDataset<T>(NPC_DATASET_KEY);
 }

--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -19,9 +19,24 @@ function Npc() {
     const [filter, setFilter] = useState<string>('')
 
     useEffect(() => {
-        loadNpcData().then((data: NpcProps[]) => {
-            setNpcs(data)
-        })
+        let isMounted = true;
+
+        const fetchNpcData = async () => {
+            try {
+                const data = await loadNpcData<NpcProps[]>();
+                if (isMounted) {
+                    setNpcs(data);
+                }
+            } catch (error) {
+                console.error('Failed to load NPC data:', error);
+            }
+        };
+
+        void fetchNpcData();
+
+        return () => {
+            isMounted = false;
+        };
     }, []);
 
     useEffect(() => {

--- a/web-client/test/npcDataLoader.test.ts
+++ b/web-client/test/npcDataLoader.test.ts
@@ -1,21 +1,67 @@
 import { loadNpcData } from '../src/npcDataLoader';
-import { loadCachedJSON } from '@client/src/utils/dataCache.ts';
+import services from '@client/src/runtime/service-registry';
+import { NPC_DATASET_KEY } from '@client/src/runtime/data';
+import type { DataCatalog } from '@client/src/runtime/data';
+import type { ServiceRegistry } from '@client/src/runtime/service-registry';
 
-jest.mock('@client/src/utils/dataCache.ts', () => ({
-  loadCachedJSON: jest.fn()
-}));
+jest.mock('@client/src/runtime/service-registry', () => {
+  const load = jest.fn();
+  const get = jest.fn();
+
+  return {
+    __esModule: true,
+    default: {
+      dataCatalog: {
+        register: jest.fn(),
+        load,
+        loadAll: jest.fn(),
+        get,
+        metadataFor: jest.fn(),
+        ready$: jest.fn(),
+      },
+    },
+  };
+});
+
+const mockServices = services as jest.Mocked<ServiceRegistry>;
+const mockCatalog = mockServices.dataCatalog as jest.Mocked<DataCatalog>;
 
 describe('npcDataLoader', () => {
   beforeEach(() => {
-    (loadCachedJSON as jest.Mock).mockClear();
+    mockCatalog.load.mockReset();
+    mockCatalog.get.mockReset();
   });
 
-  test('loadNpcData passes correct options', () => {
-    loadNpcData();
-    expect(loadCachedJSON).toHaveBeenCalledWith({
-      url: 'https://delwing.github.io/arkadia-mapa/data/npc.json',
-      indexedDB: { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' },
-      ttl: 86400000
-    });
+  test('loadNpcData loads NPC dataset via catalog when not cached', async () => {
+    const npcData = [{ name: 'foo', loc: 1 }];
+    mockCatalog.get
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce(npcData as unknown);
+    mockCatalog.load.mockResolvedValue(undefined);
+
+    await expect(loadNpcData()).resolves.toBe(npcData);
+
+    expect(mockCatalog.load).toHaveBeenCalledWith(NPC_DATASET_KEY);
+    expect(mockCatalog.get).toHaveBeenCalledTimes(2);
+  });
+
+  test('loadNpcData returns cached NPC data without reloading', async () => {
+    const cachedNpcData = [{ name: 'bar', loc: 2 }];
+    mockCatalog.get.mockReturnValueOnce(cachedNpcData as unknown);
+
+    await expect(loadNpcData()).resolves.toBe(cachedNpcData);
+
+    expect(mockCatalog.load).not.toHaveBeenCalled();
+    expect(mockCatalog.get).toHaveBeenCalledTimes(1);
+  });
+
+  test('loadNpcData surfaces loader errors', async () => {
+    const error = new Error('boom');
+    mockCatalog.get.mockReturnValueOnce(undefined);
+    mockCatalog.load.mockRejectedValue(error);
+
+    await expect(loadNpcData()).rejects.toBe(error);
+
+    expect(mockCatalog.load).toHaveBeenCalledWith(NPC_DATASET_KEY);
   });
 });


### PR DESCRIPTION
## Summary
- switch the NPC loader to pull data from the shared data catalog
- update UI callers to await catalog-backed NPC data and surface load errors
- cover catalog loading, cache hits, and error propagation with new tests

## Testing
- yarn --cwd web-client test *(fails: Jest cannot parse ESM modules in src/ui/store.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68eb131823a8832a930437869ac66027