### PR TITLE
Update Client tests after removing port dependency

### DIFF
--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -18,6 +18,7 @@ jest.mock('../src/main', () => ({
 
 import Client from '../src/Client';
 import { mudletColorLine } from '../src/Colors';
+import appEventBus from '../src/events/app-event-bus';
 import { Howl } from 'howler';
 
 jest.mock('howler', () => {
@@ -57,34 +58,38 @@ jest.mock('../src/scripts/functionalBind', () => ({
   })),
 }));
 
-
-jest.mock('../src/MapHelper', () => {
-  return {
-    __esModule: true,
-    default: jest.fn().mockImplementation(() => ({
-      parseCommand,
-      move: jest.fn((dir: string) => ({ direction: dir, moved: false })),
-      followMove: jest.fn(),
-    })),
-  };
-});
+jest.mock('../src/MapHelper', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    parseCommand,
+    move: jest.fn((dir: string) => ({ direction: dir, moved: false })),
+    followMove: jest.fn(),
+  })),
+}));
 
 beforeEach(() => {
   document.body.innerHTML = '<div id="panel_buttons_bottom"></div><iframe id="cm-frame"></iframe>';
   (window as any).Output = { flush_buffer: jest.fn(), send: jest.fn() };
   (window as any).Text = { parse_patterns: jest.fn((v: any) => v) };
   (window as any).dispatchEvent = jest.fn();
-  (global as any).portMock = { onMessage: { addListener: jest.fn() }, postMessage: jest.fn() };
-  (global as any).clientAdapterMock = { send: jest.fn(), stop: jest.fn(), connect: jest.fn(), output: jest.fn(), sendGmcp: jest.fn() };
+  appEventBus.clear();
+  parseCommand.mockImplementation((cmd: string) => `parsed:${cmd}`);
+  (global as any).clientAdapterMock = { send: jest.fn(), output: jest.fn(), sendGmcp: jest.fn() };
   outputHandlerMock.processOutput.mockReset();
   outputHandlerMock.applyClickListeners.mockReset();
   outputHandlerMock.getCallbacksForIndices.mockReset();
   outputHandlerMock.getCallbacksForIndices.mockReturnValue({});
 });
 
