### PR TITLE
Define bind settings types and persist NPC deletions

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -22,6 +22,7 @@ import {SKIP_LINE} from "./ControlConstants";
 import {stripPolishCharacters} from "./stripPolishCharacters";
 import {openMapContextMenu} from "./contextMenus";
 import appEventBus from "./events/app-event-bus";
+import type {BindSettings, CustomKeyBind, KeyBind} from "./types/binds";
 
 export interface ClientAdapter {
     send(text: string, echo?: boolean): void;
@@ -52,31 +53,11 @@ export default class Client {
         }),
     };
     aliases: { pattern: RegExp; callback: Function }[] = [];
-    lampBind = {key: "Digit4", ctrl: true} as {
-        key: string;
-        ctrl?: boolean;
-        alt?: boolean;
-        shift?: boolean;
-    };
-    attackBind = {key: "Digit1", ctrl: true} as {
-        key: string;
-        ctrl?: boolean;
-        alt?: boolean;
-        shift?: boolean;
-    };
-    supportBind = {key: "KeyQ", ctrl: true} as {
-        key: string;
-        ctrl?: boolean;
-        alt?: boolean;
-        shift?: boolean;
-    };
-    moveModeBind = {key: "Backquote"} as {
-        key: string;
-        ctrl?: boolean;
-        alt?: boolean;
-        shift?: boolean;
-    };
-    customBinds: { key: string; ctrl?: boolean; alt?: boolean; shift?: boolean; command: string }[] = [];
+    lampBind: KeyBind = {key: "Digit4", ctrl: true};
+    attackBind: KeyBind = {key: "Digit1", ctrl: true};
+    supportBind: KeyBind = {key: "KeyQ", ctrl: true};
+    moveModeBind: KeyBind = {key: "Backquote"};
+    customBinds: CustomKeyBind[] = [];
     tempBinds: { key: string; ctrl?: boolean; alt?: boolean; shift?: boolean; command: string | null }[] = [
         {key: 'F4', command: null},
         {key: 'F5', command: null},
@@ -158,7 +139,7 @@ export default class Client {
             })
         })
 
