### PR TITLE
Add typed dataset access helpers

### DIFF
--- a/client/src/runtime/data/core-loaders.ts
+++ b/client/src/runtime/data/core-loaders.ts
@@ -1,12 +1,10 @@
 import type { DataCatalog, DataLoader } from './catalog';
 import { DefaultDataCatalog } from './default-catalog';
+import { COLORS_DATASET_KEY, MAP_DATASET_KEY, NPC_DATASET_KEY } from './dataset-keys';
+export { MAP_DATASET_KEY, NPC_DATASET_KEY, COLORS_DATASET_KEY } from './dataset-keys';
 import type { DataPersistenceAdapter } from './persistence/types';
 import { IndexedDbPersistenceAdapter } from './persistence/indexeddb-adapter';
 import { LocalStoragePersistenceAdapter } from './persistence/local-storage-adapter';
-
-export const MAP_DATASET_KEY = 'maps';
-export const NPC_DATASET_KEY = 'npcs';
-export const COLORS_DATASET_KEY = 'colors';
 
 export type DataSource<T> = () => Promise<T>;
 

--- a/client/src/runtime/data/dataset-keys.ts
+++ b/client/src/runtime/data/dataset-keys.ts
@@ -1,0 +1,3 @@
+export const MAP_DATASET_KEY = 'maps';
+export const NPC_DATASET_KEY = 'npcs';
+export const COLORS_DATASET_KEY = 'colors';

--- a/client/src/runtime/data/default-catalog.ts
+++ b/client/src/runtime/data/default-catalog.ts
@@ -1,4 +1,5 @@
 import { Observable, ReplaySubject, Subject } from 'rxjs';
