### PR TITLE
Refactor FightTitle to use uiStore subscriptions

### DIFF
--- a/web-client/src/FightTitle.ts
+++ b/web-client/src/FightTitle.ts
@@ -1,49 +1,45 @@
-import ArkadiaClient from "./ArkadiaClient.ts";
+import type ArkadiaClient from "./ArkadiaClient.ts";
+import { uiStore } from "./ui/store";
 
 export default class FightTitle {
   private baseTitle: string;
   private readonly originalTitle: string;
-  private client: typeof ArkadiaClient;
-  private playerNum?: string;
   private isFighting = false;
   private readonly fightPrefix = "⚔ ";
   private readonly idlePrefix = "ㅤ ";
   private enabled = true;
+  private unsubscribeAttack?: () => void;
+  private unsubscribePreferences?: () => void;
 
-  constructor(client: typeof ArkadiaClient) {
-    this.client = client;
+  constructor(_client: typeof ArkadiaClient) {
     this.baseTitle = document.title;
     this.originalTitle = this.baseTitle;
     this.updateTitle(false, true);
-    client.on("gmcp.char.info", (info: any) => this.handleCharInfo(info));
-    client.on("gmcp.objects.data", (data: Record<string, any>) => this.handleObjectsData(data));
-    client.on("client.disconnect", () => this.reset());
-    (window as any).clientExtension?.eventTarget.addEventListener("uiSettings", (ev: CustomEvent) => {
-      if (typeof ev.detail?.fightTitleIcon === "boolean") {
-        this.enabled = ev.detail.fightTitleIcon;
-        this.updateTitle(this.isFighting, true);
-      }
-    });
-  }
-
-  private handleCharInfo(info: any) {
-    if (info && typeof info.object_num !== "undefined") {
-      this.playerNum = String(info.object_num);
+    const initialState = uiStore.getState();
+    if (typeof initialState.uiPreferences.fightTitleIcon === "boolean") {
+      this.enabled = initialState.uiPreferences.fightTitleIcon;
+      this.updateTitle(this.isFighting, true);
     }
-  }
 
-  private handleObjectsData(data: Record<string, any>) {
-    if (!this.playerNum) return;
-    const obj = data[this.playerNum];
-    if (!obj) return;
-    if (obj.attack_num === undefined) return;
-    const fighting = obj.attack_num !== false;
-    this.updateTitle(fighting);
-  }
+    this.unsubscribeAttack = uiStore.subscribe(
+      (state) => (state.charState as Record<string, unknown>).attack_num,
+      (attackNum) => {
+        const fighting = attackNum !== false && attackNum !== undefined;
+        this.updateTitle(fighting);
+      },
+      { fireImmediately: true },
+    );
 
-  private reset() {
-    this.playerNum = undefined;
-    this.updateTitle(false, true);
+    this.unsubscribePreferences = uiStore.subscribe(
+      (state) => state.uiPreferences.fightTitleIcon,
+      (next) => {
+        if (typeof next === "boolean") {
+          this.enabled = next;
+          this.updateTitle(this.isFighting, true);
+        }
+      },
+      { fireImmediately: true },
+    );
   }
 
   private updateTitle(fighting: boolean, force = false) {

--- a/web-client/test/FightTitle.test.ts
+++ b/web-client/test/FightTitle.test.ts
@@ -1,0 +1,38 @@
+import FightTitle from "../src/FightTitle";
+import { resetUiStoreForTesting, uiStore } from "../src/ui/store";
+
+describe("FightTitle", () => {
+  beforeEach(() => {
+    resetUiStoreForTesting();
+    document.title = "Arkadia";
+  });
+
+  it("updates the document title when combat state changes", () => {
+    new FightTitle({} as any);
+
+    expect(document.title).toBe("ㅤ Arkadia");
+
+    uiStore.setState({ charState: { attack_num: 1 } as any });
+    expect(document.title).toBe("⚔ Arkadia");
+
+    uiStore.setState({ charState: { attack_num: false } as any });
+    expect(document.title).toBe("ㅤ Arkadia");
+  });
+
+  it("respects fight title preference updates", () => {
+    new FightTitle({} as any);
+
+    uiStore.setState({ charState: { attack_num: true } as any });
+    expect(document.title).toBe("⚔ Arkadia");
+
+    uiStore.setState((state) => ({
+      uiPreferences: { ...state.uiPreferences, fightTitleIcon: false },
+    }));
+    expect(document.title).toBe("Arkadia");
+
+    uiStore.setState((state) => ({
+      uiPreferences: { ...state.uiPreferences, fightTitleIcon: true },
+    }));
+    expect(document.title).toBe("⚔ Arkadia");
+  });
+});

--- a/web-client/tsconfig.test.json
+++ b/web-client/tsconfig.test.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "moduleResolution": "node16",
+    "moduleResolution": "bundler",
     "types": ["jest"],
     "resolveJsonModule": true,
     "esModuleInterop": true


### PR DESCRIPTION
## Summary
- subscribe FightTitle to uiStore slices so combat and preference updates drive the document title
- update the Jest TypeScript config to resolve zustand modules via the bundler resolver
- add unit tests covering fight title behaviour when uiStore state mutates

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68eb1319c08c832ab632ccdb91487b0a