### PR TITLE
Fix idle timer test

### DIFF
--- a/client/test/idleTimer.test.ts
+++ b/client/test/idleTimer.test.ts
@@ -1,33 +1,30 @@
 import createIdleTimer from '../src/utils/idleTimer';
-import { EventEmitter } from 'events';
+import appEventBus from '../src/events/app-event-bus';
 
 describe('idle timer', () => {
-  class FakeClient {
-    private emitter = new EventEmitter();
-    addEventListener(event: string, cb: any) {
-      this.emitter.on(event, cb);
-    }
-    sendEvent(type: string, detail?: any) {
-      this.emitter.emit(type, { detail });
-    }
-  }
-
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(0);
+    appEventBus.clear();
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    appEventBus.clear();
   });
 
   test('marks idle after threshold and resets on command', () => {
-    const client = new FakeClient();
-    const timer = createIdleTimer((client as unknown) as any, 1000);
+    const timer = createIdleTimer(1000);
+    expect(timer.isIdle()).toBe(false);
+    jest.setSystemTime(999);
     expect(timer.isIdle()).toBe(false);
     jest.setSystemTime(1000);
     expect(timer.isIdle()).toBe(true);
-    client.sendEvent('command');
+    appEventBus.emit('command', 'look');
     expect(timer.isIdle()).toBe(false);
+    jest.setSystemTime(1999);
+    expect(timer.isIdle()).toBe(false);
+    jest.setSystemTime(2000);
+    expect(timer.isIdle()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- update the idle timer unit test to exercise the shared app event bus instead of a fake client
- add expectations for time-based transitions around the idle threshold

## Testing
- yarn --cwd client test idleTimer

------
https://chatgpt.com/codex/tasks/task_e_68ee8ebb7c40832aa845006fccf2c2d8