+import { COLORS_DATASET_KEY, MAP_DATASET_KEY, NPC_DATASET_KEY } from './dataset-keys';
 import type {
     DataCatalog,
     DataCatalogEntryMetadata,
@@ -7,6 +8,7 @@ import type {
     DataLoaderContext,
     DataLoaderRegistration,
 } from './catalog';
+import type { NpcDefinition } from './types';
 import type { DataPersistenceAdapter } from './persistence/types';
 
 interface CatalogEntry<T> {
@@ -22,6 +24,62 @@ export class DefaultDataCatalog implements DataCatalog {
     private readonly entries = new Map<string, CatalogEntry<unknown>>();
 
     private readonly globalReady$ = new Subject<DataCatalogReadyEvent<unknown>>();
+
+    getMapData(): MapData.Map | undefined {
+        return this.get<MapData.Map>(MAP_DATASET_KEY);
+    }
+
+    getNpcData(): readonly NpcDefinition[] | undefined {
+        return this.get<NpcDefinition[]>(NPC_DATASET_KEY);
+    }
+
+    getColorPalettes(): MapData.Env[] | undefined {
+        return this.get<MapData.Env[]>(COLORS_DATASET_KEY);
+    }
+
+    getMapMetadata(): DataCatalogEntryMetadata | undefined {
+        return this.metadataFor(MAP_DATASET_KEY);
+    }
+
+    getNpcMetadata(): DataCatalogEntryMetadata | undefined {
+        return this.metadataFor(NPC_DATASET_KEY);
+    }
+
+    getColorMetadata(): DataCatalogEntryMetadata | undefined {
+        return this.metadataFor(COLORS_DATASET_KEY);
+    }
+
+    readyForMap$(): Observable<DataCatalogReadyEvent<MapData.Map>> {
+        return this.ready$<MapData.Map>(MAP_DATASET_KEY);
+    }
+
+    readyForNpc$(): Observable<DataCatalogReadyEvent<readonly NpcDefinition[]>> {
+        return this.ready$<readonly NpcDefinition[]>(NPC_DATASET_KEY);
+    }
+
+    readyForColors$(): Observable<DataCatalogReadyEvent<MapData.Env[]>> {
+        return this.ready$<MapData.Env[]>(COLORS_DATASET_KEY);
+    }
+
+    async loadMapData(): Promise<void> {
+        await this.load(MAP_DATASET_KEY);
+    }
+
+    async loadNpcData(): Promise<void> {
+        await this.load(NPC_DATASET_KEY);
+    }
+
+    async loadColorPalettes(): Promise<void> {
+        await this.load(COLORS_DATASET_KEY);
+    }
+
+    async clearNpcData(): Promise<void> {
+        await this.clear(NPC_DATASET_KEY);
+    }
+
+    async setNpcData(value: readonly NpcDefinition[], source: DataCatalogEntryMetadata['source'] = 'loader'): Promise<void> {
+        await this.set(NPC_DATASET_KEY, [...value], source);
+    }
 
     register<T>(registration: DataLoaderRegistration<T>): void {
         if (this.entries.has(registration.key)) {

--- a/client/src/runtime/data/index.ts
+++ b/client/src/runtime/data/index.ts
@@ -2,12 +2,11 @@ export * from './catalog';
 export { DefaultDataCatalog } from './default-catalog';
 export {
     registerCoreLoaders,
-    MAP_DATASET_KEY,
-    NPC_DATASET_KEY,
-    COLORS_DATASET_KEY,
     createJsonLoader,
 } from './core-loaders';
+export { MAP_DATASET_KEY, NPC_DATASET_KEY, COLORS_DATASET_KEY } from './dataset-keys';
 export type { DataSource } from './core-loaders';
 export { IndexedDbPersistenceAdapter } from './persistence/indexeddb-adapter';
 export { LocalStoragePersistenceAdapter } from './persistence/local-storage-adapter';
 export type { DataPersistenceAdapter } from './persistence/types';
+export type { NpcDefinition } from './types';

--- a/client/src/runtime/data/types.ts
+++ b/client/src/runtime/data/types.ts
@@ -1,0 +1,4 @@
+export interface NpcDefinition {
+    readonly name: string;
+    readonly loc: number;
+}

--- a/client/test/runtime/data/catalog.test.ts
+++ b/client/test/runtime/data/catalog.test.ts
@@ -2,7 +2,7 @@ import 'fake-indexeddb/auto';
 import { firstValueFrom } from 'rxjs';
 import { timeout } from 'rxjs/operators';
 import { DefaultDataCatalog } from '../../../src/runtime/data/default-catalog';
-import type { DataCatalogReadyEvent } from '../../../src/runtime/data';
+import type { DataCatalogReadyEvent, NpcDefinition } from '../../../src/runtime/data';
 import {
     COLORS_DATASET_KEY,
     MAP_DATASET_KEY,
@@ -126,6 +126,49 @@ describe('DefaultDataCatalog', () => {
 
         expect(catalog.get('to-clear')).toBeUndefined();
         expect(catalog.metadataFor('to-clear')).toMatchObject({ key: 'to-clear', status: 'idle' });
+    });
+
+    it('exposes dedicated helpers for core datasets', async () => {
+        const baseCatalog = new DefaultDataCatalog();
+        registerCoreLoaders({
+            catalog: baseCatalog,
+            mapSource: async () => [
+                {
+                    areaName: 'Test',
+                    areaId: 'test',
+                    rooms: [],
+                    labels: [],
+                },
+            ],
+            npcSource: async () => [{ name: 'Npc', loc: 1 }] as NpcDefinition[],
+            colorSource: async () => [
+                {
+                    envId: 'env',
+                    colors: [],
+                },
+            ],
+        });
+
+        await baseCatalog.loadAll();
+
+        expect(baseCatalog.getMapData()).toEqual([
+            {
+                areaName: 'Test',
+                areaId: 'test',
+                rooms: [],
+                labels: [],
+            },
+        ]);
+        expect(baseCatalog.getNpcData()).toEqual([{ name: 'Npc', loc: 1 }]);
+        expect(baseCatalog.getColorPalettes()).toEqual([
+            {
+                envId: 'env',
+                colors: [],
+            },
+        ]);
+        expect(baseCatalog.getMapMetadata()).toMatchObject({ key: MAP_DATASET_KEY, status: 'ready' });
+        expect(baseCatalog.getNpcMetadata()).toMatchObject({ key: NPC_DATASET_KEY, status: 'ready' });
+        expect(baseCatalog.getColorMetadata()).toMatchObject({ key: COLORS_DATASET_KEY, status: 'ready' });
     });
 });
 

--- a/web-client/jest.config.cjs
+++ b/web-client/jest.config.cjs
@@ -1,3 +1,7 @@
+const path = require('path');
+
+const zustandBaseDir = path.dirname(require.resolve('zustand/package.json'));
+
 module.exports = {
   testEnvironment: 'jsdom',
   roots: ['<rootDir>/src', '<rootDir>/test'],
@@ -5,7 +9,7 @@ module.exports = {
   moduleDirectories: ['node_modules', '<rootDir>/../node_modules'],
   moduleNameMapper: {
     '^@client/(.*)$': '<rootDir>/../client/$1',
-    '^zustand/(.*)$': '<rootDir>/../node_modules/zustand/$1',
+    '^zustand/(.*)$': `${zustandBaseDir}/$1`,
   },
   transform: {
     '^.+\\.tsx?$': [

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -44,12 +44,17 @@ import "./triggerFinder"
 import MessageRouter from "@client/src/runtime/transport/message-router";
 import { runtimeEventHub } from "@client/src/runtime/event-hub";
 import services from "@client/src/runtime/service-registry";
-import { COLORS_DATASET_KEY, MAP_DATASET_KEY, NPC_DATASET_KEY } from "@client/src/runtime/data";
 import type { DataCatalogEntryStatus } from "@client/src/runtime/data";
 import { ClientCommandDispatcher } from "@client/src/runtime/command-dispatcher";
 import WebSocketTransportAdapter from "./transport/websocket-adapter";
 import {parseAnsiPatterns} from "./ansiParser";
-import { bindUiStoreToClientEvents, uiStore } from "./ui/store";
+import {
+    bindUiStoreToClientEvents,
+    ensureColorDataset,
+    ensureMapDataset,
+    ensureNpcDataset,
+    uiStore,
+} from "./ui/store";
 
 const transport = new WebSocketTransportAdapter();
 const router = new MessageRouter(transport, runtimeEventHub, { parseAnsiPatterns });
@@ -128,7 +133,7 @@ function disableTabSleepPrevention() {
 
 void (async () => {
     try {
-        const npc = await uiStore.getState().ensureDataset(NPC_DATASET_KEY);
+        const npc = await ensureNpcDataset();
         client.sendEvent("npc", npc);
     } catch (error) {
         console.error('Failed to load NPC data:', error);
@@ -180,9 +185,8 @@ const progressContainer = document.getElementById('map-progress-container')!;
 const progressBar = document.getElementById('map-progress-bar') as HTMLElement;
 
 const dataCatalog = services.dataCatalog;
-const ensureDataset = uiStore.getState().ensureDataset;
-let mapStatus: DataCatalogEntryStatus = dataCatalog.metadataFor(MAP_DATASET_KEY)?.status ?? 'idle';
-let colorStatus: DataCatalogEntryStatus = dataCatalog.metadataFor(COLORS_DATASET_KEY)?.status ?? 'idle';
+let mapStatus: DataCatalogEntryStatus = dataCatalog.getMapMetadata()?.status ?? 'idle';
+let colorStatus: DataCatalogEntryStatus = dataCatalog.getColorMetadata()?.status ?? 'idle';
 let progressMessageOverride: string | null = null;
 
 function refreshProgressDisplay() {
@@ -285,11 +289,11 @@ if (colorStatus !== 'ready') {
 }
 refreshProgressDisplay();
 
-const mapDataPromise = ensureDataset<MapData.Map>(MAP_DATASET_KEY)
+const mapDataPromise = ensureMapDataset()
     .then((mapData) => {
         mapStatus = 'ready';
 
-        const metadata = dataCatalog.metadataFor(MAP_DATASET_KEY);
+        const metadata = dataCatalog.getMapMetadata();
         if (metadata?.source) {
             progressMessageOverride = metadata.source === 'cache'
                 ? 'Loaded map data from cache'
@@ -310,7 +314,7 @@ const mapDataPromise = ensureDataset<MapData.Map>(MAP_DATASET_KEY)
         throw error;
     });
 
-const colorsPromise = ensureDataset<MapData.Env[]>(COLORS_DATASET_KEY)
+const colorsPromise = ensureColorDataset()
     .then((colors) => {
         colorStatus = 'ready';
         refreshProgressDisplay();

--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -3,19 +3,20 @@ import {ChangeEvent, useEffect, useState} from "react";
 import {Button, Form, Table} from 'react-bootstrap';
 import {TiDelete} from "react-icons/ti";
 import services from "@client/src/runtime/service-registry";
-import { NPC_DATASET_KEY } from "@client/src/runtime/data";
-import { useCatalogDataset, useUiDispatch, useUiStore } from "../ui/store";
-
-interface NpcProps {
-    name: string;
-    loc: number
-}
+import type { NpcDefinition } from "@client/src/runtime/data";
+import {
+    useEnsureNpcDataset,
+    useLoadNpcDataset,
+    useNpcDataset,
+    useSyncNpcDataset,
+    useUiDispatch,
+} from "../ui/store";
 
 function Npc() {
-    const dataset = useCatalogDataset<NpcProps[]>(NPC_DATASET_KEY);
-    const loadDataset = useUiStore((state) => state.loadDataset);
-    const ensureDataset = useUiStore((state) => state.ensureDataset);
-    const syncDataset = useUiStore((state) => state.syncDataset);
+    const dataset = useNpcDataset();
+    const loadDataset = useLoadNpcDataset();
+    const ensureDataset = useEnsureNpcDataset();
+    const syncDataset = useSyncNpcDataset();
     const [filter, setFilter] = useState<string>('');
     const dispatch = useUiDispatch();
 
@@ -28,7 +29,7 @@ function Npc() {
 
         let cancelled = false;
 
-        void ensureDataset<NpcProps[]>(NPC_DATASET_KEY).catch((error) => {
+        void ensureDataset().catch((error) => {
             if (!cancelled) {
                 console.error('Failed to load NPC data:', error);
             }
@@ -44,7 +45,7 @@ function Npc() {
             const detail = (ev as CustomEvent).detail;
             if (Array.isArray(detail)) {
                 void services.dataCatalog
-                    .set(NPC_DATASET_KEY, detail as NpcProps[], 'cache')
+                    .setNpcData(detail as NpcDefinition[], 'cache')
                     .catch((error) => console.error('Failed to persist NPC event data:', error));
             }
         };
@@ -57,8 +58,8 @@ function Npc() {
 
     async function downloadNpcs() {
         try {
-            await loadDataset(NPC_DATASET_KEY, { force: true });
-            const data = services.dataCatalog.get<NpcProps[]>(NPC_DATASET_KEY) ?? [];
+            await loadDataset({ force: true });
+            const data = services.dataCatalog.getNpcData() ?? [];
             void dispatch({ type: 'event/send', event: 'npc', payload: data });
         } catch (e) {
             console.error('Failed to update NPC data:', e);
@@ -67,8 +68,8 @@ function Npc() {
 
     async function clearNpcs() {
         try {
-            await services.dataCatalog.clear(NPC_DATASET_KEY);
-            syncDataset(NPC_DATASET_KEY);
+            await services.dataCatalog.clearNpcData();
+            syncDataset();
             void dispatch({ type: 'event/send', event: 'npc', payload: [] });
         } catch (e) {
             console.error('Failed to clear NPC data:', e);
@@ -86,16 +87,16 @@ function Npc() {
         URL.revokeObjectURL(url)
     }
 
-    function deleteNpc(npc: NpcProps) {
+    function deleteNpc(npc: NpcDefinition) {
         const updated = npcs.filter(n => !(n.name === npc.name && n.loc === npc.loc))
         void saveNpcs(updated)
         void dispatch({ type: 'event/send', event: 'npc', payload: updated });
     }
 
-    async function saveNpcs(list: NpcProps[]) {
+    async function saveNpcs(list: readonly NpcDefinition[]) {
         try {
-            await services.dataCatalog.set(NPC_DATASET_KEY, list, 'cache')
-            syncDataset(NPC_DATASET_KEY);
+            await services.dataCatalog.setNpcData(list, 'cache')
+            syncDataset();
         } catch (e) {
             console.error('Failed to save NPC list:', e)
         }

--- a/web-client/src/ui/store.ts
+++ b/web-client/src/ui/store.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { createStore } from "zustand/vanilla";
 import { subscribeWithSelector } from "zustand/middleware";
 import { useStore } from "zustand";
@@ -7,7 +8,7 @@ import { runtimeEventHub } from "@client/src/runtime/event-hub";
 import type { EventHubSubscription } from "@client/src/runtime/event-hub";
 import services from "@client/src/runtime/service-registry";
 import { COLORS_DATASET_KEY, MAP_DATASET_KEY, NPC_DATASET_KEY } from "@client/src/runtime/data";
-import type { DataCatalogEntryMetadata, DataCatalogReadyEvent } from "@client/src/runtime/data";
+import type { DataCatalogEntryMetadata, DataCatalogReadyEvent, NpcDefinition } from "@client/src/runtime/data";
 import type { SettingsSnapshot } from "@client/src/runtime/settings/settings-service";
 import { defaultSettings } from "@client/src/defaultSettings";
 import type { CommandDispatcher, ExtensionCommand } from "@client/src/runtime/command-dispatcher";
@@ -430,6 +431,40 @@ export function selectCatalogDataset<T = unknown>(key: string) {
 
 export function useCatalogDataset<T = unknown>(key: string): CatalogDatasetSlice<T> | undefined {
     return useUiStore(selectCatalogDataset<T>(key));
+}
+
+export function useNpcDataset(): CatalogDatasetSlice<readonly NpcDefinition[]> | undefined {
+    return useCatalogDataset<readonly NpcDefinition[]>(NPC_DATASET_KEY);
+}
+
+export function useLoadNpcDataset(): (options?: CatalogLoadOptions) => Promise<void> {
+    const loadDataset = useUiStore((state) => state.loadDataset);
+    return useCallback((options?: CatalogLoadOptions) => loadDataset(NPC_DATASET_KEY, options), [loadDataset]);
+}
+
+export function useEnsureNpcDataset(): (options?: CatalogLoadOptions) => Promise<readonly NpcDefinition[]> {
+    const ensureDataset = useUiStore((state) => state.ensureDataset);
+    return useCallback(
+        (options?: CatalogLoadOptions) => ensureDataset<readonly NpcDefinition[]>(NPC_DATASET_KEY, options),
+        [ensureDataset],
+    );
+}
+
+export function useSyncNpcDataset(): () => void {
+    const syncDataset = useUiStore((state) => state.syncDataset);
+    return useCallback(() => syncDataset(NPC_DATASET_KEY), [syncDataset]);
+}
+
+export function ensureMapDataset(options?: CatalogLoadOptions): Promise<MapData.Map> {
+    return uiStore.getState().ensureDataset<MapData.Map>(MAP_DATASET_KEY, options);
+}
+
+export function ensureColorDataset(options?: CatalogLoadOptions): Promise<MapData.Env[]> {
+    return uiStore.getState().ensureDataset<MapData.Env[]>(COLORS_DATASET_KEY, options);
+}
+
+export function ensureNpcDataset(options?: CatalogLoadOptions): Promise<readonly NpcDefinition[]> {
+    return uiStore.getState().ensureDataset<readonly NpcDefinition[]>(NPC_DATASET_KEY, options);
 }
 
 export function useUiDispatch() {


### PR DESCRIPTION
## Summary
- add dedicated dataset key constants and typed `NpcDefinition`
- extend the shared data catalog with helper accessors for map, NPC and color datasets and expose typed store hooks/utilities
- update NPC options UI, bootstrap logic and tests to rely on the new helpers and make Jest resolve zustand from the workspace

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68eb97749bc8832aa552c31d2785b22c