### PR TITLE
Align web-client tests with event bus architecture

### DIFF
--- a/web-client/test/AttackMode.test.ts
+++ b/web-client/test/AttackMode.test.ts
@@ -1,31 +1,31 @@
 import AttackMode from '../src/AttackMode';
+import appEventBus from '@client/src/events/app-event-bus';
 
 jest.mock('@client/src/storage.ts', () => ({
   getItemSync: jest.fn(() => ({})),
 }));
 import { getItemSync } from '@client/src/storage.ts';
 
-class MockClient {
-  private events: Record<string, Function[]> = {};
-  on(event: string, listener: Function) {
-    (this.events[event] ||= []).push(listener);
-  }
-  emit = jest.fn((event: string, ...args: any[]) => {
-    (this.events[event] || []).forEach(fn => fn(...args));
-  });
-}
+class MockClient {}
 
 describe('AttackMode', () => {
   let container: HTMLElement;
   let client: MockClient;
+  let emitSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    appEventBus.clear();
     document.body.innerHTML = '<span id="attack-mode"></span>';
     container = document.getElementById('attack-mode')!;
     client = new MockClient();
     (getItemSync as jest.Mock).mockReturnValue({ attack_mode: 'A' });
     (window as any).clientExtension = { TeamManager: { isLeader: jest.fn(() => true) } };
+    emitSpy = jest.spyOn(appEventBus, 'emit');
     new AttackMode(client as any);
+  });
+
+  afterEach(() => {
+    emitSpy.mockRestore();
   });
 
   test('updates mode display', () => {
@@ -33,22 +33,24 @@ describe('AttackMode', () => {
     expect(container.style.display).toBe('block');
     expect(container.className).toBe('A');
 
-    client.emit('attackMode', 'AW');
+    appEventBus.emit('attackMode', 'AW');
     expect(container.textContent).toBe('Atk: AW');
     expect(container.className).toBe('AW');
   });
 
   test('click cycles mode and emits event', () => {
+    emitSpy.mockClear();
+
     container.click();
-    expect(client.emit).toHaveBeenLastCalledWith('attackMode', 'AW');
+    expect(emitSpy).toHaveBeenLastCalledWith('attackMode', 'AW');
     expect(container.textContent).toBe('Atk: AW');
 
     container.click();
-    expect(client.emit).toHaveBeenLastCalledWith('attackMode', 'AWR');
+    expect(emitSpy).toHaveBeenLastCalledWith('attackMode', 'AWR');
     expect(container.textContent).toBe('Atk: AWR');
 
     container.click();
-    expect(client.emit).toHaveBeenLastCalledWith('attackMode', 'A');
+    expect(emitSpy).toHaveBeenLastCalledWith('attackMode', 'A');
     expect(container.textContent).toBe('Atk: A');
   });
 
@@ -57,10 +59,11 @@ describe('AttackMode', () => {
     container = document.getElementById('attack-mode')!;
     client = new MockClient();
     (window as any).clientExtension = { TeamManager: { isLeader: jest.fn(() => false) } };
+    appEventBus.clear();
     new AttackMode(client as any);
     expect(container.style.display).toBe('none');
     (window as any).clientExtension.TeamManager.isLeader.mockReturnValue(true);
-    client.emit('teamChange');
+    appEventBus.emit('teamChange');
     expect(container.style.display).toBe('block');
   });
 });

--- a/web-client/test/BreakItemWarning.test.ts
+++ b/web-client/test/BreakItemWarning.test.ts
@@ -1,14 +1,8 @@
 import BreakItemWarning from '../src/BreakItemWarning';
