### PR TITLE
refactor: isolate test-only helpers

### DIFF
--- a/client/test/runtime/message-router.test.ts
+++ b/client/test/runtime/message-router.test.ts
@@ -1,6 +1,6 @@
 import MessageRouter from "../../src/runtime/transport/message-router";
 import { EventHub, type RuntimeEvents } from "../../src/runtime/event-hub";
-import MockTransportAdapter from "../../src/runtime/transport/mock-adapter";
+import MockTransportAdapter from "./transport/mock-transport-adapter";
 
 describe("MessageRouter runtime event hub integration", () => {
     let eventHub: EventHub<RuntimeEvents>;

--- a/client/test/runtime/runtime-bootstrap.test.ts
+++ b/client/test/runtime/runtime-bootstrap.test.ts
@@ -6,7 +6,7 @@ jest.mock("mudlet-map-renderer", () => ({
 import type { ClientAdapter } from "../../src/Client";
 import createRuntimeBootstrap from "../../src/runtime/createRuntimeBootstrap";
 import { ServiceRegistry } from "../../src/runtime/service-registry";
-import MockTransportAdapter from "../../src/runtime/transport/mock-adapter";
+import MockTransportAdapter from "./transport/mock-transport-adapter";
 
 function createClientAdapter(): ClientAdapter {
     return {

--- a/client/test/runtime/transport/mock-transport-adapter.ts
+++ b/client/test/runtime/transport/mock-transport-adapter.ts
@@ -3,8 +3,8 @@ import type {
     TransportConnectOptions,
     TransportIn,
     TransportOut,
-} from "./types";
-import { TransportSubject } from "./subject";
+} from "../../../src/runtime/transport/types";
+import { TransportSubject } from "../../../src/runtime/transport/subject";
 
 export interface MockTransportAdapterOptions {
     emitLifecycle?: boolean;

--- a/docs/ARCHITECTURE_CHANGELOG.md
+++ b/docs/ARCHITECTURE_CHANGELOG.md
@@ -25,7 +25,7 @@ This document captures progress toward the next-generation runtime described in 
 - Added a production-ready `WebSocketTransportAdapter` that encapsulates Arkadia-specific protocol details such as GMCP framing, MCCP decompression, periodic pings, and exponential backoff reconnect logic. Unit tests simulate socket lifecycles to confirm reconnection, encoding, and ping behaviour. (see `client/src/runtime/transport/websocket-adapter.ts`, `client/test/runtime/transport/websocket-adapter.test.ts`).
 
 ### Mock transport adapter and test subject
-- Implemented a `MockTransportAdapter` plus a minimal `TransportSubject` so runtime components can be exercised without a real socket. The message-router tests rely on this adapter to simulate GMCP frames and lifecycle events deterministically. (see `client/src/runtime/transport/mock-adapter.ts`, `client/src/runtime/transport/subject.ts`, `client/test/runtime/message-router.test.ts`).
+- Implemented a `MockTransportAdapter` plus a minimal `TransportSubject` so runtime components can be exercised without a real socket. The message-router tests rely on this adapter to simulate GMCP frames and lifecycle events deterministically. (see `client/test/runtime/transport/mock-transport-adapter.ts`, `client/src/runtime/transport/subject.ts`, `client/test/runtime/message-router.test.ts`).
 
 ### Shared UI store integration
 - Introduced a Zustand-based `uiStore` that subscribes to the runtime event hub and the modernised settings service, projecting GMCP updates and preference changes into a single UI state tree. The store can also bind to legacy DOM events so existing widgets continue to work during the transition. (see `web-client/src/ui/store.ts`).

--- a/web-client/src/ui/store.ts
+++ b/web-client/src/ui/store.ts
@@ -810,7 +810,7 @@ export function bindUiStoreToClientEvents(client: ClientLike | null | undefined)
 
 export const uiStore = storeWithSelector;
 
-export function resetUiStoreForTesting() {
+function resetUiStoreForTesting() {
     clientEventCleanups.forEach((cleanup) => cleanup());
     clientEventCleanups = [];
     runtimeCleanup?.();
@@ -832,6 +832,17 @@ export function resetUiStoreForTesting() {
     subscribeToRuntime();
     subscribeToCatalog();
 }
+
+const globalProcess = typeof globalThis !== "undefined"
+    ? (globalThis as { process?: { env?: Record<string, string | undefined> } }).process
+    : undefined;
+const isTestEnvironment = globalProcess?.env?.NODE_ENV === "test";
+
+export const __uiStoreTestApi = isTestEnvironment
+    ? {
+          resetUiStoreForTesting,
+      }
+    : undefined;
 
 export function useUiStore<T>(selector: (state: UiStoreState) => T): T {
     return useStore(storeWithSelector, selector);

--- a/web-client/test/AttackMode.test.ts
+++ b/web-client/test/AttackMode.test.ts
@@ -1,5 +1,5 @@
 import AttackMode from '../src/AttackMode';
-import { resetUiStoreForTesting, uiStore } from '../src/ui/store';
+import { resetUiStoreForTesting, uiStore } from './utils/uiStoreTestUtils';
 
 jest.mock('@client/src/storage.ts', () => ({
   getItemSync: jest.fn(() => ({})),

--- a/web-client/test/CharState.test.ts
+++ b/web-client/test/CharState.test.ts
@@ -1,6 +1,6 @@
 import CharState from '../src/CharState';
 import { runtimeEventHub } from '@client/src/runtime/event-hub';
-import { resetUiStoreForTesting } from '../src/ui/store';
+import { resetUiStoreForTesting } from './utils/uiStoreTestUtils';
 
 describe('CharState', () => {
   beforeEach(() => {

--- a/web-client/test/FightTitle.test.ts
+++ b/web-client/test/FightTitle.test.ts
@@ -1,5 +1,5 @@
 import FightTitle from "../src/FightTitle";
-import { resetUiStoreForTesting, uiStore } from "../src/ui/store";
+import { resetUiStoreForTesting, uiStore } from "./utils/uiStoreTestUtils";
 
 describe("FightTitle", () => {
   beforeEach(() => {

--- a/web-client/test/ObjectList.test.ts
+++ b/web-client/test/ObjectList.test.ts
@@ -1,7 +1,7 @@
 import ObjectList from '../src/ObjectList';
 import { getItemSync, setItemSync } from '@client/src/storage';
 import type { NearbyObject } from '../src/ui/store';
-import { uiStore, resetUiStoreForTesting } from '../src/ui/store';
+import { uiStore, resetUiStoreForTesting } from './utils/uiStoreTestUtils';
 import type { CommandDispatcher } from '@client/src/runtime/command-dispatcher';
 
 jest.mock('@client/src/storage', () => ({

--- a/web-client/test/uiStore.integration.test.tsx
+++ b/web-client/test/uiStore.integration.test.tsx
@@ -4,7 +4,7 @@ import type { Root } from "react-dom/client";
 
 import { runtimeEventHub } from "@client/src/runtime/event-hub";
 import services from "@client/src/runtime/service-registry";
-import { resetUiStoreForTesting, uiStore } from "../src/ui/store";
+import { resetUiStoreForTesting, uiStore } from "./utils/uiStoreTestUtils";
 import CharState from "../src/CharState";
 import GuildsSettings from "../src/options/GuildsSettings";
 import guilds from "../src/options/guilds";

--- a/web-client/test/uiStore.test.ts
+++ b/web-client/test/uiStore.test.ts
@@ -1,5 +1,5 @@
 import type { CommandDispatcher, ExtensionCommand } from "@client/src/runtime/command-dispatcher";
-import { resetUiStoreForTesting, uiStore } from "../src/ui/store";
+import { resetUiStoreForTesting, uiStore } from "./utils/uiStoreTestUtils";
 
 describe("ui store command dispatcher", () => {
     afterEach(() => {

--- a/web-client/test/utils/uiStoreTestUtils.ts
+++ b/web-client/test/utils/uiStoreTestUtils.ts
@@ -1,0 +1,11 @@
+import { __uiStoreTestApi, uiStore } from "../../src/ui/store";
+
+if (!__uiStoreTestApi) {
+    throw new Error("UI store test utilities are unavailable outside of the test environment.");
+}
+
+export const resetUiStoreForTesting = () => {
+    __uiStoreTestApi.resetUiStoreForTesting();
+};
+
+export { uiStore };


### PR DESCRIPTION
## Summary
- expose a test-only API from the UI store and consume it through a dedicated test helper so production bundles no longer export reset utilities
- move the mock transport adapter into the client test suite and adjust documentation and tests to reference the new location

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ebfe9299a0832ab48fb55ec43aceea