### PR TITLE
Ensure PackageHelper NPCs persist after downloads

### DIFF
--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -42,6 +42,8 @@ export default class PackageHelper {
     npc: Record<string, number> = {}
     enabled = false;
 
+    private npcStore = dataCatalog.getNpcStore();
+
     private packages: { name: string; time?: string; distance?: number }[] = []
     private listTime = 0
     private timer: number | undefined
@@ -59,11 +61,14 @@ export default class PackageHelper {
     constructor(clientExtension: Client) {
         this.client = clientExtension
 
-        dataCatalog.getNpcStore().getData().then(npc => {
-            this.npc = npc.reduce((acc, npc) => {
-                acc[npc.name] = npc.loc
-                return acc
-            }, {})
+        this.npcStore.getData().then(npc => {
+            this.updateNpcCache(npc)
+        }).catch(error => {
+            console.error('Failed to load NPC data', error)
+        })
+
+        this.npcStore.addListener(npc => {
+            this.updateNpcCache(npc)
         })
 
         appEventBus.on('settings', (settings) => {
@@ -334,19 +339,48 @@ export default class PackageHelper {
     private registerDeliveryTrigger() {
         this.deliveryTrigger = this.client.Triggers.registerOneTimeTrigger(/^(Oddajesz|Zwracasz) pocztowa paczke/, (_, __, matches): undefined => {
             if (matches[1] === 'Oddajesz') {
-                if (!this.npc[this.currentPackage.name]) {
-                    this.client.println(`Nowy adresat: ${this.currentPackage.name} | ${this.client.Map.currentRoom.id}`)
-                    // this.client.port.postMessage({
-                    //     type: 'NEW_NPC',
-                    //     name: this.currentPackage.name,
-                    //     loc: this.client.Map.currentRoom.id
-                    // })
-                    //TODO persist via datastore
+                const name = this.currentPackage?.name
+                const location = this.client.Map.currentRoom?.id
+                if (!name || typeof location !== 'number') {
+                    this.currentPackage = undefined
+                    this.stopTimer()
+                    this.deliveryTrigger = undefined
+                    return
+                }
+                const knownLocation = this.findNpcLocation(name)
+                if (knownLocation === undefined) {
+                    this.client.println(`Nowy adresat: ${name} | ${location}`)
+                    this.npc[name] = location
+                    this.persistDiscoveredNpc(name, location)
                 }
             }
             this.currentPackage = undefined;
             this.stopTimer();
             this.deliveryTrigger = undefined;
+        })
+    }
+
+    private updateNpcCache(npcList: { name: string; loc: number }[]) {
+        this.npc = npcList.reduce((acc, npc) => {
+            if (typeof npc.loc === 'number') {
+                acc[npc.name] = npc.loc
+            }
+            return acc
+        }, {} as Record<string, number>)
+    }
+
+    private persistDiscoveredNpc(name: string, location: number) {
+        this.npcStore.getData().then(npcs => {
+            const exists = npcs.some(npc => npc.name === name && npc.loc === location)
+            if (exists) {
+                return
+            }
+            const updated = [...npcs, { name, loc: location, custom: true }]
+            return this.npcStore.storeData(updated).catch(error => {
+                console.error(`Failed to persist NPC ${name}`, error)
+            })
+        }).catch(error => {
+            console.error('Failed to load NPC data for persistence', error)
         })
     }
 

--- a/client/src/dataCatalog/DataCatalogEntry.ts
+++ b/client/src/dataCatalog/DataCatalogEntry.ts
@@ -11,6 +11,7 @@ interface CollectionPersistenceOptions<T, Persisted> {
   toPersistenceItems(data: T): Persisted[];
   fromPersistenceItems(items: Persisted[]): T;
   getPersistenceKey(item: Persisted): string;
+  shouldPreserveItem?: (item: Persisted) => boolean;
 }
 
 interface DataCatalogEntryOptions<T, Persisted = T> {
@@ -181,7 +182,10 @@ export class DataCatalogEntry<T, Persisted = T> {
       return;
     }
 
-    await this.persist(data, timestamp);
+    const persistedData = await this.persist(data, timestamp);
+    if (persistedData !== data) {
+      this.updateMemory(persistedData, timestamp);
+    }
   }
 
   async clearData(): Promise<void> {
@@ -213,9 +217,9 @@ export class DataCatalogEntry<T, Persisted = T> {
     }
 
     const freshData = await this.safeLoadFromSource(onProgress);
-    await this.persist(freshData);
-    this.updateMemory(freshData);
-    return freshData;
+    const persistedData = await this.persist(freshData);
+    this.updateMemory(persistedData);
+    return persistedData;
   }
 
   private async safeLoadFromPersistence(
@@ -258,10 +262,9 @@ export class DataCatalogEntry<T, Persisted = T> {
     }
   }
 
-  private async persist(data: T, timestamp: number = Date.now()): Promise<void> {
+  private async persist(data: T, timestamp: number = Date.now()): Promise<T> {
     if (this.options.collection) {
-      await this.persistCollection(data, timestamp);
-      return;
+      return this.persistCollection(data, timestamp);
     }
 
     const record: PersistenceRecord<T> = {
@@ -278,6 +281,8 @@ export class DataCatalogEntry<T, Persisted = T> {
     } catch (error) {
       console.error(`Failed to persist data for ${this.options.key}`, error);
     }
+
+    return data;
   }
 
   private updateMemory(data: T, timestamp: number = Date.now()): void {
@@ -290,7 +295,7 @@ export class DataCatalogEntry<T, Persisted = T> {
     return Date.now() - this.timestamp > this.options.ttl;
   }
 
-  private isRecordExpired(record: PersistenceRecord<T>): boolean {
+  private isRecordExpired(record: PersistenceRecord<unknown>): boolean {
     return Date.now() - record.timestamp > this.options.ttl;
   }
 
@@ -333,22 +338,7 @@ export class DataCatalogEntry<T, Persisted = T> {
         ? indexRecord.data.keys.filter((value): value is string => typeof value === 'string')
         : [];
 
-      const items: Persisted[] = [];
-      for (const key of keys) {
-        try {
-          const value = await this.options.persistenceAdapter.loadRaw<Persisted>(
-            this.options.storeName,
-            key,
-          );
-          if (value === null) {
-            continue;
-          }
-          items.push(value);
-        } catch (error) {
-          console.error(`Failed to read persisted item for ${this.options.key}:${key}`, error);
-        }
-      }
-
+      const items = await this.loadPersistedCollectionItems<Persisted>(keys);
       const data = options.fromPersistenceItems(items);
       this.updateMemory(data, indexRecord.timestamp);
       onProgress?.(1);
@@ -359,10 +349,30 @@ export class DataCatalogEntry<T, Persisted = T> {
     }
   }
 
-  private async persistCollection(data: T, timestamp: number): Promise<void> {
+  private async loadPersistedCollectionItems<PersistedItem>(keys: string[]): Promise<PersistedItem[]> {
+    const items: PersistedItem[] = [];
+    for (const key of keys) {
+      try {
+        const value = await this.options.persistenceAdapter.loadRaw<PersistedItem>(
+          this.options.storeName,
+          key,
+        );
+        if (value === null) {
+          continue;
+        }
+        items.push(value);
+      } catch (error) {
+        console.error(`Failed to read persisted item for ${this.options.key}:${key}`, error);
+      }
+    }
+
+    return items;
+  }
+
+  private async persistCollection(data: T, timestamp: number): Promise<T> {
     const options = this.options.collection;
     if (!options) {
-      return;
+      return data;
     }
 
     const items = options.toPersistenceItems(data);
@@ -375,17 +385,39 @@ export class DataCatalogEntry<T, Persisted = T> {
       uniqueItems.set(key, item);
     }
 
-    const keys = Array.from(uniqueItems.keys());
-
+    let previousKeys: string[] = [];
     try {
       const previousIndex = await this.options.persistenceAdapter.load<CollectionIndexRecord>(
         this.options.storeName,
         this.getCollectionIndexKey(),
       );
-      const previousKeys = Array.isArray(previousIndex?.data?.keys)
+      previousKeys = Array.isArray(previousIndex?.data?.keys)
         ? previousIndex.data.keys.filter((value): value is string => typeof value === 'string')
         : [];
+    } catch (error) {
+      console.error(`Failed to read persisted collection index for ${this.options.key}`, error);
+    }
 
+    if (options.shouldPreserveItem && previousKeys.length > 0) {
+      const persistedItems = await this.loadPersistedCollectionItems<Persisted>(previousKeys);
+      for (const item of persistedItems) {
+        const key = options.getPersistenceKey(item);
+        if (uniqueItems.has(key)) {
+          continue;
+        }
+        try {
+          if (options.shouldPreserveItem(item)) {
+            uniqueItems.set(key, item);
+          }
+        } catch (error) {
+          console.error(`Failed to evaluate preservation for ${this.options.key}:${key}`, error);
+        }
+      }
+    }
+
+    const keys = Array.from(uniqueItems.keys());
+
+    try {
       await Promise.all(
         keys.map((key) =>
           this.options.persistenceAdapter.saveRaw(
@@ -410,6 +442,8 @@ export class DataCatalogEntry<T, Persisted = T> {
     } catch (error) {
       console.error(`Failed to persist collection data for ${this.options.key}`, error);
     }
+
+    return options.fromPersistenceItems(Array.from(uniqueItems.values()));
   }
 
   private async clearCollectionPersistence(): Promise<void> {

--- a/client/src/dataCatalog/catalogInstance.ts
+++ b/client/src/dataCatalog/catalogInstance.ts
@@ -77,13 +77,24 @@ const npcsEntry = new DataCatalogEntry<NpcCollection, PersistedNpcEntry>({
         key: `${entry.loc}:${entry.name}`,
       })),
     fromPersistenceItems: (items) =>
-      items.map(({ key: _ignored, name, loc, cmd, body }) => ({
-        name,
-        loc: Number(loc),
-        cmd,
-        body,
-      })),
+      items.map(({ key: _ignored, name, loc, cmd, body, custom }) => {
+        const entry: NpcEntry = {
+          name,
+          loc: Number(loc),
+        };
+        if (cmd !== undefined) {
+          entry.cmd = cmd;
+        }
+        if (body !== undefined) {
+          entry.body = body;
+        }
+        if (custom === true) {
+          entry.custom = true;
+        }
+        return entry;
+      }),
     getPersistenceKey: (entry) => entry.key,
+    shouldPreserveItem: (entry) => entry.custom === true,
   },
 });
 

--- a/client/src/dataCatalog/entities.ts
+++ b/client/src/dataCatalog/entities.ts
@@ -7,6 +7,7 @@ export interface NpcEntry {
   loc: number;
   cmd?: string;
   body?: string;
+  custom?: boolean;
 }
 
 export interface MagicsFile {

--- a/client/test/PackageHelper.test.ts
+++ b/client/test/PackageHelper.test.ts
@@ -1,11 +1,64 @@
-import PackageHelper from '../src/PackageHelper';
 import { colorStringInLine, findClosestColor } from '../src/Colors';
+import appEventBus from '../src/events/app-event-bus';
+
+const npcListeners: Array<(data: any) => void> = [];
+const mockGetData = jest.fn().mockResolvedValue([]);
+const mockStoreData = jest.fn().mockResolvedValue(undefined);
+const mockAddListener = jest.fn(
+  (listener: (data: any) => void) => {
+    npcListeners.push(listener);
+    return () => {
+      const index = npcListeners.indexOf(listener);
+      if (index !== -1) {
+        npcListeners.splice(index, 1);
+      }
+    };
+  },
+);
+
+const npcStore = {
+  getData: mockGetData,
+  addListener: mockAddListener,
+  storeData: mockStoreData,
+};
+
+const mockGetNpcStore = jest.fn(() => npcStore);
+
+jest.mock('../src/dataCatalog/catalogInstance', () => ({
+  __esModule: true,
+  dataCatalog: {
+    getNpcStore: mockGetNpcStore,
+  },
+}));
+
+import PackageHelper from '../src/PackageHelper';
+
+const flushPromises = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 describe('PackageHelper', () => {
   let helper: any;
   let client: any;
+  let emitSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    npcListeners.length = 0;
+    mockGetData.mockReset();
+    mockStoreData.mockReset();
+    mockAddListener.mockReset();
+    mockGetNpcStore.mockReset();
+    mockGetData.mockResolvedValue([]);
+    mockStoreData.mockResolvedValue(undefined);
+    mockAddListener.mockImplementation((listener: (data: any) => void) => {
+      npcListeners.push(listener);
+      return () => {
+        const index = npcListeners.indexOf(listener);
+        if (index !== -1) {
+          npcListeners.splice(index, 1);
+        }
+      };
+    });
+    mockGetNpcStore.mockImplementation(() => npcStore);
+
     (global as any).Input = { send: jest.fn() };
     client = {
       Triggers: {
@@ -39,6 +92,12 @@ describe('PackageHelper', () => {
     helper = new PackageHelper(client);
     client.Triggers.registerTrigger.mockClear();
     client.Triggers.registerMultilineTrigger.mockClear();
+    client.Triggers.registerOneTimeTrigger.mockClear();
+    emitSpy = jest.spyOn(appEventBus, 'emit');
+  });
+
+  afterEach(() => {
+    emitSpy.mockRestore();
   });
 
   test('constructor initializes helper by default', () => {
@@ -133,6 +192,44 @@ describe('PackageHelper', () => {
     expect(client.Triggers.removeTrigger).toHaveBeenCalledWith('pickTrigger');
   });
 
+  test('registerDeliveryTrigger persists newly discovered NPCs', async () => {
+    mockGetData.mockClear();
+    mockStoreData.mockClear();
+    helper.currentPackage = { name: 'Nowy Odbiorca' } as any;
+    helper.npc = {};
+
+    helper['registerDeliveryTrigger']();
+    const deliveryCb = client.Triggers.registerOneTimeTrigger.mock.calls[0][1];
+
+    await deliveryCb('', '', ['','Oddajesz'] as any);
+    await flushPromises();
+
+    expect(mockGetData).toHaveBeenCalledTimes(1);
+    expect(mockStoreData).toHaveBeenCalledWith([
+      { name: 'Nowy Odbiorca', loc: 123, custom: true },
+    ]);
+    expect(helper.npc['Nowy Odbiorca']).toBe(123);
+    expect(client.println).toHaveBeenCalledWith('Nowy adresat: Nowy Odbiorca | 123');
+  });
+
+  test('registerDeliveryTrigger skips persistence for known NPCs', async () => {
+    mockGetData.mockClear();
+    mockStoreData.mockClear();
+    helper.currentPackage = { name: 'Znany Odbiorca' } as any;
+    helper.npc = {};
+    mockGetData.mockResolvedValueOnce([
+      { name: 'Znany Odbiorca', loc: 123, custom: true },
+    ]);
+
+    helper['registerDeliveryTrigger']();
+    const deliveryCb = client.Triggers.registerOneTimeTrigger.mock.calls[0][1];
+
+    await deliveryCb('', '', ['','Oddajesz'] as any);
+    await flushPromises();
+
+    expect(mockStoreData).not.toHaveBeenCalled();
+  });
+
   test('label trigger updates package status without starting timer', () => {
     helper.init();
     const trigger = client.Triggers.registerTrigger.mock.calls[0][1];
@@ -145,7 +242,7 @@ describe('PackageHelper', () => {
     const result = trigger(raw, '', match);
 
     expect(helper.currentPackage).toEqual({ name: 'Bob' });
-    expect(client.sendEvent).toHaveBeenCalledWith('packageStatus', { recipient: 'Bob' });
+    expect(emitSpy).toHaveBeenCalledWith('packageStatus', { recipient: 'Bob' });
     const expectedColor = colorStringInLine(raw, 'Bob', findClosestColor('#ffff00'));
     expect(result).toBe(expectedColor);
     expect(startSpy).not.toHaveBeenCalled();
@@ -163,7 +260,7 @@ describe('PackageHelper', () => {
     trigger(raw, '', match);
 
     expect(helper.currentPackage).toEqual({ name: 'Bob', time: '5' });
-    expect(client.sendEvent).toHaveBeenCalledWith('packageStatus', { recipient: 'Bob' });
+    expect(emitSpy).toHaveBeenCalledWith('packageStatus', { recipient: 'Bob' });
   });
 
   test('label trigger skips registering delivery trigger when already registered', () => {
@@ -191,7 +288,7 @@ describe('PackageHelper', () => {
     trigger(raw, '', match);
 
     expect(helper.currentPackage).toEqual({ name: 'Tom' });
-    expect(client.sendEvent).toHaveBeenCalledWith('packageStatus', { recipient: 'Tom' });
+    expect(emitSpy).toHaveBeenCalledWith('packageStatus', { recipient: 'Tom' });
   });
 
   test('packageTableCallback simplifies output when width is small', () => {

--- a/client/test/dataCatalogNpcPersistence.test.ts
+++ b/client/test/dataCatalogNpcPersistence.test.ts
@@ -1,0 +1,62 @@
+import { DataCatalogEntry } from '../src/dataCatalog/DataCatalogEntry';
+import { IndexedDBPersistenceAdapter } from '../src/dataCatalog/IndexedDBPersistenceAdapter';
+import { NpcCollection, NpcEntry } from '../src/dataCatalog/entities';
+
+type PersistedNpcEntry = NpcEntry & { key: string };
+
+describe('DataCatalogEntry NPC persistence', () => {
+  test('preserves custom NPC entries when reloading from source', async () => {
+    const adapter = new IndexedDBPersistenceAdapter(`TestNPCDB-${Date.now()}-${Math.random()}`);
+    const storeName = `npc-store-${Math.random()}`;
+    const load = jest.fn(async () => [{ name: 'Alice', loc: 1 }]);
+
+    const entry = new DataCatalogEntry<NpcCollection, PersistedNpcEntry>({
+      key: 'npcs',
+      ttl: 60_000,
+      storeName,
+      persistenceAdapter: adapter,
+      dataSource: { load },
+      collection: {
+        toPersistenceItems: (collection) =>
+          collection.map((npc) => ({
+            ...npc,
+            key: `${npc.loc}:${npc.name}`,
+          })),
+        fromPersistenceItems: (items) =>
+          items.map(({ key: _ignored, name, loc, custom }) => {
+            const npc: NpcEntry = {
+              name,
+              loc: Number(loc),
+            };
+            if (custom === true) {
+              npc.custom = true;
+            }
+            return npc;
+          }),
+        getPersistenceKey: (entry) => entry.key,
+        shouldPreserveItem: (entry) => entry.custom === true,
+      },
+    });
+
+    await entry.storeData([{ name: 'Alice', loc: 1 }]);
+    await entry.storeData([
+      { name: 'Alice', loc: 1 },
+      { name: 'Custom NPC', loc: 999, custom: true },
+    ]);
+
+    const withCustom = await entry.getData();
+    expect(withCustom).toEqual([
+      { name: 'Alice', loc: 1 },
+      { name: 'Custom NPC', loc: 999, custom: true },
+    ]);
+
+    load.mockResolvedValueOnce([{ name: 'Alice', loc: 1 }]);
+    const reloaded = await entry.getData({ forceReload: true });
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(reloaded).toEqual([
+      { name: 'Alice', loc: 1 },
+      { name: 'Custom NPC', loc: 999, custom: true },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure PackageHelper subscribes to NPC data updates and persists newly discovered recipients
- update the data catalog to keep custom NPC entries when reloading data and cover the behavior with tests
- expand PackageHelper tests to validate NPC persistence and event emission handling

## Testing
- yarn --cwd client test PackageHelper
- yarn --cwd client test dataCatalogNpcPersistence
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ee5fd53920832a9304fd497694f94a