### PR TITLE
Mock data catalog in herb counter tests

### DIFF
--- a/client/test/helpers/herbClient.ts
+++ b/client/test/helpers/herbClient.ts
@@ -44,6 +44,10 @@ export function initHerbClient(
     ok: true,
     json: () => Promise.resolve(herbData)
   });
+  const dataCatalogModule = require('../../src/dataCatalog/catalogInstance') as any;
+  if (typeof dataCatalogModule.__setHerbData === 'function') {
+    dataCatalogModule.__setHerbData(herbData);
+  }
   localStorage.setItem('herb_counts', JSON.stringify(herbCounts));
   initHerbCounter((client as unknown) as any, aliases);
   client.dispatch('storage', { key: 'herb_counts', value: herbCounts });

--- a/client/test/herbCounter.test.ts
+++ b/client/test/herbCounter.test.ts
@@ -2,6 +2,23 @@ import Triggers, { stripAnsiCodes } from '../src/Triggers';
 import { EventEmitter } from 'events';
 import { initHerbClient, defaultHerbData } from './helpers/herbClient';
 
+jest.mock('../src/dataCatalog/catalogInstance', () => {
+  const { defaultHerbData } = require('./helpers/herbClient');
+  let herbData = defaultHerbData;
+
+  return {
+    __esModule: true,
+    dataCatalog: {
+      getHerbsStore: () => ({
+        getData: () => Promise.resolve(herbData)
+      })
+    },
+    __setHerbData: (data: any) => {
+      herbData = data;
+    }
+  };
+});
+
 class FakeClient {
   private emitter = new EventEmitter();
   Triggers = new Triggers(({} as unknown) as any);
@@ -94,10 +111,9 @@ describe('herb counter', () => {
 
   test('prints summary from storage', () => {
     const aliases: { pattern: RegExp; callback: () => void }[] = [];
-    initHerbClient((client as unknown) as any, {}, defaultHerbData, aliases);
+    initHerbClient((client as unknown) as any, { 1: { deliona: 2 } }, defaultHerbData, aliases);
     const show = aliases[1].callback as any;
     show();
-    client.dispatch('storage', { key: 'herb_counts', value: { 1: { deliona: 2 } } });
     const printed = client.println.mock.calls[0][0];
     expect(printed).toMatch(/2/);
     expect(printed).toMatch(/deliona/);


### PR DESCRIPTION
## Summary
- add a Jest mock for the data catalog used by the herb counter tests to avoid importing worker-based modules
- ensure the test helper forwards herb data to the mock data catalog
- adjust the storage summary test to verify preloaded bag data

## Testing
- yarn --cwd client test herbCounter

------
https://chatgpt.com/codex/tasks/task_e_68ee8ea9dfa4832a8d73a683d1a7e65c