### PR TITLE
Refactor inventory list to use ui store

### DIFF
--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -1,9 +1,39 @@
-import Client from "@client/src/Client";
 import { getItemSync, setItemSync } from "@client/src/storage";
 import { COLOR_OBJECT, getColorLevel } from "./colors.ts";
+import type { UiStoreState, NearbyObject } from "./ui/store";
+import { uiStore, selectNearbyObjects, selectAttackQueue } from "./ui/store";
+
+type ObjectListStore = {
+    getState: () => UiStoreState;
+    subscribe: typeof uiStore.subscribe;
+};
+
+interface ObjectListDependencies {
+    store?: ObjectListStore;
+}
+
+function areStringArraysEqual(a: readonly string[], b: readonly string[] | undefined): boolean {
+    if (!Array.isArray(b)) {
+        return false;
+    }
+    if (a.length !== b.length) {
+        return false;
+    }
+    for (let i = 0; i < a.length; i += 1) {
+        if (a[i] !== b[i]) {
+            return false;
+        }
+    }
+    return true;
+}
 
 export default class ObjectList {
-    private client: Client;
+    private readonly store: ObjectListStore;
+    private readonly sendCommand: UiStoreState["sendCommand"];
+    private nearbyObjects: readonly NearbyObject[];
+    private attackQueue: readonly string[];
+    private unsubscribeNearby?: () => void;
+    private unsubscribeAttackQueue?: () => void;
     private readonly container: HTMLElement | null;
     private readonly content: HTMLElement | null;
     private isDragging = false;
@@ -20,8 +50,11 @@ export default class ObjectList {
     private pipStyleObserver: MutationObserver | null = null;
     private pipTitleObserver: MutationObserver | null = null;
 
-    constructor(client: Client) {
-        this.client = client;
+    constructor({ store = uiStore }: ObjectListDependencies = {}) {
+        this.store = store;
+        this.sendCommand = this.store.getState().sendCommand;
+        this.nearbyObjects = this.store.getState().nearbyObjects;
+        this.attackQueue = this.store.getState().attackQueue;
         this.container = document.getElementById("objects-list");
         this.content = this.setupContainer();
         this.isMobile = this.isMobileBrowser();
@@ -30,10 +63,28 @@ export default class ObjectList {
             this.container?.addEventListener("click", this.onClick);
         }
         window.addEventListener("resize", this.clampToViewport);
-        this.client.addEventListener("attackQueueChange", () => this.render());
-        this.client.addEventListener("gmcp.objects.nums", () => this.render());
-        this.client.addEventListener("gmcp.objects.data", () => this.render());
-        this.client.addEventListener("gmcp.char.state", () => this.render());
+        this.unsubscribeNearby = this.store.subscribe(
+            selectNearbyObjects,
+            (objects, previous) => {
+                if (objects === previous) {
+                    return;
+                }
+                this.nearbyObjects = objects;
+                this.render();
+            },
+            { fireImmediately: false },
+        );
+        this.unsubscribeAttackQueue = this.store.subscribe(
+            selectAttackQueue,
+            (queue, previous) => {
+                if (areStringArraysEqual(queue, previous)) {
+                    return;
+                }
+                this.attackQueue = queue;
+                this.render();
+            },
+            { fireImmediately: false },
+        );
         this.render();
     }
 
@@ -189,7 +240,7 @@ export default class ObjectList {
         if (numEl) {
             const num = numEl.getAttribute("data-object-num");
             if (num) {
-                this.client.sendCommand(`/z ${num}`);
+                this.sendCommand(`/z ${num}`);
             }
             return;
         }
@@ -199,34 +250,29 @@ export default class ObjectList {
         if (descEl) {
             const num = descEl.getAttribute("data-object-num");
             if (num) {
-                this.client.sendCommand(`/za ${num}`);
+                this.sendCommand(`/za ${num}`);
             }
         }
     };
 
     private render() {
         if (!this.container || !this.content) return;
-        const manager = this.client.ObjectManager;
-        if (!manager) return;
-        const objects = manager.getObjectsOnLocation();
-        const descWidth = Math.max(0, ...objects.map((o: any) => (o.desc || "").length));
-        const tm = this.client.TeamManager;
-        const nextQueuedId = tm?.getEnemyQueue?.()?.[0];
+        const objects = this.nearbyObjects;
+        const descWidth = Math.max(0, ...objects.map((obj) => (obj.desc ?? "").length));
+        const nextQueuedId = this.attackQueue[0];
         const nextQueuedIdString = typeof nextQueuedId === "undefined" ? undefined : String(nextQueuedId);
-        const teamAttacking = objects.some((o: any) => {
-            return tm?.isInTeam?.(o.desc) && o.attack_num !== false && o.attack_num !== undefined;
+        const teamAttacking = objects.some((obj) => {
+            return obj.team && obj.attackNum !== false && typeof obj.attackNum !== "undefined";
         });
-        const inCombat = objects.some(
-            (o: any) => o.attack_num !== false && o.attack_num !== undefined
-        );
 
-        const lines = objects.map((obj: any) => {
-            const num = String(obj.shortcut);
-            const isPlayer = obj.shortcut === '@';
+        const lines = objects.map((obj) => {
+            const shortcut = typeof obj.shortcut === "string" ? obj.shortcut : String(obj.shortcut ?? "");
+            const num = shortcut;
+            const isPlayer = shortcut === "@";
             let prefix = "  ";
-            if (obj.attack_target) {
+            if (obj.attackTarget) {
                 prefix = `<span style="color:orangered">>></span>`;
-            } else if (obj.defense_target) {
+            } else if (obj.defenseTarget) {
                 prefix = `<span style="color:greenyellow">>></span>`;
             }
             const isNextQueued =
@@ -242,13 +288,13 @@ export default class ObjectList {
             const numLabel = isPlayer
                 ? `${prefix}${num}`
                 : `${prefix}<span class="${numClasses.join(" ")}" data-object-id="${obj.num}" data-object-num="${num}"${numStyle}>${num}</span>`;
-            const rawDesc = obj.desc || "";
+            const rawDesc = obj.desc ?? "";
             let coloredDesc = rawDesc;
             if (!isPlayer) {
-                if (obj.avatar_target) {
+                if (obj.avatarTarget) {
                     coloredDesc = `<span style="color:#ffaaaa">${rawDesc}</span>`;
-                } else if (tm?.isInTeam?.(rawDesc)) {
-                    const isAttacking = obj.attack_num !== false && obj.attack_num !== undefined;
+                } else if (obj.team) {
+                    const isAttacking = obj.attackNum !== false && typeof obj.attackNum !== "undefined";
                     let style = "color:springgreen";
                     const classes = [] as string[];
                     if (teamAttacking && !isAttacking) {
@@ -258,14 +304,14 @@ export default class ObjectList {
                     coloredDesc = `<span${classAttr} style="${style}">${rawDesc}</span>`;
                 } else if (
                     typeof obj.state === "number" &&
-                    obj.attack_num !== false &&
-                    obj.attack_num !== undefined
+                    obj.attackNum !== false &&
+                    typeof obj.attackNum !== "undefined"
                 ) {
                     coloredDesc = `<span style="color:#b19cd9">${rawDesc}</span>`;
                 }
             }
             const padding = " ".repeat(Math.max(0, descWidth - rawDesc.length));
-            const isTeammate = tm?.isInTeam?.(rawDesc) ? "true" : "false";
+            const isTeammate = obj.team ? "true" : "false";
             const desc = isPlayer
                 ? `${rawDesc}${padding}`
                 : `<span class="object-desc" data-object-id="${obj.num}" data-object-num="${num}" data-object-desc="${rawDesc}" data-teammate="${isTeammate}">${coloredDesc}</span>${padding}`;
@@ -279,8 +325,23 @@ export default class ObjectList {
                 bar = `[<span style="color:${color}">${filled}${empty}</span>]`;
             }
             const attackers = objects
-                .filter((o: any) => o.attack_num === obj.num)
-                .map((o: any) => o.shortcut);
+                .filter((entry) => {
+                    if (entry === obj) {
+                        return false;
+                    }
+                    if (typeof entry.attackNum === "undefined" || entry.attackNum === false) {
+                        return false;
+                    }
+                    if (typeof obj.num === "undefined") {
+                        return false;
+                    }
+                    if (typeof entry.attackNum === "number" || typeof entry.attackNum === "string") {
+                        return String(entry.attackNum) === String(obj.num);
+                    }
+                    return false;
+                })
+                .map((entry) => entry.shortcut)
+                .filter((value): value is string => typeof value === "string");
             const arrow = attackers.length ? ` <- ${attackers.join(" ")}` : "";
             return `${numLabel} ${bar} ${desc}${arrow}`.trimEnd();
         });

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -1053,7 +1053,7 @@ document.addEventListener('DOMContentLoaded', () => {
     new PackageStatus(arkadiaClient);
     const fightTitle = new FightTitle(arkadiaClient);
     new HpTitle(arkadiaClient, fightTitle);
-    new ObjectList(client);
+    new ObjectList();
     new LetterComposer(arkadiaClient);
 
     // Initialize mobile direction buttons

--- a/web-client/src/ui/store.ts
+++ b/web-client/src/ui/store.ts
@@ -230,6 +230,7 @@ export interface UiStoreState {
     playerObjectId?: string;
     nearbyObjects: readonly NearbyObject[];
     teamStatus: TeamStatus;
+    attackQueue: readonly string[];
     commandDispatcher: CommandDispatcher | null;
     setCommandDispatcher: (dispatcher: CommandDispatcher | null) => void;
     sendCommand: (command: string, options?: { echo?: boolean }) => void;
@@ -298,6 +299,7 @@ const baseState = {
     playerObjectId: defaultObjectsState.playerId,
     nearbyObjects: [] as NearbyObject[],
     teamStatus: { ...emptyTeamStatus },
+    attackQueue: [] as string[],
     datasets: {} as Record<string, CatalogDatasetSlice<unknown>>,
 };
 
@@ -718,9 +720,7 @@ function subscribeToRuntime() {
 
 subscribeToRuntime();
 subscribeToCatalog();
-let uiSettingsCleanup: ListenerCleanup | null = null;
-let uiSettingsListener: EventListener | null = null;
-let lastClient: ClientLike | null = null;
+let clientEventCleanups: ListenerCleanup[] = [];
 
 type ClientLike = {
     addEventListener: (
@@ -740,9 +740,12 @@ export function bindUiStoreToClientEvents(client: ClientLike | null | undefined)
         return;
     }
 
-    uiSettingsCleanup?.();
+    clientEventCleanups.forEach((cleanup) => cleanup());
+    clientEventCleanups = [];
 
-    const listener: EventListener = (event: Event) => {
+    const cleanups: ListenerCleanup[] = [];
+
+    const handleUiSettings: EventListener = (event: Event) => {
         const detail = (event as CustomEvent).detail ?? {};
         const next: Partial<UiPreferences> = {};
         if (typeof detail.emojiLabels === "boolean") {
@@ -761,25 +764,36 @@ export function bindUiStoreToClientEvents(client: ClientLike | null | undefined)
         }
     };
 
-    client.addEventListener("uiSettings", listener);
-    uiSettingsListener = listener;
-    lastClient = client;
-    uiSettingsCleanup = () => {
+    client.addEventListener("uiSettings", handleUiSettings);
+    cleanups.push(() => {
         if (typeof client.removeEventListener === "function") {
-            client.removeEventListener("uiSettings", listener);
+            client.removeEventListener("uiSettings", handleUiSettings);
         }
-        uiSettingsListener = null;
-        lastClient = null;
+    });
+
+    const handleAttackQueueChange: EventListener = (event: Event) => {
+        const detail = (event as CustomEvent).detail;
+        if (Array.isArray(detail)) {
+            const normalized = detail.map((entry) => String(entry));
+            store.setState({ attackQueue: normalized });
+        }
     };
+
+    client.addEventListener("attackQueueChange", handleAttackQueueChange);
+    cleanups.push(() => {
+        if (typeof client.removeEventListener === "function") {
+            client.removeEventListener("attackQueueChange", handleAttackQueueChange);
+        }
+    });
+
+    clientEventCleanups = cleanups;
 }
 
 export const uiStore = storeWithSelector;
 
 export function resetUiStoreForTesting() {
-    uiSettingsCleanup?.();
-    uiSettingsCleanup = null;
-    uiSettingsListener = null;
-    lastClient = null;
+    clientEventCleanups.forEach((cleanup) => cleanup());
+    clientEventCleanups = [];
     runtimeCleanup?.();
     runtimeCleanup = null;
     catalogSubscription?.unsubscribe();
@@ -792,6 +806,7 @@ export function resetUiStoreForTesting() {
         playerObjectId: undefined,
         nearbyObjects: [],
         teamStatus: { ...emptyTeamStatus },
+        attackQueue: [],
         commandDispatcher: null,
     });
     subscribeToRuntime();
@@ -813,6 +828,8 @@ export function useCatalogDataset<T = unknown>(key: string): CatalogDatasetSlice
 export const selectNearbyObjects = (state: UiStoreState) => state.nearbyObjects;
 
 export const selectTeamStatus = (state: UiStoreState) => state.teamStatus;
+
+export const selectAttackQueue = (state: UiStoreState) => state.attackQueue;
 
 export function useNearbyObjects(): readonly NearbyObject[] {
     return useUiStore((state) => state.nearbyObjects);

--- a/web-client/test/ObjectList.test.ts
+++ b/web-client/test/ObjectList.test.ts
@@ -1,22 +1,37 @@
 import ObjectList from '../src/ObjectList';
 import { getItemSync, setItemSync } from '@client/src/storage';
-import ObjectManager from '@client/src/ObjectManager';
-import { EventEmitter } from 'events';
+import type { NearbyObject } from '../src/ui/store';
+import { uiStore, resetUiStoreForTesting } from '../src/ui/store';
+import type { CommandDispatcher } from '@client/src/runtime/command-dispatcher';
 
 jest.mock('@client/src/storage', () => ({
   getItemSync: jest.fn(),
   setItemSync: jest.fn(),
 }));
 
-class MockClient {
-  ObjectManager = { getObjectsOnLocation: () => [] as any[] };
-  TeamManager = { isInTeam: (_d: string) => false, getEnemyQueue: () => [] as string[] };
-  addEventListener() {}
-  sendCommand = jest.fn();
+function setNearbyObjects(objects: NearbyObject[]) {
+  uiStore.setState({ nearbyObjects: objects });
+}
+
+function setAttackQueue(queue: string[]) {
+  uiStore.setState({ attackQueue: queue });
+}
+
+function createDispatcher(): CommandDispatcher {
+  return {
+    sendCommand: jest.fn(),
+    sendEvent: jest.fn(),
+    sendExtensionCommand: jest.fn().mockReturnValue(false),
+  };
 }
 
 describe('ObjectList', () => {
+  let dispatcher: CommandDispatcher;
+
   beforeEach(() => {
+    resetUiStoreForTesting();
+    dispatcher = createDispatcher();
+    uiStore.getState().setCommandDispatcher(dispatcher);
     (getItemSync as jest.Mock).mockReset();
     (setItemSync as jest.Mock).mockReset();
     document.body.innerHTML = '';
@@ -26,14 +41,12 @@ describe('ObjectList', () => {
 
   test('non team members not fighting are not purple', () => {
     document.body.innerHTML = '<div id="objects-list"></div>';
-    const client = new MockClient();
-    const objectList = new ObjectList(client as any);
-    const objects = [
-      { shortcut: '1', desc: 'Goblin', state: 10 },
-      { shortcut: '2', desc: 'Orc', state: 10, attack_num: true },
+    new ObjectList();
+    const objects: NearbyObject[] = [
+      { id: '1', num: 1, shortcut: '1', desc: 'Goblin', state: 10 } as NearbyObject,
+      { id: '2', num: 2, shortcut: '2', desc: 'Orc', state: 10, attackNum: true } as NearbyObject,
     ];
-    client.ObjectManager.getObjectsOnLocation = () => objects;
-    (objectList as any).render();
+    setNearbyObjects(objects);
     const html = (
       document.querySelector('#objects-list .objects-list-content') as HTMLElement
     ).innerHTML.split('<br>');
@@ -56,8 +69,7 @@ describe('ObjectList', () => {
       width: container.offsetWidth,
       height: container.offsetHeight,
     });
-    const client = new MockClient();
-    new ObjectList(client as any);
+    new ObjectList();
     expect(container.style.left).toBe('700px');
     expect(container.style.top).toBe('50px');
   });
@@ -78,8 +90,7 @@ describe('ObjectList', () => {
     });
     container.setPointerCapture = jest.fn();
     container.releasePointerCapture = jest.fn();
-    const client = new MockClient();
-    const ol: any = new ObjectList(client as any);
+    const ol: any = new ObjectList();
     const downEvent = {
       clientX: 0,
       clientY: 0,
@@ -96,11 +107,11 @@ describe('ObjectList', () => {
     document.body.innerHTML = '<div id="objects-list"></div>';
     const container = document.getElementById('objects-list') as any;
     container.setPointerCapture = jest.fn();
-    const client = new MockClient();
-    const ol: any = new ObjectList(client as any);
-    const objects = [{ shortcut: '1', desc: 'Goblin', num: 1 }];
-    client.ObjectManager.getObjectsOnLocation = () => objects;
-    (ol as any).render();
+    const ol: any = new ObjectList();
+    const objects: NearbyObject[] = [
+      { id: '1', num: 1, shortcut: '1', desc: 'Goblin' } as NearbyObject,
+    ];
+    setNearbyObjects(objects);
     const num = document.querySelector('.object-num') as HTMLElement;
     const downEventNum = {
       pointerId: 1,
@@ -126,52 +137,49 @@ describe('ObjectList', () => {
 
   test('clicking number attacks that target', () => {
     document.body.innerHTML = '<div id="objects-list"></div>';
-    const client = new MockClient();
-    const objectList = new ObjectList(client as any);
-    const objects = [ { shortcut: '1', desc: 'Orc', num: 123 } ];
-    client.ObjectManager.getObjectsOnLocation = () => objects;
-    (objectList as any).render();
+    new ObjectList();
+    const objects: NearbyObject[] = [
+      { id: '123', num: 123, shortcut: '1', desc: 'Orc' } as NearbyObject,
+    ];
+    setNearbyObjects(objects);
     const num = document.querySelector('.object-num[data-object-num="1"]') as HTMLElement;
     num.click();
-    expect(client.sendCommand).toHaveBeenCalledWith('/z 1');
+    expect(dispatcher.sendCommand).toHaveBeenCalledWith('/z 1', undefined);
   });
 
   test('clicking teammate shields them', () => {
     document.body.innerHTML = '<div id="objects-list"></div>';
-    const client = new MockClient();
-    client.TeamManager.isInTeam = (d: string) => d === 'Ally';
-    const objectList = new ObjectList(client as any);
-    const objects = [ { shortcut: '1', desc: 'Ally', num: 42 } ];
-    client.ObjectManager.getObjectsOnLocation = () => objects;
-    (objectList as any).render();
+    new ObjectList();
+    const objects: NearbyObject[] = [
+      { id: '42', num: 42, shortcut: '1', desc: 'Ally', team: true } as NearbyObject,
+    ];
+    setNearbyObjects(objects);
     const desc = document.querySelector('.object-desc[data-object-num="1"]') as HTMLElement;
     desc.click();
-    expect(client.sendCommand).toHaveBeenCalledWith('/za 1');
+    expect(dispatcher.sendCommand).toHaveBeenCalledWith('/za 1', undefined);
   });
 
   test('clicking enemy shields against them', () => {
     document.body.innerHTML = '<div id="objects-list"></div>';
-    const client = new MockClient();
-    const objectList = new ObjectList(client as any);
-    const objects = [ { shortcut: '1', desc: 'Goblin', num: 77 } ];
-    client.ObjectManager.getObjectsOnLocation = () => objects;
-    (objectList as any).render();
+    new ObjectList();
+    const objects: NearbyObject[] = [
+      { id: '77', num: 77, shortcut: '1', desc: 'Goblin' } as NearbyObject,
+    ];
+    setNearbyObjects(objects);
     const desc = document.querySelector('.object-desc[data-object-num="1"]') as HTMLElement;
     desc.click();
-    expect(client.sendCommand).toHaveBeenCalledWith('/za 1');
+    expect(dispatcher.sendCommand).toHaveBeenCalledWith('/za 1', undefined);
   });
 
   test('highlights next queued enemy number in gold', () => {
     document.body.innerHTML = '<div id="objects-list"></div>';
-    const client = new MockClient();
-    client.TeamManager.getEnemyQueue = () => ['123'];
-    const objectList = new ObjectList(client as any);
-    const objects = [
-      { shortcut: '1', desc: 'Ork', num: 123 },
-      { shortcut: '2', desc: 'Goblin', num: 456 },
+    new ObjectList();
+    const objects: NearbyObject[] = [
+      { id: '123', num: 123, shortcut: '1', desc: 'Ork' } as NearbyObject,
+      { id: '456', num: 456, shortcut: '2', desc: 'Goblin' } as NearbyObject,
     ];
-    client.ObjectManager.getObjectsOnLocation = () => objects;
-    (objectList as any).render();
+    setNearbyObjects(objects);
+    setAttackQueue(['123']);
     const highlighted = document.querySelector(
       '.object-num[data-object-id="123"]',
     ) as HTMLElement;
@@ -182,40 +190,27 @@ describe('ObjectList', () => {
 
   test('player object is not clickable', () => {
     document.body.innerHTML = '<div id="objects-list"></div>';
-    const client = new MockClient();
-    const objectList = new ObjectList(client as any);
-    const objects = [ { shortcut: '@', desc: 'Hero', num: 99 } ];
-    client.ObjectManager.getObjectsOnLocation = () => objects;
-    (objectList as any).render();
+    new ObjectList();
+    const objects: NearbyObject[] = [
+      { id: '99', num: 99, shortcut: '@', desc: 'Hero' } as NearbyObject,
+    ];
+    setNearbyObjects(objects);
     expect(document.querySelector('.object-num[data-object-id="99"]')).toBeNull();
     expect(document.querySelector('.object-desc[data-object-id="99"]')).toBeNull();
     const content = document.querySelector('#objects-list .objects-list-content') as HTMLElement;
     content.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    expect(client.sendCommand).not.toHaveBeenCalled();
+    expect(dispatcher.sendCommand).not.toHaveBeenCalled();
   });
 
   test('moves non-combat objects to the end with shortcuts starting at 50', () => {
     document.body.innerHTML = '<div id="objects-list"></div>';
-    class TestClient {
-      private emitter = new EventEmitter();
-      ObjectManager = new ObjectManager(this as any);
-      TeamManager = { isInTeam: (_d: string) => false };
-      sendCommand = jest.fn();
-      addEventListener(event: string, cb: any) {
-        this.emitter.on(event, cb);
-      }
-      sendEvent(type: string, detail?: any) {
-        this.emitter.emit(type, { detail });
-      }
-    }
-    const client = new TestClient();
-    new ObjectList(client as any);
-    client.sendEvent('gmcp.objects.data', {
-      '1': { desc: 'Fighter', attack_num: true },
-      '2': { desc: 'Rock' },
-      '3': { desc: 'Tree' },
-    });
-    client.sendEvent('gmcp.objects.nums', ['1', '2', '3']);
+    new ObjectList();
+    const objects: NearbyObject[] = [
+      { id: '1', num: 1, shortcut: '1', desc: 'Fighter', attackNum: 1 } as NearbyObject,
+      { id: '2', num: 2, shortcut: '50', desc: 'Rock' } as NearbyObject,
+      { id: '3', num: 3, shortcut: '51', desc: 'Tree' } as NearbyObject,
+    ];
+    setNearbyObjects(objects);
     const html = (
       document.querySelector('#objects-list .objects-list-content') as HTMLElement
     ).innerHTML.split('<br>');
@@ -226,8 +221,7 @@ describe('ObjectList', () => {
 
   test('hides picture-in-picture control when unsupported', () => {
     document.body.innerHTML = '<div id="objects-list"></div>';
-    const client = new MockClient();
-    new ObjectList(client as any);
+    new ObjectList();
     expect(document.getElementById('objects-list-pip-button')).toBeNull();
     const container = document.getElementById('objects-list') as HTMLElement;
     expect(container.classList.contains('objects-list-pip-supported')).toBe(false);
@@ -251,16 +245,16 @@ describe('ObjectList', () => {
     const requestWindow = jest.fn().mockResolvedValue(pipWindow);
     (window as any).documentPictureInPicture = { requestWindow };
 
-    const client = new MockClient();
-    const objectList = new ObjectList(client as any);
+    new ObjectList();
     const container = document.getElementById('objects-list') as HTMLElement;
     expect(container.classList.contains('objects-list-pip-supported')).toBe(true);
     const button = document.getElementById('objects-list-pip-button') as HTMLButtonElement;
     expect(button).toBeTruthy();
 
-    const objects = [ { shortcut: '1', desc: 'Orc', num: 123 } ];
-    client.ObjectManager.getObjectsOnLocation = () => objects;
-    (objectList as any).render();
+    const objects: NearbyObject[] = [
+      { id: '123', num: 123, shortcut: '1', desc: 'Orc' } as NearbyObject,
+    ];
+    setNearbyObjects(objects);
 
     button.click();
     await Promise.resolve();
@@ -292,13 +286,12 @@ describe('ObjectList', () => {
     const requestWindow = jest.fn().mockResolvedValue(pipWindow);
     (window as any).documentPictureInPicture = { requestWindow };
 
-    const client = new MockClient();
-    const objectList = new ObjectList(client as any);
+    const objectList: any = new ObjectList();
     const button = document.getElementById('objects-list-pip-button') as HTMLButtonElement;
-    client.ObjectManager.getObjectsOnLocation = () => [
-      { shortcut: '1', desc: 'Goblin', num: 7 },
+    const objects: NearbyObject[] = [
+      { id: '7', num: 7, shortcut: '1', desc: 'Goblin' } as NearbyObject,
     ];
-    (objectList as any).render();
+    setNearbyObjects(objects);
 
     button.click();
     await Promise.resolve();
@@ -306,12 +299,12 @@ describe('ObjectList', () => {
     const pipNum = pipDoc.body.querySelector('.object-num[data-object-num="1"]') as HTMLElement;
     expect(pipNum).toBeTruthy();
     pipNum.click();
-    expect(client.sendCommand).toHaveBeenCalledWith('/z 1');
+    expect(dispatcher.sendCommand).toHaveBeenCalledWith('/z 1', undefined);
 
     const pipDesc = pipDoc.body.querySelector('.object-desc[data-object-num="1"]') as HTMLElement;
     expect(pipDesc).toBeTruthy();
     pipDesc.click();
-    expect(client.sendCommand).toHaveBeenCalledWith('/za 1');
+    expect(dispatcher.sendCommand).toHaveBeenCalledWith('/za 1', undefined);
 
     const foreignTarget = {
       nodeType: Node.ELEMENT_NODE,
@@ -334,8 +327,8 @@ describe('ObjectList', () => {
         return null;
       },
     } as unknown as HTMLElement;
-    (objectList as any).onClick({ target: foreignTarget } as unknown as MouseEvent);
-    expect(client.sendCommand).toHaveBeenCalledWith('/z 1');
+    objectList.onClick({ target: foreignTarget } as unknown as MouseEvent);
+    expect(dispatcher.sendCommand).toHaveBeenCalledWith('/z 1', undefined);
 
     delete (window as any).documentPictureInPicture;
   });
@@ -353,8 +346,7 @@ describe('ObjectList', () => {
     const requestWindow = jest.fn().mockResolvedValue(pipWindow);
     (window as any).documentPictureInPicture = { requestWindow };
 
-    const client = new MockClient();
-    new ObjectList(client as any);
+    new ObjectList();
     const button = document.getElementById('objects-list-pip-button') as HTMLButtonElement;
     button.click();
     await Promise.resolve();


### PR DESCRIPTION
## Summary
- refactor the ObjectList inventory widget to subscribe to uiStore selectors, render from NearbyObject data, and dispatch commands through the store while respecting the shared attack queue state【F:web-client/src/ObjectList.ts†L1-L353】
- extend the ui store with an attackQueue slice, a client event binding, and a selector so UI components can highlight queued targets without touching window.clientExtension【F:web-client/src/ui/store.ts†L223-L832】
- adjust main initialization and the ObjectList unit tests to use the shared store and command dispatcher instead of mock clients【F:web-client/src/main.ts†L1040-L1067】【F:web-client/test/ObjectList.test.ts†L1-L334】

## Testing
- yarn --cwd web-client test ObjectList.test.ts【f87d25†L1-L20】
- yarn --cwd web-client build【7cec29†L1-L15】

------
https://chatgpt.com/codex/tasks/task_e_68ebc4deca00832aa745e14f757aa03e