+import appEventBus from '@client/src/events/app-event-bus';
 
 class MockClient {
-  private events: Record<string, Function[]> = {};
   sendCommand = jest.fn();
-  on(event: string, listener: Function) {
-    (this.events[event] ||= []).push(listener);
-  }
-  emit(event: string, ...args: any[]) {
-    (this.events[event] || []).forEach(fn => fn(...args));
-  }
 }
 
 describe('BreakItemWarning', () => {
@@ -16,6 +10,7 @@ describe('BreakItemWarning', () => {
   let client: MockClient;
 
   beforeEach(() => {
+    appEventBus.clear();
     document.body.innerHTML = '<div id="break-item-warning"></div>';
     container = document.getElementById('break-item-warning')!;
     client = new MockClient();
@@ -23,13 +18,13 @@ describe('BreakItemWarning', () => {
   });
 
   test('hides on null data', () => {
-    client.emit('breakItem', null);
+    appEventBus.emit('breakItem', null);
     expect(container.style.display).toBe('none');
     expect(container.textContent).toBe('');
   });
 
   test('shows text and executes command on click', () => {
-    client.emit('breakItem', { text: 'Warning!', command: 'run' });
+    appEventBus.emit('breakItem', { text: 'Warning!', command: 'run' });
     expect(container.textContent).toBe('Warning!');
     expect(container.style.display).toBe('block');
     container.click();
@@ -38,7 +33,7 @@ describe('BreakItemWarning', () => {
   });
 
   test('handles click with no command', () => {
-    client.emit('breakItem', { text: 'Only text' });
+    appEventBus.emit('breakItem', { text: 'Only text' });
     container.click();
     expect(client.sendCommand).not.toHaveBeenCalled();
     expect(container.style.display).toBe('none');

--- a/web-client/test/CharState.test.ts
+++ b/web-client/test/CharState.test.ts
@@ -1,36 +1,25 @@
 import CharState from '../src/CharState';
-
-class MockClient {
-  private events: Record<string, Function[]> = {};
-  on(event: string, listener: Function) {
-    (this.events[event] ||= []).push(listener);
-  }
-  emit(event: string, ...args: any[]) {
-    (this.events[event] || []).forEach(fn => fn(...args));
-  }
-}
+import appEventBus from '@client/src/events/app-event-bus';
 
 describe('CharState', () => {
-  let client: MockClient;
-
   beforeEach(() => {
+    appEventBus.clear();
     document.body.innerHTML = '<div id="char-state" data-footer-mode="3"><span id="char-state-text"></span><div id="char-state-bars"></div></div>';
-    client = new MockClient();
-    new CharState(client as any);
+    new CharState();
   });
 
   test('progress values stay white in graphical mode', () => {
-    client.emit('gmcp.char.state', { hp: 5 });
+    appEventBus.emit('gmcp.char.state', { hp: 5 });
     const valueSpan = document.querySelector('#char-state-bars .progress-value') as HTMLElement;
     expect(valueSpan).not.toBeNull();
     expect(valueSpan.style.color).toBe('white');
   });
 
   test('form is hidden when gmcp option disables form', () => {
-    client.emit('gmcp.char.state', { form: 0 });
+    appEventBus.emit('gmcp.char.state', { form: 0 });
     let formBar = document.querySelector('#char-state-bars .char-state-bar[title="form"]');
     expect(formBar).not.toBeNull();
-    client.emit('gmcp.char.options', { form: 0 });
+    appEventBus.emit('gmcp.char.options', { form: 0 });
     formBar = document.querySelector('#char-state-bars .char-state-bar[title="form"]');
     expect(formBar).toBeNull();
   });

--- a/web-client/test/CoverTimer.test.ts
+++ b/web-client/test/CoverTimer.test.ts
@@ -1,20 +1,14 @@
 import CoverTimer from '../src/CoverTimer';
+import appEventBus from '@client/src/events/app-event-bus';
 
-class MockClient {
-  private events: Record<string, Function[]> = {};
-  on(event: string, listener: Function) {
-    (this.events[event] ||= []).push(listener);
-  }
-  emit(event: string, ...args: any[]) {
-    (this.events[event] || []).forEach(fn => fn(...args));
-  }
-}
+class MockClient {}
 
 describe('CoverTimer', () => {
   let container: HTMLElement;
   let client: MockClient;
 
   beforeEach(() => {
+    appEventBus.clear();
     document.body.innerHTML = '<span id="cover-timer"></span>';
     container = document.getElementById('cover-timer')!;
     client = new MockClient();
@@ -22,14 +16,14 @@ describe('CoverTimer', () => {
   });
 
   test('shows ready when no time', () => {
-    client.emit('coverTimer', null);
+    appEventBus.emit('coverTimer', null);
     expect(container.textContent).toBe('Zas: OK');
     expect(container.style.display).toBe('block');
     expect(container.className).toBe('green');
   });
 
   test('shows time with two decimals', () => {
-    client.emit('coverTimer', 4.567);
+    appEventBus.emit('coverTimer', 4.567);
     expect(container.textContent).toBe('Zas: 4.57');
     expect(container.className).toBe('yellow');
   });

--- a/web-client/test/LampTimer.test.ts
+++ b/web-client/test/LampTimer.test.ts
@@ -1,20 +1,14 @@
 import LampTimer from '../src/LampTimer';
+import appEventBus from '@client/src/events/app-event-bus';
 
-class MockClient {
-  private events: Record<string, Function[]> = {};
-  on(event: string, listener: Function) {
-    (this.events[event] ||= []).push(listener);
-  }
-  emit(event: string, ...args: any[]) {
-    (this.events[event] || []).forEach(fn => fn(...args));
-  }
-}
+class MockClient {}
 
 describe('LampTimer', () => {
   let container: HTMLElement;
   let client: MockClient;
 
   beforeEach(() => {
+    appEventBus.clear();
     document.body.innerHTML = '<div id="lamp-timer"></div>';
     container = document.getElementById('lamp-timer')!;
     client = new MockClient();
@@ -22,22 +16,22 @@ describe('LampTimer', () => {
   });
 
   test('hides timer when no time', () => {
-    client.emit('lampTimer', null);
+    appEventBus.emit('lampTimer', null);
     expect(container.style.display).toBe('none');
     expect(container.textContent).toBe('');
     expect(container.className).toBe('');
   });
 
   test('updates display and class based on time', () => {
-    client.emit('lampTimer', 65);
+    appEventBus.emit('lampTimer', 65);
     expect(container.textContent).toBe('lamp 1:05');
     expect(container.style.display).toBe('block');
     expect(container.className).toBe('green');
 
-    client.emit('lampTimer', 55);
+    appEventBus.emit('lampTimer', 55);
     expect(container.className).toBe('yellow');
 
-    client.emit('lampTimer', 25);
+    appEventBus.emit('lampTimer', 25);
     expect(container.className).toBe('red');
   });
 });

--- a/web-client/test/ObjectList.test.ts
+++ b/web-client/test/ObjectList.test.ts
@@ -1,7 +1,7 @@
 import ObjectList from '../src/ObjectList';
 import { getItemSync, setItemSync } from '@client/src/storage';
 import ObjectManager from '@client/src/ObjectManager';
-import { EventEmitter } from 'events';
+import appEventBus from '@client/src/events/app-event-bus';
 
 jest.mock('@client/src/storage', () => ({
   getItemSync: jest.fn(),
@@ -22,6 +22,7 @@ describe('ObjectList', () => {
     document.body.innerHTML = '';
     Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
     Object.defineProperty(window, 'innerHeight', { value: 768, writable: true });
+    appEventBus.clear();
   });
 
   test('non team members not fighting are not purple', () => {
@@ -197,25 +198,18 @@ describe('ObjectList', () => {
   test('moves non-combat objects to the end with shortcuts starting at 50', () => {
     document.body.innerHTML = '<div id="objects-list"></div>';
     class TestClient {
-      private emitter = new EventEmitter();
-      ObjectManager = new ObjectManager(this as any);
+      ObjectManager = new ObjectManager();
       TeamManager = { isInTeam: (_d: string) => false };
       sendCommand = jest.fn();
-      addEventListener(event: string, cb: any) {
-        this.emitter.on(event, cb);
-      }
-      sendEvent(type: string, detail?: any) {
-        this.emitter.emit(type, { detail });
-      }
     }
     const client = new TestClient();
     new ObjectList(client as any);
-    client.sendEvent('gmcp.objects.data', {
+    appEventBus.emit('gmcp.objects.data', {
       '1': { desc: 'Fighter', attack_num: true },
       '2': { desc: 'Rock' },
       '3': { desc: 'Tree' },
     });
-    client.sendEvent('gmcp.objects.nums', ['1', '2', '3']);
+    appEventBus.emit('gmcp.objects.nums', ['1', '2', '3']);
     const html = (
       document.querySelector('#objects-list .objects-list-content') as HTMLElement
     ).innerHTML.split('<br>');

--- a/web-client/test/Recorder.test.ts
+++ b/web-client/test/Recorder.test.ts
@@ -1,24 +1,31 @@
 import Recorder from '../src/Recorder';
+import appEventBus from '@client/src/events/app-event-bus';
 
 describe('Recorder playback', () => {
   test('replayRecordedMessagesTimed echoes outgoing commands', () => {
-    const hooks = {
-      processIncomingData: jest.fn(),
-      send: jest.fn(),
-      emit: jest.fn(),
-    };
     const adapter = {
-      messages$: { subscribe: jest.fn() },
+      messages$: {
+        subscribe: jest.fn(),
+        next: jest.fn(),
+      },
     };
-    const recorder = new Recorder(hooks as any, adapter as any);
-    (window as any).clientExtension = { sendCommand: jest.fn() };
-    (window as any).Output = { send: jest.fn() };
+    appEventBus.clear();
+    const emitSpy = jest.spyOn(appEventBus, 'emit');
+    const recorder = new Recorder(adapter as any);
     recorder.setRecordedMessages([
       { message: 'look', timestamp: 0, direction: 'out' },
     ]);
     jest.useFakeTimers();
-    recorder.replayRecordedMessagesTimed();
-    jest.runAllTimers();
-    expect((window as any).Output.send).toHaveBeenCalledWith('→ look');
+    try {
+      recorder.replayRecordedMessagesTimed();
+      jest.runAllTimers();
+      expect(emitSpy.mock.calls).toContainEqual([
+        'message',
+        expect.objectContaining({ text: '→ look', type: 'command' }),
+      ]);
+    } finally {
+      emitSpy.mockRestore();
+      jest.useRealTimers();
+    }
   });
 });

--- a/web-client/test/settingsPropagation.test.ts
+++ b/web-client/test/settingsPropagation.test.ts
@@ -3,6 +3,7 @@ import initShortExits from '@client/src/scripts/shortExits';
 import Triggers from '@client/src/Triggers';
 import { colorString, findClosestColor } from '@client/src/Colors';
 import { defaultSettings } from '@client/src/defaultSettings';
+import appEventBus from '@client/src/events/app-event-bus';
 
 const ORANGE = findClosestColor('#ffa500');
 
@@ -21,6 +22,7 @@ class FakeClient {
 describe('settings propagation to scripts', () => {
   beforeEach(() => {
     localStorage.clear();
+    appEventBus.clear();
   });
 
   test('shortenExits setting affects script', async () => {
@@ -32,7 +34,8 @@ describe('settings propagation to scripts', () => {
 
     storage.onChanged?.addListener(changes => {
       if (changes.settings) {
-        client.dispatch('settings', changes.settings.newValue);
+        const merged = { ...defaultSettings, ...changes.settings.newValue };
+        appEventBus.emit('settings', merged as any);
       }
     });
 


### PR DESCRIPTION
## Summary
- update web-client unit tests to emit events through the shared app event bus
- refresh expectations to match current UI behaviors and constructors
- verify recorder playback via message events instead of legacy globals

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68ee8b23d350832a9bb10a6185747786