### PR TITLE
Add progress reporting to data catalog loads

### DIFF
--- a/client/src/dataCatalog/APIDataSource.ts
+++ b/client/src/dataCatalog/APIDataSource.ts
@@ -1,9 +1,9 @@
-import { DataSource } from './types';
+import { DataSource, DataStoreProgressListener } from './types';
 
 export class APIDataSource<T> implements DataSource<T> {
   constructor(private readonly url: string) {}
 
-  async load(): Promise<T> {
+  async load(onProgress?: DataStoreProgressListener): Promise<T> {
     try {
       const response = await fetch(this.url, {
         headers: {
@@ -15,7 +15,49 @@ export class APIDataSource<T> implements DataSource<T> {
         throw new Error(`API request failed with status ${response.status}`);
       }
 
-      return (await response.json()) as T;
+      if (!onProgress) {
+        return (await response.json()) as T;
+      }
+
+      onProgress(0);
+
+      if (!response.body) {
+        const data = (await response.json()) as T;
+        onProgress(1);
+        return data;
+      }
+
+      const contentLengthHeader =
+        response.headers.get('content-length') ?? response.headers.get('Content-Length');
+      const totalLength = contentLengthHeader ? Number(contentLengthHeader) : NaN;
+      const hasTotalLength = Number.isFinite(totalLength) && totalLength > 0;
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let receivedLength = 0;
+      let jsonText = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+
+        if (value) {
+          receivedLength += value.byteLength;
+          jsonText += decoder.decode(value, { stream: true });
+
+          if (hasTotalLength && totalLength > 0) {
+            const progress = Math.min(receivedLength / totalLength, 1);
+            onProgress(progress);
+          }
+        }
+      }
+
+      jsonText += decoder.decode();
+      onProgress(1);
+
+      return JSON.parse(jsonText) as T;
     } catch (error) {
       console.error(`APIDataSource failed to load ${this.url}`, error);
       throw error;

--- a/client/src/dataCatalog/DataCatalog.ts
+++ b/client/src/dataCatalog/DataCatalog.ts
@@ -1,5 +1,5 @@
 import { DataCatalogEntry } from './DataCatalogEntry';
-import { DataStoreListener } from './types';
+import { DataStoreGetOptions, DataStoreListener } from './types';
 
 import {
   HerbsCollection,
@@ -13,7 +13,7 @@ import {
 } from './entities';
 
 export interface DataCatalogStore<T> {
-  getData(options?: { forceReload?: boolean }): Promise<T>;
+  getData(options?: DataStoreGetOptions): Promise<T>;
   addListener(listener: DataStoreListener<T>): () => void;
   invalidate(): Promise<void>;
   storeData(data: T, options?: { persist?: boolean; timestamp?: number }): Promise<void>;
@@ -32,9 +32,9 @@ export class DataCatalog {
     this.entries.set(key, entry as DataCatalogEntry<unknown, unknown>);
   }
 
-  async getData<T>(key: string, options?: { forceReload?: boolean }): Promise<T> {
+  async getData<T>(key: string, options?: DataStoreGetOptions): Promise<T> {
     const entry = this.getEntry<T>(key);
-    return entry.getData(options?.forceReload);
+    return entry.getData(options);
   }
 
   addListener<T>(key: string, listener: DataStoreListener<T>): () => void {
@@ -68,7 +68,7 @@ export class DataCatalog {
 
     const entry = this.getEntry<T>(key);
     const store: DataCatalogStore<T> = {
-      getData: (options) => entry.getData(options?.forceReload),
+      getData: (options) => entry.getData(options),
       addListener: (listener) => entry.addListener(listener),
       invalidate: () => entry.invalidate(),
       storeData: (data, options) => entry.storeData(data, options),

--- a/client/src/dataCatalog/DataCatalogEntry.ts
+++ b/client/src/dataCatalog/DataCatalogEntry.ts
@@ -1,5 +1,11 @@
 import { IndexedDBPersistenceAdapter } from './IndexedDBPersistenceAdapter';
-import { DataSource, DataStoreListener, PersistenceRecord } from './types';
+import {
+  DataSource,
+  DataStoreGetOptions,
+  DataStoreListener,
+  DataStoreProgressListener,
+  PersistenceRecord,
+} from './types';
 
 interface CollectionPersistenceOptions<T, Persisted> {
   toPersistenceItems(data: T): Persisted[];
@@ -30,6 +36,8 @@ export class DataCatalogEntry<T, Persisted = T> {
   private loadingPromise: Promise<T> | null = null;
   private readonly listeners = new Set<DataStoreListener<T>>();
   private readonly persistenceKey: string;
+  private loadProgressListeners: Set<DataStoreProgressListener> | null = null;
+  private currentProgress = 0;
 
   constructor(private readonly options: DataCatalogEntryOptions<T, Persisted>) {
     this.persistenceKey = options.persistenceKey ?? options.key;
@@ -39,14 +47,19 @@ export class DataCatalogEntry<T, Persisted = T> {
     }
   }
 
-  async getData(forceReload = false): Promise<T> {
+  async getData(
+    forceReloadOrOptions?: boolean | DataStoreGetOptions,
+  ): Promise<T> {
+    const { forceReload, onProgress } = this.normalizeGetDataOptions(forceReloadOrOptions);
+
     if (!forceReload && this.data !== null && !this.isExpired()) {
+      onProgress?.(1);
       return this.data;
     }
 
     let persisted: T | null = null;
     if (!forceReload) {
-      persisted = await this.safeLoadFromPersistence();
+      persisted = await this.safeLoadFromPersistence(onProgress);
       if (persisted !== null) {
         return persisted;
       }
@@ -54,7 +67,7 @@ export class DataCatalogEntry<T, Persisted = T> {
 
     if (!this.options.dataSource) {
       if (forceReload) {
-        persisted = await this.safeLoadFromPersistence();
+        persisted = await this.safeLoadFromPersistence(onProgress);
       }
 
       if (persisted !== null) {
@@ -62,6 +75,7 @@ export class DataCatalogEntry<T, Persisted = T> {
       }
 
       if (this.data !== null) {
+        onProgress?.(1);
         return this.data;
       }
 
@@ -71,20 +85,83 @@ export class DataCatalogEntry<T, Persisted = T> {
     }
 
     if (this.loadingPromise) {
+      if (onProgress) {
+        this.addProgressListener(onProgress);
+      }
       return this.loadingPromise;
     }
 
-    this.loadingPromise = this.loadData(forceReload)
+    this.loadProgressListeners = new Set();
+    this.currentProgress = 0;
+    if (onProgress) {
+      this.addProgressListener(onProgress);
+    }
+
+    const progressCallback: DataStoreProgressListener = (progress) => {
+      this.notifyProgressListeners(progress);
+    };
+
+    this.loadingPromise = this.loadData(forceReload, progressCallback)
+      .then((value) => {
+        this.notifyProgressListeners(1);
+        this.loadingPromise = null;
+        this.clearProgressListeners();
+        return value;
+      })
       .catch((error) => {
         this.loadingPromise = null;
+        this.clearProgressListeners();
         throw error;
-      })
-      .then((value) => {
-        this.loadingPromise = null;
-        return value;
       });
 
     return this.loadingPromise;
+  }
+
+  private normalizeGetDataOptions(
+    forceReloadOrOptions?: boolean | DataStoreGetOptions,
+  ): { forceReload: boolean; onProgress?: DataStoreProgressListener } {
+    if (typeof forceReloadOrOptions === 'boolean' || forceReloadOrOptions === undefined) {
+      return { forceReload: forceReloadOrOptions ?? false };
+    }
+
+    return {
+      forceReload: forceReloadOrOptions.forceReload ?? false,
+      onProgress: forceReloadOrOptions.onProgress,
+    };
+  }
+
+  private addProgressListener(listener: DataStoreProgressListener): void {
+    if (!this.loadProgressListeners) {
+      this.loadProgressListeners = new Set();
+    }
+
+    this.loadProgressListeners.add(listener);
+
+    try {
+      listener(this.currentProgress);
+    } catch (error) {
+      console.error(`Data progress listener for ${this.options.key} failed`, error);
+    }
+  }
+
+  private notifyProgressListeners(progress: number): void {
+    this.currentProgress = progress;
+    if (!this.loadProgressListeners || this.loadProgressListeners.size === 0) {
+      return;
+    }
+
+    for (const listener of this.loadProgressListeners) {
+      try {
+        listener(progress);
+      } catch (error) {
+        console.error(`Data progress listener for ${this.options.key} failed`, error);
+      }
+    }
+  }
+
+  private clearProgressListeners(): void {
+    this.loadProgressListeners = null;
+    this.currentProgress = 0;
   }
 
   addListener(listener: DataStoreListener<T>): () => void {
@@ -114,6 +191,7 @@ export class DataCatalogEntry<T, Persisted = T> {
     this.data = null;
     this.timestamp = 0;
     this.loadingPromise = null;
+    this.clearProgressListeners();
     if (!this.options.collection) {
       await this.options.persistenceAdapter.delete(this.options.storeName, this.persistenceKey);
       return;
@@ -122,28 +200,33 @@ export class DataCatalogEntry<T, Persisted = T> {
     await this.clearCollectionPersistence();
   }
 
-  private async loadData(forceReload: boolean): Promise<T> {
+  private async loadData(
+    forceReload: boolean,
+    onProgress?: DataStoreProgressListener,
+  ): Promise<T> {
     if (!this.options.dataSource) {
       throw new Error(`No data source configured for ${this.options.key}`);
     }
 
     if (!forceReload) {
-      const persisted = await this.safeLoadFromPersistence();
+      const persisted = await this.safeLoadFromPersistence(onProgress);
       if (persisted) {
         return persisted;
       }
     }
 
-    const freshData = await this.safeLoadFromSource();
+    const freshData = await this.safeLoadFromSource(onProgress);
     await this.persist(freshData);
     this.updateMemory(freshData);
     return freshData;
   }
 
-  private async safeLoadFromPersistence(): Promise<T | null> {
+  private async safeLoadFromPersistence(
+    onProgress?: DataStoreProgressListener,
+  ): Promise<T | null> {
     try {
       if (this.options.collection) {
-        return await this.safeLoadCollectionFromPersistence();
+        return await this.safeLoadCollectionFromPersistence(onProgress);
       }
 
       const record = await this.options.persistenceAdapter.load<T>(
@@ -159,6 +242,7 @@ export class DataCatalogEntry<T, Persisted = T> {
       }
 
       this.updateMemory(record.data, record.timestamp);
+      onProgress?.(1);
       return record.data;
     } catch (error) {
       console.error(`Failed to read persisted data for ${this.options.key}`, error);
@@ -166,9 +250,11 @@ export class DataCatalogEntry<T, Persisted = T> {
     }
   }
 
-  private async safeLoadFromSource(): Promise<T> {
+  private async safeLoadFromSource(
+    onProgress?: DataStoreProgressListener,
+  ): Promise<T> {
     try {
-      return await this.options.dataSource!.load();
+      return await this.options.dataSource!.load(onProgress);
     } catch (error) {
       console.error(`Failed to load data from source for ${this.options.key}`, error);
       throw error;
@@ -225,7 +311,9 @@ export class DataCatalogEntry<T, Persisted = T> {
     return `${this.persistenceKey}::${COLLECTION_INDEX_SUFFIX}`;
   }
 
-  private async safeLoadCollectionFromPersistence(): Promise<T | null> {
+  private async safeLoadCollectionFromPersistence(
+    onProgress?: DataStoreProgressListener,
+  ): Promise<T | null> {
     const options = this.options.collection;
     if (!options) {
       return null;
@@ -266,6 +354,7 @@ export class DataCatalogEntry<T, Persisted = T> {
 
       const data = options.fromPersistenceItems(items);
       this.updateMemory(data, indexRecord.timestamp);
+      onProgress?.(1);
       return data;
     } catch (error) {
       console.error(`Failed to read persisted collection data for ${this.options.key}`, error);

--- a/client/src/dataCatalog/WorkerDataSource.ts
+++ b/client/src/dataCatalog/WorkerDataSource.ts
@@ -1,4 +1,4 @@
-import { DataSource } from './types';
+import { DataSource, DataStoreProgressListener } from './types';
 
 interface WorkerRequest {
   type: 'load';
@@ -24,7 +24,7 @@ export class WorkerDataSource<T> implements DataSource<T> {
 
   constructor(private readonly createWorker: WorkerFactory) {}
 
-  async load(): Promise<T> {
+  async load(onProgress?: DataStoreProgressListener): Promise<T> {
     const worker = await this.getWorker();
 
     return new Promise<T>((resolve, reject) => {
@@ -36,6 +36,7 @@ export class WorkerDataSource<T> implements DataSource<T> {
 
         cleanup();
         if (data.type === 'success') {
+          onProgress?.(1);
           resolve(data.payload);
         } else {
           reject(new Error(data.message));
@@ -55,6 +56,7 @@ export class WorkerDataSource<T> implements DataSource<T> {
 
       worker.addEventListener('message', messageListener);
       worker.addEventListener('error', errorListener);
+      onProgress?.(0);
       const request: WorkerRequest = { type: 'load' };
       worker.postMessage(request);
     });

--- a/client/src/dataCatalog/types.ts
+++ b/client/src/dataCatalog/types.ts
@@ -1,8 +1,15 @@
+export type DataStoreProgressListener = (progress: number) => void;
+
 export interface DataSource<T> {
-  load(): Promise<T>;
+  load(onProgress?: DataStoreProgressListener): Promise<T>;
 }
 
 export type DataStoreListener<T> = (data: T) => void;
+
+export interface DataStoreGetOptions {
+  forceReload?: boolean;
+  onProgress?: DataStoreProgressListener;
+}
 
 export interface PersistenceRecord<T> {
   data: T;


### PR DESCRIPTION
## Summary
- allow data catalog consumers to request progress callbacks when loading entries
- propagate progress updates through persistence reads and the API/worker data sources
- expose a unified data store options type so downstream code can provide progress listeners

## Testing
- yarn --cwd client test *(fails: existing repository TypeScript/test breakages)*
- yarn --cwd web-client test *(fails: existing repository TypeScript/test breakages)*
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ee21c34598832a976d71082c083ec8