### PR TITLE
Remove window.clientExtension global in favor of store bindings

### DIFF
--- a/client/test/runtime/message-router.test.ts
+++ b/client/test/runtime/message-router.test.ts
@@ -15,7 +15,6 @@ describe("MessageRouter runtime event hub integration", () => {
 
     afterEach(() => {
         router.dispose();
-        delete (window as any).clientExtension;
     });
 
     function processFrame(frame: string) {
@@ -36,8 +35,6 @@ describe("MessageRouter runtime event hub integration", () => {
 
     test("uses an identity line transform by default", () => {
         const outputLines: RuntimeEvents["outputLine"][] = [];
-        const transformSpy = jest.fn();
-        (window as any).clientExtension = { onLine: transformSpy };
         const subscription = eventHub.on("outputLine", (payload) => {
             outputLines.push(payload);
         });
@@ -52,7 +49,6 @@ describe("MessageRouter runtime event hub integration", () => {
                 type: "room.info",
             },
         ]);
-        expect(transformSpy).not.toHaveBeenCalled();
 
         subscription.unsubscribe();
     });

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,8 +117,8 @@ graph TD
   from the store and dispatch intents (e.g., `UIStore.dispatch(saveSettings)`).
 - **HUD Widgets** (imperative overlays) subscribe to the same store so DOM
   manipulations remain in sync with React panels. Commands (movement, actions)
-  go back to the runtime through an injected `CommandDispatcher` instead of
-  writing to `window.clientExtension`.
+  go back to the runtime through the injected `CommandDispatcher` or store
+  provided client bindings instead of writing to a global object.
 
 ## Interaction flow without window globals
 
@@ -177,8 +177,8 @@ teardown behaviour.
    adapter and router. Ensure legacy `ArkadiaClient` delegates entirely to the
    adapter before removing it.
 4. **Adopt the UIStore** for new UI features, then migrate existing widgets and
-   React panels. Replace `window.clientExtension` calls with an injected
-   `CommandDispatcher`.
+   React panels. Replace `window.clientExtension` calls with the injected
+   `CommandDispatcher` or `uiStore` client bindings.
 5. **Decommission legacy code** once all modules consume the new services:
    remove window globals, delete compatibility files, and simplify bootstrap
    scripts.
@@ -186,3 +186,30 @@ teardown behaviour.
 This architecture keeps the powerful feature module ecosystem while delivering
 cleaner boundaries and a single reactive data flow between transport, runtime,
 settings, data, and UI.
+
+### Migrating third-party scripts away from `window.clientExtension`
+
+Legacy extensions could reach runtime helpers by accessing `window.clientExtension`.
+That surface has been replaced by explicit dependency injection through the
+shared UI store:
+
+1. Import the store utilities exposed by the client (`import { uiStore } from "web-client/ui/store";`).
+2. Read injected services from `uiStore.getState().clientBindings`—the bindings
+   include the runtime `Client`, map helper, trigger manager, output handler,
+   team manager, and notification helpers.
+3. Send commands or events through `uiStore.getState().sendCommand()` /
+   `sendEvent()` (or by dispatching intents) instead of calling
+   `clientExtension.sendCommand`.
+
+Scripts that still require direct helpers should destructure them from the
+bindings:
+
+```ts
+const { map, triggers } = uiStore.getState().clientBindings;
+const currentRoomId = map?.currentRoom?.id;
+const allTriggers = [...(triggers?.triggers.values() ?? [])];
+```
+
+Always wait until the UI store has been initialised (for example inside a
+`DOMContentLoaded` listener) before reading the bindings to avoid race
+conditions during bootstrap.

--- a/docs/ARCHITECTURE_CHANGELOG.md
+++ b/docs/ARCHITECTURE_CHANGELOG.md
@@ -51,6 +51,11 @@ This document captures progress toward the next-generation runtime described in 
 - Rebuilt the legacy object list controller so it binds directly to `uiStore` selectors for nearby objects and the attack queue, reuses the centralised command dispatcher, and keeps the DOM in sync across both the main HUD and the Picture-in-Picture surface. (see `web-client/src/ObjectList.ts`).
 - Extended the shared `uiStore` to surface the attack queue emitted by the legacy client bridge and expose a `selectAttackQueue` helper, allowing classic widgets to follow the unified state shape without bespoke events. (see `web-client/src/ui/store.ts`).
 
+### Client extension global removal
+- Removed the `window.clientExtension` bootstrap assignment and replaced it with a `clientBindings` slice in the shared `uiStore`, exposing the runtime `Client`, helpers (map, triggers, output handler), and notification utilities through dependency injection. (see `web-client/src/main.ts`, `web-client/src/ui/store.ts`).
+- Updated HUD helpers, modals, debug tooling, sandbox utilities, and trigger inspectors to resolve services via the store or the `CommandDispatcher`, eliminating direct global lookups. (see `web-client/src/debug.ts`, `web-client/src/embed.ts`, `web-client/src/options/Shortcuts.tsx`, `web-client/src/sandbox.ts`, `web-client/src/triggerFinder.ts`, `web-client/src/triggerTester.ts`).
+- Documented migration guidance for third-party scripts that previously depended on the global, highlighting the new `uiStore` selectors and dispatcher entry points for commands, events, and runtime helpers. (see `docs/ARCHITECTURE.md`).
+
 ## Planned next steps
 - Continue migrating remaining runtime modules from the legacy `eventBus` to direct `EventHub` subscriptions so the bridge shim can eventually be removed.
 - Expose the shared data catalog to feature modules and UI consumers, retiring bespoke loaders such as `mapDataLoader` and `npcDataLoader`.

--- a/web-client/src/debug.ts
+++ b/web-client/src/debug.ts
@@ -1,4 +1,5 @@
 import Modal from "bootstrap/js/dist/modal";
+import { uiStore } from "./ui/store";
 
 function initDebug() {
   const debugButton = document.getElementById("debug-button") as HTMLButtonElement | null;
@@ -40,13 +41,13 @@ function initDebug() {
 
   if (scheduleButton) {
     scheduleButton.addEventListener("click", () => {
-      const client = (window as any).clientExtension;
-      if (!client) return;
-      client.enableNotifications?.();
-      client.sendEvent?.("notify", { text: "Powiadomienie za 5s" });
+      const { enableNotifications, notify } = uiStore.getState().clientBindings;
+      const { sendEvent } = uiStore.getState();
+      enableNotifications?.();
+      sendEvent("notify", { text: "Powiadomienie za 5s" });
       setTimeout(() => {
-        client.notify?.("Test notification");
-        client.sendEvent?.("notify", { text: "Test notification" });
+        notify?.("Test notification");
+        sendEvent("notify", { text: "Test notification" });
       }, 5000);
     });
   }

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -1,5 +1,6 @@
 import {MapReader, Renderer, PathFinder, Settings, RoomContextMenuEventDetail, LabelRenderMode} from "mudlet-map-renderer";
 import {getCurrentCharacter, getItemSync, setItemSync} from "@client/src/storage";
+import { uiStore } from "./ui/store";
 
 const STORAGE_KEY = 'mapperRoomId';
 const VISITED_DB_NAME = 'ArkadiaVisitedRoomsDB';
@@ -194,7 +195,7 @@ export class EmbeddedMap {
 
         const room = ev.detail.roomId
         if (room) {
-            const client: any = (window as any).clientExtension;
+            const client = uiStore.getState().clientBindings.client;
             client?.openMapContextMenu?.(room, ev.detail.position.x, ev.detail.position.y);
         }
     }

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -66,7 +66,15 @@ const client = new Client(arkadiaClient, new MockPort(), runtimeEventHub)
 router.setLineTransform(client.onLine.bind(client));
 const commandDispatcher = new ClientCommandDispatcher(client);
 uiStore.getState().setCommandDispatcher(commandDispatcher);
-window.clientExtension = client;
+uiStore.getState().setClientBindings({
+    client,
+    outputHandler: client.OutputHandler,
+    map: client.Map,
+    triggers: client.Triggers,
+    teamManager: client.TeamManager,
+    enableNotifications: client.enableNotifications.bind(client),
+    notify: client.notify.bind(client),
+});
 bindUiStoreToClientEvents(client);
 registerScripts(client)
 client.connect(client.port, true)
@@ -233,7 +241,7 @@ let isSplitView = false;
 const STICKY_LINES = 15;
 
 function processSticky(count: number) {
-    const handler: any = (window as any).clientExtension?.OutputHandler;
+    const handler: any = client.OutputHandler;
     if (handler && typeof handler.processOutput === 'function') {
         const prev = handler.output;
         handler.output = stickyArea;
@@ -518,10 +526,10 @@ document.addEventListener('keydown', (e) => {
     if (direction) {
         e.preventDefault();
         if (direction === 'special') {
-            const exits = (window as any).clientExtension?.Map.currentRoom?.specialExits ?? {};
+            const exits = client.Map.currentRoom?.specialExits ?? {};
             const first = Object.keys(exits)[0];
             if (first) {
-                (window as any).clientExtension.sendCommand(first);
+                commandDispatcher.sendCommand(first);
             }
         } else {
             client.sendCommand(direction);
@@ -752,7 +760,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (shareLocationButton && locationQrImage && locationShareModal) {
         shareLocationButton.addEventListener('click', () => {
-            const roomId = (window as any).clientExtension?.Map?.currentRoom?.id;
+            const roomId = client.Map?.currentRoom?.id;
             if (!roomId) {
                 return;
             }

--- a/web-client/src/options/Shortcuts.tsx
+++ b/web-client/src/options/Shortcuts.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Button, Form, Table } from 'react-bootstrap';
 import { TiDelete } from 'react-icons/ti';
 import storage from "@client/src/storage";
-import { useUiDispatch } from "../ui/store";
+import { uiStore, useUiDispatch } from "../ui/store";
 
 interface ShortcutEntry {
     key: string;
@@ -53,7 +53,7 @@ function Shortcuts() {
     }
 
     function useCurrent() {
-        const id = (window as any).clientExtension?.Map?.currentRoom?.id;
+        const id = uiStore.getState().clientBindings.map?.currentRoom?.id;
         if (id) {
             setLoc(String(id));
         }

--- a/web-client/src/sandbox.ts
+++ b/web-client/src/sandbox.ts
@@ -2,6 +2,7 @@ import './sandbox.css';
 import arkadiaClient from "./ArkadiaClient.ts";
 import { runtimeEventHub } from "@client/src/runtime/event-hub";
 import type { RuntimeEvents } from "@client/src/runtime/event-hub";
+import { uiStore } from "./ui/store";
 
 // Disable real network and echo commands locally
 arkadiaClient.connect = () => {
@@ -22,7 +23,8 @@ arkadiaClient.send = (message: string, echo: boolean = true) => {
 (arkadiaClient as any).receivedFirstGmcp = true;
 
 window.addEventListener('load', () => {
-    const client: any = (window as any).clientExtension;
+    const { client: runtimeClient, teamManager } = uiStore.getState().clientBindings;
+    const { sendEvent } = uiStore.getState();
     arkadiaClient.emit('client.connect');
     const memberInput = document.getElementById('sandbox-member-name') as HTMLInputElement | null;
     const addMemberButton = document.getElementById('sandbox-add-member') as HTMLButtonElement | null;
@@ -35,7 +37,7 @@ window.addEventListener('load', () => {
     const hps = new Map<number, number>();
 
     function emitGmcp(path: string, value: unknown) {
-        client?.sendEvent?.(`gmcp.${path}`, value);
+        sendEvent(`gmcp.${path}`, value);
         runtimeEventHub.emit(`gmcp.${path}` as keyof RuntimeEvents, value as never);
         runtimeEventHub.emit('gmcp', { path, value } as RuntimeEvents['gmcp']);
     }
@@ -61,8 +63,9 @@ window.addEventListener('load', () => {
     function renderTeam() {
         if (!preview) return;
         preview.innerHTML = '';
-        const members: string[] = client.TeamManager?.getTeamMembers?.() ?? [];
-        const leader = client.TeamManager?.getLeader?.();
+        const manager = teamManager ?? runtimeClient?.TeamManager;
+        const members: string[] = manager?.getTeamMembers?.() ?? [];
+        const leader = manager?.getLeader?.();
         members.forEach((name) => {
             const li = document.createElement('li');
             li.className = 'sandbox-team-member';
@@ -95,7 +98,8 @@ window.addEventListener('load', () => {
     }
 
     function setLeader(name: string) {
-        const currentLeader = client.TeamManager?.getLeader?.();
+        const manager = teamManager ?? runtimeClient?.TeamManager;
+        const currentLeader = manager?.getLeader?.();
         if (currentLeader && currentLeader !== name) {
             sendTeam(currentLeader, false);
         }
@@ -112,7 +116,8 @@ window.addEventListener('load', () => {
             emitGmcp('objects.data', update);
             emitGmcp('objects.nums', Array.from(objectNums));
         }
-        client.TeamManager?.removeMember?.(name);
+        const manager: any = teamManager ?? runtimeClient?.TeamManager;
+        manager?.removeMember?.(name);
     }
 
     function addEnemy() {
@@ -129,7 +134,7 @@ window.addEventListener('load', () => {
         emitGmcp('objects.nums', Array.from(objectNums));
     }
 
-    client.addEventListener?.('teamChange', renderTeam);
+    runtimeClient?.addEventListener?.('teamChange', renderTeam);
 
     const playerName = 'Player';
     const charInfo = { name: playerName, object_num: id };

--- a/web-client/src/triggerFinder.ts
+++ b/web-client/src/triggerFinder.ts
@@ -2,6 +2,7 @@ import Modal from "bootstrap/js/dist/modal";
 import { stripAnsiCodes } from "@client/src/stripAnsiCodes";
 import type { Trigger } from "@client/src/Triggers";
 import { getMatchingPatterns, matchTrigger, patternToString } from "./triggerUtils";
+import { uiStore } from "./ui/store";
 
 type TriggerSource = "regular" | "multiline" | "token";
 
@@ -29,8 +30,7 @@ function initTriggerFinder() {
     });
 
     runBtn.addEventListener("click", () => {
-        // @ts-ignore
-        const manager = (window as any).clientExtension?.Triggers;
+        const manager = uiStore.getState().clientBindings.triggers;
         if (!manager) {
             outputEl.textContent = "No trigger manager.";
             return;

--- a/web-client/src/triggerTester.ts
+++ b/web-client/src/triggerTester.ts
@@ -1,6 +1,7 @@
 import Modal from "bootstrap/js/dist/modal";
 import type { Trigger } from "@client/src/Triggers";
 import { matchTrigger, patternToString } from "./triggerUtils";
+import { uiStore } from "./ui/store";
 
 function initTriggerTester() {
     const button = document.getElementById('trigger-tester-button') as HTMLButtonElement | null;
@@ -31,8 +32,7 @@ function initTriggerTester() {
         selectedPath = null;
         selectedEl = null;
         treeEl.innerHTML = '';
-        // @ts-ignore
-        const manager = (window as any).clientExtension?.Triggers;
+        const manager = uiStore.getState().clientBindings.triggers;
         if (!manager) return;
         const roots: Trigger[] = [
             ...Array.from(manager.triggers.values()),
@@ -77,8 +77,7 @@ function initTriggerTester() {
         const line = lineInput.value;
         const type = typeInput.value.trim();
         outputEl.textContent = '';
-        // @ts-ignore
-        const triggers = (window as any).clientExtension?.Triggers;
+        const triggers = uiStore.getState().clientBindings.triggers;
         if (!triggers) {
             outputEl.textContent = 'No trigger manager.';
             return;

--- a/web-client/src/types/globals.d.ts
+++ b/web-client/src/types/globals.d.ts
@@ -47,7 +47,6 @@ declare global {
         Text: ClientText;
         Conf: ClientConf
         Gmcp: ClientGmcp;
-        clientExtension: Client
     }
 
     declare var Input: ClientInput;

--- a/web-client/src/ui/store.ts
+++ b/web-client/src/ui/store.ts
@@ -13,6 +13,11 @@ import type { SettingsSnapshot } from "@client/src/runtime/settings/settings-ser
 import { defaultSettings } from "@client/src/defaultSettings";
 import type { CommandDispatcher, ExtensionCommand } from "@client/src/runtime/command-dispatcher";
 import toTitleCase from "@client/src/utils/toTitleCase";
+import type Client from "@client/src/Client";
+import type MapHelper from "@client/src/MapHelper";
+import type OutputHandler from "@client/src/OutputHandler";
+import type TeamManager from "@client/src/TeamManager";
+import type Triggers from "@client/src/Triggers";
 
 import type { CharStateData } from "../CharState";
 
@@ -233,6 +238,8 @@ export interface UiStoreState {
     attackQueue: readonly string[];
     commandDispatcher: CommandDispatcher | null;
     setCommandDispatcher: (dispatcher: CommandDispatcher | null) => void;
+    clientBindings: ClientBindings;
+    setClientBindings: (bindings: ClientBindings) => void;
     sendCommand: (command: string, options?: { echo?: boolean }) => void;
     sendEvent: (event: string, payload?: unknown) => void;
     sendExtensionCommand: (command: ExtensionCommand) => boolean;
@@ -248,6 +255,16 @@ export type UiIntent =
     | { type: "command/send"; command: string; echo?: boolean }
     | { type: "event/send"; event: string; payload?: unknown }
     | { type: "extension/command"; command: ExtensionCommand };
+
+export interface ClientBindings {
+    client?: Client;
+    outputHandler?: OutputHandler;
+    map?: MapHelper;
+    triggers?: Triggers;
+    teamManager?: TeamManager;
+    enableNotifications?: () => void;
+    notify?: (message: string) => void;
+}
 
 const defaultPreferences: UiPreferences = {
     emojiLabels: null,
@@ -300,6 +317,7 @@ const baseState = {
     nearbyObjects: [] as NearbyObject[],
     teamStatus: { ...emptyTeamStatus },
     attackQueue: [] as string[],
+    clientBindings: {} as ClientBindings,
     datasets: {} as Record<string, CatalogDatasetSlice<unknown>>,
 };
 
@@ -308,6 +326,7 @@ const store = createStore(
         ...baseState,
         commandDispatcher: null,
         setCommandDispatcher: (dispatcher) => set({ commandDispatcher: dispatcher }),
+        setClientBindings: (bindings) => set({ clientBindings: bindings }),
         sendCommand: (command, options) => {
             const dispatcher = get().commandDispatcher;
             if (!dispatcher) {
@@ -808,6 +827,7 @@ export function resetUiStoreForTesting() {
         teamStatus: { ...emptyTeamStatus },
         attackQueue: [],
         commandDispatcher: null,
+        clientBindings: {},
     });
     subscribeToRuntime();
     subscribeToCatalog();
@@ -830,6 +850,8 @@ export const selectNearbyObjects = (state: UiStoreState) => state.nearbyObjects;
 export const selectTeamStatus = (state: UiStoreState) => state.teamStatus;
 
 export const selectAttackQueue = (state: UiStoreState) => state.attackQueue;
+
+export const selectClientBindings = (state: UiStoreState) => state.clientBindings;
 
 export function useNearbyObjects(): readonly NearbyObject[] {
     return useUiStore((state) => state.nearbyObjects);

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -1,5 +1,6 @@
 import Modal from "bootstrap/js/dist/modal";
 import {Settings} from "mudlet-map-renderer";
+import { uiStore } from "./ui/store";
 
 const mapPositions = [
     'top-overlay',
@@ -135,20 +136,14 @@ function apply(settings: UiSettings) {
     (window as any).embedded?.setInstantMove?.(settings.instantMove);
     Settings.highlightCurrentRoom = settings.highlightCurrentRoom;
     (window as any).embedded?.setHighlightCurrentRoom?.(settings.highlightCurrentRoom);
-    if ((window as any).clientExtension?.eventTarget) {
-        (window as any).clientExtension.eventTarget.dispatchEvent(
-            new CustomEvent('uiSettings', {
-                detail: {
-                    mobileDirectionButtons: settings.showButtons,
-                    hapticFeedback: settings.hapticFeedback,
-                    emojiLabels: settings.emojiLabels,
-                    xtermPalette: settings.xtermPalette,
-                    footerMode: settings.footerMode,
-                    fightTitleIcon: settings.fightTitleIcon,
-                },
-            })
-        );
-    }
+    uiStore.getState().sendEvent('uiSettings', {
+        mobileDirectionButtons: settings.showButtons,
+        hapticFeedback: settings.hapticFeedback,
+        emojiLabels: settings.emojiLabels,
+        xtermPalette: settings.xtermPalette,
+        footerMode: settings.footerMode,
+        fightTitleIcon: settings.fightTitleIcon,
+    });
     if (typeof window !== 'undefined') {
         window.dispatchEvent(new CustomEvent('map-position-change'));
     }


### PR DESCRIPTION
## Summary
- add a clientBindings slice to the shared uiStore and configure it during bootstrap so runtime helpers are injected instead of leaked on window
- update HUD scripts, sandbox utilities, trigger tools, and shortcuts to resolve services via the store or command dispatcher, removing window.clientExtension usages
- document the new integration path for third-party scripts and clean up tests and global typings accordingly

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ebcf87ca08832abe6083a520da3008