### PR TITLE
Fix PackageStatus test to use app event bus

### DIFF
--- a/web-client/test/PackageStatus.test.ts
+++ b/web-client/test/PackageStatus.test.ts
@@ -1,38 +1,28 @@
 import PackageStatus from '../src/PackageStatus';
-
-class MockClient {
-  private events: Record<string, Function[]> = {};
-  on(event: string, listener: Function) {
-    (this.events[event] ||= []).push(listener);
-  }
-  emit(event: string, ...args: any[]) {
-    (this.events[event] || []).forEach(fn => fn(...args));
-  }
-}
+import appEventBus from '@client/src/events/app-event-bus';
 
 describe('PackageStatus', () => {
   let container: HTMLElement;
-  let client: MockClient;
 
   beforeEach(() => {
+    appEventBus.clear();
     document.body.innerHTML = '<div id="package-status"></div>';
     container = document.getElementById('package-status')!;
-    client = new MockClient();
-    new PackageStatus(client as any);
+    new PackageStatus({} as any);
   });
 
   test('hides when no data', () => {
-    client.emit('packageStatus', null);
+    appEventBus.emit('packageStatus', null);
     expect(container.style.display).toBe('none');
     expect(container.textContent).toBe('');
   });
 
   test('shows recipient and time', () => {
-    client.emit('packageStatus', { recipient: 'Bob', seconds: 70 });
+    appEventBus.emit('packageStatus', { recipient: 'Bob', seconds: 70 });
     expect(container.textContent).toBe('📦: Bob 1:10');
     expect(container.style.display).toBe('block');
 
-    client.emit('packageStatus', { recipient: 'Alice' });
+    appEventBus.emit('packageStatus', { recipient: 'Alice' });
     expect(container.textContent).toBe('📦: Alice');
   });
 });


### PR DESCRIPTION
## Summary
- update PackageStatus test to interact with the shared app event bus instead of a local mock
- ensure each test starts from a clean event bus state

## Testing
- yarn --cwd web-client test -- test/PackageStatus.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ee857b17c4832a968e98fe16e970c0