### PR TITLE
Introduce runtime bootstrap helper for the web client

### DIFF
--- a/client/src/runtime/command-dispatcher.ts
+++ b/client/src/runtime/command-dispatcher.ts
@@ -1,4 +1,4 @@
-import type Client from "@client/src/Client";
+import type Client from "../Client";
 
 export interface MultibindPortRecord {
     roomId: number;

--- a/client/src/runtime/createRuntimeBootstrap.ts
+++ b/client/src/runtime/createRuntimeBootstrap.ts
@@ -1,0 +1,76 @@
+import Client from "../Client";
+import type { ClientAdapter } from "../Client";
+
+import type { CommandDispatcher } from "./command-dispatcher";
+import type { DefaultDataCatalog, DataCatalogEntryMetadata } from "./data";
+import type { EventHub, RuntimeEvents } from "./event-hub";
+import type MessageRouter from "./transport/message-router";
+import type { TransportAdapter } from "./transport/types";
+import services, { ServiceRegistry } from "./service-registry";
+
+interface AdapterConfiguration {
+    transport: TransportAdapter;
+    router: MessageRouter;
+    eventHub: EventHub<RuntimeEvents>;
+}
+
+export interface RuntimeBootstrapOptions {
+    clientAdapter: ClientAdapter;
+    port?: unknown;
+    parseAnsiPatterns: (text: string) => string;
+    transformLine?: (text: string, type: string) => string;
+    registry?: ServiceRegistry;
+    transportFactory?: () => TransportAdapter;
+    configureAdapter?: (configuration: AdapterConfiguration) => void;
+}
+
+export interface RuntimeBootstrapResult {
+    registry: ServiceRegistry;
+    client: Client;
+    eventHub: EventHub<RuntimeEvents>;
+    commandDispatcher: CommandDispatcher;
+    dataCatalog: DefaultDataCatalog;
+    catalogMetadata: {
+        map: DataCatalogEntryMetadata | undefined;
+        npc: DataCatalogEntryMetadata | undefined;
+        colors: DataCatalogEntryMetadata | undefined;
+    };
+}
+
+export function createRuntimeBootstrap(options: RuntimeBootstrapOptions): RuntimeBootstrapResult {
+    const registry = options.registry ?? services;
+
+    if (options.transportFactory) {
+        registry.configureTransport(options.transportFactory);
+    }
+
+    const eventHub = registry.eventHub;
+    const client = new Client(options.clientAdapter, options.port, eventHub);
+
+    const hasTransformOverride = Object.prototype.hasOwnProperty.call(options, "transformLine");
+    const transformLine = hasTransformOverride ? options.transformLine : client.onLine.bind(client);
+
+    const router = registry.configureMessageRouter({
+        parseAnsiPatterns: options.parseAnsiPatterns,
+        transformLine,
+    });
+
+    options.configureAdapter?.({
+        transport: registry.transport,
+        router,
+        eventHub,
+    });
+
+    const commandDispatcher = registry.getCommandDispatcher(client);
+
+    return {
+        registry,
+        client,
+        eventHub,
+        commandDispatcher,
+        dataCatalog: registry.dataCatalog,
+        catalogMetadata: registry.getCatalogMetadata(),
+    };
+}
+
+export default createRuntimeBootstrap;

--- a/client/src/runtime/service-registry.ts
+++ b/client/src/runtime/service-registry.ts
@@ -1,23 +1,132 @@
-import { DefaultDataCatalog, registerCoreLoaders } from './data';
-import type { SettingsService } from './settings/settings-service';
-import { LocalStorageSettingsService } from './settings/local-storage-service';
+import type Client from "../Client";
+import { ClientCommandDispatcher } from "./command-dispatcher";
+import type { CommandDispatcher } from "./command-dispatcher";
+import { DefaultDataCatalog, registerCoreLoaders } from "./data";
+import type { DataCatalogEntryMetadata } from "./data";
+import type { EventHub } from "./event-hub";
+import { runtimeEventHub } from "./event-hub";
+import MessageRouter from "./transport/message-router";
+import type { MessageRouterOptions } from "./transport/message-router";
+import type { TransportAdapter } from "./transport/types";
+import WebSocketTransportAdapter from "./transport/websocket-adapter";
+import type { SettingsService } from "./settings/settings-service";
+import { LocalStorageSettingsService } from "./settings/local-storage-service";
+import type { RuntimeEvents } from "./event-hub";
+
+export type RouterConfiguration = Pick<MessageRouterOptions, "parseAnsiPatterns" | "transformLine">;
+type TransportFactory = () => TransportAdapter;
+type CommandDispatcherFactory = (client: Client) => CommandDispatcher;
+
+export interface ServiceRegistryOptions {
+    transportFactory?: TransportFactory;
+    eventHub?: EventHub<RuntimeEvents>;
+    commandDispatcherFactory?: CommandDispatcherFactory;
+    router?: RouterConfiguration;
+}
 
 class ServiceRegistry {
     readonly settings: SettingsService;
     private readonly catalog: DefaultDataCatalog;
+    private readonly internalEventHub: EventHub<RuntimeEvents>;
 
-    constructor() {
+    private transportFactory: TransportFactory;
+    private transportInstance?: TransportAdapter;
+
+    private routerConfig: RouterConfiguration;
+    private router?: MessageRouter;
+
+    private readonly commandDispatcherFactory: CommandDispatcherFactory;
+    private commandDispatcher?: CommandDispatcher;
+    private commandDispatcherClient?: Client;
+
+    constructor(options: ServiceRegistryOptions = {}) {
         this.settings = new LocalStorageSettingsService();
         this.catalog = new DefaultDataCatalog();
         registerCoreLoaders({ catalog: this.catalog });
+
+        this.internalEventHub = options.eventHub ?? runtimeEventHub;
+        this.transportFactory = options.transportFactory ?? (() => new WebSocketTransportAdapter());
+        this.routerConfig = options.router ?? {
+            parseAnsiPatterns: (text: string) => text,
+            transformLine: undefined,
+        };
+        this.commandDispatcherFactory = options.commandDispatcherFactory ?? ((client) => new ClientCommandDispatcher(client));
     }
 
     get dataCatalog(): DefaultDataCatalog {
         return this.catalog;
+    }
+
+    get eventHub(): EventHub<RuntimeEvents> {
+        return this.internalEventHub;
+    }
+
+    get transport(): TransportAdapter {
+        if (!this.transportInstance) {
+            this.transportInstance = this.transportFactory();
+        }
+        return this.transportInstance;
+    }
+
+    get messageRouter(): MessageRouter {
+        if (!this.router) {
+            this.router = new MessageRouter(this.transport, this.internalEventHub, {
+                parseAnsiPatterns: this.routerConfig.parseAnsiPatterns,
+                transformLine: this.routerConfig.transformLine,
+            });
+        }
+        return this.router;
+    }
+
+    configureTransport(factory: TransportFactory): void {
+        if (this.transportInstance) {
+            throw new Error("Transport adapter has already been instantiated.");
+        }
+        this.transportFactory = factory;
+    }
+
+    configureMessageRouter(options: RouterConfiguration): MessageRouter {
+        this.routerConfig = {
+            parseAnsiPatterns: options.parseAnsiPatterns,
+            transformLine: Object.prototype.hasOwnProperty.call(options, "transformLine")
+                ? options.transformLine
+                : this.routerConfig.transformLine,
+        };
+
+        if (!this.router) {
+            this.router = new MessageRouter(this.transport, this.internalEventHub, {
+                parseAnsiPatterns: this.routerConfig.parseAnsiPatterns,
+                transformLine: this.routerConfig.transformLine,
+            });
+        } else if (Object.prototype.hasOwnProperty.call(options, "transformLine")) {
+            this.router.setLineTransform(this.routerConfig.transformLine);
+        }
+
+        return this.router;
+    }
+
+    getCommandDispatcher(client: Client): CommandDispatcher {
+        if (!this.commandDispatcher || this.commandDispatcherClient !== client) {
+            this.commandDispatcher = this.commandDispatcherFactory(client);
+            this.commandDispatcherClient = client;
+        }
+        return this.commandDispatcher;
+    }
+
+    getCatalogMetadata(): {
+        map: DataCatalogEntryMetadata | undefined;
+        npc: DataCatalogEntryMetadata | undefined;
+        colors: DataCatalogEntryMetadata | undefined;
+    } {
+        return {
+            map: this.catalog.getMapMetadata(),
+            npc: this.catalog.getNpcMetadata(),
+            colors: this.catalog.getColorMetadata(),
+        };
     }
 }
 
 const services = new ServiceRegistry();
 
 export default services;
-export type { ServiceRegistry };
+export { ServiceRegistry };

--- a/client/test/runtime/runtime-bootstrap.test.ts
+++ b/client/test/runtime/runtime-bootstrap.test.ts
@@ -1,0 +1,61 @@
+jest.mock("mudlet-map-renderer", () => ({
+    MapReader: jest.fn(),
+    PathFinder: jest.fn(),
+}));
+
+import type { ClientAdapter } from "../../src/Client";
+import createRuntimeBootstrap from "../../src/runtime/createRuntimeBootstrap";
+import { ServiceRegistry } from "../../src/runtime/service-registry";
+import MockTransportAdapter from "../../src/runtime/transport/mock-adapter";
+
+function createClientAdapter(): ClientAdapter {
+    return {
+        send: jest.fn(),
+        output: jest.fn(),
+        sendGmcp: jest.fn(),
+        parseAnsiPatterns: jest.fn((text: string) => text),
+        flushMessageBuffer: jest.fn(),
+    };
+}
+
+describe("createRuntimeBootstrap", () => {
+    test("initializes runtime services and exposes runtime handles", () => {
+        const registry = new ServiceRegistry();
+        const transport = new MockTransportAdapter({ emitLifecycle: false });
+        const clientAdapter = createClientAdapter();
+        const configureAdapter = jest.fn();
+
+        const port = { onMessage: { addListener: jest.fn() } };
+
+        const bootstrap = createRuntimeBootstrap({
+            clientAdapter,
+            registry,
+            parseAnsiPatterns: (text) => `parsed:${text}`,
+            transportFactory: () => transport,
+            configureAdapter,
+            port,
+        });
+
+        expect(configureAdapter).toHaveBeenCalledTimes(1);
+        expect(configureAdapter).toHaveBeenCalledWith({
+            transport,
+            router: registry.messageRouter,
+            eventHub: registry.eventHub,
+        });
+
+        expect(bootstrap.client).toBeDefined();
+        expect(bootstrap.eventHub).toBe(registry.eventHub);
+        expect(bootstrap.dataCatalog).toBe(registry.dataCatalog);
+        expect(bootstrap.catalogMetadata.map?.status).toBe("idle");
+        expect(bootstrap.catalogMetadata.colors?.status).toBe("idle");
+        expect(bootstrap.catalogMetadata.npc?.status).toBe("idle");
+
+        bootstrap.commandDispatcher.sendCommand("look", { echo: false });
+        expect(clientAdapter.send).toHaveBeenCalledWith("look", false);
+
+        expect(registry.transport).toBe(transport);
+        expect(registry.messageRouter).toBe(configureAdapter.mock.calls[0][0].router);
+
+        bootstrap.registry.messageRouter.dispose();
+    });
+});

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -41,12 +41,8 @@ import {
 } from "./mobileButtonSettings"
 import "./triggerTester"
 import "./triggerFinder"
-import MessageRouter from "@client/src/runtime/transport/message-router";
-import { runtimeEventHub } from "@client/src/runtime/event-hub";
-import services from "@client/src/runtime/service-registry";
+import createRuntimeBootstrap from "@client/src/runtime/createRuntimeBootstrap";
 import type { DataCatalogEntryStatus } from "@client/src/runtime/data";
-import { ClientCommandDispatcher } from "@client/src/runtime/command-dispatcher";
-import WebSocketTransportAdapter from "./transport/websocket-adapter";
 import {parseAnsiPatterns} from "./ansiParser";
 import {
     bindUiStoreToClientEvents,
@@ -56,15 +52,18 @@ import {
     uiStore,
 } from "./ui/store";
 
-const transport = new WebSocketTransportAdapter();
-const router = new MessageRouter(transport, runtimeEventHub, { parseAnsiPatterns });
-configureArkadiaClient({ transport, router });
+const runtimeBootstrap = createRuntimeBootstrap({
+    clientAdapter: arkadiaClient,
+    port: new MockPort(),
+    parseAnsiPatterns,
+    configureAdapter: ({ transport, router }) => {
+        configureArkadiaClient({ transport, router });
+    },
+});
 
 initSessionLogger(arkadiaClient).catch(err => console.error('Logger init failed', err));
 
-const client = new Client(arkadiaClient, new MockPort(), runtimeEventHub)
-router.setLineTransform(client.onLine.bind(client));
-const commandDispatcher = new ClientCommandDispatcher(client);
+const { client, commandDispatcher, dataCatalog, catalogMetadata } = runtimeBootstrap;
 uiStore.getState().setCommandDispatcher(commandDispatcher);
 window.clientExtension = client;
 bindUiStoreToClientEvents(client);
@@ -185,9 +184,8 @@ updateMapLayoutOffsets()
 const progressContainer = document.getElementById('map-progress-container')!;
 const progressBar = document.getElementById('map-progress-bar') as HTMLElement;
 
-const dataCatalog = services.dataCatalog;
-let mapStatus: DataCatalogEntryStatus = dataCatalog.getMapMetadata()?.status ?? 'idle';
-let colorStatus: DataCatalogEntryStatus = dataCatalog.getColorMetadata()?.status ?? 'idle';
+let mapStatus: DataCatalogEntryStatus = catalogMetadata.map?.status ?? 'idle';
+let colorStatus: DataCatalogEntryStatus = catalogMetadata.colors?.status ?? 'idle';
 let progressMessageOverride: string | null = null;
 
 function refreshProgressDisplay() {


### PR DESCRIPTION
## Summary
- extend the runtime service registry to manage transport creation, router configuration, and command dispatcher lifecycles
- add a `createRuntimeBootstrap` helper that wires the registry, client, and adapter dependencies while returning runtime handles and catalog metadata
- refactor the web client bootstrap to use the new helper and cover it with a runtime bootstrap test

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ebcf7ff7c8832aba29d2ec11957355