### PR TITLE
Refactor NPC data loader to use shared catalog

### DIFF
--- a/client/src/runtime/data/catalog.ts
+++ b/client/src/runtime/data/catalog.ts
@@ -36,6 +36,8 @@ export interface DataCatalog {
     register<T>(registration: DataLoaderRegistration<T>): void;
     load(key: string): Promise<void>;
     loadAll(): Promise<void>;
+    clear(key: string): Promise<void>;
+    set<T>(key: string, value: T, source?: DataCatalogEntryMetadata['source']): Promise<void>;
     get<T>(key: string): T | undefined;
     metadataFor(key: string): DataCatalogEntryMetadata | undefined;
     ready$<T = unknown>(key?: string): Observable<DataCatalogReadyEvent<T>>;

--- a/client/src/runtime/data/default-catalog.ts
+++ b/client/src/runtime/data/default-catalog.ts
@@ -103,6 +103,39 @@ export class DefaultDataCatalog implements DataCatalog {
         await Promise.all(Array.from(this.entries.keys()).map((key) => this.load(key)));
     }
 
+    async clear<T>(key: string): Promise<void> {
+        const entry = this.getEntry<T>(key);
+
+        entry.data = undefined;
+        entry.metadata = {
+            key,
+            status: 'idle',
+        };
+
+        if (entry.persistence) {
+            await entry.persistence.clear();
+        }
+    }
+
+    async set<T>(key: string, value: T, source: DataCatalogEntryMetadata['source'] = 'loader'): Promise<void> {
+        const entry = this.getEntry<T>(key);
+
+        entry.data = value;
+
+        if (entry.persistence) {
+            await entry.persistence.write(value);
+        }
+
+        entry.metadata = {
+            key,
+            status: 'ready',
+            updatedAt: Date.now(),
+            source,
+        };
+
+        this.emitReady(entry);
+    }
+
     get<T>(key: string): T | undefined {
         const entry = this.entries.get(key);
         return entry?.data as T | undefined;

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -125,9 +125,14 @@ function disableTabSleepPrevention() {
     updateWakeLockButton();
 }
 
-loadNpcData().then(npc => {
-    client.sendEvent("npc", npc)
-})
+void (async () => {
+    try {
+        const npc = await loadNpcData();
+        client.sendEvent("npc", npc);
+    } catch (error) {
+        console.error('Failed to load NPC data:', error);
+    }
+})();
 
 arkadiaClient.on('settings', (detail: any) => {
     if (detail?.binds?.directions) {

--- a/web-client/src/npcDataLoader.ts
+++ b/web-client/src/npcDataLoader.ts
@@ -1,12 +1,32 @@
-// Loader for NPC data sharing cache logic with map loader.
-import { loadCachedJSON } from "@client/src/utils/dataCache.ts";
+import services from "@client/src/runtime/service-registry";
+import { NPC_DATASET_KEY } from "@client/src/runtime/data";
 
-const TTL = 24 * 60 * 60 * 1000; // 24h
+let loadPromise: Promise<void> | null = null;
 
-export function loadNpcData() {
-    return loadCachedJSON({
-        url: 'https://delwing.github.io/arkadia-mapa/data/npc.json',
-        indexedDB: { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' },
-        ttl: TTL,
-    });
+function ensureLoad(): Promise<void> {
+    if (!loadPromise) {
+        loadPromise = services.dataCatalog.load(NPC_DATASET_KEY).finally(() => {
+            loadPromise = null;
+        });
+    }
+
+    return loadPromise;
+}
+
+export async function loadNpcData<T = unknown>(): Promise<T> {
+    const metadata = services.dataCatalog.metadataFor(NPC_DATASET_KEY);
+    const cached = services.dataCatalog.get<T>(NPC_DATASET_KEY);
+
+    if (metadata?.status === "ready" && typeof cached !== "undefined") {
+        return cached;
+    }
+
+    await ensureLoad();
+
+    const data = services.dataCatalog.get<T>(NPC_DATASET_KEY);
+    if (typeof data === "undefined") {
+        throw new Error("NPC data is unavailable after catalog load.");
+    }
+
+    return data;
 }

--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -1,12 +1,10 @@
 import '../style.css'
 import {ChangeEvent, useEffect, useState} from "react";
 import {Button, Form, Table} from 'react-bootstrap';
-import {clearIndexedDB, updateIndexedDB} from "@client/src/utils/dataCache.ts";
 import {TiDelete} from "react-icons/ti";
 import {loadNpcData} from "../npcDataLoader.ts";
-
-const DB_CONFIG = { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' } as const;
-const NPC_URL = 'https://delwing.github.io/arkadia-mapa/data/npc.json';
+import services from "@client/src/runtime/service-registry";
+import { NPC_DATASET_KEY } from "@client/src/runtime/data";
 
 interface NpcProps {
     name: string;
@@ -19,9 +17,24 @@ function Npc() {
     const [filter, setFilter] = useState<string>('')
 
     useEffect(() => {
-        loadNpcData().then((data: NpcProps[]) => {
-            setNpcs(data)
-        })
+        let cancelled = false;
+
+        const load = async () => {
+            try {
+                const data = await loadNpcData<NpcProps[]>();
+                if (!cancelled) {
+                    setNpcs(data);
+                }
+            } catch (error) {
+                console.error('Failed to load NPC data:', error);
+            }
+        };
+
+        void load();
+
+        return () => {
+            cancelled = true;
+        };
     }, []);
 
     useEffect(() => {
@@ -37,17 +50,19 @@ function Npc() {
         }
     }, [])
 
-    function downloadNpcs() {
-        updateIndexedDB<NpcProps[]>(DB_CONFIG, NPC_URL)
-            .then(data => {
-                setNpcs(data)
-                ;(window as any).clientExtension?.sendEvent('npc', data)
-            })
-            .catch(e => console.error('Failed to update NPC data:', e));
+    async function downloadNpcs() {
+        try {
+            await services.dataCatalog.load(NPC_DATASET_KEY);
+            const data = await loadNpcData<NpcProps[]>();
+            setNpcs(data);
+            ;(window as any).clientExtension?.sendEvent('npc', data);
+        } catch (e) {
+            console.error('Failed to update NPC data:', e);
+        }
     }
 
     function clearNpcs() {
-        clearIndexedDB(DB_CONFIG)
+        services.dataCatalog.clear(NPC_DATASET_KEY)
             .then(() => {
                 setNpcs([])
                 ;(window as any).clientExtension?.sendEvent('npc', [])
@@ -69,37 +84,16 @@ function Npc() {
     function deleteNpc(npc: NpcProps) {
         const updated = npcs.filter(n => !(n.name === npc.name && n.loc === npc.loc))
         setNpcs(updated)
-        saveNpcs(updated)
+        void saveNpcs(updated)
         ;(window as any).clientExtension?.sendEvent('npc', updated)
     }
 
     async function saveNpcs(list: NpcProps[]) {
         try {
-            const db = await openDb()
-            await new Promise<void>((resolve, reject) => {
-                const tx = db.transaction([DB_CONFIG.storeName], 'readwrite')
-                const store = tx.objectStore(DB_CONFIG.storeName)
-                const req = store.put({ id: DB_CONFIG.key, data: list, timestamp: Date.now() })
-                req.onsuccess = () => resolve()
-                req.onerror = () => reject(new Error('Failed to store data'))
-            })
+            await services.dataCatalog.set(NPC_DATASET_KEY, list, 'cache')
         } catch (e) {
             console.error('Failed to save NPC list:', e)
         }
-    }
-
-    function openDb(): Promise<IDBDatabase> {
-        return new Promise((resolve, reject) => {
-            const request = indexedDB.open(DB_CONFIG.dbName, 1)
-            request.onupgradeneeded = () => {
-                const db = request.result
-                if (!db.objectStoreNames.contains(DB_CONFIG.storeName)) {
-                    db.createObjectStore(DB_CONFIG.storeName, { keyPath: 'id' })
-                }
-            }
-            request.onsuccess = () => resolve(request.result)
-            request.onerror = () => reject(new Error('Failed to open IndexedDB'))
-        })
     }
 
     return (

--- a/web-client/test/mapDataLoader.test.ts
+++ b/web-client/test/mapDataLoader.test.ts
@@ -26,6 +26,8 @@ describe('mapDataLoader', () => {
       register: jest.fn(),
       load: jest.fn(),
       loadAll: jest.fn(),
+      clear: jest.fn(),
+      set: jest.fn(),
       get: jest.fn((key: string) => dataByKey.get(key)),
       metadataFor: jest.fn((key: string) => metadataByKey.get(key)),
       ready$: jest.fn((key?: string) => {

--- a/web-client/test/npcDataLoader.test.ts
+++ b/web-client/test/npcDataLoader.test.ts
@@ -1,21 +1,93 @@
-import { loadNpcData } from '../src/npcDataLoader';
-import { loadCachedJSON } from '@client/src/utils/dataCache.ts';
-
-jest.mock('@client/src/utils/dataCache.ts', () => ({
-  loadCachedJSON: jest.fn()
-}));
+import type { DataCatalog, DataCatalogEntryMetadata } from '@client/src/runtime/data';
+import { NPC_DATASET_KEY } from '@client/src/runtime/data';
 
 describe('npcDataLoader', () => {
+  let metadataByKey: Map<string, DataCatalogEntryMetadata | undefined>;
+  let dataByKey: Map<string, unknown>;
+  let dataCatalogMock: jest.Mocked<DataCatalog>;
+
+  const requireLoader = async () => {
+    const module = await import('../src/npcDataLoader');
+    return module;
+  };
+
   beforeEach(() => {
-    (loadCachedJSON as jest.Mock).mockClear();
+    metadataByKey = new Map();
+    dataByKey = new Map();
+
+    dataCatalogMock = {
+      register: jest.fn(),
+      load: jest.fn(),
+      loadAll: jest.fn(),
+      clear: jest.fn(),
+      set: jest.fn(),
+      get: jest.fn((key: string) => dataByKey.get(key)),
+      metadataFor: jest.fn((key: string) => metadataByKey.get(key)),
+      ready$: jest.fn(() => {
+        throw new Error('ready$ should not be called in npcDataLoader tests');
+      }),
+    } as jest.Mocked<DataCatalog>;
+
+    jest.resetModules();
+    jest.doMock('@client/src/runtime/service-registry', () => ({
+      __esModule: true,
+      default: { dataCatalog: dataCatalogMock },
+    }));
   });
 
-  test('loadNpcData passes correct options', () => {
-    loadNpcData();
-    expect(loadCachedJSON).toHaveBeenCalledWith({
-      url: 'https://delwing.github.io/arkadia-mapa/data/npc.json',
-      indexedDB: { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' },
-      ttl: 86400000
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('loadNpcData returns cached catalog data when ready', async () => {
+    const cachedData = [{ name: 'npc', loc: 1 }];
+    dataByKey.set(NPC_DATASET_KEY, cachedData);
+    metadataByKey.set(NPC_DATASET_KEY, {
+      key: NPC_DATASET_KEY,
+      status: 'ready',
+      source: 'cache',
     });
+
+    const { loadNpcData } = await requireLoader();
+
+    await expect(loadNpcData<typeof cachedData>()).resolves.toBe(cachedData);
+    expect(dataCatalogMock.load).not.toHaveBeenCalled();
+  });
+
+  test('loadNpcData triggers catalog load when data not ready', async () => {
+    metadataByKey.set(NPC_DATASET_KEY, { key: NPC_DATASET_KEY, status: 'idle' });
+
+    let resolveLoad: () => void = () => {};
+    dataCatalogMock.load.mockImplementation(() => new Promise<void>((resolve) => {
+      resolveLoad = resolve;
+    }));
+
+    const { loadNpcData } = await requireLoader();
+
+    const resultPromise = loadNpcData<unknown[]>();
+    expect(dataCatalogMock.load).toHaveBeenCalledWith(NPC_DATASET_KEY);
+
+    const npcData: unknown[] = [];
+    dataByKey.set(NPC_DATASET_KEY, npcData);
+    metadataByKey.set(NPC_DATASET_KEY, {
+      key: NPC_DATASET_KEY,
+      status: 'ready',
+      source: 'loader',
+    });
+
+    resolveLoad();
+
+    await expect(resultPromise).resolves.toBe(npcData);
+  });
+
+  test('loadNpcData propagates load errors', async () => {
+    const loadError = new Error('boom');
+    metadataByKey.set(NPC_DATASET_KEY, { key: NPC_DATASET_KEY, status: 'idle' });
+    dataCatalogMock.load.mockRejectedValue(loadError);
+
+    const { loadNpcData } = await requireLoader();
+
+    await expect(loadNpcData()).rejects.toBe(loadError);
+    expect(dataCatalogMock.load).toHaveBeenCalledWith(NPC_DATASET_KEY);
   });
 });


### PR DESCRIPTION
## Summary
- replace the NPC data loader with a catalog-backed implementation and ensure the main entry point awaits it
- expose clear/set helpers on the data catalog and update the NPC options UI to use them for loading, saving, and clearing data
- add focused tests that verify the NPC loader interacts with the catalog for cached values, loading, and error propagation

## Testing
- yarn --cwd web-client test npcDataLoader.test.ts
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68eb16b0bf34832aa9129ff1039b8830