### PR TITLE
Improve IndexedDB store recovery after deletion

### DIFF
--- a/client/src/dataCatalog/IndexedDBPersistenceAdapter.ts
+++ b/client/src/dataCatalog/IndexedDBPersistenceAdapter.ts
@@ -159,9 +159,16 @@ export class IndexedDBPersistenceAdapter implements PersistenceAdapter {
       try {
         transaction = db.transaction(storeName, mode);
       } catch (error) {
-        if (allowRetry && this.isMissingStoreError(error)) {
-          this.retryWithFreshStore(storeName, mode, createRequest, transform, resolve, reject);
-          return;
+        if (allowRetry) {
+          if (this.isMissingStoreError(error)) {
+            this.retryWithFreshStore(storeName, mode, createRequest, transform, resolve, reject);
+            return;
+          }
+
+          if (this.isDatabaseClosingError(error)) {
+            this.retryAfterDatabaseReconnect(storeName, mode, createRequest, transform, resolve, reject);
+            return;
+          }
         }
 
         reject(error);
@@ -172,9 +179,16 @@ export class IndexedDBPersistenceAdapter implements PersistenceAdapter {
       try {
         store = transaction.objectStore(storeName);
       } catch (error) {
-        if (allowRetry && this.isMissingStoreError(error)) {
-          this.retryWithFreshStore(storeName, mode, createRequest, transform, resolve, reject);
-          return;
+        if (allowRetry) {
+          if (this.isMissingStoreError(error)) {
+            this.retryWithFreshStore(storeName, mode, createRequest, transform, resolve, reject);
+            return;
+          }
+
+          if (this.isDatabaseClosingError(error)) {
+            this.retryAfterDatabaseReconnect(storeName, mode, createRequest, transform, resolve, reject);
+            return;
+          }
         }
 
         reject(error);
@@ -185,6 +199,11 @@ export class IndexedDBPersistenceAdapter implements PersistenceAdapter {
       try {
         request = createRequest(store);
       } catch (error) {
+        if (allowRetry && this.isDatabaseClosingError(error)) {
+          this.retryAfterDatabaseReconnect(storeName, mode, createRequest, transform, resolve, reject);
+          return;
+        }
+
         reject(error);
         return;
       }
@@ -199,9 +218,16 @@ export class IndexedDBPersistenceAdapter implements PersistenceAdapter {
 
       request.onerror = () => {
         const error = request.error;
-        if (allowRetry && this.isMissingStoreError(error)) {
-          this.retryWithFreshStore(storeName, mode, createRequest, transform, resolve, reject);
-          return;
+        if (allowRetry) {
+          if (this.isMissingStoreError(error)) {
+            this.retryWithFreshStore(storeName, mode, createRequest, transform, resolve, reject);
+            return;
+          }
+
+          if (this.isDatabaseClosingError(error)) {
+            this.retryAfterDatabaseReconnect(storeName, mode, createRequest, transform, resolve, reject);
+            return;
+          }
         }
 
         reject(error ?? new Error('IndexedDB request failed'));
@@ -224,6 +250,22 @@ export class IndexedDBPersistenceAdapter implements PersistenceAdapter {
 
   private isMissingStoreError(error: unknown): boolean {
     return error instanceof DOMException && error.name === 'NotFoundError';
+  }
+
+  private isDatabaseClosingError(error: unknown): boolean {
+    return error instanceof DOMException && error.name === 'InvalidStateError';
+  }
+
+  private retryAfterDatabaseReconnect<TRequest, TResult>(
+    storeName: string,
+    mode: IDBTransactionMode,
+    createRequest: (store: IDBObjectStore) => IDBRequest<TRequest>,
+    transform: (value: TRequest) => TResult,
+    resolve: (value: TResult | PromiseLike<TResult>) => void,
+    reject: (reason?: unknown) => void,
+  ): void {
+    this.resetDatabase();
+    this.runWithStore(storeName, mode, createRequest, transform, false).then(resolve).catch(reject);
   }
 
   private resetDatabase(): void {


### PR DESCRIPTION
## Summary
- reset the IndexedDB persistence adapter connection when retrying after a missing object store so it can recreate the store before repeating the request

## Testing
- yarn --cwd client test *(fails: existing TypeScript errors in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68ee1a3605d8832ab705210ad08cc2d7