### PR TITLE
Refactor test helpers out of production modules

### DIFF
--- a/client/src/runtime/service-registry.ts
+++ b/client/src/runtime/service-registry.ts
@@ -1,20 +1,17 @@
-import { DefaultDataCatalog, registerCoreLoaders, registerPeopleLoader } from './data';
-import type { SettingsService } from './settings/settings-service';
-import { LocalStorageSettingsService } from './settings/local-storage-service';
-import type Client from "../Client";
-import { ClientCommandDispatcher } from "./command-dispatcher";
-import type { CommandDispatcher } from "./command-dispatcher";
-import { DefaultDataCatalog, registerCoreLoaders } from "./data";
+import { DefaultDataCatalog, registerCoreLoaders, registerPeopleLoader } from "./data";
 import type { DataCatalogEntryMetadata } from "./data";
 import type { EventHub } from "./event-hub";
 import { runtimeEventHub } from "./event-hub";
+import type { RuntimeEvents } from "./event-hub";
+import { ClientCommandDispatcher } from "./command-dispatcher";
+import type { CommandDispatcher } from "./command-dispatcher";
+import WebSocketTransportAdapter from "./transport/websocket-adapter";
 import MessageRouter from "./transport/message-router";
 import type { MessageRouterOptions } from "./transport/message-router";
 import type { TransportAdapter } from "./transport/types";
-import WebSocketTransportAdapter from "./transport/websocket-adapter";
+import type Client from "../Client";
 import type { SettingsService } from "./settings/settings-service";
 import { LocalStorageSettingsService } from "./settings/local-storage-service";
-import type { RuntimeEvents } from "./event-hub";
 
 export type RouterConfiguration = Pick<MessageRouterOptions, "parseAnsiPatterns" | "transformLine">;
 type TransportFactory = () => TransportAdapter;

--- a/client/test/runtime/message-router.test.ts
+++ b/client/test/runtime/message-router.test.ts
@@ -1,6 +1,6 @@
 import MessageRouter from "../../src/runtime/transport/message-router";
 import { EventHub, type RuntimeEvents } from "../../src/runtime/event-hub";
