### PR TITLE
Use UI store for timer widgets

### DIFF
--- a/web-client/src/CoverTimer.ts
+++ b/web-client/src/CoverTimer.ts
@@ -1,11 +1,10 @@
-import ArkadiaClient from "./ArkadiaClient.ts";
+import { uiStore, selectCoverTimer } from "./ui/store";
 
 export default class CoverTimer {
   private container: HTMLElement | null;
-  constructor(client: typeof ArkadiaClient) {
+  constructor() {
     this.container = document.getElementById("cover-timer");
-    client.on("coverTimer", (sec: number | null) => this.update(sec));
-    this.update(null);
+    uiStore.subscribe(selectCoverTimer, (seconds) => this.update(seconds), { fireImmediately: true });
   }
 
   private update(seconds: number | null) {

--- a/web-client/src/LampTimer.ts
+++ b/web-client/src/LampTimer.ts
@@ -1,10 +1,10 @@
-import ArkadiaClient from "./ArkadiaClient.ts";
+import { uiStore, selectLampTimer } from "./ui/store";
 
 export default class LampTimer {
   private container: HTMLElement | null;
-  constructor(client: typeof ArkadiaClient) {
+  constructor() {
     this.container = document.getElementById("lamp-timer");
-    client.on("lampTimer", (seconds: number | null) => this.update(seconds));
+    uiStore.subscribe(selectLampTimer, (seconds) => this.update(seconds), { fireImmediately: true });
   }
 
   private update(seconds: number | null) {

--- a/web-client/src/ZaskTimer.ts
+++ b/web-client/src/ZaskTimer.ts
@@ -1,20 +1,15 @@
-import ArkadiaClient from "./ArkadiaClient.ts";
-
-interface ZaskTimerPayload {
-  seconds: number;
-  ok: boolean;
-}
+import { uiStore, selectZaskTimer } from "./ui/store";
+import type { ZaskTimerState } from "./ui/store";
 
 export default class ZaskTimer {
   private container: HTMLElement | null;
 
-  constructor(client: typeof ArkadiaClient) {
+  constructor() {
     this.container = document.getElementById("zask-timer");
-    client.on("zaskTimer", (payload: ZaskTimerPayload | null) => this.update(payload));
-    this.update(null);
+    uiStore.subscribe(selectZaskTimer, (payload) => this.update(payload), { fireImmediately: true });
   }
 
-  private update(payload: ZaskTimerPayload | null) {
+  private update(payload: ZaskTimerState | null) {
     if (!this.container) return;
 
     if (!payload) {

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -1050,9 +1050,9 @@ document.addEventListener('DOMContentLoaded', () => {
     new MultiBinds(arkadiaClient);
     new CharState(arkadiaClient);
     new CharStateInfo(arkadiaClient);
-    new LampTimer(arkadiaClient);
-    new CoverTimer(arkadiaClient);
-    new ZaskTimer(arkadiaClient);
+    new LampTimer();
+    new CoverTimer();
+    new ZaskTimer();
     new BreakItemWarning(arkadiaClient);
     new ReleaseGuard(arkadiaClient);
     new AttackMode(arkadiaClient);

--- a/web-client/src/ui/store.ts
+++ b/web-client/src/ui/store.ts
@@ -57,6 +57,11 @@ export interface TeamStatus {
     readonly leaderId?: string;
 }
 
+export interface ZaskTimerState {
+    readonly seconds: number;
+    readonly ok: boolean;
+}
+
 interface ObjectsState {
     readonly data: Record<string, RuntimeObjectData>;
     readonly nums: readonly string[];
@@ -236,6 +241,9 @@ export interface UiStoreState {
     nearbyObjects: readonly NearbyObject[];
     teamStatus: TeamStatus;
     attackQueue: readonly string[];
+    lampTimer: number | null;
+    coverTimer: number | null;
+    zaskTimer: ZaskTimerState | null;
     commandDispatcher: CommandDispatcher | null;
     setCommandDispatcher: (dispatcher: CommandDispatcher | null) => void;
     clientBindings: ClientBindings;
@@ -317,6 +325,9 @@ const baseState = {
     nearbyObjects: [] as NearbyObject[],
     teamStatus: { ...emptyTeamStatus },
     attackQueue: [] as string[],
+    lampTimer: null as number | null,
+    coverTimer: null as number | null,
+    zaskTimer: null as ZaskTimerState | null,
     clientBindings: {} as ClientBindings,
     datasets: {} as Record<string, CatalogDatasetSlice<unknown>>,
 };
@@ -754,6 +765,34 @@ type ClientLike = {
     ) => void;
 };
 
+function normalizeTimerValue(value: unknown): number | null {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+    }
+    return null;
+}
+
+function parseZaskTimerPayload(detail: unknown): ZaskTimerState | null {
+    if (!detail || typeof detail !== "object") {
+        return null;
+    }
+    const data = detail as { seconds?: unknown; ok?: unknown };
+    if (typeof data.ok !== "boolean" || typeof data.seconds !== "number" || !Number.isFinite(data.seconds)) {
+        return null;
+    }
+    return { seconds: data.seconds, ok: data.ok };
+}
+
+function zaskTimerEquals(a: ZaskTimerState | null, b: ZaskTimerState | null): boolean {
+    if (a === b) {
+        return true;
+    }
+    if (!a || !b) {
+        return false;
+    }
+    return a.seconds === b.seconds && a.ok === b.ok;
+}
+
 export function bindUiStoreToClientEvents(client: ClientLike | null | undefined) {
     if (!client || typeof client.addEventListener !== "function") {
         return;
@@ -802,6 +841,42 @@ export function bindUiStoreToClientEvents(client: ClientLike | null | undefined)
     cleanups.push(() => {
         if (typeof client.removeEventListener === "function") {
             client.removeEventListener("attackQueueChange", handleAttackQueueChange);
+        }
+    });
+
+    const handleLampTimer: EventListener = (event: Event) => {
+        const seconds = normalizeTimerValue((event as CustomEvent).detail);
+        store.setState((current) => (current.lampTimer === seconds ? {} : { lampTimer: seconds }));
+    };
+
+    client.addEventListener("lampTimer", handleLampTimer);
+    cleanups.push(() => {
+        if (typeof client.removeEventListener === "function") {
+            client.removeEventListener("lampTimer", handleLampTimer);
+        }
+    });
+
+    const handleCoverTimer: EventListener = (event: Event) => {
+        const seconds = normalizeTimerValue((event as CustomEvent).detail);
+        store.setState((current) => (current.coverTimer === seconds ? {} : { coverTimer: seconds }));
+    };
+
+    client.addEventListener("coverTimer", handleCoverTimer);
+    cleanups.push(() => {
+        if (typeof client.removeEventListener === "function") {
+            client.removeEventListener("coverTimer", handleCoverTimer);
+        }
+    });
+
+    const handleZaskTimer: EventListener = (event: Event) => {
+        const next = parseZaskTimerPayload((event as CustomEvent).detail);
+        store.setState((current) => (zaskTimerEquals(current.zaskTimer, next) ? {} : { zaskTimer: next }));
+    };
+
+    client.addEventListener("zaskTimer", handleZaskTimer);
+    cleanups.push(() => {
+        if (typeof client.removeEventListener === "function") {
+            client.removeEventListener("zaskTimer", handleZaskTimer);
         }
     });
 
@@ -861,6 +936,12 @@ export const selectNearbyObjects = (state: UiStoreState) => state.nearbyObjects;
 export const selectTeamStatus = (state: UiStoreState) => state.teamStatus;
 
 export const selectAttackQueue = (state: UiStoreState) => state.attackQueue;
+
+export const selectLampTimer = (state: UiStoreState) => state.lampTimer;
+
+export const selectCoverTimer = (state: UiStoreState) => state.coverTimer;
+
+export const selectZaskTimer = (state: UiStoreState) => state.zaskTimer;
 
 export const selectClientBindings = (state: UiStoreState) => state.clientBindings;
 

--- a/web-client/test/CoverTimer.test.ts
+++ b/web-client/test/CoverTimer.test.ts
@@ -1,35 +1,30 @@
 import CoverTimer from '../src/CoverTimer';
-
-class MockClient {
-  private events: Record<string, Function[]> = {};
-  on(event: string, listener: Function) {
-    (this.events[event] ||= []).push(listener);
-  }
-  emit(event: string, ...args: any[]) {
-    (this.events[event] || []).forEach(fn => fn(...args));
-  }
-}
+import { uiStore, __uiStoreTestApi } from '../src/ui/store';
 
 describe('CoverTimer', () => {
   let container: HTMLElement;
-  let client: MockClient;
 
   beforeEach(() => {
+    __uiStoreTestApi?.resetUiStoreForTesting();
     document.body.innerHTML = '<span id="cover-timer"></span>';
     container = document.getElementById('cover-timer')!;
-    client = new MockClient();
-    new CoverTimer(client as any);
+    new CoverTimer();
   });
 
   test('shows ready when no time', () => {
-    client.emit('coverTimer', null);
+    expect(container.textContent).toBe('Zas: OK');
+    expect(container.style.display).toBe('block');
+    expect(container.className).toBe('green');
+
+    uiStore.setState({ coverTimer: 2 });
+    uiStore.setState({ coverTimer: null });
     expect(container.textContent).toBe('Zas: OK');
     expect(container.style.display).toBe('block');
     expect(container.className).toBe('green');
   });
 
   test('shows time with two decimals', () => {
-    client.emit('coverTimer', 4.567);
+    uiStore.setState({ coverTimer: 4.567 });
     expect(container.textContent).toBe('Zas: 4.57');
     expect(container.className).toBe('yellow');
   });

--- a/web-client/test/LampTimer.test.ts
+++ b/web-client/test/LampTimer.test.ts
@@ -1,43 +1,38 @@
 import LampTimer from '../src/LampTimer';
-
-class MockClient {
-  private events: Record<string, Function[]> = {};
-  on(event: string, listener: Function) {
-    (this.events[event] ||= []).push(listener);
-  }
-  emit(event: string, ...args: any[]) {
-    (this.events[event] || []).forEach(fn => fn(...args));
-  }
-}
+import { uiStore, __uiStoreTestApi } from '../src/ui/store';
 
 describe('LampTimer', () => {
   let container: HTMLElement;
-  let client: MockClient;
 
   beforeEach(() => {
+    __uiStoreTestApi?.resetUiStoreForTesting();
     document.body.innerHTML = '<div id="lamp-timer"></div>';
     container = document.getElementById('lamp-timer')!;
-    client = new MockClient();
-    new LampTimer(client as any);
+    new LampTimer();
   });
 
   test('hides timer when no time', () => {
-    client.emit('lampTimer', null);
+    expect(container.style.display).toBe('none');
+    expect(container.textContent).toBe('');
+    expect(container.className).toBe('');
+
+    uiStore.setState({ lampTimer: 30 });
+    uiStore.setState({ lampTimer: null });
     expect(container.style.display).toBe('none');
     expect(container.textContent).toBe('');
     expect(container.className).toBe('');
   });
 
   test('updates display and class based on time', () => {
-    client.emit('lampTimer', 65);
+    uiStore.setState({ lampTimer: 65 });
     expect(container.textContent).toBe('lamp 1:05');
     expect(container.style.display).toBe('block');
     expect(container.className).toBe('green');
 
-    client.emit('lampTimer', 55);
+    uiStore.setState({ lampTimer: 55 });
     expect(container.className).toBe('yellow');
 
-    client.emit('lampTimer', 25);
+    uiStore.setState({ lampTimer: 25 });
     expect(container.className).toBe('red');
   });
 });

--- a/web-client/test/ZaskTimer.test.ts
+++ b/web-client/test/ZaskTimer.test.ts
@@ -1,0 +1,43 @@
+import ZaskTimer from '../src/ZaskTimer';
+import { uiStore, __uiStoreTestApi } from '../src/ui/store';
+
+describe('ZaskTimer', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    __uiStoreTestApi?.resetUiStoreForTesting();
+    document.body.innerHTML = '<div id="zask-timer"></div>';
+    container = document.getElementById('zask-timer')!;
+    new ZaskTimer();
+  });
+
+  test('hides timer when no payload', () => {
+    expect(container.style.display).toBe('none');
+    expect(container.textContent).toBe('');
+    expect(container.className).toBe('');
+
+    uiStore.setState({ zaskTimer: { seconds: 5, ok: false } });
+    expect(container.style.display).toBe('block');
+    expect(container.textContent).toBe('Zask: 5');
+    expect(container.className).toBe('red');
+
+    uiStore.setState({ zaskTimer: null });
+    expect(container.style.display).toBe('none');
+    expect(container.textContent).toBe('');
+    expect(container.className).toBe('');
+  });
+
+  test('shows green state when ok', () => {
+    uiStore.setState({ zaskTimer: { seconds: 30, ok: true } });
+    expect(container.style.display).toBe('block');
+    expect(container.textContent).toBe('Zask: OK');
+    expect(container.className).toBe('green');
+  });
+
+  test('shows yellow when nearing safe threshold', () => {
+    uiStore.setState({ zaskTimer: { seconds: 25, ok: false } });
+    expect(container.style.display).toBe('block');
+    expect(container.textContent).toBe('Zask: 25');
+    expect(container.className).toBe('yellow');
+  });
+});


### PR DESCRIPTION
## Summary
- add lamp, cover, and zask timer slices and selectors to the UI store and map client timer events into state updates
- refactor the timer widgets to subscribe to the store and adjust main bootstrap wiring accordingly
- update timer unit tests to assert behaviour via the store and add coverage for the zask timer

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ec07c94e2c832a98887c4c1d2e2d3c