### PR TITLE
Refactor module catalog metadata access

### DIFF
--- a/client/src/runtime/createRuntimeBootstrap.ts
+++ b/client/src/runtime/createRuntimeBootstrap.ts
@@ -10,7 +10,6 @@ import type {
     MagicDataCatalog,
     MagicKeysDataCatalog,
     HerbsDataCatalog,
-    DataCatalogEntryMetadata,
 } from "./data";
 import type { EventHub, RuntimeEvents } from "./event-hub";
 import type MessageRouter from "./transport/message-router";
@@ -50,15 +49,6 @@ export interface RuntimeBootstrapResult {
         magicKeys: MagicKeysDataCatalog;
         herbs: HerbsDataCatalog;
     };
-    catalogMetadata: {
-        map: DataCatalogEntryMetadata | undefined;
-        npc: DataCatalogEntryMetadata | undefined;
-        colors: DataCatalogEntryMetadata | undefined;
-        people: DataCatalogEntryMetadata | undefined;
-        magic: DataCatalogEntryMetadata | undefined;
-        magicKeys: DataCatalogEntryMetadata | undefined;
-        herbs: DataCatalogEntryMetadata | undefined;
-    };
 }
 
 export function createRuntimeBootstrap(options: RuntimeBootstrapOptions): RuntimeBootstrapResult {
@@ -86,8 +76,6 @@ export function createRuntimeBootstrap(options: RuntimeBootstrapOptions): Runtim
     });
 
     const commandDispatcher = registry.getCommandDispatcher(client);
-    const catalogMetadata = registry.getCatalogMetadata();
-
     const moduleLoader = options.registerModules ?? registerLegacyModules;
     moduleLoader?.({
         client,
@@ -103,7 +91,6 @@ export function createRuntimeBootstrap(options: RuntimeBootstrapOptions): Runtim
             magicKeys: registry.magicKeysCatalog,
             herbs: registry.herbsCatalog,
         },
-        catalogMetadata,
     });
 
     return {
@@ -120,7 +107,6 @@ export function createRuntimeBootstrap(options: RuntimeBootstrapOptions): Runtim
             magicKeys: registry.magicKeysCatalog,
             herbs: registry.herbsCatalog,
         },
-        catalogMetadata,
     };
 }
 

--- a/client/src/runtime/feature-module.ts
+++ b/client/src/runtime/feature-module.ts
@@ -8,7 +8,6 @@ import type {
     MagicDataCatalog,
     MagicKeysDataCatalog,
     HerbsDataCatalog,
-    DataCatalogEntryMetadata,
 } from "./data";
 import type { EventHub, RuntimeEvents } from "./event-hub";
 import type { SettingsService } from "./settings/settings-service";
@@ -26,15 +25,6 @@ export interface FeatureModuleContext {
         magic: MagicDataCatalog;
         magicKeys: MagicKeysDataCatalog;
         herbs: HerbsDataCatalog;
-    };
-    catalogMetadata: {
-        map: DataCatalogEntryMetadata | undefined;
-        npc: DataCatalogEntryMetadata | undefined;
-        colors: DataCatalogEntryMetadata | undefined;
-        people: DataCatalogEntryMetadata | undefined;
-        magic: DataCatalogEntryMetadata | undefined;
-        magicKeys: DataCatalogEntryMetadata | undefined;
-        herbs: DataCatalogEntryMetadata | undefined;
     };
 }
 

--- a/client/src/runtime/service-registry.ts
+++ b/client/src/runtime/service-registry.ts
@@ -19,7 +19,6 @@ import {
     MAGIC_KEYS_DATASET_KEY,
     HERBS_DATASET_KEY,
 } from "./data";
-import type { DataCatalogEntryMetadata } from "./data";
 import type { EventHub } from "./event-hub";
 import { runtimeEventHub } from "./event-hub";
 import type { RuntimeEvents } from "./event-hub";
@@ -179,25 +178,6 @@ class ServiceRegistry {
         return this.commandDispatcher;
     }
 
