### PR TITLE
Refactor UI commands to shared dispatcher

### DIFF
--- a/client/src/runtime/command-dispatcher.ts
+++ b/client/src/runtime/command-dispatcher.ts
@@ -1,0 +1,40 @@
+import type Client from "@client/src/Client";
+
+export interface MultibindPortRecord {
+    roomId: number;
+    index: number;
+    action: string;
+}
+
+export type ExtensionCommand =
+    | { type: "MULTIBINDS_LOAD" }
+    | { type: "MULTIBINDS_SAVE"; value: MultibindPortRecord[] };
+
+export interface CommandDispatcher {
+    sendCommand(command: string, options?: { echo?: boolean }): void;
+    sendEvent(type: string, payload?: unknown): void;
+    sendExtensionCommand(command: ExtensionCommand): boolean;
+}
+
+export class ClientCommandDispatcher implements CommandDispatcher {
+    constructor(private readonly client: Client) {}
+
+    sendCommand(command: string, options?: { echo?: boolean }): void {
+        const echo = options?.echo ?? true;
+        this.client.sendCommand(command, echo);
+    }
+
+    sendEvent(type: string, payload?: unknown): void {
+        this.client.sendEvent(type, payload);
+    }
+
+    sendExtensionCommand(command: ExtensionCommand): boolean {
+        const port = this.client.port;
+        if (port && typeof port.postMessage === "function") {
+            port.postMessage(command);
+            return true;
+        }
+        return false;
+    }
+}
+

--- a/web-client/jest.config.cjs
+++ b/web-client/jest.config.cjs
@@ -2,6 +2,7 @@ module.exports = {
   testEnvironment: 'jsdom',
   roots: ['<rootDir>/src', '<rootDir>/test'],
   setupFiles: ['<rootDir>/jest.setup.js'],
+  moduleDirectories: ['node_modules', '<rootDir>/../node_modules'],
   moduleNameMapper: {
     '^@client/(.*)$': '<rootDir>/../client/$1'
   },

--- a/web-client/src/Recorder.ts
+++ b/web-client/src/Recorder.ts
@@ -171,7 +171,6 @@ export default class Recorder {
             this.hooks.processIncomingData(ev.message);
         } else {
             Output.send('→ ' + ev.message);
-            window.clientExtension.sendCommand(ev.message, false);
             this.hooks.sendCommand(ev.message, false);
         }
     }

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -48,9 +48,10 @@ import { runtimeEventHub } from "@client/src/runtime/event-hub";
 import services from "@client/src/runtime/service-registry";
 import { COLORS_DATASET_KEY, MAP_DATASET_KEY } from "@client/src/runtime/data";
 import type { DataCatalogEntryStatus } from "@client/src/runtime/data";
+import { ClientCommandDispatcher } from "@client/src/runtime/command-dispatcher";
 import WebSocketTransportAdapter from "./transport/websocket-adapter";
 import {parseAnsiPatterns} from "./ansiParser";
-import { bindUiStoreToClientEvents } from "./ui/store";
+import { bindUiStoreToClientEvents, uiStore } from "./ui/store";
 
 const transport = new WebSocketTransportAdapter();
 const router = new MessageRouter(transport, runtimeEventHub, { parseAnsiPatterns });
@@ -59,6 +60,8 @@ configureArkadiaClient({ transport, router });
 initSessionLogger(arkadiaClient).catch(err => console.error('Logger init failed', err));
 
 const client = new Client(arkadiaClient, new MockPort())
+const commandDispatcher = new ClientCommandDispatcher(client);
+uiStore.getState().setCommandDispatcher(commandDispatcher);
 window.clientExtension = client;
 bindUiStoreToClientEvents(client);
 registerScripts(client)
@@ -440,7 +443,7 @@ arkadiaClient.on('client.connect', () => {
     isConnected = true;
     isConnecting = false;
     updateConnectButtons();
-    window.clientExtension.sendEvent('refreshPositionWhenAble');
+    commandDispatcher.sendEvent('refreshPositionWhenAble');
     console.log('Client connected to Arkadia server.');
 });
 

--- a/web-client/src/options/Binds.tsx
+++ b/web-client/src/options/Binds.tsx
@@ -3,6 +3,7 @@ import {Alert, Button, Form, Modal, ProgressBar, Spinner, Table} from 'react-boo
 import storage from "@client/src/storage";
 import { parseMultibindsDatabase, type MultibindImportRow } from "./multibindImport";
 import { readMultibinds, replaceMultibinds, type StoredMultibindRecord } from "../multibindStorage";
