### PR TITLE
Fix NPC catalog synchronization loop on startup

### DIFF
--- a/web-client/src/MockPort.ts
+++ b/web-client/src/MockPort.ts
@@ -2,40 +2,7 @@ import storage, { setItemSync, getItemSync } from "@client/src/storage";
 import services from "@client/src/runtime/service-registry";
 import type { NpcDefinition } from "@client/src/runtime/data";
 import { readMultibinds, replaceMultibinds } from "./multibindStorage";
-
-const NPC_STORAGE_KEY = 'npc' as const;
-
-function normalizeNpcList(value: unknown): NpcDefinition[] {
-    if (!Array.isArray(value)) {
-        return [];
-    }
-
-    return value
-        .filter((entry): entry is NpcDefinition => Boolean(entry && typeof entry === 'object'))
-        .map((entry) => ({
-            name: String((entry as NpcDefinition).name ?? ''),
-            loc: Number((entry as NpcDefinition).loc ?? (entry as any).loc),
-        }))
-        .filter((entry) => entry.name.length > 0 && Number.isFinite(entry.loc));
-}
-
-function areNpcEntriesEqual(a: NpcDefinition, b: NpcDefinition): boolean {
-    return a.name === b.name && a.loc === b.loc;
-}
-
-function npcListsEqual(a: readonly NpcDefinition[], b: readonly NpcDefinition[]): boolean {
-    if (a.length !== b.length) {
-        return false;
-    }
-
-    for (let i = 0; i < a.length; i += 1) {
-        if (!areNpcEntriesEqual(a[i], b[i])) {
-            return false;
-        }
-    }
-
-    return true;
-}
+import { NPC_STORAGE_KEY, normalizeNpcList, npcListsEqual, areNpcEntriesEqual } from "./npcData";
 
 function getNpcCatalogData(): NpcDefinition[] {
     const current = services.dataCatalog.getNpcData();

--- a/web-client/src/npcData.ts
+++ b/web-client/src/npcData.ts
@@ -1,0 +1,38 @@
+import type { NpcDefinition } from "@client/src/runtime/data";
+
+export const NPC_STORAGE_KEY = "npc" as const;
+
+export function normalizeNpcList(value: unknown): NpcDefinition[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value
+        .filter((entry): entry is NpcDefinition => Boolean(entry && typeof entry === "object"))
+        .map((entry) => ({
+            name: String((entry as NpcDefinition).name ?? ""),
+            loc: Number((entry as NpcDefinition).loc ?? (entry as any).loc),
+        }))
+        .filter((entry) => entry.name.length > 0 && Number.isFinite(entry.loc));
+}
+
+export function areNpcEntriesEqual(a: NpcDefinition, b: NpcDefinition): boolean {
+    return a.name === b.name && a.loc === b.loc;
+}
+
+export function npcListsEqual(
+    a: readonly NpcDefinition[],
+    b: readonly NpcDefinition[],
+): boolean {
+    if (a.length !== b.length) {
+        return false;
+    }
+
+    for (let i = 0; i < a.length; i += 1) {
+        if (!areNpcEntriesEqual(a[i], b[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -4,6 +4,7 @@ import {Button, Form, Table} from 'react-bootstrap';
 import {TiDelete} from "react-icons/ti";
 import services from "@client/src/runtime/service-registry";
 import type { NpcDefinition } from "@client/src/runtime/data";
+import { normalizeNpcList, npcListsEqual } from "../npcData";
 import {
     useEnsureNpcDataset,
     useLoadNpcDataset,
@@ -43,11 +44,17 @@ function Npc() {
     useEffect(() => {
         const handler = (ev: Event) => {
             const detail = (ev as CustomEvent).detail;
-            if (Array.isArray(detail)) {
-                void services.dataCatalog
-                    .setNpcData(detail as NpcDefinition[], 'cache')
-                    .catch((error) => console.error('Failed to persist NPC event data:', error));
+            const normalized = normalizeNpcList(detail);
+            const current = services.dataCatalog.getNpcData();
+            const currentList = Array.isArray(current) ? current : [];
+
+            if (npcListsEqual(currentList, normalized)) {
+                return;
             }
+
+            void services.dataCatalog
+                .setNpcData(normalized, 'cache')
+                .catch((error) => console.error('Failed to persist NPC event data:', error));
         };
 
         window.addEventListener('npc', handler as EventListener);


### PR DESCRIPTION
## Summary
- extract reusable NPC normalization and comparison helpers
- update MockPort to rely on shared helpers when syncing catalog changes
- avoid re-persisting unchanged NPC payloads emitted through the npc event to break the startup loop

## Testing
- yarn --cwd web-client test MockPort

------
https://chatgpt.com/codex/tasks/task_e_68ebe1fde738832a9612c42a7fba46b9