### PR TITLE
Fix CharStateInfo test to use app event bus

### DIFF
--- a/web-client/test/CharStateInfo.test.ts
+++ b/web-client/test/CharStateInfo.test.ts
@@ -1,35 +1,29 @@
 import CharStateInfo from '../src/CharStateInfo';
-
-class MockClient {
-  private events: Record<string, Function[]> = {};
-  on(event: string, listener: Function) {
-    (this.events[event] ||= []).push(listener);
-  }
-  emit(event: string, ...args: any[]) {
-    (this.events[event] || []).forEach(fn => fn(...args));
-  }
-}
+import appEventBus from '@client/src/events/app-event-bus.ts';
 
 describe('CharStateInfo', () => {
   let container: HTMLElement;
-  let client: MockClient;
 
   beforeEach(() => {
     document.body.innerHTML = '<span id="state-info"></span>';
     container = document.getElementById('state-info')!;
-    client = new MockClient();
-    new CharStateInfo(client as any);
+    appEventBus.clear();
+    new CharStateInfo({} as any);
   });
 
   test('hides when no state text', () => {
-    client.emit('gmcp.char.state', {});
+    appEventBus.emit('gmcp.char.state', {} as any);
     expect(container.style.display).toBe('none');
     expect(container.textContent).toBe('');
   });
 
   test('shows state text', () => {
-    client.emit('gmcp.char.state', { state: 'swietny' });
+    appEventBus.emit('gmcp.char.state', { state: 'swietny' } as any);
     expect(container.textContent).toBe('swietny');
     expect(container.style.display).toBe('block');
+  });
+
+  afterEach(() => {
+    appEventBus.clear();
   });
 });


### PR DESCRIPTION
## Summary
- update the CharStateInfo unit test to emit gmcp.char.state events through the shared app event bus
- clear the global event bus between tests to avoid leaking listeners

## Testing
- yarn --cwd web-client test CharStateInfo.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ee858595a4832a825eedf5b150d69e