### PR TITLE
Use runtime client from store in recordings panel

### DIFF
--- a/web-client/src/options/Recordings.tsx
+++ b/web-client/src/options/Recordings.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { Button, Table, Form } from 'react-bootstrap';
 import { getRecordingNames, deleteRecording, getRecording, saveRecording } from './recordingStorage';
+import { selectClientBindings, useUiStore } from '../ui/store';
 
 function Recordings() {
     const [names, setNames] = useState<string[]>([]);
@@ -8,6 +9,7 @@ function Recordings() {
     const [recording, setRecording] = useState(false);
     const [message, setMessage] = useState('');
     const fileInput = useRef<HTMLInputElement>(null);
+    const { client: runtimeClient } = useUiStore(selectClientBindings);
 
     const load = () => {
         getRecordingNames().then(setNames).catch(() => setNames([]));
@@ -16,7 +18,7 @@ function Recordings() {
     useEffect(load, []);
 
     useEffect(() => {
-        if (!window.client) return;
+        if (!runtimeClient) return;
 
         const startHandler = (name: string) => {
             setRecordingName(name);
@@ -28,13 +30,13 @@ function Recordings() {
             if (save) load();
         };
 
-        window.client.on('recording.start', startHandler);
-        window.client.on('recording.stop', stopHandler);
+        runtimeClient.on('recording.start', startHandler);
+        runtimeClient.on('recording.stop', stopHandler);
         return () => {
-            window.client.off('recording.start', startHandler);
-            window.client.off('recording.stop', stopHandler);
+            runtimeClient.off('recording.start', startHandler);
+            runtimeClient.off('recording.stop', stopHandler);
         };
-    }, []);
+    }, [runtimeClient]);
 
     function activeTabAction(msg: any) {
         chrome.tabs?.query({ active: true, currentWindow: true }, tabs => {
@@ -45,9 +47,9 @@ function Recordings() {
     }
 
     async function handlePlay(name: string) {
-        if (window.client) {
-            await window.client.loadRecording(name);
-            window.client.replayRecordedMessages();
+        if (runtimeClient) {
+            await runtimeClient.loadRecording(name);
+            runtimeClient.replayRecordedMessages();
         } else {
             const events = await getRecording(name);
             if (!events) return;
@@ -56,9 +58,9 @@ function Recordings() {
     }
 
     async function handlePlayTimed(name: string) {
-        if (window.client) {
-            await window.client.loadRecording(name);
-            window.client.replayRecordedMessagesTimed();
+        if (runtimeClient) {
+            await runtimeClient.loadRecording(name);
+            runtimeClient.replayRecordedMessagesTimed();
         } else {
             const events = await getRecording(name);
             if (!events) return;
@@ -67,8 +69,8 @@ function Recordings() {
     }
 
     async function handleDelete(name: string) {
-        if (window.client) {
-            await window.client.deleteRecording(name);
+        if (runtimeClient) {
+            await runtimeClient.deleteRecording(name);
             load();
         } else {
             await deleteRecording(name);
@@ -142,8 +144,8 @@ function Recordings() {
     function start() {
         const name = recordingName.trim();
         if (!name) return;
-        if (window.client) {
-            window.client.startRecording(name);
+        if (runtimeClient) {
+            runtimeClient.startRecording(name);
         } else {
             activeTabAction({ type: 'START_RECORDING', name });
         }
@@ -151,8 +153,8 @@ function Recordings() {
     }
 
     async function stop(save: boolean) {
-        if (window.client) {
-            await window.client.stopRecording(save);
+        if (runtimeClient) {
+            await runtimeClient.stopRecording(save);
             if (save) load();
         } else {
             activeTabAction({ type: 'STOP_RECORDING', save });


### PR DESCRIPTION
## Summary
- read the runtime client bindings for the recordings panel from the UI store
- replace direct window.client usage with the store-sourced runtime client instance

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68ec10dadec4832a9d3a25f57eb9fe0f