### PR TITLE
Fix service registry imports and wasm Jest mapping

### DIFF
--- a/client/src/runtime/service-registry.ts
+++ b/client/src/runtime/service-registry.ts
@@ -1,20 +1,21 @@
-import { DefaultDataCatalog, registerCoreLoaders, registerPeopleLoader } from './data';
-import type { SettingsService } from './settings/settings-service';
-import { LocalStorageSettingsService } from './settings/local-storage-service';
 import type Client from "../Client";
 import { ClientCommandDispatcher } from "./command-dispatcher";
 import type { CommandDispatcher } from "./command-dispatcher";
-import { DefaultDataCatalog, registerCoreLoaders } from "./data";
+import {
+    DefaultDataCatalog,
+    registerCoreLoaders,
+    registerPeopleLoader,
+} from "./data";
 import type { DataCatalogEntryMetadata } from "./data";
 import type { EventHub } from "./event-hub";
 import { runtimeEventHub } from "./event-hub";
-import MessageRouter from "./transport/message-router";
-import type { MessageRouterOptions } from "./transport/message-router";
-import type { TransportAdapter } from "./transport/types";
-import WebSocketTransportAdapter from "./transport/websocket-adapter";
+import type { RuntimeEvents } from "./event-hub";
 import type { SettingsService } from "./settings/settings-service";
 import { LocalStorageSettingsService } from "./settings/local-storage-service";
-import type { RuntimeEvents } from "./event-hub";
+import type { MessageRouterOptions } from "./transport/message-router";
+import MessageRouter from "./transport/message-router";
+import type { TransportAdapter } from "./transport/types";
+import WebSocketTransportAdapter from "./transport/websocket-adapter";
 
 export type RouterConfiguration = Pick<MessageRouterOptions, "parseAnsiPatterns" | "transformLine">;
 type TransportFactory = () => TransportAdapter;

--- a/web-client/jest.config.cjs
+++ b/web-client/jest.config.cjs
@@ -3,6 +3,7 @@ const path = require('path');
 
 const moduleNameMapper = {
   '^@client/(.*)$': '<rootDir>/../client/$1',
+  '\\.(?:wasm)\\?url$': '<rootDir>/../client/test/__mocks__/wasmUrlMock.js',
 };
 
 const candidateZustandDirs = [


### PR DESCRIPTION
## Summary
- deduplicate service registry imports to avoid TypeScript duplicate identifier errors in tests
- map sql.js wasm asset to the shared mock in the web-client Jest configuration so tests can resolve it

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ebfb45a900832a844c94a9598bb7be