### PR TITLE
Remove Chrome extension specific code

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,6 @@
     "sql.js": "^1.13.0"
   },
   "devDependencies": {
-    "@types/chrome": "^0.0.326",
     "@types/jest": "^29.5.5",
     "fake-indexeddb": "^6.0.1",
     "jest": "^30.0.4",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -753,13 +753,6 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
-"@types/chrome@^0.0.326":
-  version "0.0.326"
-  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.326.tgz#db759bc8b80182b97aa89f3b34da8dc4c6870ed5"
-  integrity sha512-WS7jKf3ZRZFHOX7dATCZwqNJgdfiSF0qBRFxaO0LhIOvTNBrfkab26bsZwp6EBpYtqp8loMHJTnD6vDTLWPKYw==
-  dependencies:
-    "@types/filesystem" "*"
-    "@types/har-format" "*"
 
 "@types/eslint-scope@^3.7.7":
   version "3.7.7"

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
-    "@types/chrome": "^0.0.313",
     "@types/jest": "^29.5.5",
     "@types/node": "^20.11.0",
     "@types/react": "^19.1.2",

--- a/web-client/src/options/Recordings.tsx
+++ b/web-client/src/options/Recordings.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { Button, Table, Form } from 'react-bootstrap';
-import { getRecordingNames, deleteRecording, getRecording, saveRecording } from './recordingStorage';
+import { getRecordingNames, getRecording, saveRecording } from './recordingStorage';
 import { useUiStore } from '../ui/store';
 
 function Recordings() {
@@ -38,22 +38,12 @@ function Recordings() {
         };
     }, [client]);
 
-    function activeTabAction(msg: any) {
-        chrome.tabs?.query({ active: true, currentWindow: true }, tabs => {
-            if (tabs[0]?.id) {
-                chrome.tabs.sendMessage(tabs[0].id!, msg);
-            }
-        });
-    }
-
     async function handlePlay(name: string) {
         if (client) {
             await client.loadRecording(name);
             client.replayRecordedMessages();
         } else {
-            const events = await getRecording(name);
-            if (!events) return;
-            activeTabAction({ type: 'PLAY_RECORDING', events });
+            setMessage('Brak aktywnego klienta. Nie można odtworzyć nagrania.');
         }
     }
 
@@ -62,18 +52,13 @@ function Recordings() {
             await client.loadRecording(name);
             client.replayRecordedMessagesTimed();
         } else {
-            const events = await getRecording(name);
-            if (!events) return;
-            activeTabAction({ type: 'PLAY_RECORDING_TIMED', events });
+            setMessage('Brak aktywnego klienta. Nie można odtworzyć nagrania z opóźnieniem.');
         }
     }
 
     async function handleDelete(name: string) {
         if (client) {
             await client.deleteRecording(name);
-            load();
-        } else {
-            await deleteRecording(name);
             load();
         }
     }
@@ -147,7 +132,8 @@ function Recordings() {
         if (client) {
             client.startRecording(name);
         } else {
-            activeTabAction({ type: 'START_RECORDING', name });
+            setMessage('Brak aktywnego klienta. Nie można rozpocząć nagrywania.');
+            return;
         }
         setRecording(true);
     }
@@ -157,7 +143,8 @@ function Recordings() {
             await client.stopRecording(save);
             if (save) load();
         } else {
-            activeTabAction({ type: 'STOP_RECORDING', save });
+            setMessage('Brak aktywnego klienta. Nie można zatrzymać nagrywania.');
+            return;
         }
         setRecording(false);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1660,21 +1660,6 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
-"@types/chrome@^0.0.313":
-  version "0.0.313"
-  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.313.tgz#86487f51072c181a12495ae3e63a6701ade1a296"
-  integrity sha512-9R5T7gTaYZhkxlu+Ho4wk9FL+y/werWQY2yjGWSqCuiTsqS7nL/BE5UMTP6rU7J+oIG2FRKqrEycHhJATeltVA==
-  dependencies:
-    "@types/filesystem" "*"
-    "@types/har-format" "*"
-
-"@types/chrome@^0.0.326":
-  version "0.0.326"
-  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.326.tgz#db759bc8b80182b97aa89f3b34da8dc4c6870ed5"
-  integrity sha512-WS7jKf3ZRZFHOX7dATCZwqNJgdfiSF0qBRFxaO0LhIOvTNBrfkab26bsZwp6EBpYtqp8loMHJTnD6vDTLWPKYw==
-  dependencies:
-    "@types/filesystem" "*"
-    "@types/har-format" "*"
 
 "@types/eslint-scope@^3.7.7":
   version "3.7.7"


### PR DESCRIPTION
## Summary
- drop the legacy Chrome extension typings from the client and web-client packages
- simplify the recordings options page to avoid using chrome.tabs APIs when no client is bound

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ec18062d8c832a90a6b611251a1de1