### PR TITLE
Normalize IndexedDB datastores

### DIFF
--- a/client/src/dataCatalog/IndexedDBPersistenceAdapter.ts
+++ b/client/src/dataCatalog/IndexedDBPersistenceAdapter.ts
@@ -5,16 +5,155 @@ interface StoreInitStatus {
   promise: Promise<void> | null;
 }
 
+type PersistenceDataType = 'array' | 'object' | 'primitive';
+
 interface MetadataRecord {
   id: string;
   timestamp: number;
+  dataType: PersistenceDataType;
 }
 
-const DB_VERSION = 2;
+interface NormalizedEntry {
+  key: string;
+  value: Record<string, unknown>;
+}
+
+const DB_VERSION = 3;
 const METADATA_STORE = '__metadata__';
+const INTERNAL_PREFIX = '__arkadia__';
+const PARENT_FIELD = `${INTERNAL_PREFIX}parent`;
+const INDEX_FIELD = `${INTERNAL_PREFIX}index`;
+const VALUE_FIELD = `${INTERNAL_PREFIX}value`;
+const PARENT_INDEX = `${INTERNAL_PREFIX}by_parent`;
+const ENTRY_SEPARATOR = '::';
 
 function buildMetadataKey(storeName: string, key: IDBValidKey | string): string {
   return `${storeName}:${String(key)}`;
+}
+
+function determineDataType(value: unknown): PersistenceDataType {
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return 'object';
+  }
+
+  return 'primitive';
+}
+
+function buildArrayEntryKey(parentKey: string, index: number): string {
+  return `${parentKey}${ENTRY_SEPARATOR}${index}`;
+}
+
+function normalizeArrayEntry(parentKey: string, index: number, entry: unknown): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {
+    [PARENT_FIELD]: parentKey,
+    [INDEX_FIELD]: index,
+  };
+
+  if (entry !== null && typeof entry === 'object' && !Array.isArray(entry)) {
+    Object.assign(normalized, entry as Record<string, unknown>);
+  } else {
+    normalized[VALUE_FIELD] = entry as unknown;
+  }
+
+  return normalized;
+}
+
+function normalizeData(key: string, value: unknown): { entries: NormalizedEntry[]; dataType: PersistenceDataType } {
+  const dataType = determineDataType(value);
+
+  if (dataType === 'array') {
+    const arrayValue = value as unknown[];
+    const entries = arrayValue.map((item, index) => ({
+      key: buildArrayEntryKey(key, index),
+      value: normalizeArrayEntry(key, index, item),
+    }));
+
+    return { entries, dataType };
+  }
+
+  if (dataType === 'object') {
+    const objectValue = value as Record<string, unknown>;
+    return {
+      entries: [
+        {
+          key,
+          value: { ...objectValue },
+        },
+      ],
+      dataType,
+    };
+  }
+
+  return {
+    entries: [
+      {
+        key,
+        value: { [VALUE_FIELD]: value },
+      },
+    ],
+    dataType: 'primitive',
+  };
+}
+
+function denormalizeArrayEntries(entries: Record<string, unknown>[]): unknown[] {
+  const sorted = entries
+    .slice()
+    .sort((a, b) => {
+      const aIndex = (a[INDEX_FIELD] as number | undefined) ?? 0;
+      const bIndex = (b[INDEX_FIELD] as number | undefined) ?? 0;
+      return aIndex - bIndex;
+    });
+
+  return sorted.map((entry) => {
+    const hasPrimitiveValue = Object.prototype.hasOwnProperty.call(entry, VALUE_FIELD);
+    const primitiveValue = entry[VALUE_FIELD];
+    const result: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(entry)) {
+      if (key === PARENT_FIELD || key === INDEX_FIELD || key === VALUE_FIELD) {
+        continue;
+      }
+
+      result[key] = value;
+    }
+
+    if (hasPrimitiveValue) {
+      return primitiveValue;
+    }
+
+    return result;
+  });
+}
+
+function inferDataType(directValue: unknown, arrayEntries: Record<string, unknown>[]): PersistenceDataType {
+  if (arrayEntries.length > 0) {
+    return 'array';
+  }
+
+  if (Array.isArray(directValue)) {
+    return 'array';
+  }
+
+  if (directValue !== null && typeof directValue === 'object') {
+    const record = directValue as Record<string, unknown>;
+    if ('data' in record && Array.isArray(record.data)) {
+      return 'array';
+    }
+
+    return 'object';
+  }
+
+  return 'primitive';
+}
+
+function ensureParentIndex(store: IDBObjectStore): void {
+  if (!store.indexNames.contains(PARENT_INDEX)) {
+    store.createIndex(PARENT_INDEX, PARENT_FIELD, { unique: false });
+  }
 }
 
 function migrateLegacyStores(transaction: IDBTransaction | null, db: IDBDatabase): void {
@@ -32,6 +171,8 @@ function migrateLegacyStores(transaction: IDBTransaction | null, db: IDBDatabase
       }
 
       const store = transaction.objectStore(storeName);
+      ensureParentIndex(store);
+
       const cursorRequest = store.openCursor();
 
       cursorRequest.onsuccess = () => {
@@ -40,12 +181,66 @@ function migrateLegacyStores(transaction: IDBTransaction | null, db: IDBDatabase
           return;
         }
 
-        const value = cursor.value as PersistenceRecord<unknown> | undefined;
-        if (value && typeof value === 'object' && 'data' in value && 'timestamp' in value) {
-          const metadataKey = buildMetadataKey(storeName, cursor.key ?? '');
-          metadataStore.put({ id: metadataKey, timestamp: value.timestamp });
-          cursor.update(value.data);
+        const primaryKey = cursor.primaryKey as IDBValidKey;
+        const key = String(primaryKey);
+        const rawValue = cursor.value as unknown;
+
+        if (
+          rawValue !== null &&
+          typeof rawValue === 'object' &&
+          PARENT_FIELD in (rawValue as Record<string, unknown>)
+        ) {
+          cursor.continue();
+          return;
         }
+
+        let data: unknown = rawValue;
+        if (rawValue && typeof rawValue === 'object' && 'data' in (rawValue as Record<string, unknown>)) {
+          data = (rawValue as Record<string, unknown>).data;
+        }
+
+        const dataType = determineDataType(data);
+
+        if (dataType === 'array') {
+          cursor.delete();
+          const normalized = normalizeData(key, data);
+          for (const entry of normalized.entries) {
+            store.put(entry.value, entry.key);
+          }
+        } else if (dataType === 'primitive') {
+          if (
+            !(
+              rawValue &&
+              typeof rawValue === 'object' &&
+              VALUE_FIELD in (rawValue as Record<string, unknown>)
+            )
+          ) {
+            cursor.update({ [VALUE_FIELD]: data });
+          }
+        } else if (dataType === 'object') {
+          if (
+            rawValue &&
+            typeof rawValue === 'object' &&
+            'data' in (rawValue as Record<string, unknown>)
+          ) {
+            cursor.update({ ...(data as Record<string, unknown>) });
+          }
+        }
+
+        const metadataKey = buildMetadataKey(storeName, key);
+        const metadataRequest = metadataStore.get(metadataKey);
+        metadataRequest.onsuccess = () => {
+          const existing = metadataRequest.result as MetadataRecord | undefined;
+          const timestamp =
+            existing?.timestamp ??
+            (rawValue &&
+            typeof rawValue === 'object' &&
+            'timestamp' in (rawValue as Record<string, unknown>) &&
+            typeof (rawValue as Record<string, unknown>).timestamp === 'number'
+              ? Number((rawValue as Record<string, unknown>).timestamp)
+              : Date.now());
+          metadataStore.put({ id: metadataKey, timestamp, dataType });
+        };
 
         cursor.continue();
       };
@@ -72,29 +267,92 @@ export class IndexedDBPersistenceAdapter implements PersistenceAdapter {
       const store = transaction.objectStore(storeName);
       const metadataStore = transaction.objectStore(METADATA_STORE);
 
-      const dataRequest = store.get(key);
-      const metadataRequest = metadataStore.get(buildMetadataKey(storeName, key));
+      const metadataKey = buildMetadataKey(storeName, key);
+      const metadataRequest = metadataStore.get(metadataKey);
+      const directRequest = store.get(key);
+      const arrayEntries: Record<string, unknown>[] = [];
+
+      if (store.indexNames.contains(PARENT_INDEX)) {
+        const range = IDBKeyRange.only(key);
+        const cursorRequest = store.index(PARENT_INDEX).openCursor(range);
+        cursorRequest.onsuccess = () => {
+          const cursor = cursorRequest.result as IDBCursorWithValue | null;
+          if (!cursor) {
+            return;
+          }
+
+          arrayEntries.push(cursor.value as Record<string, unknown>);
+          cursor.continue();
+        };
+      }
 
       transaction.oncomplete = () => {
-        const data = dataRequest.result as T | PersistenceRecord<T> | undefined;
-        if (data === undefined) {
+        const metadata = metadataRequest.result as MetadataRecord | undefined;
+        const directValue = directRequest.result as unknown;
+
+        if (!metadata && directValue === undefined && arrayEntries.length === 0) {
           resolve(null);
           return;
         }
 
-        const metadata = metadataRequest.result as MetadataRecord | undefined;
+        const dataType = metadata?.dataType ?? inferDataType(directValue, arrayEntries);
+        const timestampFromMetadata = metadata?.timestamp ?? null;
 
-        if (metadata?.timestamp !== undefined) {
-          resolve({ data: data as T, timestamp: metadata.timestamp });
+        const timestamp =
+          timestampFromMetadata ??
+          (directValue && typeof directValue === 'object' && directValue !== null && 'timestamp' in (directValue as Record<string, unknown>)
+            ? Number((directValue as Record<string, unknown>).timestamp)
+            : Date.now());
+
+        let data: unknown;
+
+        if (dataType === 'array') {
+          if (arrayEntries.length > 0) {
+            data = denormalizeArrayEntries(arrayEntries);
+          } else if (Array.isArray(directValue)) {
+            data = directValue;
+          } else if (
+            directValue &&
+            typeof directValue === 'object' &&
+            'data' in (directValue as Record<string, unknown>) &&
+            Array.isArray((directValue as Record<string, unknown>).data)
+          ) {
+            data = (directValue as Record<string, unknown>).data;
+          } else {
+            data = [];
+          }
+        } else if (dataType === 'primitive') {
+          if (directValue && typeof directValue === 'object' && directValue !== null) {
+            const record = directValue as Record<string, unknown>;
+            if (VALUE_FIELD in record) {
+              data = record[VALUE_FIELD];
+            } else if ('data' in record) {
+              data = record.data;
+            } else {
+              data = null;
+            }
+          } else {
+            data = directValue ?? null;
+          }
+        } else {
+          if (directValue && typeof directValue === 'object' && directValue !== null) {
+            const record = directValue as Record<string, unknown>;
+            if ('data' in record) {
+              data = record.data;
+            } else {
+              data = record;
+            }
+          } else {
+            data = directValue ?? null;
+          }
+        }
+
+        if (data === null) {
+          resolve(null);
           return;
         }
 
-        if (typeof data === 'object' && data !== null && 'data' in data && 'timestamp' in data) {
-          resolve(data as PersistenceRecord<T>);
-          return;
-        }
-
-        resolve({ data: data as T, timestamp: Date.now() });
+        resolve({ data: data as T, timestamp });
       };
 
       transaction.onerror = () => {
@@ -108,14 +366,21 @@ export class IndexedDBPersistenceAdapter implements PersistenceAdapter {
     await this.ensureStore(storeName);
     const db = await this.dbPromise;
 
+    const { entries, dataType } = normalizeData(key, record.data);
+
+    await this.clearExistingEntries(db, storeName, key);
+
     return new Promise((resolve, reject) => {
       const transaction = db.transaction([storeName, METADATA_STORE], 'readwrite');
       const store = transaction.objectStore(storeName);
       const metadataStore = transaction.objectStore(METADATA_STORE);
-
       const metadataKey = buildMetadataKey(storeName, key);
-      store.put(record.data, key);
-      metadataStore.put({ id: metadataKey, timestamp: record.timestamp });
+
+      for (const entry of entries) {
+        store.put(entry.value, entry.key);
+      }
+
+      metadataStore.put({ id: metadataKey, timestamp: record.timestamp, dataType });
 
       transaction.oncomplete = () => resolve();
       transaction.onerror = () => {
@@ -133,12 +398,11 @@ export class IndexedDBPersistenceAdapter implements PersistenceAdapter {
     await this.ensureStore(storeName);
     const db = await this.dbPromise;
 
-    return new Promise((resolve, reject) => {
-      const transaction = db.transaction([storeName, METADATA_STORE], 'readwrite');
-      const store = transaction.objectStore(storeName);
-      const metadataStore = transaction.objectStore(METADATA_STORE);
+    await this.clearExistingEntries(db, storeName, key);
 
-      store.delete(key);
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(METADATA_STORE, 'readwrite');
+      const metadataStore = transaction.objectStore(METADATA_STORE);
       metadataStore.delete(buildMetadataKey(storeName, key));
 
       transaction.oncomplete = () => resolve();
@@ -179,33 +443,53 @@ export class IndexedDBPersistenceAdapter implements PersistenceAdapter {
     const newVersion = Math.max(db.version + 1, DB_VERSION);
     db.close();
 
-    this.dbPromise = this.openDatabase(newVersion, (database) => {
+    this.dbPromise = this.openDatabase(newVersion, (database, transaction) => {
       if (!database.objectStoreNames.contains(storeName)) {
-        database.createObjectStore(storeName);
+        const store = database.createObjectStore(storeName);
+        ensureParentIndex(store);
+      } else if (transaction) {
+        const existingStore = transaction.objectStore(storeName);
+        ensureParentIndex(existingStore);
       }
     });
 
     await this.dbPromise;
   }
 
-  private openDatabase(version?: number, upgradeCallback?: (db: IDBDatabase) => void): Promise<IDBDatabase> {
+  private openDatabase(
+    version?: number,
+    upgradeCallback?: (db: IDBDatabase, transaction: IDBTransaction | null) => void,
+  ): Promise<IDBDatabase> {
     const targetVersion = Math.max(version ?? DB_VERSION, DB_VERSION);
 
     return new Promise((resolve, reject) => {
       const request = indexedDB.open(this.dbName, targetVersion);
 
-      request.onupgradeneeded = () => {
+      request.onupgradeneeded = (event) => {
         const db = request.result;
+        const transaction = request.transaction;
         try {
           if (!db.objectStoreNames.contains(METADATA_STORE)) {
             db.createObjectStore(METADATA_STORE, { keyPath: 'id' });
           }
 
-          if (request.oldVersion < DB_VERSION) {
-            migrateLegacyStores(request.transaction, db);
+          if (transaction) {
+            for (const name of Array.from(db.objectStoreNames)) {
+              if (name === METADATA_STORE) {
+                continue;
+              }
+
+              const store = transaction.objectStore(name);
+              ensureParentIndex(store);
+            }
           }
 
-          upgradeCallback?.(db);
+          const previousVersion = (event as IDBVersionChangeEvent).oldVersion ?? 0;
+          if (previousVersion < DB_VERSION) {
+            migrateLegacyStores(transaction, db);
+          }
+
+          upgradeCallback?.(db, transaction ?? null);
         } catch (error) {
           console.error('IndexedDB upgrade callback failed', error);
         }
@@ -222,4 +506,36 @@ export class IndexedDBPersistenceAdapter implements PersistenceAdapter {
     });
   }
 
+  private clearExistingEntries(db: IDBDatabase, storeName: string, key: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(storeName, 'readwrite');
+      const store = transaction.objectStore(storeName);
+
+      store.delete(key);
+
+      if (store.indexNames.contains(PARENT_INDEX)) {
+        const range = IDBKeyRange.only(key);
+        const cursorRequest = store.index(PARENT_INDEX).openKeyCursor(range);
+        cursorRequest.onsuccess = () => {
+          const cursor = cursorRequest.result as IDBCursor | null;
+          if (!cursor) {
+            return;
+          }
+
+          store.delete(cursor.primaryKey);
+          cursor.continue();
+        };
+      }
+
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => {
+        console.error(`IndexedDB cleanup failed for ${storeName}:${key}`, transaction.error);
+        reject(transaction.error);
+      };
+      transaction.onabort = () => {
+        console.error(`IndexedDB cleanup aborted for ${storeName}:${key}`, transaction.error);
+        reject(transaction.error);
+      };
+    });
+  }
 }

--- a/client/src/utils/dataCache.ts
+++ b/client/src/utils/dataCache.ts
@@ -1,209 +1,69 @@
+import { IndexedDBPersistenceAdapter } from "../dataCatalog/IndexedDBPersistenceAdapter";
+
 export interface IndexedDBConfig {
     dbName: string;
     storeName: string;
     key: string;
 }
 
-interface MetadataRecord {
-    id: string;
-    timestamp: number;
-}
-
-interface EntryRecord<T = unknown> {
-    id: string;
-    data: T;
-}
-
-const DB_VERSION = 2;
-
 function isIndexedDBSupported() {
     return typeof indexedDB !== "undefined";
 }
 
-const dbCache: Record<string, Promise<IDBDatabase>> = {};
+const adapterCache = new Map<string, IndexedDBPersistenceAdapter>();
 
-function getMetadataStoreName(config: IndexedDBConfig): string {
-    return `${config.storeName}_metadata`;
-}
-
-async function getDatabase(config: IndexedDBConfig): Promise<IDBDatabase> {
-    if (!dbCache[config.dbName]) {
-        dbCache[config.dbName] = new Promise((resolve, reject) => {
-            if (!isIndexedDBSupported()) {
-                reject(new Error('IndexedDB is not supported'));
-                return;
-            }
-
-            const request = indexedDB.open(config.dbName, DB_VERSION);
-            request.onupgradeneeded = (event) => {
-                const db = request.result;
-                const metadataStoreName = getMetadataStoreName(config);
-
-                if (!db.objectStoreNames.contains(config.storeName)) {
-                    db.createObjectStore(config.storeName, { keyPath: 'id' });
-                }
-
-                if (!db.objectStoreNames.contains(metadataStoreName)) {
-                    db.createObjectStore(metadataStoreName, { keyPath: 'id' });
-                }
-
-                if ((event.oldVersion ?? 0) < DB_VERSION) {
-                    migrateToNormalizedStore(request.transaction, config.storeName, metadataStoreName);
-                }
-            };
-            request.onsuccess = () => resolve(request.result);
-            request.onerror = () => reject(new Error('Failed to open IndexedDB'));
-        });
+function getAdapter(dbName: string): IndexedDBPersistenceAdapter {
+    let adapter = adapterCache.get(dbName);
+    if (!adapter) {
+        adapter = new IndexedDBPersistenceAdapter(dbName);
+        adapterCache.set(dbName, adapter);
     }
-    return dbCache[config.dbName];
-}
-
-function migrateToNormalizedStore(
-    transaction: IDBTransaction | null,
-    storeName: string,
-    metadataStoreName: string,
-) {
-    if (!transaction) {
-        return;
-    }
-
-    try {
-        const entriesStore = transaction.objectStore(storeName);
-        const metadataStore = transaction.objectStore(metadataStoreName);
-        const cursorRequest = entriesStore.openCursor();
-
-        cursorRequest.onsuccess = () => {
-            const cursor = cursorRequest.result as IDBCursorWithValue | null;
-            if (!cursor) {
-                return;
-            }
-
-            const value = cursor.value as Partial<EntryRecord> & { timestamp?: number };
-            const recordId = (cursor.key as string) ?? value?.id;
-
-            if (recordId) {
-                const timestamp = value?.timestamp ?? Date.now();
-                metadataStore.put({ id: recordId, timestamp });
-
-                if (value && 'data' in value && value.data !== undefined) {
-                    cursor.update({ id: recordId, data: value.data });
-                }
-            }
-
-            cursor.continue();
-        };
-    } catch (error) {
-        console.error('Failed to migrate IndexedDB store to normalized structure', error);
-    }
-}
-
-async function getStores(config: IndexedDBConfig, mode: IDBTransactionMode) {
-    const db = await getDatabase(config);
-    const metadataStoreName = getMetadataStoreName(config);
-    const transaction = db.transaction([config.storeName, metadataStoreName], mode);
-
-    return {
-        transaction,
-        entriesStore: transaction.objectStore(config.storeName),
-        metadataStore: transaction.objectStore(metadataStoreName),
-    };
-}
-
-async function getEntriesStore(config: IndexedDBConfig, mode: IDBTransactionMode): Promise<IDBObjectStore> {
-    const db = await getDatabase(config);
-    return db.transaction(config.storeName, mode).objectStore(config.storeName);
-}
-
-async function getMetadataStore(config: IndexedDBConfig, mode: IDBTransactionMode): Promise<IDBObjectStore> {
-    const db = await getDatabase(config);
-    return db
-        .transaction(getMetadataStoreName(config), mode)
-        .objectStore(getMetadataStoreName(config));
-}
-
-function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
-    return new Promise((resolve, reject) => {
-        request.onsuccess = () => resolve(request.result);
-        request.onerror = () => reject(request.error ?? new Error('IndexedDB request failed'));
-    });
-}
-
-function waitForTransaction(transaction: IDBTransaction): Promise<void> {
-    return new Promise((resolve, reject) => {
-        transaction.oncomplete = () => resolve();
-        transaction.onerror = () => reject(transaction.error ?? new Error('IndexedDB transaction failed'));
-        transaction.onabort = () => reject(transaction.error ?? new Error('IndexedDB transaction aborted'));
-    });
+    return adapter;
 }
 
 export async function storeInIndexedDB(config: IndexedDBConfig, data: any) {
-    try {
-        const { transaction, entriesStore, metadataStore } = await getStores(config, 'readwrite');
-        const timestamp = Date.now();
+    if (!isIndexedDBSupported()) {
+        throw new Error('IndexedDB is not supported');
+    }
 
-        await requestToPromise(entriesStore.put({ id: config.key, data }));
-        await requestToPromise(metadataStore.put({ id: config.key, timestamp }));
-        await waitForTransaction(transaction);
+    try {
+        const adapter = getAdapter(config.dbName);
+        await adapter.save(config.storeName, config.key, { data, timestamp: Date.now() });
     } catch {
         throw new Error('Failed to store data in IndexedDB');
     }
 }
 
-async function readEntryRecord<T>(config: IndexedDBConfig): Promise<EntryRecord<T> | null> {
-    const entriesStore = await getEntriesStore(config, 'readonly');
-    const request = entriesStore.get(config.key);
-    try {
-        const result = (await requestToPromise(request)) as EntryRecord<T> | undefined;
-        return result ?? null;
-    } catch {
-        throw new Error('Failed to get data from IndexedDB');
-    }
-}
-
-async function readMetadataRecord(config: IndexedDBConfig): Promise<MetadataRecord | null> {
-    const metadataStore = await getMetadataStore(config, 'readonly');
-    const request = metadataStore.get(config.key);
-    try {
-        const result = (await requestToPromise(request)) as MetadataRecord | undefined;
-        return result ?? null;
-    } catch {
-        throw new Error('Failed to get data from IndexedDB');
-    }
-}
-
 export async function getFromIndexedDB<T = any>(config: IndexedDBConfig, ttl?: number): Promise<T | null> {
+    if (!isIndexedDBSupported()) {
+        throw new Error('IndexedDB is not supported');
+    }
+
     try {
-        const entry = await readEntryRecord<T>(config);
-        if (!entry) {
+        const adapter = getAdapter(config.dbName);
+        const record = await adapter.load<T>(config.storeName, config.key);
+        if (!record) {
             return null;
         }
 
-        let metadata = await readMetadataRecord(config);
-
-        if (!metadata) {
-            // Fallback for legacy entries where timestamp lived with the data
-            const legacyTimestamp = (entry as unknown as { timestamp?: number }).timestamp;
-            if (legacyTimestamp) {
-                metadata = { id: config.key, timestamp: legacyTimestamp };
-            }
-        }
-
-        if (ttl && metadata && metadata.timestamp + ttl <= Date.now()) {
+        if (ttl && record.timestamp + ttl <= Date.now()) {
             return null;
         }
 
-        return entry.data as T;
+        return record.data as T;
     } catch {
         throw new Error('Failed to get data from IndexedDB');
     }
 }
 
 export async function clearIndexedDB(config: IndexedDBConfig): Promise<void> {
+    if (!isIndexedDBSupported()) {
+        throw new Error('IndexedDB is not supported');
+    }
+
     try {
-        const { transaction, entriesStore, metadataStore } = await getStores(config, 'readwrite');
-        await requestToPromise(entriesStore.delete(config.key));
-        await requestToPromise(metadataStore.delete(config.key));
-        await waitForTransaction(transaction);
+        const adapter = getAdapter(config.dbName);
+        await adapter.delete(config.storeName, config.key);
     } catch {
         throw new Error('Failed to clear IndexedDB');
     }
@@ -219,7 +79,6 @@ export async function updateIndexedDB<T>(config: IndexedDBConfig, url: string): 
         throw new Error('Failed to update IndexedDB');
     }
 }
-
 
 export interface LoadOptions {
     url: string;


### PR DESCRIPTION
## Summary
- normalize the shared IndexedDB cache by defining database versions, isolating metadata records, and migrating legacy entries
- update the DataCatalog persistence adapter to persist timestamps in a dedicated metadata store and migrate existing records

## Testing
- yarn --cwd client test *(fails: existing TypeScript expectations in client tests)*
- yarn --cwd web-client test *(fails: existing Jest suites with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ed770e90b4832a9696d1f2c7d32610