### PR TITLE
Avoid blocking catalog loads on slow persistence writes

### DIFF
--- a/client/src/runtime/data/default-catalog.ts
+++ b/client/src/runtime/data/default-catalog.ts
@@ -119,7 +119,9 @@ export class DefaultDataCatalog implements DataCatalog {
         const persist = async (value: T): Promise<void> => {
             entry.data = value;
             if (entry.persistence) {
-                await entry.persistence.write(value);
+                void entry.persistence.write(value).catch((error) => {
+                    console.error(`Failed to persist dataset "${key}"`, error);
+                });
             }
         };
 


### PR DESCRIPTION
## Summary
- prevent catalog loads from waiting on slow persistence writes so map data can initialize immediately
- log persistence failures when asynchronous writes fail for easier diagnosis

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ebdc995078832aaf7694c5e168a6ed