+import { useUiDispatch, useUiStore } from "../ui/store";
 
 interface Bind {
     key: string;
@@ -174,6 +175,8 @@ function Binds() {
     const [isParsingDb, setIsParsingDb] = useState(false);
     const [isRunningImport, setIsRunningImport] = useState(false);
     const [importProgress, setImportProgress] = useState<{ processed: number; total: number; eta: number | null } | null>(null);
+    const dispatch = useUiDispatch();
+    const commandDispatcher = useUiStore(state => state.commandDispatcher);
     const [importCancelled, setImportCancelled] = useState(false);
     const fileInputRef = useRef<HTMLInputElement | null>(null);
     const cancelImportRef = useRef(false);
@@ -212,12 +215,15 @@ function Binds() {
             setMultibinds(normalizeMultibinds(detail));
         };
         window.addEventListener('multibindsStorage', handler as EventListener);
-        window.clientExtension?.port?.postMessage?.({ type: 'MULTIBINDS_LOAD' });
+        if (commandDispatcher) {
+            void dispatch({ type: 'extension/command', command: { type: 'MULTIBINDS_LOAD' } })
+                .catch(err => console.error('Failed to request multibinds from extension', err));
+        }
         return () => {
             active = false;
             window.removeEventListener('multibindsStorage', handler as EventListener);
         };
-    }, []);
+    }, [dispatch, commandDispatcher]);
 
     const importPlan = useMemo<ImportPlan | null>(() => {
         if (!importData) {
@@ -357,27 +363,32 @@ function Binds() {
         }
         const finalList = Array.from(finalMap.values()).sort((a, b) => (a.roomId - b.roomId) || (a.index - b.index));
         try {
-            if (window.clientExtension?.port) {
-                await new Promise<void>((resolve) => {
-                    let settled = false;
-                    const handler = () => {
-                        if (settled) return;
-                        settled = true;
-                        window.removeEventListener('multibindsStorage', handler as EventListener);
-                        resolve();
-                    };
-                    window.addEventListener('multibindsStorage', handler as EventListener, { once: true });
-                    window.clientExtension.port.postMessage({ type: 'MULTIBINDS_SAVE', value: finalList });
-                    setTimeout(() => {
-                        if (settled) return;
-                        settled = true;
-                        window.removeEventListener('multibindsStorage', handler as EventListener);
-                        resolve();
-                    }, 1500);
-                });
-            } else {
-                await replaceMultibinds(finalList);
-                window.dispatchEvent(new CustomEvent('multibindsStorage', { detail: finalList }));
+            let usedFallback = true;
+            if (commandDispatcher) {
+                const posted = commandDispatcher.sendExtensionCommand({ type: 'MULTIBINDS_SAVE', value: finalList });
+                if (posted) {
+                    usedFallback = false;
+                    await new Promise<void>((resolve) => {
+                        let settled = false;
+                        const handler = () => {
+                            if (settled) return;
+                            settled = true;
+                            window.removeEventListener('multibindsStorage', handler as EventListener);
+                            resolve();
+                        };
+                        window.addEventListener('multibindsStorage', handler as EventListener, { once: true });
+                        setTimeout(() => {
+                            if (settled) return;
+                            settled = true;
+                            window.removeEventListener('multibindsStorage', handler as EventListener);
+                            resolve();
+                        }, 1500);
+                    });
+                }
+            }
+            if (usedFallback) {
+                const stored = await replaceMultibinds(finalList);
+                window.dispatchEvent(new CustomEvent('multibindsStorage', { detail: stored }));
             }
             setMultibinds(finalList);
             setImportResult({

--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -5,6 +5,7 @@ import {TiDelete} from "react-icons/ti";
 import {loadNpcData} from "../npcDataLoader.ts";
 import services from "@client/src/runtime/service-registry";
 import { NPC_DATASET_KEY } from "@client/src/runtime/data";
+import { useUiDispatch } from "../ui/store";
 
 interface NpcProps {
     name: string;
@@ -15,6 +16,7 @@ function Npc() {
 
     const [npcs, setNpcs] = useState<NpcProps[]>([])
     const [filter, setFilter] = useState<string>('')
+    const dispatch = useUiDispatch();
 
     useEffect(() => {
         let cancelled = false;
@@ -55,7 +57,7 @@ function Npc() {
             await services.dataCatalog.load(NPC_DATASET_KEY);
             const data = await loadNpcData<NpcProps[]>();
             setNpcs(data);
-            ;(window as any).clientExtension?.sendEvent('npc', data);
+            void dispatch({ type: 'event/send', event: 'npc', payload: data });
         } catch (e) {
             console.error('Failed to update NPC data:', e);
         }
@@ -65,7 +67,7 @@ function Npc() {
         services.dataCatalog.clear(NPC_DATASET_KEY)
             .then(() => {
                 setNpcs([])
-                ;(window as any).clientExtension?.sendEvent('npc', [])
+                void dispatch({ type: 'event/send', event: 'npc', payload: [] });
             })
             .catch(e => console.error('Failed to clear NPC data:', e));
     }
@@ -85,7 +87,7 @@ function Npc() {
         const updated = npcs.filter(n => !(n.name === npc.name && n.loc === npc.loc))
         setNpcs(updated)
         void saveNpcs(updated)
-        ;(window as any).clientExtension?.sendEvent('npc', updated)
+        void dispatch({ type: 'event/send', event: 'npc', payload: updated });
     }
 
     async function saveNpcs(list: NpcProps[]) {

--- a/web-client/src/options/Shortcuts.tsx
+++ b/web-client/src/options/Shortcuts.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Button, Form, Table } from 'react-bootstrap';
 import { TiDelete } from 'react-icons/ti';
 import storage from "@client/src/storage";
+import { useUiDispatch } from "../ui/store";
 
 interface ShortcutEntry {
     key: string;
@@ -15,6 +16,7 @@ function Shortcuts() {
     const [key, setKey] = useState('');
     const [loc, setLoc] = useState('');
     const [label, setLabel] = useState('');
+    const dispatch = useUiDispatch();
 
     useEffect(() => {
         storage.getItem('shortcuts').then(res => {
@@ -89,7 +91,10 @@ function Shortcuts() {
                         <td>{item.id}</td>
                         <td>{item.label}</td>
                         <td className="d-flex gap-2">
-                            <Button size="sm" onClick={() => (window as any).clientExtension?.sendEvent('leadTo', item.id)}>Prowadź</Button>
+                            <Button
+                                size="sm"
+                                onClick={() => { void dispatch({ type: 'event/send', event: 'leadTo', payload: item.id }); }}
+                            >Prowadź</Button>
                             <Button size="sm" variant="danger" onClick={() => remove(item.key)}><TiDelete /></Button>
                         </td>
                     </tr>

--- a/web-client/src/ui/store.ts
+++ b/web-client/src/ui/store.ts
@@ -7,6 +7,7 @@ import type { EventHubSubscription } from "@client/src/runtime/event-hub";
 import services from "@client/src/runtime/service-registry";
 import type { SettingsSnapshot } from "@client/src/runtime/settings/settings-service";
 import { defaultSettings } from "@client/src/defaultSettings";
+import type { CommandDispatcher, ExtensionCommand } from "@client/src/runtime/command-dispatcher";
 
 import type { CharStateData } from "../CharState";
 
@@ -27,11 +28,16 @@ export interface UiStoreState {
     charState: Partial<CharStateData>;
     charOptions: CharOptionsState;
     uiPreferences: UiPreferences;
+    commandDispatcher: CommandDispatcher | null;
+    setCommandDispatcher: (dispatcher: CommandDispatcher | null) => void;
     dispatch: (intent: UiIntent) => Promise<void>;
 }
 
 export type UiIntent =
-    | { type: "settings/update"; patch: Partial<SettingsSnapshot> };
+    | { type: "settings/update"; patch: Partial<SettingsSnapshot> }
+    | { type: "command/send"; command: string; echo?: boolean }
+    | { type: "event/send"; event: string; payload?: unknown }
+    | { type: "extension/command"; command: ExtensionCommand };
 
 const defaultPreferences: UiPreferences = {
     emojiLabels: null,
@@ -39,12 +45,38 @@ const defaultPreferences: UiPreferences = {
     fightTitleIcon: null,
 };
 
-async function handleUiIntent(intent: UiIntent): Promise<void> {
-    if (intent.type === "settings/update") {
-        await services.settings.update(intent.patch);
-        return;
+async function handleUiIntent(intent: UiIntent, get: () => UiStoreState): Promise<void> {
+    switch (intent.type) {
+        case "settings/update":
+            await services.settings.update(intent.patch);
+            return;
+        case "command/send": {
+            const dispatcher = get().commandDispatcher;
+            if (!dispatcher) {
+                throw new Error("Command dispatcher not configured");
+            }
+            dispatcher.sendCommand(intent.command, { echo: intent.echo });
+            return;
+        }
+        case "event/send": {
+            const dispatcher = get().commandDispatcher;
+            if (!dispatcher) {
+                throw new Error("Command dispatcher not configured");
+            }
+            dispatcher.sendEvent(intent.event, intent.payload);
+            return;
+        }
+        case "extension/command": {
+            const dispatcher = get().commandDispatcher;
+            if (!dispatcher) {
+                throw new Error("Command dispatcher not configured");
+            }
+            dispatcher.sendExtensionCommand(intent.command);
+            return;
+        }
+        default:
+            throw new Error(`Unhandled UI intent: ${JSON.stringify(intent)}`);
     }
-    throw new Error(`Unhandled UI intent: ${JSON.stringify(intent)}`);
 }
 
 const baseState = {
@@ -55,9 +87,11 @@ const baseState = {
 };
 
 const store = createStore(
-    subscribeWithSelector<UiStoreState>(() => ({
+    subscribeWithSelector<UiStoreState>((set, get) => ({
         ...baseState,
-        dispatch: handleUiIntent,
+        commandDispatcher: null,
+        setCommandDispatcher: (dispatcher) => set({ commandDispatcher: dispatcher }),
+        dispatch: (intent) => handleUiIntent(intent, get),
     }))
 );
 
@@ -204,7 +238,7 @@ export function resetUiStoreForTesting() {
     lastClient = null;
     runtimeCleanup?.();
     runtimeCleanup = null;
-    store.setState({ ...baseState, dispatch: handleUiIntent });
+    store.setState({ ...baseState, commandDispatcher: null });
     subscribeToRuntime();
 }
 

--- a/web-client/test/Recorder.test.ts
+++ b/web-client/test/Recorder.test.ts
@@ -8,7 +8,6 @@ describe('Recorder playback', () => {
       emit: jest.fn(),
     };
     const recorder = new Recorder(hooks as any);
-    (window as any).clientExtension = { sendCommand: jest.fn() };
     (window as any).Output = { send: jest.fn() };
     recorder.setRecordedMessages([
       { message: 'look', timestamp: 0, direction: 'out' },
@@ -17,5 +16,6 @@ describe('Recorder playback', () => {
     recorder.replayRecordedMessagesTimed();
     jest.runAllTimers();
     expect((window as any).Output.send).toHaveBeenCalledWith('→ look');
+    expect(hooks.sendCommand).toHaveBeenCalledWith('look', false);
   });
 });

--- a/web-client/test/uiStore.test.ts
+++ b/web-client/test/uiStore.test.ts
@@ -1,0 +1,25 @@
+import type { CommandDispatcher, ExtensionCommand } from "@client/src/runtime/command-dispatcher";
+import { resetUiStoreForTesting, uiStore } from "../src/ui/store";
+
+describe("ui store command dispatcher", () => {
+    afterEach(() => {
+        resetUiStoreForTesting();
+    });
+
+    test("forwards extension commands when dispatcher configured", async () => {
+        const dispatcher: CommandDispatcher = {
+            sendCommand: jest.fn(),
+            sendEvent: jest.fn(),
+            sendExtensionCommand: jest.fn<ReturnType<CommandDispatcher["sendExtensionCommand"]>, [ExtensionCommand]>(() => true),
+        };
+        uiStore.getState().setCommandDispatcher(dispatcher);
+        await uiStore.getState().dispatch({ type: "extension/command", command: { type: "MULTIBINDS_LOAD" } });
+        expect(dispatcher.sendExtensionCommand).toHaveBeenCalledWith({ type: "MULTIBINDS_LOAD" });
+    });
+
+    test("throws when dispatcher missing", async () => {
+        await expect(
+            uiStore.getState().dispatch({ type: "extension/command", command: { type: "MULTIBINDS_LOAD" } })
+        ).rejects.toThrow("Command dispatcher not configured");
+    });
+});


### PR DESCRIPTION
## Summary
- introduce a shared CommandDispatcher in the runtime and register it through the UI store
- update Binds, NPC, and Shortcuts panels plus the main entrypoint to use store-backed intents instead of window globals
- drop legacy window.clientExtension usage in the recorder and extend Jest config/tests for the new store wiring

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68eb7000a268832a9d377c69a93fbcd1