### PR TITLE
Add timeouts to core dataset fetches

### DIFF
--- a/client/src/runtime/data/core-loaders.ts
+++ b/client/src/runtime/data/core-loaders.ts
@@ -16,7 +16,10 @@ export interface CoreLoaderOptions {
     readonly npcPersistence?: DataPersistenceAdapter<unknown>;
     readonly colorPersistence?: DataPersistenceAdapter<unknown>;
     readonly catalog?: DataCatalog;
+    readonly fetchTimeoutMs?: number;
 }
+
+const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
 
 export function createJsonLoader<T>(source: DataSource<T>): DataLoader<T> {
     return async ({ persist }) => {
@@ -31,15 +34,16 @@ export function registerCoreLoaders(options: CoreLoaderOptions = {}): DataCatalo
     const mapPersistence = options.mapPersistence ?? new IndexedDbPersistenceAdapter(MAP_DATASET_KEY);
     const npcPersistence = options.npcPersistence ?? new LocalStoragePersistenceAdapter(NPC_DATASET_KEY);
     const colorPersistence = options.colorPersistence ?? new LocalStoragePersistenceAdapter(COLORS_DATASET_KEY);
+    const fetchTimeoutMs = options.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
 
     const mapLoader = createJsonLoader(
-        options.mapSource ?? createFetchJsonSource('https://delwing.github.io/arkadia-mapa/data/mapExport.json'),
+        options.mapSource ?? createFetchJsonSource('https://delwing.github.io/arkadia-mapa/data/mapExport.json', fetchTimeoutMs),
     );
     const npcLoader = createJsonLoader(
-        options.npcSource ?? createFetchJsonSource('https://delwing.github.io/arkadia-mapa/data/npc.json'),
+        options.npcSource ?? createFetchJsonSource('https://delwing.github.io/arkadia-mapa/data/npc.json', fetchTimeoutMs),
     );
     const colorLoader = createJsonLoader(
-        options.colorSource ?? createFetchJsonSource('https://delwing.github.io/arkadia-mapa/data/colors.json'),
+        options.colorSource ?? createFetchJsonSource('https://delwing.github.io/arkadia-mapa/data/colors.json', fetchTimeoutMs),
     );
 
     catalog.register({
@@ -63,17 +67,57 @@ export function registerCoreLoaders(options: CoreLoaderOptions = {}): DataCatalo
     return catalog;
 }
 
-function createFetchJsonSource<T>(resourceUrl: string): DataSource<T> {
+function createFetchJsonSource<T>(resourceUrl: string, timeoutMs: number): DataSource<T> {
     return async () => {
         if (typeof fetch !== 'function') {
             throw new Error('Fetch API is not available to load core dataset.');
         }
 
-        const response = await fetch(resourceUrl);
-        if (!response.ok) {
-            throw new Error(`Failed to load dataset from ${resourceUrl}: ${response.status} ${response.statusText}`);
+        const supportsAbort = typeof AbortController === 'function';
+        const controller = supportsAbort ? new AbortController() : undefined;
+
+        const fetchTask = (async () => {
+            const response = await fetch(resourceUrl, controller ? { signal: controller.signal } : undefined);
+            if (!response.ok) {
+                throw new Error(`Failed to load dataset from ${resourceUrl}: ${response.status} ${response.statusText}`);
+            }
+
+            return (await response.json()) as T;
+        })();
+
+        if (!timeoutMs || timeoutMs <= 0) {
+            return await fetchTask;
         }
 
-        return (await response.json()) as T;
+        let timedOut = false;
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        const timeoutTask = new Promise<never>((_, reject) => {
+            timeoutId = setTimeout(() => {
+                timedOut = true;
+                if (controller) {
+                    controller.abort();
+                }
+                reject(new Error(`Timed out loading dataset from ${resourceUrl} after ${timeoutMs} ms.`));
+            }, timeoutMs);
+        });
+
+        try {
+            return await Promise.race([fetchTask, timeoutTask]);
+        } catch (error) {
+            if (timedOut) {
+                // Ensure the fetch task rejection is handled when timing out.
+                void fetchTask.catch(() => undefined);
+
+                if (controller && controller.signal.aborted && error instanceof DOMException && error.name === 'AbortError') {
+                    throw new Error(`Timed out loading dataset from ${resourceUrl} after ${timeoutMs} ms.`);
+                }
+            }
+
+            throw error;
+        } finally {
+            if (typeof timeoutId !== 'undefined') {
+                clearTimeout(timeoutId);
+            }
+        }
     };
 }

--- a/client/test/runtime/data/catalog.test.ts
+++ b/client/test/runtime/data/catalog.test.ts
@@ -228,4 +228,35 @@ describe('core data loaders', () => {
         expect(await npcAdapter.read()).toEqual({ npcs: [] });
         expect(await colorAdapter.read()).toEqual({ palette: [] });
     });
+
+    it('fails fast when fetching a dataset exceeds the timeout', async () => {
+        jest.useFakeTimers();
+        const originalFetch = global.fetch as typeof fetch | undefined;
+        const fetchMock = jest.fn(() => new Promise<Response>(() => {}));
+        (global as any).fetch = fetchMock as typeof fetch;
+
+        try {
+            const catalog = registerCoreLoaders({
+                catalog: new DefaultDataCatalog(),
+                fetchTimeoutMs: 5,
+                mapPersistence: new MemoryAdapter<unknown>(),
+                npcPersistence: new MemoryAdapter<unknown>(),
+                colorPersistence: new MemoryAdapter<unknown>(),
+            });
+
+            const loadPromise = catalog.load(MAP_DATASET_KEY);
+
+            jest.advanceTimersByTime(5);
+
+            await expect(loadPromise).rejects.toThrow(/Timed out loading dataset/);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+        } finally {
+            if (originalFetch) {
+                (global as any).fetch = originalFetch;
+            } else {
+                delete (global as any).fetch;
+            }
+            jest.useRealTimers();
+        }
+    });
 });


### PR DESCRIPTION
## Summary
- add an optional fetch timeout to the core data loader registration so stalled requests surface an error
- ensure the default loaders for map, NPC, and color datasets abort when the timeout elapses instead of hanging indefinitely
- cover the timeout behaviour with a Jest test that simulates a fetch that never resolves

## Testing
- yarn --cwd client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ebd6fa32dc832abd8a11d46afd9dc6