-    getCatalogMetadata(): {
-        map: DataCatalogEntryMetadata | undefined;
-        npc: DataCatalogEntryMetadata | undefined;
-        colors: DataCatalogEntryMetadata | undefined;
-        people: DataCatalogEntryMetadata | undefined;
-        magic: DataCatalogEntryMetadata | undefined;
-        magicKeys: DataCatalogEntryMetadata | undefined;
-        herbs: DataCatalogEntryMetadata | undefined;
-    } {
-        return {
-            map: this.mapCatalogInstance.getMapMetadata(),
-            npc: this.npcCatalogInstance.getNpcMetadata(),
-            colors: this.mapCatalogInstance.getColorMetadata(),
-            people: this.peopleCatalogInstance.getPeopleMetadata(),
-            magic: this.magicCatalogInstance.getMagicMetadata(),
-            magicKeys: this.magicKeysCatalogInstance.getMagicKeysMetadata(),
-            herbs: this.herbsCatalogInstance.getHerbsMetadata(),
-        };
-    }
 }
 
 const services = new ServiceRegistry();

--- a/client/test/runtime/runtime-bootstrap.test.ts
+++ b/client/test/runtime/runtime-bootstrap.test.ts
@@ -54,13 +54,13 @@ describe("createRuntimeBootstrap", () => {
         expect(bootstrap.catalogs.map).toBe(registry.mapCatalog);
         expect(bootstrap.catalogs.npc).toBe(registry.npcCatalog);
         expect(bootstrap.catalogs.people).toBe(registry.peopleCatalog);
-        expect(bootstrap.catalogMetadata.map?.status).toBe("idle");
-        expect(bootstrap.catalogMetadata.colors?.status).toBe("idle");
-        expect(bootstrap.catalogMetadata.npc?.status).toBe("idle");
-        expect(bootstrap.catalogMetadata.people?.status).toBe("idle");
-        expect(bootstrap.catalogMetadata.magic).toBeUndefined();
-        expect(bootstrap.catalogMetadata.magicKeys).toBeUndefined();
-        expect(bootstrap.catalogMetadata.herbs).toBeUndefined();
+        expect(bootstrap.catalogs.map.getMapMetadata()?.status).toBe("idle");
+        expect(bootstrap.catalogs.map.getColorMetadata()?.status).toBe("idle");
+        expect(bootstrap.catalogs.npc.getNpcMetadata()?.status).toBe("idle");
+        expect(bootstrap.catalogs.people.getPeopleMetadata()?.status).toBe("idle");
+        expect(bootstrap.catalogs.magic.getMagicMetadata()).toBeUndefined();
+        expect(bootstrap.catalogs.magicKeys.getMagicKeysMetadata()).toBeUndefined();
+        expect(bootstrap.catalogs.herbs.getHerbsMetadata()).toBeUndefined();
 
         const result = bootstrap.commandDispatcher.sendCommand("look", { echo: false });
         expect(result).toBe(true);

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -65,7 +65,7 @@ const runtimeBootstrap = createRuntimeBootstrap({
 
 initSessionLogger(arkadiaClient).catch(err => console.error('Logger init failed', err));
 
-const { client, commandDispatcher, dataCatalog, catalogs, catalogMetadata } = runtimeBootstrap;
+const { client, commandDispatcher, dataCatalog, catalogs } = runtimeBootstrap;
 uiStore.getState().setCommandDispatcher(commandDispatcher);
 uiStore.getState().setClientBindings({
     client,
@@ -193,8 +193,8 @@ updateMapLayoutOffsets()
 const progressContainer = document.getElementById('map-progress-container')!;
 const progressBar = document.getElementById('map-progress-bar') as HTMLElement;
 
-let mapStatus: DataCatalogEntryStatus = catalogMetadata.map?.status ?? 'idle';
-let colorStatus: DataCatalogEntryStatus = catalogMetadata.colors?.status ?? 'idle';
+let mapStatus: DataCatalogEntryStatus = catalogs.map.getMapMetadata()?.status ?? 'idle';
+let colorStatus: DataCatalogEntryStatus = catalogs.map.getColorMetadata()?.status ?? 'idle';
 let progressMessageOverride: string | null = null;
 
 function refreshProgressDisplay() {


### PR DESCRIPTION
## Summary
- remove the aggregated catalog metadata object from the runtime bootstrap API
- rely on catalog instances for metadata lookups in modules and the web client
- update runtime bootstrap tests to assert metadata through the catalog getters

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ec12d8badc832a832a2585af825e0e