### PR TITLE
Add multibinds store to data catalog

### DIFF
--- a/client/src/dataCatalog/DataCatalog.ts
+++ b/client/src/dataCatalog/DataCatalog.ts
@@ -7,6 +7,7 @@ import {
   MagicsCollection,
   MapColors,
   MapExportData,
+  MultibindsCollection,
   NpcCollection,
   PeopleCollection,
 } from './entities';
@@ -15,6 +16,8 @@ export interface DataCatalogStore<T> {
   getData(options?: { forceReload?: boolean }): Promise<T>;
   addListener(listener: DataStoreListener<T>): () => void;
   invalidate(): Promise<void>;
+  storeData(data: T, options?: { persist?: boolean; timestamp?: number }): Promise<void>;
+  clearData(): Promise<void>;
 }
 
 export class DataCatalog {
@@ -44,6 +47,20 @@ export class DataCatalog {
     await entry.invalidate();
   }
 
+  async storeData<T>(
+    key: string,
+    data: T,
+    options?: { persist?: boolean; timestamp?: number },
+  ): Promise<void> {
+    const entry = this.getEntry<T>(key);
+    await entry.storeData(data, options);
+  }
+
+  async clearData(key: string): Promise<void> {
+    const entry = this.getEntry(key);
+    await entry.clearData();
+  }
+
   getStore<T>(key: string): DataCatalogStore<T> {
     if (this.stores.has(key)) {
       return this.stores.get(key) as DataCatalogStore<T>;
@@ -54,6 +71,8 @@ export class DataCatalog {
       getData: (options) => entry.getData(options?.forceReload),
       addListener: (listener) => entry.addListener(listener),
       invalidate: () => entry.invalidate(),
+      storeData: (data, options) => entry.storeData(data, options),
+      clearData: () => entry.clearData(),
     };
 
     this.stores.set(key, store as DataCatalogStore<unknown>);
@@ -98,5 +117,9 @@ export class GameDataCatalog extends DataCatalog {
 
   getPeopleStore(): DataCatalogStore<PeopleCollection> {
     return this.getStore('people');
+  }
+
+  getMultibindsStore(): DataCatalogStore<MultibindsCollection> {
+    return this.getStore('multibinds');
   }
 }

--- a/client/src/dataCatalog/DataCatalogEntry.ts
+++ b/client/src/dataCatalog/DataCatalogEntry.ts
@@ -6,8 +6,9 @@ interface DataCatalogEntryOptions<T> {
   ttl: number;
   storeName: string;
   persistenceAdapter: IndexedDBPersistenceAdapter;
-  dataSource: DataSource<T>;
+  dataSource?: DataSource<T>;
   persistenceKey?: string;
+  initialData?: T;
 }
 
 export class DataCatalogEntry<T> {
@@ -19,11 +20,41 @@ export class DataCatalogEntry<T> {
 
   constructor(private readonly options: DataCatalogEntryOptions<T>) {
     this.persistenceKey = options.persistenceKey ?? options.key;
+    if (options.initialData !== undefined) {
+      this.data = options.initialData ?? null;
+      this.timestamp = Date.now();
+    }
   }
 
   async getData(forceReload = false): Promise<T> {
     if (!forceReload && this.data !== null && !this.isExpired()) {
       return this.data;
+    }
+
+    let persisted: T | null = null;
+    if (!forceReload) {
+      persisted = await this.safeLoadFromPersistence();
+      if (persisted !== null) {
+        return persisted;
+      }
+    }
+
+    if (!this.options.dataSource) {
+      if (forceReload) {
+        persisted = await this.safeLoadFromPersistence();
+      }
+
+      if (persisted !== null) {
+        return persisted;
+      }
+
+      if (this.data !== null) {
+        return this.data;
+      }
+
+      throw new Error(
+        `DataCatalog entry with key ${this.options.key} has no data source and no stored data`,
+      );
     }
 
     if (this.loadingPromise) {
@@ -53,12 +84,31 @@ export class DataCatalogEntry<T> {
   }
 
   async invalidate(): Promise<void> {
+    await this.clearData();
+  }
+
+  async storeData(data: T, options?: { persist?: boolean; timestamp?: number }): Promise<void> {
+    const timestamp = options?.timestamp ?? Date.now();
+    this.updateMemory(data, timestamp);
+    if (options?.persist === false) {
+      return;
+    }
+
+    await this.persist(data, timestamp);
+  }
+
+  async clearData(): Promise<void> {
     this.data = null;
     this.timestamp = 0;
+    this.loadingPromise = null;
     await this.options.persistenceAdapter.delete(this.options.storeName, this.persistenceKey);
   }
 
   private async loadData(forceReload: boolean): Promise<T> {
+    if (!this.options.dataSource) {
+      throw new Error(`No data source configured for ${this.options.key}`);
+    }
+
     if (!forceReload) {
       const persisted = await this.safeLoadFromPersistence();
       if (persisted) {
@@ -96,17 +146,17 @@ export class DataCatalogEntry<T> {
 
   private async safeLoadFromSource(): Promise<T> {
     try {
-      return await this.options.dataSource.load();
+      return await this.options.dataSource!.load();
     } catch (error) {
       console.error(`Failed to load data from source for ${this.options.key}`, error);
       throw error;
     }
   }
 
-  private async persist(data: T): Promise<void> {
+  private async persist(data: T, timestamp: number = Date.now()): Promise<void> {
     const record: PersistenceRecord<T> = {
       data,
-      timestamp: Date.now(),
+      timestamp,
     };
 
     try {

--- a/client/src/dataCatalog/catalogInstance.ts
+++ b/client/src/dataCatalog/catalogInstance.ts
@@ -8,6 +8,7 @@ import {
   MagicKeysCollection,
   MapColors,
   MapExportData,
+  MultibindsCollection,
   NpcCollection,
   PeopleCollection,
 } from './entities';
@@ -21,6 +22,7 @@ const STORE_NAMES = {
   keys: 'magicKeys',
   herbs: 'herbs',
   people: 'people',
+  multibinds: 'multibinds',
 } as const;
 
 type StoreNameKey = keyof typeof STORE_NAMES;
@@ -107,6 +109,15 @@ const peopleEntry = new DataCatalogEntry<PeopleCollection>({
   ),
 });
 
+const multibindsEntry = new DataCatalogEntry<MultibindsCollection>({
+  key: 'multibinds',
+  ttl: Number.POSITIVE_INFINITY,
+  storeName: STORE_NAMES.multibinds,
+  persistenceKey: 'multibinds',
+  persistenceAdapter: sharedPersistenceAdapter,
+  initialData: [],
+});
+
 catalog.register('mapData', mapDataEntry);
 catalog.register('colors', colorsEntry);
 catalog.register('npcs', npcsEntry);
@@ -114,6 +125,7 @@ catalog.register('magic', magicsEntry);
 catalog.register('keys', magicKeysEntry);
 catalog.register('herbs', herbsEntry);
 catalog.register('people', peopleEntry);
+catalog.register('multibinds', multibindsEntry);
 
 export type CatalogEntityKey = StoreNameKey;
 export const dataCatalog = catalog;

--- a/client/src/dataCatalog/entities.ts
+++ b/client/src/dataCatalog/entities.ts
@@ -49,3 +49,11 @@ export type MagicsCollection = MagicsFile;
 export type MagicKeysCollection = MagicKeysFile;
 export type HerbsCollection = HerbsData;
 export type PeopleCollection = Person[];
+
+export interface MultibindRecord {
+  roomId: number;
+  index: number;
+  action: string;
+}
+
+export type MultibindsCollection = MultibindRecord[];

--- a/client/src/scripts/multibinds.ts
+++ b/client/src/scripts/multibinds.ts
@@ -1,14 +1,12 @@
 import Client from "../Client";
-import {getMultibindLabel, MULTIBIND_KEYS} from "../multibindKeys";
+import {dataCatalog} from "../dataCatalog/catalogInstance";
+import type {MultibindsCollection} from "../dataCatalog/entities";
 import appEventBus from "../events/app-event-bus";
+import {getMultibindLabel, MULTIBIND_KEYS} from "../multibindKeys";
 
 const MAX_BINDS = 4;
 
-interface StoredMultibind {
-    roomId: number;
-    index: number;
-    action: string;
-}
+type StoredMultibind = MultibindsCollection[number];
 
 interface DisplayMultibind {
     index: number;
@@ -22,8 +20,9 @@ function isValidIndex(index: number) {
 
 export default function initMultibinds(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
     const data = new Map<number, Map<number, string>>();
+    const store = dataCatalog.getMultibindsStore();
 
-    function serialize(): StoredMultibind[] {
+    function serialize(): MultibindsCollection {
         const entries: StoredMultibind[] = [];
         data.forEach((roomMap, roomId) => {
             roomMap.forEach((action, index) => {
@@ -35,7 +34,9 @@ export default function initMultibinds(client: Client, aliases?: { pattern: RegE
 
     function persist() {
         const payload = serialize();
-        //TODO save multbinds
+        store.storeData(payload).catch((error) => {
+            console.error('Failed to store multibinds', error);
+        });
     }
 
     function set(roomId: number, index: number, action: string) {
@@ -202,7 +203,7 @@ export default function initMultibinds(client: Client, aliases?: { pattern: RegE
         run(roomId, index);
     }
 
-    function applyStored(list: StoredMultibind[]) {
+    function applyStored(list: MultibindsCollection) {
         data.clear();
         list.forEach(item => {
             const roomId = Number(item.roomId);
@@ -219,7 +220,10 @@ export default function initMultibinds(client: Client, aliases?: { pattern: RegE
         sendUpdate(Number.isNaN(event.id) ? null : event.id);
     });
 
-    //TODO apply stored multibinds
+    store.addListener(applyStored);
+    store.getData().catch((error) => {
+        console.error('Failed to load multibinds data', error);
+    });
 
     window.addEventListener('keydown', (ev) => {
         if (ev.repeat) {


### PR DESCRIPTION
## Summary
- allow catalog entries to skip data sources and expose manual store/clear operations
- register a shared multibinds entry in the data catalog with infinite TTL
- persist client multibind changes through the catalog and rehydrate stored data

## Testing
- yarn --cwd client test *(fails: existing TypeScript and Jest failures in the suite)*
- yarn --cwd web-client test *(fails: existing Jest assertions and type errors in the suite)*
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ed6bfb57b8832a8c31977c8d2ed8e5