+afterEach(() => {
+  appEventBus.clear();
+  jest.restoreAllMocks();
+  document.head.innerHTML = '';
+});
+
 test('requests notification permission on demand', () => {
   (global as any).Notification = { permission: 'default', requestPermission: jest.fn() };
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   client.enableNotifications();
   expect((global as any).Notification.requestPermission).toHaveBeenCalledTimes(1);
   delete (global as any).Notification;
@@ -92,7 +97,7 @@ test('requests notification permission on demand', () => {
 
 test('does not request notification permission when already decided', () => {
   (global as any).Notification = { permission: 'granted', requestPermission: jest.fn() };
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   client.enableNotifications();
   expect((global as any).Notification.requestPermission).not.toHaveBeenCalled();
   delete (global as any).Notification;
@@ -102,7 +107,7 @@ test('registers service worker if available', () => {
   (global as any).Notification = { permission: 'granted', requestPermission: jest.fn() };
   const original = (navigator as any).serviceWorker;
   (navigator as any).serviceWorker = { register: jest.fn().mockResolvedValue(undefined) };
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   client.enableNotifications();
   expect((navigator as any).serviceWorker.register).toHaveBeenCalledWith('sw.js');
   const calledPath = (navigator as any).serviceWorker.register.mock.calls[0][0];
@@ -116,44 +121,22 @@ test('registers service worker using base path', () => {
   document.head.innerHTML = '<base href="/test/">';
   const original = (navigator as any).serviceWorker;
   (navigator as any).serviceWorker = { register: jest.fn().mockResolvedValue(undefined) };
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   client.enableNotifications();
   expect((navigator as any).serviceWorker.register).toHaveBeenCalledWith('sw.js');
   const calledPath = (navigator as any).serviceWorker.register.mock.calls[0][0];
   expect(new URL(calledPath, document.baseURI).pathname).toBe('/test/sw.js');
   (navigator as any).serviceWorker = original;
-  document.head.innerHTML = '';
   delete (global as any).Notification;
 });
 
-test('port messages trigger window events', () => {
-  new Client((global as any).clientAdapterMock as any, (global as any).portMock);
-  const listener = (global as any).portMock.onMessage.addListener.mock.calls[0][0];
-  const detail = [{ name: 'Foo', loc: 1 }];
-  listener({ npc: detail });
-  expect((window as any).dispatchEvent).toHaveBeenCalledWith(
-    expect.objectContaining({ type: 'npc', detail })
-  );
-});
-
 test('createEvent returns object with type and data', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   expect(client.createEvent('t', 123)).toEqual({ type: 't', data: 123 });
 });
 
-test('addEventListener allows removal', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
-  const handler = jest.fn();
-  const remove = client.addEventListener('foo', handler);
-  client.eventTarget.dispatchEvent(new CustomEvent('foo', { detail: 'bar' }));
-  expect(handler).toHaveBeenCalledTimes(1);
-  remove();
-  client.eventTarget.dispatchEvent(new CustomEvent('foo', { detail: 'bar' }));
-  expect(handler).toHaveBeenCalledTimes(1);
-});
-
 test('println uses print with newline', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   const spy = jest.spyOn(client, 'print').mockImplementation();
   client.println('hi');
   expect(spy).toHaveBeenNthCalledWith(1, '\n');
@@ -162,7 +145,7 @@ test('println uses print with newline', () => {
 });
 
 test('createButton creates button attached to panel', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   const cb = jest.fn();
   const button = client.createButton('name', cb);
   expect(button.value).toBe('name');
@@ -173,17 +156,19 @@ test('createButton creates button attached to panel', () => {
 });
 
 test('sendCommand dispatches event and splits commands', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const emitSpy = jest.spyOn(appEventBus, 'emit');
+  const client = new Client((global as any).clientAdapterMock as any);
   client.sendCommand('foo#bar');
   expect(parseCommand).toHaveBeenCalledWith('foo#bar');
   expect(parseCommand).toHaveBeenCalledWith('parsed:foo');
   expect(parseCommand).toHaveBeenCalledWith('bar');
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(1, 'parsed:parsed:foo', true);
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'parsed:bar', true);
+  expect(emitSpy).toHaveBeenCalledWith('command', 'foo#bar');
 });
 
 test('sendCommand allows empty command', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   client.sendCommand('');
   expect(parseCommand).toHaveBeenCalledWith('');
   expect((global as any).clientAdapterMock.send).toHaveBeenCalledWith('parsed:', true);
@@ -191,7 +176,7 @@ test('sendCommand allows empty command', () => {
 
 test('sendCommand splits commands returned by parseCommand', () => {
   parseCommand.mockImplementationOnce(() => 'foo;bar');
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   client.sendCommand('e');
   expect(parseCommand).toHaveBeenCalledWith('e');
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(1, 'parsed:foo', true);
@@ -200,16 +185,19 @@ test('sendCommand splits commands returned by parseCommand', () => {
 
 test('sendCommand prints echo commands locally', () => {
   parseCommand.mockImplementationOnce((cmd: string) => cmd);
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   const printSpy = jest.spyOn(client, 'print').mockImplementation();
   client.sendCommand('echo <red> text');
   expect(printSpy).toHaveBeenCalledWith(mudletColorLine('<red> text'));
   expect((global as any).clientAdapterMock.send).not.toHaveBeenCalled();
 });
 
-test('onLine sends printed messages after line and restores Output.send', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
-  const originalOutputSend = (window as any).Output.send;
+test('onLine emits processed output and buffered prints', () => {
+  const client = new Client((global as any).clientAdapterMock as any);
+  const outputs: Array<{ message: string; type?: string; clickCallbacks?: any }> = [];
+  const off = appEventBus.on('output', (payload) => {
+    outputs.push(payload!);
+  });
 
   client.Triggers.parseLine = jest.fn(() => {
     client.print('printed');
@@ -220,18 +208,14 @@ test('onLine sends printed messages after line and restores Output.send', () => 
 
   const expected = '\x1b[22;38;5;255mprocessed';
   expect(result).toBe(expected);
-  expect((window as any).Output.send).toBe(originalOutputSend);
-  expect(originalOutputSend).not.toHaveBeenCalled();
-
-  originalOutputSend(result);
-  client.sendEvent('output-sent');
-
-  expect(originalOutputSend).toHaveBeenNthCalledWith(1, expected);
-  expect((global as any).clientAdapterMock.output).toHaveBeenCalledWith('printed', undefined, undefined);
+  expect(outputs).toHaveLength(2);
+  expect(outputs[0]).toEqual({ message: expected, type: '' });
+  expect(outputs[1]).toEqual({ message: 'printed', type: undefined });
+  off();
 });
 
 test('onLine replaces reset sequences with preceding ANSI code', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   const line = '\x1b[22;38;5;1mRED\x1b[0m text \x1b[22;38;5;2mGREEN\x1b[0m';
 
   const result = client.onLine(line, '');
@@ -242,7 +226,7 @@ test('onLine replaces reset sequences with preceding ANSI code', () => {
 });
 
 test('onLine keeps trailing resets without preceding color', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   const line = '\x1b[22;38;5;1mred\x1b[0m\x1b[0m';
 
   const result = client.onLine(line, '');
@@ -252,7 +236,7 @@ test('onLine keeps trailing resets without preceding color', () => {
 });
 
 test('onLine restores color after inserting enclosed color', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   const gray = '\x1b[22;38;5;8m';
   const yellow = '\x1b[22;38;5;11m';
   const orange = '\x1b[22;38;5;215m';
@@ -286,7 +270,7 @@ test('onLine restores color after inserting enclosed color', () => {
 });
 
 test('onLine preserves final reset at line end', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   const gray = '\x1b[22;38;5;8m';
   const line = gray + 'gray text' + '\x1b[0m';
 
@@ -296,9 +280,9 @@ test('onLine preserves final reset at line end', () => {
 });
 
 test('flushBuffer emits click callback mapping with output event', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   const listener = jest.fn();
-  client.addEventListener('output', listener);
+  const off = appEventBus.on('output', (payload) => listener(payload));
   const callback = jest.fn();
   outputHandlerMock.getCallbacksForIndices.mockReturnValue({ 3: callback });
   client.OutputHandler.clickerCallbacks = [() => undefined, () => undefined, () => undefined, callback];
@@ -309,22 +293,16 @@ test('flushBuffer emits click callback mapping with output event', () => {
   expect(outputHandlerMock.getCallbacksForIndices).toHaveBeenCalledTimes(1);
   const [[indicesArg]] = outputHandlerMock.getCallbacksForIndices.mock.calls as any;
   expect(indicesArg).toEqual(new Set([3]));
-  expect((global as any).clientAdapterMock.output).toHaveBeenCalledWith(
-    expect.stringContaining('<span data-click-index="3" data-click-title="Opis">Klik</span>'),
-    'info',
-    { 3: callback }
-  );
-
   expect(listener).toHaveBeenCalledTimes(1);
-  const event = listener.mock.calls[0][0] as CustomEvent;
-  const { message, type, clickCallbacks } = event.detail as any;
+  const { message, type, clickCallbacks } = listener.mock.calls[0][0];
   expect(message).toContain('<span data-click-index="3" data-click-title="Opis">Klik</span>');
   expect(type).toBe('info');
   expect(clickCallbacks).toEqual({ 3: callback });
+  off();
 });
 
 test('playSound restarts sound when called twice', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   const sound = (Howl as jest.Mock).mock.results[0].value;
 
   client.playSound('beep');
@@ -343,13 +321,13 @@ test('updateContentWidth measures characters per line', () => {
   Object.defineProperty(wrapper, 'clientWidth', { value: 100, configurable: true });
   const measure = document.getElementById('content-width-measure')!;
   (measure as any).getBoundingClientRect = jest.fn(() => ({ width: 10 }));
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   client.updateContentWidth();
   expect(client.contentWidth).toBe(10);
 });
 
 test('support sends commands to support leader', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   jest.spyOn(client, 'sendCommand');
   jest.spyOn(client.TeamManager, 'getLeaderId').mockReturnValue('5');
   client.support();
@@ -358,7 +336,7 @@ test('support sends commands to support leader', () => {
 });
 
 test('sendCommand expands object shortcuts', () => {
-  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  const client = new Client((global as any).clientAdapterMock as any);
   jest.spyOn(client.ObjectManager, 'getObjectsOnLocation').mockReturnValue([
     { num: 5, shortcut: '1' },
     { num: 7, shortcut: 'A' },
@@ -374,4 +352,3 @@ test('sendCommand expands object shortcuts', () => {
   client.sendCommand('help @@');
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(3, 'parsed:help ob_42', true);
 });
-


### PR DESCRIPTION
## Summary
- update Client tests to reflect the portless Client constructor and remove obsolete port message assertions
- use the shared app event bus in assertions, clearing it between runs and checking emitted output payloads
- fix ANSI expectations to use real escape sequences and continue covering sendCommand and map/object behaviors

## Testing
- yarn --cwd client test Client.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ee7c9033e4832a98a18ee94ef5a6d1