### PR TITLE
Use sandbox transport adapter in sandbox client

### DIFF
--- a/web-client/src/SandboxTransportAdapter.ts
+++ b/web-client/src/SandboxTransportAdapter.ts
@@ -1,0 +1,56 @@
+import WebSocketTransportAdapter from "@client/src/transport/websocket-adapter.ts";
+import {TransportSubject} from "@client/src/transport/subject.ts";
+import type {TransportIn, TransportOut} from "@client/src/transport/types";
+
+function createOpenEvent(): Event {
+    if (typeof Event !== "undefined") {
+        return new Event("open");
+    }
+    return {type: "open"} as Event;
+}
+
+function createCloseEvent(): CloseEvent {
+    if (typeof CloseEvent !== "undefined") {
+        return new CloseEvent("close");
+    }
+    return {type: "close"} as CloseEvent;
+}
+
+export default class SandboxTransportAdapter extends WebSocketTransportAdapter {
+    private readonly sandboxSubject: TransportSubject<TransportIn>;
+    private connected = false;
+
+    constructor() {
+        super();
+        this.sandboxSubject = this.messages$ as unknown as TransportSubject<TransportIn>;
+    }
+
+    override connect(): void {
+        this.connected = true;
+        this.sandboxSubject.next({type: "open", event: createOpenEvent()});
+    }
+
+    override disconnect(): void {
+        if (!this.connected) {
+            return;
+        }
+        this.connected = false;
+        this.sandboxSubject.next({type: "close", event: createCloseEvent()});
+    }
+
+    override isConnected(): boolean {
+        return this.connected;
+    }
+
+    override send(message: string): void {
+        this.emitCommand({kind: "text", payload: message});
+    }
+
+    override sendGmcp(path: string, payload?: unknown): void {
+        this.emitCommand({kind: "gmcp", path, payload});
+    }
+
+    private emitCommand(message: TransportOut): void {
+        this.sandboxSubject.next({type: "command", payload: message});
+    }
+}

--- a/web-client/src/sandbox.ts
+++ b/web-client/src/sandbox.ts
@@ -1,28 +1,16 @@
 import './sandbox.css';
+import SandboxTransportAdapter from "./SandboxTransportAdapter.ts";
 import ArkadiaClient from "./ArkadiaClient.ts";
 
-
-// Disable real network and echo commands locally
-arkadiaClient.connect = () => {
-    console.log('Sandbox mode: connection disabled');
-};
+const sandboxAdapter = new SandboxTransportAdapter();
+const arkadiaClient = new ArkadiaClient(sandboxAdapter);
 arkadiaClient.sendGmcp = () => {};
-arkadiaClient.send = (message: string, echo: boolean = true) => {
-    arkadiaClient.recorder?.handleOutgoing?.(message);
-    if ((arkadiaClient as any).receivedFirstGmcp && message) {
-        const formatted = `→ ${message}`;
-        if (echo) {
-            arkadiaClient.output(formatted, 'command');
-        } else {
-            arkadiaClient.output(`<i>${formatted}</i>`, 'command');
-        }
-    }
-};
+arkadiaClient.connect();
 (arkadiaClient as any).receivedFirstGmcp = true;
+window.client = arkadiaClient;
 
 window.addEventListener('load', () => {
     const client: any = (window as any).clientExtension;
-    arkadiaClient.emit('client.connect');
     const memberInput = document.getElementById('sandbox-member-name') as HTMLInputElement | null;
     const addMemberButton = document.getElementById('sandbox-add-member') as HTMLButtonElement | null;
     const addEnemyButton = document.getElementById('sandbox-add-enemy') as HTMLButtonElement | null;


### PR DESCRIPTION
## Summary
- add a sandbox transport adapter that overrides the websocket behavior without opening a real connection
- initialize the sandbox client with the sandbox adapter and rely on the synthetic connect event instead of manual bus emission

## Testing
- yarn --cwd web-client test *(fails: existing suite expectation mismatches)*
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ee781384ac832aa5a4b503d2da9784