### PR TITLE
Route main command input through dispatcher

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -410,46 +410,51 @@ export default class Client {
         this.sendCommand('przestan kryc sie za zaslona')
     }
 
-    sendCommand(command: string, echo: boolean = true) {
+    sendCommand(command: string, echo: boolean = true): boolean {
         if (command) {
             command = stripPolishCharacters(command)
         }
         this.eventTarget.dispatchEvent(new CustomEvent('command', {detail: command}))
 
-        let preparse = command
-        command = this.Map.parseCommand(command)
-        command = this.expandObjectShortcuts(command)
-        if (command.startsWith('echo ')) {
-            this.print(mudletColorLine(command.substring(5)))
-            return
+        const preparse = command
+        let parsed = this.Map.parseCommand(command)
+        parsed = this.expandObjectShortcuts(parsed)
+        if (parsed.startsWith('echo ')) {
+            this.print(mudletColorLine(parsed.substring(5)))
+            return true
         }
-        const split = command.split(/[#;]/)
+        const split = parsed.split(/[#;]/)
         if (split.length > 1) {
+            let handled = false
             split.forEach(part => {
                 if (part !== preparse) {
-                    this.sendCommand(part, echo)
+                    handled = this.sendCommand(part, echo) || handled
                 } else {
                     this.sendMovement(part, echo)
+                    handled = true
                 }
             })
-            return
+            return handled
         }
 
-        const isAlias = this.aliases.find(alias => {
-            const matches = command.match(alias.pattern)
+        const handledByAlias = this.aliases.some(alias => {
+            const matches = parsed.match(alias.pattern)
             if (matches) {
                 alias.callback(matches)
                 return true
             }
             return false
         })
-        if (!isAlias) {
-            if (command.trim().startsWith('/')) {
-                this.print(mudletColorLine(`--- <tomato>Nieznany alias<reset>: ${command}`))
-                return
-            }
-            this.sendMovement(command, echo)
+        if (handledByAlias) {
+            return true
         }
+
+        if (parsed.trim().startsWith('/')) {
+            this.print(mudletColorLine(`--- <tomato>Nieznany alias<reset>: ${parsed}`))
+            return false
+        }
+        this.sendMovement(parsed, echo)
+        return true
     }
 
     sendGMCP(type: string, payload?: any) {

--- a/client/src/runtime/command-dispatcher.ts
+++ b/client/src/runtime/command-dispatcher.ts
@@ -11,7 +11,7 @@ export type ExtensionCommand =
     | { type: "MULTIBINDS_SAVE"; value: MultibindPortRecord[] };
 
 export interface CommandDispatcher {
-    sendCommand(command: string, options?: { echo?: boolean }): void;
+    sendCommand(command: string, options?: { echo?: boolean }): boolean;
     sendEvent(type: string, payload?: unknown): void;
     sendExtensionCommand(command: ExtensionCommand): boolean;
 }
@@ -19,9 +19,9 @@ export interface CommandDispatcher {
 export class ClientCommandDispatcher implements CommandDispatcher {
     constructor(private readonly client: Client) {}
 
-    sendCommand(command: string, options?: { echo?: boolean }): void {
+    sendCommand(command: string, options?: { echo?: boolean }): boolean {
         const echo = options?.echo ?? true;
-        this.client.sendCommand(command, echo);
+        return this.client.sendCommand(command, echo);
     }
 
     sendEvent(type: string, payload?: unknown): void {

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -161,7 +161,8 @@ test('createButton creates button attached to panel', () => {
 
 test('sendCommand dispatches event and splits commands', () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
-  client.sendCommand('foo#bar');
+  const result = client.sendCommand('foo#bar');
+  expect(result).toBe(true);
   expect(parseCommand).toHaveBeenCalledWith('foo#bar');
   expect(parseCommand).toHaveBeenCalledWith('parsed:foo');
   expect(parseCommand).toHaveBeenCalledWith('bar');
@@ -171,7 +172,8 @@ test('sendCommand dispatches event and splits commands', () => {
 
 test('sendCommand allows empty command', () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
-  client.sendCommand('');
+  const result = client.sendCommand('');
+  expect(result).toBe(true);
   expect(parseCommand).toHaveBeenCalledWith('');
   expect((global as any).clientAdapterMock.send).toHaveBeenCalledWith('parsed:', true);
 });
@@ -179,7 +181,8 @@ test('sendCommand allows empty command', () => {
 test('sendCommand splits commands returned by parseCommand', () => {
   parseCommand.mockImplementationOnce(() => 'foo;bar');
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
-  client.sendCommand('e');
+  const result = client.sendCommand('e');
+  expect(result).toBe(true);
   expect(parseCommand).toHaveBeenCalledWith('e');
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(1, 'parsed:foo', true);
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'parsed:bar', true);
@@ -189,7 +192,8 @@ test('sendCommand prints echo commands locally', () => {
   parseCommand.mockImplementationOnce((cmd: string) => cmd);
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   const printSpy = jest.spyOn(client, 'print').mockImplementation();
-  client.sendCommand('echo <red> text');
+  const result = client.sendCommand('echo <red> text');
+  expect(result).toBe(true);
   expect(printSpy).toHaveBeenCalledWith(mudletColorLine('<red> text'));
   expect((global as any).clientAdapterMock.send).not.toHaveBeenCalled();
 });

--- a/client/test/runtime/runtime-bootstrap.test.ts
+++ b/client/test/runtime/runtime-bootstrap.test.ts
@@ -57,7 +57,8 @@ describe("createRuntimeBootstrap", () => {
         expect(bootstrap.catalogMetadata.magicKeys).toBeUndefined();
         expect(bootstrap.catalogMetadata.herbs).toBeUndefined();
 
-        bootstrap.commandDispatcher.sendCommand("look", { echo: false });
+        const result = bootstrap.commandDispatcher.sendCommand("look", { echo: false });
+        expect(result).toBe(true);
         expect(clientAdapter.send).toHaveBeenCalledWith("look", false);
 
         expect(registry.transport).toBe(transport);

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -292,8 +292,9 @@ class ArkadiaClient implements ClientAdapter {
         this.sendGmcp('client.conf.set', data);
     }
 
-    sendCommand(command: string, echo: boolean = true): void {
+    sendCommand(command: string, echo: boolean = true): boolean {
         this.send(command, echo);
+        return true;
     }
 
     output(text?: string, type?: string) {

--- a/web-client/src/Recorder.ts
+++ b/web-client/src/Recorder.ts
@@ -2,7 +2,7 @@ import { saveRecording, getRecording, getRecordingNames, deleteRecording, Record
 
 export interface RecorderHooks {
     processIncomingData(data: string): void;
-    sendCommand(command: string, echo?: boolean): void;
+    sendCommand(command: string, echo?: boolean): boolean;
     emit(event: string, ...args: any[]): void;
 }
 

--- a/web-client/src/commandInput.ts
+++ b/web-client/src/commandInput.ts
@@ -1,0 +1,47 @@
+import type { CommandDispatcher } from "@client/src/runtime/command-dispatcher";
+import type ArkadiaClient from "./ArkadiaClient";
+
+export interface CommandHistoryState {
+    history: string[];
+    index: number;
+    currentInput: string;
+}
+
+export interface SendMessageDependencies {
+    dispatcher: CommandDispatcher;
+    arkadiaClient: typeof ArkadiaClient;
+    history: CommandHistoryState;
+}
+
+export function sendMessageFromInput(
+    input: HTMLInputElement,
+    { dispatcher, arkadiaClient, history }: SendMessageDependencies,
+    focus = true,
+): void {
+    const message = input.value.trim();
+    if (message) {
+        const dispatched = dispatcher.sendCommand(message);
+        if (!dispatched) {
+            return;
+        }
+        if (arkadiaClient.hasReceivedFirstGmcp()) {
+            const { history: entries } = history;
+            if (entries.length === 0 || entries[entries.length - 1] !== message) {
+                entries.push(message);
+            }
+            history.index = -1;
+            history.currentInput = '';
+            if (focus) {
+                input.select();
+            }
+        } else {
+            input.value = '';
+        }
+        return;
+    }
+
+    const dispatched = dispatcher.sendCommand('');
+    if (dispatched && focus) {
+        input.select();
+    }
+}

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -51,6 +51,7 @@ import {
     ensureNpcDataset,
     uiStore,
 } from "./ui/store";
+import { sendMessageFromInput, type CommandHistoryState } from "./commandInput";
 
 const runtimeBootstrap = createRuntimeBootstrap({
     clientAdapter: arkadiaClient,
@@ -530,7 +531,7 @@ document.addEventListener('keydown', (e) => {
                 commandDispatcher.sendCommand(first);
             }
         } else {
-            client.sendCommand(direction);
+            commandDispatcher.sendCommand(direction);
         }
     }
 });
@@ -880,75 +881,64 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Command history implementation
-    const commandHistory: string[] = [];
-    let historyIndex = -1;
-    let currentInput = '';
+    const historyState: CommandHistoryState = {
+        history: [],
+        index: -1,
+        currentInput: '',
+    };
 
     function navigateHistory(direction: 'up' | 'down') {
         // Only allow command history navigation if we've received the first GMCP event
         if (!arkadiaClient.hasReceivedFirstGmcp()) return;
-        if (commandHistory.length === 0) return;
+        const entries = historyState.history;
+        if (entries.length === 0) return;
 
         const wasFocused = document.activeElement === messageInput;
 
-        if (historyIndex === -1) {
-            currentInput = messageInput.value;
+        if (historyState.index === -1) {
+            historyState.currentInput = messageInput.value;
             // Skip the just sent command if the input wasn't modified
             if (
                 direction === 'up' &&
-                commandHistory.length > 1 &&
-                messageInput.value === commandHistory[commandHistory.length - 1]
+                entries.length > 1 &&
+                messageInput.value === entries[entries.length - 1]
             ) {
-                historyIndex = 1;
-                messageInput.value = commandHistory[commandHistory.length - 1 - historyIndex];
+                historyState.index = 1;
+                messageInput.value = entries[entries.length - 1 - historyState.index];
                 if (wasFocused) messageInput.select();
                 return;
             }
         }
 
         if (direction === 'up') {
-            if (historyIndex < commandHistory.length - 1) {
-                historyIndex++;
-                messageInput.value = commandHistory[commandHistory.length - 1 - historyIndex];
+            if (historyState.index < entries.length - 1) {
+                historyState.index += 1;
+                messageInput.value = entries[entries.length - 1 - historyState.index];
                 if (wasFocused) messageInput.select();
             }
         } else {
-            if (historyIndex > 0) {
-                historyIndex--;
-                messageInput.value = commandHistory[commandHistory.length - 1 - historyIndex];
+            if (historyState.index > 0) {
+                historyState.index -= 1;
+                messageInput.value = entries[entries.length - 1 - historyState.index];
                 if (wasFocused) messageInput.select();
-            } else if (historyIndex === 0) {
-                historyIndex = -1;
-                messageInput.value = currentInput;
+            } else if (historyState.index === 0) {
+                historyState.index = -1;
+                messageInput.value = historyState.currentInput;
                 if (wasFocused) messageInput.select();
             }
         }
     }
 
     function sendMessage(focus = true) {
-        const message = messageInput.value.trim();
-        if (message) {
-            // Only add command to history if we've received the first GMCP event
-            if (arkadiaClient.hasReceivedFirstGmcp()) {
-                // Add command to history if it's different from the last one
-                if (commandHistory.length === 0 || commandHistory[commandHistory.length - 1] !== message) {
-                    commandHistory.push(message);
-                }
-                // Reset history index
-                historyIndex = -1;
-                currentInput = '';
-
-                client.sendCommand(message);
-                if (focus) messageInput.select();
-            } else {
-                // If we haven't received the first GMCP event yet, clear the input field
-                client.sendCommand(message);
-                messageInput.value = '';
-            }
-        } else {
-            client.sendCommand('');
-            if (focus) messageInput.select();
-        }
+        sendMessageFromInput(
+            messageInput,
+            {
+                dispatcher: commandDispatcher,
+                arkadiaClient,
+                history: historyState,
+            },
+            focus,
+        );
     }
 
     sendButton.addEventListener('click', () => sendMessage(false));

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -870,15 +870,14 @@ export default class MobileDirectionButtons {
         button.title = title;
     }
 
-    private sendCommand(command: string, options?: { echo?: boolean }) {
+    private sendCommand(command: string, options?: { echo?: boolean }): boolean {
         if (!command) {
-            return;
+            return false;
         }
         if (this.dispatcher) {
-            this.dispatcher.sendCommand(command, options);
-        } else {
-            this.client.sendCommand(command, options?.echo ?? true);
+            return this.dispatcher.sendCommand(command, options);
         }
+        return this.client.sendCommand(command, options?.echo ?? true);
     }
 
     private sendEvent(event: string, payload?: unknown) {

--- a/web-client/src/ui/store.ts
+++ b/web-client/src/ui/store.ts
@@ -240,7 +240,7 @@ export interface UiStoreState {
     setCommandDispatcher: (dispatcher: CommandDispatcher | null) => void;
     clientBindings: ClientBindings;
     setClientBindings: (bindings: ClientBindings) => void;
-    sendCommand: (command: string, options?: { echo?: boolean }) => void;
+    sendCommand: (command: string, options?: { echo?: boolean }) => boolean;
     sendEvent: (event: string, payload?: unknown) => void;
     sendExtensionCommand: (command: ExtensionCommand) => boolean;
     dispatch: (intent: UiIntent) => Promise<void>;
@@ -332,7 +332,7 @@ const store = createStore(
             if (!dispatcher) {
                 throw new Error("Command dispatcher not configured");
             }
-            dispatcher.sendCommand(command, options);
+            return dispatcher.sendCommand(command, options);
         },
         sendEvent: (event, payload) => {
             const dispatcher = get().commandDispatcher;

--- a/web-client/test/ObjectList.test.ts
+++ b/web-client/test/ObjectList.test.ts
@@ -19,7 +19,7 @@ function setAttackQueue(queue: string[]) {
 
 function createDispatcher(): CommandDispatcher {
   return {
-    sendCommand: jest.fn(),
+    sendCommand: jest.fn(() => true),
     sendEvent: jest.fn(),
     sendExtensionCommand: jest.fn().mockReturnValue(false),
   };

--- a/web-client/test/Recorder.test.ts
+++ b/web-client/test/Recorder.test.ts
@@ -4,7 +4,7 @@ describe('Recorder playback', () => {
   test('replayRecordedMessagesTimed echoes outgoing commands', () => {
     const hooks = {
       processIncomingData: jest.fn(),
-      sendCommand: jest.fn(),
+      sendCommand: jest.fn(() => true),
       emit: jest.fn(),
     };
     const recorder = new Recorder(hooks as any);

--- a/web-client/test/commandInput.test.ts
+++ b/web-client/test/commandInput.test.ts
@@ -1,0 +1,82 @@
+import type { CommandDispatcher } from "@client/src/runtime/command-dispatcher";
+
+import { sendMessageFromInput, type CommandHistoryState } from "../src/commandInput";
+
+describe("sendMessageFromInput", () => {
+    let dispatcher: jest.Mocked<CommandDispatcher>;
+    let arkadiaClient: { hasReceivedFirstGmcp: jest.Mock<boolean, []> };
+    let history: CommandHistoryState;
+    let input: HTMLInputElement;
+
+    beforeEach(() => {
+        dispatcher = {
+            sendCommand: jest.fn(() => true),
+            sendEvent: jest.fn(),
+            sendExtensionCommand: jest.fn(() => false),
+        } as unknown as jest.Mocked<CommandDispatcher>;
+        arkadiaClient = { hasReceivedFirstGmcp: jest.fn(() => true) };
+        history = { history: [], index: -1, currentInput: "" };
+        input = document.createElement("input");
+        jest.spyOn(input, "select").mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("dispatches command and records it in history", () => {
+        input.value = "look";
+
+        sendMessageFromInput(input, { dispatcher, arkadiaClient: arkadiaClient as any, history });
+
+        expect(dispatcher.sendCommand).toHaveBeenCalledWith("look");
+        expect(history.history).toEqual(["look"]);
+        expect(history.index).toBe(-1);
+        expect(history.currentInput).toBe("");
+        expect(input.select).toHaveBeenCalled();
+    });
+
+    test("does not alter history when dispatcher rejects command", () => {
+        dispatcher.sendCommand.mockReturnValue(false);
+        input.value = "look";
+
+        sendMessageFromInput(input, { dispatcher, arkadiaClient: arkadiaClient as any, history });
+
+        expect(dispatcher.sendCommand).toHaveBeenCalledWith("look");
+        expect(history.history).toHaveLength(0);
+        expect(history.index).toBe(-1);
+        expect(input.select).not.toHaveBeenCalled();
+    });
+
+    test("clears input when GMCP handshake not complete", () => {
+        arkadiaClient.hasReceivedFirstGmcp.mockReturnValue(false);
+        input.value = "look";
+
+        sendMessageFromInput(input, { dispatcher, arkadiaClient: arkadiaClient as any, history });
+
+        expect(dispatcher.sendCommand).toHaveBeenCalledWith("look");
+        expect(input.value).toBe("");
+        expect(history.history).toHaveLength(0);
+        expect(input.select).not.toHaveBeenCalled();
+    });
+
+    test("dispatches blank command without modifying history", () => {
+        input.value = "   ";
+
+        sendMessageFromInput(input, { dispatcher, arkadiaClient: arkadiaClient as any, history });
+
+        expect(dispatcher.sendCommand).toHaveBeenCalledWith("");
+        expect(history.history).toHaveLength(0);
+        expect(history.index).toBe(-1);
+        expect(input.select).toHaveBeenCalled();
+    });
+
+    test("respects focus flag when dispatching blank command", () => {
+        input.value = "";
+
+        sendMessageFromInput(input, { dispatcher, arkadiaClient: arkadiaClient as any, history }, false);
+
+        expect(dispatcher.sendCommand).toHaveBeenCalledWith("");
+        expect(input.select).not.toHaveBeenCalled();
+    });
+});

--- a/web-client/test/uiStore.test.ts
+++ b/web-client/test/uiStore.test.ts
@@ -8,7 +8,7 @@ describe("ui store command dispatcher", () => {
 
     test("forwards extension commands when dispatcher configured", async () => {
         const dispatcher: CommandDispatcher = {
-            sendCommand: jest.fn(),
+            sendCommand: jest.fn(() => true),
             sendEvent: jest.fn(),
             sendExtensionCommand: jest.fn<ReturnType<CommandDispatcher["sendExtensionCommand"]>, [ExtensionCommand]>(() => true),
         };


### PR DESCRIPTION
## Summary
- make the command dispatcher return a boolean result from Client.sendCommand and expose it through the UI store
- route the main command input (including numpad shortcuts) through the dispatcher via a reusable helper tied to history state
- add focused unit coverage for the command sender and update existing tests to assert dispatcher usage

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ec07dc8f34832a90126028f03dfdeb