### PR TITLE
Use shared event bus for multibind sync

### DIFF
--- a/client/src/eventBus.ts
+++ b/client/src/eventBus.ts
@@ -39,7 +39,7 @@ type Handler<T> = (...args: Params<T>) => void;
 class EventBus<Events extends Record<string, any>> extends EventTarget {
     private wrappers = new WeakMap<Handler<any>, EventListener>();
 
-    on<K extends keyof Events>(event: K, listener: Handler<Events[K]>, options?: AddEventListenerOptions | boolean) {
+    on<K extends keyof Events>(event: K, listener: Handler<Events[K]>, options?: AddEventListenerOptions | boolean): () => void {
         const wrapper: EventListener = (ev: Event) => {
             const detail = (ev as CustomEvent).detail;
             if (Array.isArray(detail)) {
@@ -52,6 +52,7 @@ class EventBus<Events extends Record<string, any>> extends EventTarget {
         };
         this.wrappers.set(listener, wrapper);
         this.addEventListener(event as string, wrapper, options);
+        return () => this.off(event, listener);
     }
 
     off<K extends keyof Events>(event: K, listener: Handler<Events[K]>) {

--- a/web-client/src/options/Binds.tsx
+++ b/web-client/src/options/Binds.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {Alert, Button, Form, Modal, ProgressBar, Spinner, Table} from 'react-bootstrap';
 import storage from "@client/src/storage";
+import eventBus from "@client/src/eventBus";
 import { parseMultibindsDatabase, type MultibindImportRow } from "./multibindImport";
 import { readMultibinds, replaceMultibinds, type StoredMultibindRecord } from "../multibindStorage";
 
@@ -207,15 +208,14 @@ function Binds() {
                 setMultibinds(list);
             }
         });
-        const handler = (ev: Event) => {
-            const detail = (ev as CustomEvent).detail;
+        const handler = (detail: unknown) => {
             setMultibinds(normalizeMultibinds(detail));
         };
-        window.addEventListener('multibindsStorage', handler as EventListener);
+        const unsubscribe = eventBus.on('multibindsStorage', handler);
         window.clientExtension?.port?.postMessage?.({ type: 'MULTIBINDS_LOAD' });
         return () => {
             active = false;
-            window.removeEventListener('multibindsStorage', handler as EventListener);
+            unsubscribe();
         };
     }, []);
 
@@ -360,24 +360,27 @@ function Binds() {
             if (window.clientExtension?.port) {
                 await new Promise<void>((resolve) => {
                     let settled = false;
+                    let unsubscribe: (() => void) | undefined;
+                    let timeout: ReturnType<typeof setTimeout>;
                     const handler = () => {
                         if (settled) return;
                         settled = true;
-                        window.removeEventListener('multibindsStorage', handler as EventListener);
+                        clearTimeout(timeout);
+                        unsubscribe?.();
                         resolve();
                     };
-                    window.addEventListener('multibindsStorage', handler as EventListener, { once: true });
-                    window.clientExtension.port.postMessage({ type: 'MULTIBINDS_SAVE', value: finalList });
-                    setTimeout(() => {
+                    timeout = setTimeout(() => {
                         if (settled) return;
                         settled = true;
-                        window.removeEventListener('multibindsStorage', handler as EventListener);
+                        unsubscribe?.();
                         resolve();
                     }, 1500);
+                    unsubscribe = eventBus.on('multibindsStorage', handler, { once: true });
+                    window.clientExtension.port.postMessage({ type: 'MULTIBINDS_SAVE', value: finalList });
                 });
             } else {
                 await replaceMultibinds(finalList);
-                window.dispatchEvent(new CustomEvent('multibindsStorage', { detail: finalList }));
+                eventBus.emit('multibindsStorage', finalList);
             }
             setMultibinds(finalList);
             setImportResult({


### PR DESCRIPTION
## Summary
- subscribe the binds options panel to multibind updates via the shared event bus
- emit multibind changes on the bus after local saves and await background responses with managed bus subscriptions
- expose an unsubscribe function from the shared event bus helper

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68ecf79f8754832aa7c52f72cf01a9f1