-import MockTransportAdapter from "../../src/runtime/transport/mock-adapter";
+import MockTransportAdapter from "../utils/mock-transport-adapter";
 
 describe("MessageRouter runtime event hub integration", () => {
     let eventHub: EventHub<RuntimeEvents>;

--- a/client/test/runtime/runtime-bootstrap.test.ts
+++ b/client/test/runtime/runtime-bootstrap.test.ts
@@ -6,7 +6,7 @@ jest.mock("mudlet-map-renderer", () => ({
 import type { ClientAdapter } from "../../src/Client";
 import createRuntimeBootstrap from "../../src/runtime/createRuntimeBootstrap";
 import { ServiceRegistry } from "../../src/runtime/service-registry";
-import MockTransportAdapter from "../../src/runtime/transport/mock-adapter";
+import MockTransportAdapter from "../utils/mock-transport-adapter";
 
 function createClientAdapter(): ClientAdapter {
     return {

--- a/client/test/utils/mock-transport-adapter.ts
+++ b/client/test/utils/mock-transport-adapter.ts
@@ -3,8 +3,8 @@ import type {
     TransportConnectOptions,
     TransportIn,
     TransportOut,
-} from "./types";
-import { TransportSubject } from "./subject";
+} from "../../src/runtime/transport/types";
+import { TransportSubject } from "../../src/runtime/transport/subject";
 
 export interface MockTransportAdapterOptions {
     emitLifecycle?: boolean;

--- a/docs/ARCHITECTURE_CHANGELOG.md
+++ b/docs/ARCHITECTURE_CHANGELOG.md
@@ -25,7 +25,7 @@ This document captures progress toward the next-generation runtime described in 
 - Added a production-ready `WebSocketTransportAdapter` that encapsulates Arkadia-specific protocol details such as GMCP framing, MCCP decompression, periodic pings, and exponential backoff reconnect logic. Unit tests simulate socket lifecycles to confirm reconnection, encoding, and ping behaviour. (see `client/src/runtime/transport/websocket-adapter.ts`, `client/test/runtime/transport/websocket-adapter.test.ts`).
 
 ### Mock transport adapter and test subject
-- Implemented a `MockTransportAdapter` plus a minimal `TransportSubject` so runtime components can be exercised without a real socket. The message-router tests rely on this adapter to simulate GMCP frames and lifecycle events deterministically. (see `client/src/runtime/transport/mock-adapter.ts`, `client/src/runtime/transport/subject.ts`, `client/test/runtime/message-router.test.ts`).
+- Implemented a `MockTransportAdapter` plus a minimal `TransportSubject` so runtime components can be exercised without a real socket. The message-router tests rely on this adapter to simulate GMCP frames and lifecycle events deterministically. (see `client/test/utils/mock-transport-adapter.ts`, `client/src/runtime/transport/subject.ts`, `client/test/runtime/message-router.test.ts`).
 
 ### Shared UI store integration
 - Introduced a Zustand-based `uiStore` that subscribes to the runtime event hub and the modernised settings service, projecting GMCP updates and preference changes into a single UI state tree. The store can also bind to legacy DOM events so existing widgets continue to work during the transition. (see `web-client/src/ui/store.ts`).

--- a/web-client/jest.config.cjs
+++ b/web-client/jest.config.cjs
@@ -3,6 +3,7 @@ const path = require('path');
 
 const moduleNameMapper = {
   '^@client/(.*)$': '<rootDir>/../client/$1',
+  'sql\\.js/dist/sql-wasm\\.wasm\\?url$': '<rootDir>/test/__mocks__/sqljs-wasm-url.ts',
 };
 
 const candidateZustandDirs = [

--- a/web-client/src/ui/store.testing.ts
+++ b/web-client/src/ui/store.testing.ts
@@ -1,0 +1,17 @@
+import {
+    clearUiStoreClientEventBindings,
+    resetUiStoreCatalogTracking,
+    resetUiStoreRuntimeCleanup,
+    restoreUiStoreBaseState,
+    subscribeToCatalog,
+    subscribeToRuntime,
+} from "./store";
+
+export function resetUiStoreForTesting() {
+    clearUiStoreClientEventBindings();
+    resetUiStoreRuntimeCleanup();
+    resetUiStoreCatalogTracking();
+    restoreUiStoreBaseState();
+    subscribeToRuntime();
+    subscribeToCatalog();
+}

--- a/web-client/src/ui/store.ts
+++ b/web-client/src/ui/store.ts
@@ -632,7 +632,7 @@ async function ensureCatalogDataset<T>(key: string, options: CatalogLoadOptions 
     return value;
 }
 
-function subscribeToCatalog(): void {
+export function subscribeToCatalog(): void {
     if (catalogSubscription) {
         return;
     }
@@ -685,7 +685,7 @@ function updatePreferencesFromSnapshot(snapshot: SettingsSnapshot) {
 let subscriptionsInitialised = false;
 let runtimeCleanup: ListenerCleanup | null = null;
 
-function subscribeToRuntime() {
+export function subscribeToRuntime() {
     if (subscriptionsInitialised) {
         return;
     }
@@ -740,6 +740,36 @@ function subscribeToRuntime() {
 subscribeToRuntime();
 subscribeToCatalog();
 let clientEventCleanups: ListenerCleanup[] = [];
+
+export function clearUiStoreClientEventBindings() {
+    clientEventCleanups.forEach((cleanup) => cleanup());
+    clientEventCleanups = [];
+}
+
+export function resetUiStoreRuntimeCleanup() {
+    runtimeCleanup?.();
+    runtimeCleanup = null;
+}
+
+export function resetUiStoreCatalogTracking() {
+    catalogSubscription?.unsubscribe();
+    catalogSubscription = null;
+    pendingCatalogLoads.clear();
+}
+
+export function restoreUiStoreBaseState() {
+    store.setState({
+        ...baseState,
+        objectData: {},
+        objectNums: [],
+        playerObjectId: undefined,
+        nearbyObjects: [],
+        teamStatus: { ...emptyTeamStatus },
+        attackQueue: [],
+        commandDispatcher: null,
+        clientBindings: {},
+    });
+}
 
 type ClientLike = {
     addEventListener: (
@@ -809,29 +839,6 @@ export function bindUiStoreToClientEvents(client: ClientLike | null | undefined)
 }
 
 export const uiStore = storeWithSelector;
-
-export function resetUiStoreForTesting() {
-    clientEventCleanups.forEach((cleanup) => cleanup());
-    clientEventCleanups = [];
-    runtimeCleanup?.();
-    runtimeCleanup = null;
-    catalogSubscription?.unsubscribe();
-    catalogSubscription = null;
-    pendingCatalogLoads.clear();
-    store.setState({
-        ...baseState,
-        objectData: {},
-        objectNums: [],
-        playerObjectId: undefined,
-        nearbyObjects: [],
-        teamStatus: { ...emptyTeamStatus },
-        attackQueue: [],
-        commandDispatcher: null,
-        clientBindings: {},
-    });
-    subscribeToRuntime();
-    subscribeToCatalog();
-}
 
 export function useUiStore<T>(selector: (state: UiStoreState) => T): T {
     return useStore(storeWithSelector, selector);

--- a/web-client/test/AttackMode.test.ts
+++ b/web-client/test/AttackMode.test.ts
@@ -1,5 +1,6 @@
 import AttackMode from '../src/AttackMode';
-import { resetUiStoreForTesting, uiStore } from '../src/ui/store';
+import { uiStore } from "../src/ui/store";
+import { resetUiStoreForTesting } from "../src/ui/store.testing";
 
 jest.mock('@client/src/storage.ts', () => ({
   getItemSync: jest.fn(() => ({})),

--- a/web-client/test/CharState.test.ts
+++ b/web-client/test/CharState.test.ts
@@ -1,6 +1,6 @@
 import CharState from '../src/CharState';
 import { runtimeEventHub } from '@client/src/runtime/event-hub';
-import { resetUiStoreForTesting } from '../src/ui/store';
+import { resetUiStoreForTesting } from "../src/ui/store.testing";
 
 describe('CharState', () => {
   beforeEach(() => {

--- a/web-client/test/FightTitle.test.ts
+++ b/web-client/test/FightTitle.test.ts
@@ -1,5 +1,6 @@
 import FightTitle from "../src/FightTitle";
-import { resetUiStoreForTesting, uiStore } from "../src/ui/store";
+import { uiStore } from "../src/ui/store";
+import { resetUiStoreForTesting } from "../src/ui/store.testing";
 
 describe("FightTitle", () => {
   beforeEach(() => {

--- a/web-client/test/ObjectList.test.ts
+++ b/web-client/test/ObjectList.test.ts
@@ -1,7 +1,8 @@
 import ObjectList from '../src/ObjectList';
 import { getItemSync, setItemSync } from '@client/src/storage';
 import type { NearbyObject } from '../src/ui/store';
-import { uiStore, resetUiStoreForTesting } from '../src/ui/store';
+import { uiStore } from "../src/ui/store";
+import { resetUiStoreForTesting } from "../src/ui/store.testing";
 import type { CommandDispatcher } from '@client/src/runtime/command-dispatcher';
 
 jest.mock('@client/src/storage', () => ({

--- a/web-client/test/__mocks__/sqljs-wasm-url.ts
+++ b/web-client/test/__mocks__/sqljs-wasm-url.ts
@@ -1,0 +1,2 @@
+const wasmUrl = "mock-sql-wasm.wasm";
+export default wasmUrl;

--- a/web-client/test/uiStore.integration.test.tsx
+++ b/web-client/test/uiStore.integration.test.tsx
@@ -4,7 +4,8 @@ import type { Root } from "react-dom/client";
 
 import { runtimeEventHub } from "@client/src/runtime/event-hub";
 import services from "@client/src/runtime/service-registry";
-import { resetUiStoreForTesting, uiStore } from "../src/ui/store";
+import { uiStore } from "../src/ui/store";
+import { resetUiStoreForTesting } from "../src/ui/store.testing";
 import CharState from "../src/CharState";
 import GuildsSettings from "../src/options/GuildsSettings";
 import guilds from "../src/options/guilds";

--- a/web-client/test/uiStore.test.ts
+++ b/web-client/test/uiStore.test.ts
@@ -1,5 +1,6 @@
 import type { CommandDispatcher, ExtensionCommand } from "@client/src/runtime/command-dispatcher";
-import { resetUiStoreForTesting, uiStore } from "../src/ui/store";
+import { uiStore } from "../src/ui/store";
+import { resetUiStoreForTesting } from "../src/ui/store.testing";
 
 describe("ui store command dispatcher", () => {
     afterEach(() => {


### PR DESCRIPTION
## Summary
- move the runtime MockTransportAdapter into a client test utility module and update the architecture changelog
- expose ui-store reset helpers through a dedicated test entry point while keeping production exports focused
- mock the sql.js wasm URL in Jest so web-client tests no longer depend on the real asset

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ebfbaac0a8832a973ca8856e14893d