### PR TITLE
Remove chrome extension dependencies and hooks

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
-    "prebuild": "mkdirp ../extension/dist/",
+    "prebuild": "mkdirp dist/",
     "build": "webpack",
     "watch": "webpack --watch",
     "test": "jest"
@@ -16,7 +16,6 @@
     "sql.js": "^1.13.0"
   },
   "devDependencies": {
-    "@types/chrome": "^0.0.326",
     "@types/jest": "^29.5.5",
     "fake-indexeddb": "^6.0.1",
     "jest": "^30.0.4",

--- a/client/src/runtime/command-dispatcher.ts
+++ b/client/src/runtime/command-dispatcher.ts
@@ -1,19 +1,8 @@
 import type Client from "../Client";
 
-export interface MultibindPortRecord {
-    roomId: number;
-    index: number;
-    action: string;
-}
-
-export type ExtensionCommand =
-    | { type: "MULTIBINDS_LOAD" }
-    | { type: "MULTIBINDS_SAVE"; value: MultibindPortRecord[] };
-
 export interface CommandDispatcher {
     sendCommand(command: string, options?: { echo?: boolean }): boolean;
     sendEvent(type: string, payload?: unknown): void;
-    sendExtensionCommand(command: ExtensionCommand): boolean;
 }
 
 export class ClientCommandDispatcher implements CommandDispatcher {
@@ -26,15 +15,6 @@ export class ClientCommandDispatcher implements CommandDispatcher {
 
     sendEvent(type: string, payload?: unknown): void {
         this.client.sendEvent(type, payload);
-    }
-
-    sendExtensionCommand(command: ExtensionCommand): boolean {
-        const port = this.client.port;
-        if (port && typeof port.postMessage === "function") {
-            port.postMessage(command);
-            return true;
-        }
-        return false;
     }
 }
 

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
         main: "./src/main.ts",
     },
     output: {
-        path: path.resolve(__dirname, '../extension/dist'),
+        path: path.resolve(__dirname, 'dist'),
         filename: "main.js"
     },
     resolve: {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -753,14 +753,6 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
-"@types/chrome@^0.0.326":
-  version "0.0.326"
-  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.326.tgz#db759bc8b80182b97aa89f3b34da8dc4c6870ed5"
-  integrity sha512-WS7jKf3ZRZFHOX7dATCZwqNJgdfiSF0qBRFxaO0LhIOvTNBrfkab26bsZwp6EBpYtqp8loMHJTnD6vDTLWPKYw==
-  dependencies:
-    "@types/filesystem" "*"
-    "@types/har-format" "*"
-
 "@types/eslint-scope@^3.7.7":
   version "3.7.7"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
-    "@types/chrome": "^0.0.313",
     "@types/jest": "^29.5.5",
     "@types/node": "^20.11.0",
     "@types/react": "^19.1.2",

--- a/web-client/src/options/Binds.tsx
+++ b/web-client/src/options/Binds.tsx
@@ -3,7 +3,6 @@ import {Alert, Button, Form, Modal, ProgressBar, Spinner, Table} from 'react-boo
 import storage from "@client/src/storage";
 import { parseMultibindsDatabase, type MultibindImportRow } from "./multibindImport";
 import { readMultibinds, replaceMultibinds, type StoredMultibindRecord } from "../multibindStorage";
-import { useUiDispatch, useUiStore } from "../ui/store";
 
 interface Bind {
     key: string;
@@ -175,8 +174,6 @@ function Binds() {
     const [isParsingDb, setIsParsingDb] = useState(false);
     const [isRunningImport, setIsRunningImport] = useState(false);
     const [importProgress, setImportProgress] = useState<{ processed: number; total: number; eta: number | null } | null>(null);
-    const dispatch = useUiDispatch();
-    const commandDispatcher = useUiStore(state => state.commandDispatcher);
     const [importCancelled, setImportCancelled] = useState(false);
     const fileInputRef = useRef<HTMLInputElement | null>(null);
     const cancelImportRef = useRef(false);
@@ -215,15 +212,11 @@ function Binds() {
             setMultibinds(normalizeMultibinds(detail));
         };
         window.addEventListener('multibindsStorage', handler as EventListener);
-        if (commandDispatcher) {
-            void dispatch({ type: 'extension/command', command: { type: 'MULTIBINDS_LOAD' } })
-                .catch(err => console.error('Failed to request multibinds from extension', err));
-        }
         return () => {
             active = false;
             window.removeEventListener('multibindsStorage', handler as EventListener);
         };
-    }, [dispatch, commandDispatcher]);
+    }, []);
 
     const importPlan = useMemo<ImportPlan | null>(() => {
         if (!importData) {
@@ -363,33 +356,8 @@ function Binds() {
         }
         const finalList = Array.from(finalMap.values()).sort((a, b) => (a.roomId - b.roomId) || (a.index - b.index));
         try {
-            let usedFallback = true;
-            if (commandDispatcher) {
-                const posted = commandDispatcher.sendExtensionCommand({ type: 'MULTIBINDS_SAVE', value: finalList });
-                if (posted) {
-                    usedFallback = false;
-                    await new Promise<void>((resolve) => {
-                        let settled = false;
-                        const handler = () => {
-                            if (settled) return;
-                            settled = true;
-                            window.removeEventListener('multibindsStorage', handler as EventListener);
-                            resolve();
-                        };
-                        window.addEventListener('multibindsStorage', handler as EventListener, { once: true });
-                        setTimeout(() => {
-                            if (settled) return;
-                            settled = true;
-                            window.removeEventListener('multibindsStorage', handler as EventListener);
-                            resolve();
-                        }, 1500);
-                    });
-                }
-            }
-            if (usedFallback) {
-                const stored = await replaceMultibinds(finalList);
-                window.dispatchEvent(new CustomEvent('multibindsStorage', { detail: stored }));
-            }
+            const stored = await replaceMultibinds(finalList);
+            window.dispatchEvent(new CustomEvent('multibindsStorage', { detail: stored }));
             setMultibinds(finalList);
             setImportResult({
                 newCount,

--- a/web-client/src/options/Recordings.tsx
+++ b/web-client/src/options/Recordings.tsx
@@ -36,44 +36,34 @@ function Recordings() {
         };
     }, []);
 
-    function activeTabAction(msg: any) {
-        chrome.tabs?.query({ active: true, currentWindow: true }, tabs => {
-            if (tabs[0]?.id) {
-                chrome.tabs.sendMessage(tabs[0].id!, msg);
-            }
-        });
-    }
-
     async function handlePlay(name: string) {
-        if (window.client) {
-            await window.client.loadRecording(name);
-            window.client.replayRecordedMessages();
-        } else {
-            const events = await getRecording(name);
-            if (!events) return;
-            activeTabAction({ type: 'PLAY_RECORDING', events });
+        const client = window.client;
+        if (!client) {
+            setMessage('Funkcje nagrań dostępne są tylko w kliencie Arkadia.');
+            return;
         }
+        await client.loadRecording(name);
+        client.replayRecordedMessages();
     }
 
     async function handlePlayTimed(name: string) {
-        if (window.client) {
-            await window.client.loadRecording(name);
-            window.client.replayRecordedMessagesTimed();
-        } else {
-            const events = await getRecording(name);
-            if (!events) return;
-            activeTabAction({ type: 'PLAY_RECORDING_TIMED', events });
+        const client = window.client;
+        if (!client) {
+            setMessage('Funkcje nagrań dostępne są tylko w kliencie Arkadia.');
+            return;
         }
+        await client.loadRecording(name);
+        client.replayRecordedMessagesTimed();
     }
 
     async function handleDelete(name: string) {
-        if (window.client) {
-            await window.client.deleteRecording(name);
-            load();
+        const client = window.client;
+        if (client) {
+            await client.deleteRecording(name);
         } else {
             await deleteRecording(name);
-            load();
         }
+        load();
     }
 
     function createDownload(json: string, filename: string) {
@@ -142,21 +132,23 @@ function Recordings() {
     function start() {
         const name = recordingName.trim();
         if (!name) return;
-        if (window.client) {
-            window.client.startRecording(name);
-        } else {
-            activeTabAction({ type: 'START_RECORDING', name });
+        const client = window.client;
+        if (!client) {
+            setMessage('Funkcje nagrań dostępne są tylko w kliencie Arkadia.');
+            return;
         }
+        client.startRecording(name);
         setRecording(true);
     }
 
     async function stop(save: boolean) {
-        if (window.client) {
-            await window.client.stopRecording(save);
-            if (save) load();
-        } else {
-            activeTabAction({ type: 'STOP_RECORDING', save });
+        const client = window.client;
+        if (!client) {
+            setMessage('Funkcje nagrań dostępne są tylko w kliencie Arkadia.');
+            return;
         }
+        await client.stopRecording(save);
+        if (save) load();
         setRecording(false);
     }
 

--- a/web-client/src/ui/store.ts
+++ b/web-client/src/ui/store.ts
@@ -11,7 +11,7 @@ import { COLORS_DATASET_KEY, MAP_DATASET_KEY, NPC_DATASET_KEY } from "@client/sr
 import type { DataCatalogEntryMetadata, DataCatalogReadyEvent, NpcDefinition } from "@client/src/runtime/data";
 import type { SettingsSnapshot } from "@client/src/runtime/settings/settings-service";
 import { defaultSettings } from "@client/src/defaultSettings";
-import type { CommandDispatcher, ExtensionCommand } from "@client/src/runtime/command-dispatcher";
+import type { CommandDispatcher } from "@client/src/runtime/command-dispatcher";
 import toTitleCase from "@client/src/utils/toTitleCase";
 import type Client from "@client/src/Client";
 import type MapHelper from "@client/src/MapHelper";
@@ -250,7 +250,6 @@ export interface UiStoreState {
     setClientBindings: (bindings: ClientBindings) => void;
     sendCommand: (command: string, options?: { echo?: boolean }) => boolean;
     sendEvent: (event: string, payload?: unknown) => void;
-    sendExtensionCommand: (command: ExtensionCommand) => boolean;
     dispatch: (intent: UiIntent) => Promise<void>;
     datasets: Record<string, CatalogDatasetSlice<unknown>>;
     loadDataset: (key: string, options?: CatalogLoadOptions) => Promise<void>;
@@ -261,8 +260,7 @@ export interface UiStoreState {
 export type UiIntent =
     | { type: "settings/update"; patch: Partial<SettingsSnapshot> }
     | { type: "command/send"; command: string; echo?: boolean }
-    | { type: "event/send"; event: string; payload?: unknown }
-    | { type: "extension/command"; command: ExtensionCommand };
+    | { type: "event/send"; event: string; payload?: unknown };
 
 export interface ClientBindings {
     client?: Client;
@@ -299,14 +297,6 @@ async function handleUiIntent(intent: UiIntent, get: () => UiStoreState): Promis
                 throw new Error("Command dispatcher not configured");
             }
             dispatcher.sendEvent(intent.event, intent.payload);
-            return;
-        }
-        case "extension/command": {
-            const dispatcher = get().commandDispatcher;
-            if (!dispatcher) {
-                throw new Error("Command dispatcher not configured");
-            }
-            dispatcher.sendExtensionCommand(intent.command);
             return;
         }
         default:
@@ -351,13 +341,6 @@ const store = createStore(
                 throw new Error("Command dispatcher not configured");
             }
             dispatcher.sendEvent(event, payload);
-        },
-        sendExtensionCommand: (command) => {
-            const dispatcher = get().commandDispatcher;
-            if (!dispatcher) {
-                throw new Error("Command dispatcher not configured");
-            }
-            return dispatcher.sendExtensionCommand(command);
         },
         dispatch: (intent) => handleUiIntent(intent, get),
         loadDataset: (key, options) => loadCatalogDataset(key, options),

--- a/web-client/test/ObjectList.test.ts
+++ b/web-client/test/ObjectList.test.ts
@@ -21,7 +21,6 @@ function createDispatcher(): CommandDispatcher {
   return {
     sendCommand: jest.fn(() => true),
     sendEvent: jest.fn(),
-    sendExtensionCommand: jest.fn().mockReturnValue(false),
   };
 }
 

--- a/web-client/test/commandInput.test.ts
+++ b/web-client/test/commandInput.test.ts
@@ -12,7 +12,6 @@ describe("sendMessageFromInput", () => {
         dispatcher = {
             sendCommand: jest.fn(() => true),
             sendEvent: jest.fn(),
-            sendExtensionCommand: jest.fn(() => false),
         } as unknown as jest.Mocked<CommandDispatcher>;
         arkadiaClient = { hasReceivedFirstGmcp: jest.fn(() => true) };
         history = { history: [], index: -1, currentInput: "" };

--- a/web-client/test/uiStore.test.ts
+++ b/web-client/test/uiStore.test.ts
@@ -1,4 +1,4 @@
-import type { CommandDispatcher, ExtensionCommand } from "@client/src/runtime/command-dispatcher";
+import type { CommandDispatcher } from "@client/src/runtime/command-dispatcher";
 import { resetUiStoreForTesting, uiStore } from "./utils/uiStoreTestUtils";
 
 describe("ui store command dispatcher", () => {
@@ -6,20 +6,29 @@ describe("ui store command dispatcher", () => {
         resetUiStoreForTesting();
     });
 
-    test("forwards extension commands when dispatcher configured", async () => {
+    test("forwards commands when dispatcher configured", async () => {
         const dispatcher: CommandDispatcher = {
             sendCommand: jest.fn(() => true),
             sendEvent: jest.fn(),
-            sendExtensionCommand: jest.fn<ReturnType<CommandDispatcher["sendExtensionCommand"]>, [ExtensionCommand]>(() => true),
         };
         uiStore.getState().setCommandDispatcher(dispatcher);
-        await uiStore.getState().dispatch({ type: "extension/command", command: { type: "MULTIBINDS_LOAD" } });
-        expect(dispatcher.sendExtensionCommand).toHaveBeenCalledWith({ type: "MULTIBINDS_LOAD" });
+        await uiStore.getState().dispatch({ type: "command/send", command: "say hello", echo: false });
+        expect(dispatcher.sendCommand).toHaveBeenCalledWith("say hello", { echo: false });
+    });
+
+    test("forwards events when dispatcher configured", async () => {
+        const dispatcher: CommandDispatcher = {
+            sendCommand: jest.fn(() => true),
+            sendEvent: jest.fn(),
+        };
+        uiStore.getState().setCommandDispatcher(dispatcher);
+        await uiStore.getState().dispatch({ type: "event/send", event: "custom", payload: { foo: "bar" } });
+        expect(dispatcher.sendEvent).toHaveBeenCalledWith("custom", { foo: "bar" });
     });
 
     test("throws when dispatcher missing", async () => {
         await expect(
-            uiStore.getState().dispatch({ type: "extension/command", command: { type: "MULTIBINDS_LOAD" } })
+            uiStore.getState().dispatch({ type: "command/send", command: "say" })
         ).rejects.toThrow("Command dispatcher not configured");
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1660,22 +1660,6 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
-"@types/chrome@^0.0.313":
-  version "0.0.313"
-  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.313.tgz#86487f51072c181a12495ae3e63a6701ade1a296"
-  integrity sha512-9R5T7gTaYZhkxlu+Ho4wk9FL+y/werWQY2yjGWSqCuiTsqS7nL/BE5UMTP6rU7J+oIG2FRKqrEycHhJATeltVA==
-  dependencies:
-    "@types/filesystem" "*"
-    "@types/har-format" "*"
-
-"@types/chrome@^0.0.326":
-  version "0.0.326"
-  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.326.tgz#db759bc8b80182b97aa89f3b34da8dc4c6870ed5"
-  integrity sha512-WS7jKf3ZRZFHOX7dATCZwqNJgdfiSF0qBRFxaO0LhIOvTNBrfkab26bsZwp6EBpYtqp8loMHJTnD6vDTLWPKYw==
-  dependencies:
-    "@types/filesystem" "*"
-    "@types/har-format" "*"
-
 "@types/eslint-scope@^3.7.7":
   version "3.7.7"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
@@ -1696,23 +1680,6 @@
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
-
-"@types/filesystem@*":
-  version "0.0.36"
-  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.36.tgz#7227c2d76bfed1b21819db310816c7821d303857"
-  integrity sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==
-  dependencies:
-    "@types/filewriter" "*"
-
-"@types/filewriter@*":
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.33.tgz#d9d611db9d9cd99ae4e458de420eeb64ad604ea8"
-  integrity sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==
-
-"@types/har-format@*":
-  version "1.2.16"
-  resolved "https://registry.yarnpkg.com/@types/har-format/-/har-format-1.2.16.tgz#b71ede8681400cc08b3685f061c31e416cf94944"
-  integrity sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1", "@types/istanbul-lib-coverage@^2.0.6":
   version "2.0.6"


### PR DESCRIPTION
## Summary
- remove the chrome-specific fallback from the recordings panel and rely solely on the client runtime
- drop extension command plumbing from the UI store and multibinds import flow
- delete the unused @types/chrome dependency and chrome extension build output path

## Testing
- yarn --cwd web-client test
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68ec11c6ad98832abe2440df58696fe2