### PR TITLE
Fix zi alias test setup

### DIFF
--- a/client/test/helpers/herbClient.ts
+++ b/client/test/helpers/herbClient.ts
@@ -44,6 +44,7 @@ export function initHerbClient(
     ok: true,
     json: () => Promise.resolve(herbData)
   });
+  localStorage.setItem('herb_counts', JSON.stringify(herbCounts));
   initHerbCounter((client as unknown) as any, aliases);
   client.dispatch('storage', { key: 'herb_counts', value: herbCounts });
 }

--- a/client/test/zi.test.ts
+++ b/client/test/zi.test.ts
@@ -1,4 +1,14 @@
-import { FakeClient, initHerbClient } from './helpers/herbClient';
+import { FakeClient, initHerbClient, defaultHerbData } from './helpers/herbClient';
+
+jest.mock('../src/dataCatalog/catalogInstance', () => {
+  return {
+    dataCatalog: {
+      getHerbsStore: () => ({
+        getData: jest.fn().mockResolvedValue(defaultHerbData)
+      })
+    }
+  };
+});
 
 beforeEach(() => {
   jest.clearAllMocks();


### PR DESCRIPTION
## Summary
- mock the data catalog module in the /zi alias test to avoid worker imports in Jest
- seed herb count storage in the herb client test helper so stored bag data is available

## Testing
- yarn --cwd client test zi.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ee8ca03fa8832a8fe47e505133d4e2