### PR TITLE
Refactor MockPort NPC loader to use data catalog

### DIFF
--- a/web-client/src/MockPort.ts
+++ b/web-client/src/MockPort.ts
@@ -1,48 +1,49 @@
 import storage, { setItemSync, getItemSync } from "@client/src/storage";
+import services from "@client/src/runtime/service-registry";
+import type { NpcDefinition } from "@client/src/runtime/data";
 import { readMultibinds, replaceMultibinds } from "./multibindStorage";
 
-const DB_CONFIG = { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' } as const;
+const NPC_STORAGE_KEY = 'npc' as const;
 
-function openDb(): Promise<IDBDatabase> {
-    return new Promise((resolve, reject) => {
-        const request = indexedDB.open(DB_CONFIG.dbName, 1);
-        request.onupgradeneeded = () => {
-            const db = request.result;
-            if (!db.objectStoreNames.contains(DB_CONFIG.storeName)) {
-                db.createObjectStore(DB_CONFIG.storeName, { keyPath: 'id' });
-            }
-        };
-        request.onsuccess = () => resolve(request.result);
-        request.onerror = () => reject(new Error('Failed to open IndexedDB'));
-    });
-}
-
-async function getNpcs(): Promise<any[]> {
-    try {
-        const db = await openDb();
-        return new Promise((resolve, reject) => {
-            const tx = db.transaction([DB_CONFIG.storeName], 'readonly');
-            const store = tx.objectStore(DB_CONFIG.storeName);
-            const req = store.get(DB_CONFIG.key);
-            req.onsuccess = () => {
-                resolve(req.result ? req.result.data : []);
-            };
-            req.onerror = () => reject(new Error('Failed to read data'));
-        });
-    } catch {
+function normalizeNpcList(value: unknown): NpcDefinition[] {
+    if (!Array.isArray(value)) {
         return [];
     }
+
+    return value
+        .filter((entry): entry is NpcDefinition => Boolean(entry && typeof entry === 'object'))
+        .map((entry) => ({
+            name: String((entry as NpcDefinition).name ?? ''),
+            loc: Number((entry as NpcDefinition).loc ?? (entry as any).loc),
+        }))
+        .filter((entry) => entry.name.length > 0 && Number.isFinite(entry.loc));
 }
 
-async function saveNpcs(list: any[]) {
-    const db = await openDb();
-    return new Promise<void>((resolve, reject) => {
-        const tx = db.transaction([DB_CONFIG.storeName], 'readwrite');
-        const store = tx.objectStore(DB_CONFIG.storeName);
-        const req = store.put({ id: DB_CONFIG.key, data: list, timestamp: Date.now() });
-        req.onsuccess = () => resolve();
-        req.onerror = () => reject(new Error('Failed to store data'));
-    });
+function areNpcEntriesEqual(a: NpcDefinition, b: NpcDefinition): boolean {
+    return a.name === b.name && a.loc === b.loc;
+}
+
+function npcListsEqual(a: readonly NpcDefinition[], b: readonly NpcDefinition[]): boolean {
+    if (a.length !== b.length) {
+        return false;
+    }
+
+    for (let i = 0; i < a.length; i += 1) {
+        if (!areNpcEntriesEqual(a[i], b[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function getNpcCatalogData(): NpcDefinition[] {
+    const current = services.dataCatalog.getNpcData();
+    return Array.isArray(current) ? [...current] : [];
+}
+
+async function persistNpcCatalogData(list: readonly NpcDefinition[]): Promise<void> {
+    await services.dataCatalog.setNpcData(list, 'cache');
 }
 
 export default class MockPort {
@@ -60,7 +61,28 @@ export default class MockPort {
                 if (key === 'settings' || key === 'npc' || key === 'uiSettings' || key === 'binds') {
                     this.dispatch({[key]: newValue});
                 }
+                if (key === NPC_STORAGE_KEY) {
+                    const normalized = normalizeNpcList(newValue);
+                    const current = getNpcCatalogData();
+                    if (normalized.length === 0 && current.length === 0) {
+                        return;
+                    }
+                    if (!npcListsEqual(normalized, current)) {
+                        void persistNpcCatalogData(normalized).catch((error) => {
+                            console.error('Failed to sync NPC storage to catalog:', error);
+                        });
+                    }
+                }
             });
+        });
+
+        const initialNpc = getNpcCatalogData();
+        if (initialNpc.length > 0) {
+            this.broadcastNpc(initialNpc);
+        }
+
+        services.dataCatalog.readyForNpc$().subscribe(({ data }) => {
+            this.broadcastNpc(normalizeNpcList(data));
         });
     }
 
@@ -68,17 +90,29 @@ export default class MockPort {
         this.listeners.forEach(l => l(message));
     }
 
+    private broadcastNpc(list: readonly NpcDefinition[]): void {
+        const normalized = normalizeNpcList(list);
+        this.dispatch({ npc: normalized });
+        this.dispatch({ storage: { key: NPC_STORAGE_KEY, value: normalized } });
+    }
+
     postMessage(message: any) {
         if (message.type === 'NEW_NPC') {
-            getNpcs().then(async npc => {
-                npc = Array.isArray(npc) ? npc : [];
-                if (!npc.some((n: any) => n.name === message.name && n.loc === message.loc)) {
-                    npc.push({ name: message.name, loc: message.loc });
-                    await saveNpcs(npc);
-                }
-                this.dispatch({ npc });
-                this.dispatch({ storage: { key: 'npc', value: npc } });
-            }).catch(e => console.error('Failed to add NPC:', e));
+            const existing = getNpcCatalogData();
+            const trimmedName = String(message.name ?? '').trim();
+            const numericLoc = Number(message.loc);
+            if (!trimmedName || !Number.isFinite(numericLoc)) {
+                return;
+            }
+            const nextEntry: NpcDefinition = { name: trimmedName, loc: numericLoc };
+            if (!existing.some((npc) => areNpcEntriesEqual(npc, nextEntry))) {
+                existing.push(nextEntry);
+                void persistNpcCatalogData(existing).catch((error) => {
+                    console.error('Failed to add NPC:', error);
+                });
+            } else {
+                this.broadcastNpc(existing);
+            }
             return;
         }
         if (message.type === 'MULTIBINDS_LOAD') {
@@ -111,6 +145,10 @@ export default class MockPort {
     }
 
     private sendStorage(key: string) {
+        if (key === NPC_STORAGE_KEY) {
+            this.broadcastNpc(getNpcCatalogData());
+            return;
+        }
         const data = getItemSync(key);
         const value = data ? data[key] : {};
         this.dispatch({ storage: { key, value } });

--- a/web-client/test/MockPort.test.ts
+++ b/web-client/test/MockPort.test.ts
@@ -1,0 +1,123 @@
+import type { NpcDefinition } from "@client/src/runtime/data";
+import { Subject } from "rxjs";
+
+jest.mock("@client/src/runtime/service-registry", () => {
+  const { Subject } = jest.requireActual("rxjs");
+  let readySubject = new Subject();
+  const dataCatalog = {
+    readyForNpc$: jest.fn(() => readySubject.asObservable()),
+    getNpcData: jest.fn(),
+    setNpcData: jest.fn(() => Promise.resolve()),
+  };
+
+  return {
+    __esModule: true,
+    default: {
+      dataCatalog,
+    },
+    __dataCatalogMock: dataCatalog,
+    __setReadySubject: (nextSubject: typeof readySubject) => {
+      readySubject = nextSubject;
+    },
+    __getReadySubject: () => readySubject,
+  };
+});
+
+jest.mock("@client/src/storage", () => {
+  const listeners: Array<(changes: Record<string, { newValue: unknown }>) => void> = [];
+
+  return {
+    __esModule: true,
+    default: {
+      onChanged: {
+        addListener: (cb: (changes: Record<string, { newValue: unknown }>) => void) => {
+          listeners.push(cb);
+        },
+      },
+    },
+    setItemSync: jest.fn(),
+    getItemSync: jest.fn(() => ({})),
+    __storageListeners: listeners,
+  };
+});
+
+jest.mock("../src/multibindStorage", () => ({
+  readMultibinds: jest.fn(() => Promise.resolve([])),
+  replaceMultibinds: jest.fn((value: unknown) => Promise.resolve(value)),
+}));
+
+import MockPort from "../src/MockPort";
+
+const servicesModule = jest.requireMock("@client/src/runtime/service-registry") as any;
+const storageModule = jest.requireMock("@client/src/storage") as any;
+
+function setCatalogData(data: readonly NpcDefinition[]) {
+  servicesModule.__dataCatalogMock.getNpcData.mockReturnValue([...data]);
+}
+
+describe("MockPort NPC catalog integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    servicesModule.__setReadySubject(new Subject());
+    setCatalogData([]);
+  });
+
+  test("persists NPC additions through the data catalog", () => {
+    setCatalogData([{ name: "Existing", loc: 10 }]);
+    const port = new MockPort();
+
+    port.postMessage({ type: "NEW_NPC", name: "New", loc: 20 });
+
+    expect(servicesModule.__dataCatalogMock.setNpcData).toHaveBeenCalledWith(
+      [{ name: "Existing", loc: 10 }, { name: "New", loc: 20 }],
+      "cache",
+    );
+  });
+
+  test("ignores duplicate NPC additions", () => {
+    setCatalogData([{ name: "Existing", loc: 10 }]);
+    const port = new MockPort();
+
+    port.postMessage({ type: "NEW_NPC", name: "Existing", loc: 10 });
+
+    expect(servicesModule.__dataCatalogMock.setNpcData).not.toHaveBeenCalled();
+  });
+
+  test("dispatches NPC data when catalog emits readiness", () => {
+    const readySubject: Subject<{ data: readonly NpcDefinition[] }> = new Subject();
+    servicesModule.__setReadySubject(readySubject);
+    setCatalogData([]);
+    const port = new MockPort();
+    const listener = jest.fn();
+    port.onMessage.addListener(listener);
+
+    readySubject.next({ data: [{ name: "Ready", loc: 42 }] });
+
+    expect(listener).toHaveBeenCalledWith({ npc: [{ name: "Ready", loc: 42 }] });
+    expect(listener).toHaveBeenCalledWith({ storage: { key: "npc", value: [{ name: "Ready", loc: 42 }] } });
+  });
+
+  test("responds to storage requests using catalog data", () => {
+    setCatalogData([{ name: "Stored", loc: 5 }]);
+    const port = new MockPort();
+    const listener = jest.fn();
+    port.onMessage.addListener(listener);
+
+    port.postMessage({ type: "GET_STORAGE", key: "npc" });
+
+    expect(listener).toHaveBeenCalledWith({ npc: [{ name: "Stored", loc: 5 }] });
+    expect(listener).toHaveBeenCalledWith({ storage: { key: "npc", value: [{ name: "Stored", loc: 5 }] } });
+  });
+
+  test("syncs storage changes back into the catalog", () => {
+    const port = new MockPort();
+    const [listener] = storageModule.__storageListeners as Array<(changes: Record<string, { newValue: unknown }>) => void>;
+
+    listener({ npc: { newValue: [{ name: "Sync", loc: 99 }] } });
+
+    expect(servicesModule.__dataCatalogMock.setNpcData).toHaveBeenCalledWith(
+      [{ name: "Sync", loc: 99 }],
+      "cache",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- replace MockPort's bespoke IndexedDB NPC loader with the shared data catalog integration and normalized event dispatching
- add Jest coverage that exercises NPC catalog persistence, readiness broadcasts, and storage synchronisation

## Testing
- yarn --cwd web-client test
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68ebc4ddbea4832aa909e249a737094f