-        const applyBinds = (b: any) => {
+        const applyBinds = (b: BindSettings | undefined) => {
             const bind = b?.main
             if (bind) {
                 this.FunctionalBind.updateOptions({

--- a/client/src/defaultSettings.ts
+++ b/client/src/defaultSettings.ts
@@ -1,3 +1,5 @@
+import type {BindSettings} from "./types/binds";
+
 export interface Settings {
     packageHelper: boolean;
     inlineCompassRose: boolean;
@@ -17,9 +19,9 @@ export interface Settings {
     letterLineWidth: number;
     guilds: string[];
     enemyGuilds: string[];
-    binds: any;//TODO type
+    binds: BindSettings;
     autoWalkDelay: string;
-    guildColors: any;//TODO type
+    guildColors: Record<string, string | undefined>;
 }
 
 export const defaultSettings: Settings = {
@@ -43,5 +45,5 @@ export const defaultSettings: Settings = {
     enemyGuilds: [],
     binds: {},
     autoWalkDelay: "1",
-    guildColors: [],
+    guildColors: {},
 };

--- a/client/src/events/app-event-bus.ts
+++ b/client/src/events/app-event-bus.ts
@@ -2,12 +2,13 @@ import {EventBus} from "./event-bus";
 import type {ClickCallbackMap} from "../OutputHandler";
 import type {LetterSubmitPayload} from "../types/letter";
 import {Settings} from "../defaultSettings";
+import type {BindSettings} from "../types/binds";
 import {UiSettings} from "sandbox-react/src/uiSettings";
 import {ButtonSetting} from "sandbox-react/src/mobileButtonSettings";
 
 type AppEvents = {
     "attackQueueChange": string[];
-    "binds": any; //TODO type and check whether this is needed
+    "binds": BindSettings;
     'client.disconnect': void;
     'client.connect': void;
     'command': string;

--- a/client/src/types/binds.ts
+++ b/client/src/types/binds.ts
@@ -1,0 +1,36 @@
+export type DirectionKey =
+    | 'n'
+    | 's'
+    | 'w'
+    | 'e'
+    | 'nw'
+    | 'ne'
+    | 'sw'
+    | 'se'
+    | 'u'
+    | 'd'
+    | 'special';
+
+export interface KeyBind {
+    key: string;
+    ctrl?: boolean;
+    alt?: boolean;
+    shift?: boolean;
+}
+
+export interface CustomKeyBind extends KeyBind {
+    command: string;
+}
+
+export type DirectionBindMap = Partial<Record<DirectionKey, KeyBind>>;
+
+export interface BindSettings {
+    main?: KeyBind;
+    lamp?: KeyBind;
+    attack?: KeyBind;
+    support?: KeyBind;
+    moveMode?: KeyBind;
+    directions?: DirectionBindMap;
+    custom?: CustomKeyBind[];
+    temp?: KeyBind[];
+}

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -2,6 +2,7 @@ import 'bootswatch/dist/darkly/bootstrap.min.css';
 import './style.css'
 import ArkadiaClient from "./ArkadiaClient.ts";
 import type { ClickCallbackMap, ClickCallback } from "@client/src/OutputHandler.ts";
+import type {DirectionBindMap} from "@client/src/types/binds.ts";
 import {Modal, Dropdown} from 'bootstrap';
 import CharState from "./CharState";
 import ObjectList from "./ObjectList";
@@ -490,12 +491,12 @@ const numpadDirections: { [key: string]: string } = {
     'Numpad5': 'zerknij'
 };
 
-function applyDirectionBinds(dirs: any) {
+function applyDirectionBinds(dirs: DirectionBindMap | undefined) {
     Object.keys(numpadDirections).forEach(k => {
         if (!['NumpadDivide', 'Numpad0', 'Numpad5'].includes(k)) delete numpadDirections[k];
     });
-    Object.entries(dirs || {}).forEach(([dir, bind]: any) => {
-        if (bind && bind.key) {
+    Object.entries(dirs || {}).forEach(([dir, bind]) => {
+        if (bind?.key) {
             numpadDirections[bind.key] = dir;
         }
     });

--- a/web-client/src/options/Binds.tsx
+++ b/web-client/src/options/Binds.tsx
@@ -5,33 +5,13 @@ import { parseMultibindsDatabase, type MultibindImportRow } from "./multibindImp
 import { readMultibinds, replaceMultibinds, type StoredMultibindRecord } from "../multibindStorage";
 import appEventBus from "@client/src/events/app-event-bus.ts";
 import {dataCatalog} from "@client/src/dataCatalog/catalogInstance.ts";
+import type {BindSettings as StoredBindSettings, CustomKeyBind, DirectionKey, KeyBind} from "@client/src/types/binds.ts";
 
-interface Bind {
-    key: string;
-    ctrl?: boolean;
-    alt?: boolean;
-    shift?: boolean;
-}
+type Bind = KeyBind;
+type CustomBind = CustomKeyBind;
+type DirectionBinds = Record<DirectionKey, Bind>;
 
-interface CustomBind extends Bind {
-    command: string;
-}
-
-interface DirectionBinds {
-    n: Bind;
-    s: Bind;
-    w: Bind;
-    e: Bind;
-    nw: Bind;
-    ne: Bind;
-    sw: Bind;
-    se: Bind;
-    u: Bind;
-    d: Bind;
-    special: Bind;
-}
-
-interface BindSettings {
+type FullBindSettings = StoredBindSettings & {
     main: Bind;
     lamp: Bind;
     attack: Bind;
@@ -40,9 +20,11 @@ interface BindSettings {
     directions: DirectionBinds;
     custom: CustomBind[];
     temp: Bind[];
-}
+};
 
-const defaultBinds: BindSettings = {
+type CapturableBindKey = 'main' | 'lamp' | 'attack' | 'support' | 'moveMode';
+
+const defaultBinds: FullBindSettings = {
     main: { key: 'BracketRight' },
     lamp: { key: 'Digit4', ctrl: true },
     attack: { key: 'Digit1', ctrl: true },
@@ -165,7 +147,7 @@ function label(bind: Bind) {
 }
 
 function Binds() {
-    const [binds, setBinds] = useState<BindSettings>(defaultBinds);
+    const [binds, setBinds] = useState<FullBindSettings>(defaultBinds);
     const [multibinds, setMultibinds] = useState<StoredMultibindRecord[]>([]);
     const [importData, setImportData] = useState<ImportData | null>(null);
     const [conflictPolicy, setConflictPolicy] = useState<ConflictPolicy>('keep-last');
@@ -386,7 +368,7 @@ function Binds() {
         setImportResult(null);
     }
 
-    function handleCapture(name: keyof BindSettings, ev: React.KeyboardEvent) {
+    function handleCapture(name: CapturableBindKey, ev: React.KeyboardEvent) {
         ev.preventDefault();
         const { code, ctrlKey, altKey, shiftKey } = ev;
         setBinds(prev => ({ ...prev, [name]: { key: code, ctrl: ctrlKey, alt: altKey, shift: shiftKey } }));

--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -25,11 +25,6 @@ function Npc() {
         )
     }, []);
 
-    useEffect(() => {
-        //TODO download on demand only
-        dataCatalog.getNpcStore().getData().then(npc => setNpcs(npc))
-    }, [])
-
     function downloadNpcs() {
         dataCatalog.getNpcStore().getData({forceReload: true})
             .then(npc => {
@@ -58,7 +53,8 @@ function Npc() {
     function deleteNpc(npc: NpcProps) {
         const updated = npcs.filter(n => !(n.name === npc.name && n.loc === npc.loc))
         setNpcs(updated)
-        //TODO persist deletion
+        dataCatalog.getNpcStore().storeData(updated)
+            .catch(e => console.error('Failed to persist NPC deletion:', e))
     }
 
     return (


### PR DESCRIPTION
## Summary
- add shared bind type definitions and apply them across client and web UI code
- tighten settings typing for binds and guild colors while adjusting bind configuration components
- persist NPC deletions and clean up redundant data fetch logic in the NPC options view

## Testing
- yarn --cwd client test *(fails: numerous pre-existing suite and type errors)*
- yarn --cwd web-client test *(fails: numerous pre-existing suite and type errors)*
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ee5317e230832a8cdd43c8da93e275