### PR TITLE
Stop mutating stored package distances on catalog refresh

### DIFF
--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -2,6 +2,8 @@ import {colorStringInLine, findClosestColor, RESET} from "./Colors";
 import Client from "./Client";
 import { Trigger } from "./Triggers";
 import toTitleCase from "./utils/toTitleCase";
+import services from "./runtime/service-registry";
+import type { DefaultDataCatalog, NpcDefinition } from "./runtime/data";
 
 const tag = "packageHelper";
 const pickCommand = "wybierz paczke"
@@ -36,6 +38,7 @@ const UNKNOWN_NPC_COLOR = findClosestColor('#aaaaaa');
 export default class PackageHelper {
 
     private client: Client
+    private readonly catalog: DefaultDataCatalog
     npc: Record<string, number> = {}
     enabled = false;
 
@@ -53,11 +56,12 @@ export default class PackageHelper {
     private pickTrigger: Trigger;
     private failTrigger: Trigger;
 
-    constructor(clientExtension: Client) {
+    constructor(clientExtension: Client, catalog: DefaultDataCatalog = services.dataCatalog) {
         this.client = clientExtension
-        this.client.addEventListener('npc', (event) => {
-            event.detail.forEach((item: { name: string | number; loc: number; }) => this.npc[item.name] = item.loc)
-        })
+        this.catalog = catalog
+
+        this.subscribeToNpcCatalog()
+        this.applyInitialNpcData()
 
 
         this.client.addEventListener('settings', (event) => {
@@ -89,6 +93,30 @@ export default class PackageHelper {
             return colorStringInLine(rawLine, matches[1], colorCode)
         }, tag)
         this.client.Triggers.registerMultilineTrigger(packageTableRegex, this.packageTableCallback(), tag)
+    }
+
+    private subscribeToNpcCatalog() {
+        const ready$ = this.catalog.readyForNpc$()
+        ready$.subscribe(({ data }) => {
+            this.updateNpcData(data)
+        })
+    }
+
+    private applyInitialNpcData() {
+        const initial = this.catalog.getNpcData()
+        if (initial) {
+            this.updateNpcData(initial)
+        }
+    }
+
+    private updateNpcData(data: readonly NpcDefinition[]) {
+        this.npc = {}
+        data.forEach(({ name, loc }) => {
+            this.npc[name] = loc
+        })
+        if (this.currentPackage) {
+            this.leadToPackage(this.currentPackage.name)
+        }
     }
 
     private onPackageList() {

--- a/client/test/PackageHelper.test.ts
+++ b/client/test/PackageHelper.test.ts
@@ -1,9 +1,21 @@
+import { Subject } from 'rxjs';
 import PackageHelper from '../src/PackageHelper';
 import { colorStringInLine, findClosestColor } from '../src/Colors';
+import type { DataCatalogReadyEvent, NpcDefinition } from '../src/runtime/data';
 
 describe('PackageHelper', () => {
   let helper: any;
   let client: any;
+  let catalog: any;
+  let npcReady$: Subject<DataCatalogReadyEvent<readonly NpcDefinition[]>>;
+
+  const emitNpcData = (defs: readonly NpcDefinition[]) => {
+    npcReady$.next({
+      key: 'npc',
+      data: defs,
+      metadata: { key: 'npc', status: 'ready' },
+    } as DataCatalogReadyEvent<readonly NpcDefinition[]>);
+  };
 
   beforeEach(() => {
     (global as any).Input = { send: jest.fn() };
@@ -36,9 +48,29 @@ describe('PackageHelper', () => {
       FunctionalBind: { set: jest.fn(), clear: jest.fn(), newMessage: jest.fn() },
       sendCommand: jest.fn(),
     };
-    helper = new PackageHelper(client);
+    npcReady$ = new Subject<DataCatalogReadyEvent<readonly NpcDefinition[]>>();
+    catalog = {
+      readyForNpc$: jest.fn(() => npcReady$.asObservable()),
+      getNpcData: jest.fn(() => undefined),
+    };
+    helper = new PackageHelper(client, catalog);
     client.Triggers.registerTrigger.mockClear();
     client.Triggers.registerMultilineTrigger.mockClear();
+  });
+
+  test('updates NPC data and leads to current package when catalog emits event', () => {
+    helper.currentPackage = { name: 'Bob' } as any;
+    helper['packages'] = [{ name: 'Bob', time: undefined, distance: 7 }];
+    const leadSpy = jest.spyOn(helper as any, 'leadToPackage');
+
+    emitNpcData([
+      { name: 'Bob', loc: 123 },
+    ]);
+
+    expect(helper.npc).toEqual({ Bob: 123 });
+    expect(helper['packages'][0].distance).toBe(7);
+    expect(leadSpy).toHaveBeenCalledWith('Bob');
+    expect(client.addEventListener).not.toHaveBeenCalledWith('npc', expect.any(Function));
   });
 
   test('constructor initializes helper by default', () => {
@@ -63,7 +95,12 @@ describe('PackageHelper', () => {
       FunctionalBind: { set: jest.fn(), clear: jest.fn(), newMessage: jest.fn() },
       sendCommand: jest.fn(),
     };
-    const h = new PackageHelper(c as any);
+    const ready = new Subject<DataCatalogReadyEvent<readonly NpcDefinition[]>>();
+    const cat = {
+      readyForNpc$: jest.fn(() => ready.asObservable()),
+      getNpcData: jest.fn(() => undefined),
+    };
+    const h = new PackageHelper(c as any, cat as any);
     expect(c.Triggers.registerTrigger).toHaveBeenCalled();
     expect(h.enabled).toBe(true);
   });
@@ -152,6 +189,20 @@ describe('PackageHelper', () => {
     expect(registerSpy).toHaveBeenCalled();
   });
 
+  test('label trigger highlights known NPCs from catalog data', () => {
+    helper.init();
+    emitNpcData([{ name: 'Bob', loc: 123 }]);
+    const trigger = client.Triggers.registerTrigger.mock.calls[0][1];
+    const raw = 'Wypisano na niej duzymi literami: Bob';
+    const regex = /^Wypisano na niej duzymi literami: ([a-zA-Z ']+).*$/;
+    const match = raw.match(regex)!;
+
+    const result = trigger(raw, '', match);
+
+    const expectedColor = colorStringInLine(raw, 'Bob', findClosestColor('#63ba41'));
+    expect(result).toBe(expectedColor);
+  });
+
   test('label trigger does not overwrite current package when name matches', () => {
     helper.init();
     helper.currentPackage = { name: 'Bob', time: '5' } as any;
@@ -198,8 +249,10 @@ describe('PackageHelper', () => {
     client.contentWidth = 50;
     client.OutputHandler.makeClickable.mockImplementation(l => l);
 
-    helper.npc['Bob'] = 123;
-    helper.npc['Tom'] = 456;
+    emitNpcData([
+      { name: 'Bob', loc: 123 },
+      { name: 'Tom', loc: 456 },
+    ]);
     const cb = helper['packageTableCallback']();
     const raw =
       'Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:\n' +
@@ -228,8 +281,10 @@ describe('PackageHelper', () => {
     const originalUA = navigator.userAgent;
     Object.defineProperty(navigator, 'userAgent', { value: 'Android', configurable: true });
 
-    helper.npc['Bob'] = 123;
-    helper.npc['Tom'] = 456;
+    emitNpcData([
+      { name: 'Bob', loc: 123 },
+      { name: 'Tom', loc: 456 },
+    ]);
     const cb = helper['packageTableCallback']();
     const raw =
       'Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:\n' +
@@ -257,8 +312,10 @@ describe('PackageHelper', () => {
     client.contentWidth = 120;
     client.OutputHandler.makeClickable.mockImplementation(l => l);
 
-    helper.npc['Borgaf Kriegmann'] = 123;
-    helper.npc['Georg Blaskovitz'] = 456;
+    emitNpcData([
+      { name: 'Borgaf Kriegmann', loc: 123 },
+      { name: 'Georg Blaskovitz', loc: 456 },
+    ]);
     const cb = helper['packageTableCallback']();
     const raw =
       'Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:\n' +
@@ -313,7 +370,9 @@ describe('PackageHelper', () => {
   test('packageTableCallback keeps custom borders aligned', () => {
     client.contentWidth = 140;
     client.OutputHandler.makeClickable.mockImplementation(l => l);
-    helper.npc['Borgaf Kriegmann'] = 123;
+    emitNpcData([
+      { name: 'Borgaf Kriegmann', loc: 123 },
+    ]);
 
     const cb = helper['packageTableCallback']();
     const raw =


### PR DESCRIPTION
## Summary
- switch PackageHelper to use the shared data catalog for NPC locations instead of DOM events
- keep package guidance driven by catalog refreshes without recomputing stored package distances
- update PackageHelper tests to expect stable stored distances after catalog updates

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68eb9c77cbd0832a88a281acdb8ef8b4