### PR TITLE
Fix deposit, magics, and magic keys Jest tests

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -7,7 +7,9 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',
-      {},
+      {
+        tsconfig: '<rootDir>/tsconfig.jest.json',
+      },
     ],
   },
   moduleNameMapper: {

--- a/client/src/dataCatalog/catalogInstance.ts
+++ b/client/src/dataCatalog/catalogInstance.ts
@@ -137,6 +137,7 @@ const peopleEntry = new DataCatalogEntry<PeopleCollection, Person>({
   storeName: STORE_NAMES.people,
   persistenceAdapter: sharedPersistenceAdapter,
   dataSource: new WorkerDataSource<PeopleCollection>(() =>
+    // @ts-ignore -- import.meta is supported by the bundler, but tests compile with CommonJS modules.
     new Worker(new URL('./peopleWorker.ts', import.meta.url), { type: 'module' }),
   ),
   collection: {

--- a/client/src/scripts/magicKeys.ts
+++ b/client/src/scripts/magicKeys.ts
@@ -5,14 +5,15 @@ import {dataCatalog} from "../dataCatalog/catalogInstance";
 export const KEYS_COLOR = findClosestColor("#00ff7f");
 export default async function initMagicKeys(client: Client) {
     const tag = "magicKeys";
-    dataCatalog.getMagicKeysStore().getData().then(keys => {
+    try {
+        const keys = await dataCatalog.getMagicKeysStore().getData();
         keys.magic_keys.forEach((pattern: string) => {
             client.Triggers.registerTokenTrigger(pattern, (raw) => {
                 return colorTokenInLine(raw, pattern, KEYS_COLOR);
             }, tag, {caseInsensitive: true});
         });
-    }).catch(e => {
+    } catch (e) {
         console.error("Failed to load magic keys", e);
-    })
+    }
 }
 

--- a/client/test/deposit.test.ts
+++ b/client/test/deposit.test.ts
@@ -1,3 +1,8 @@
+jest.mock('../src/scripts/magicKeyLoader', () => jest.fn().mockResolvedValue([]));
+jest.mock('../src/scripts/magicsLoader', () => jest.fn().mockResolvedValue([]));
+jest.mock('../src/scripts/magicKeys', () => ({ KEYS_COLOR: '#00ff7f', default: jest.fn() }));
+jest.mock('../src/scripts/magics', () => ({ MAGICS_COLOR: '#ff0000', default: jest.fn() }));
+
 jest.mock('../src/scripts/prettyContainers', () => {
   const actual = jest.requireActual('../src/scripts/prettyContainers');
   return { ...actual, prettyPrintContainer: jest.fn(() => 'table') };
@@ -7,6 +12,7 @@ import initDeposits, { deposits } from '../src/scripts/deposits';
 import Triggers, { stripAnsiCodes } from '../src/Triggers';
 import { prettyPrintContainer } from '../src/scripts/prettyContainers';
 import { EventEmitter } from 'events';
+import appEventBus from '../src/events/app-event-bus';
 
 class FakeClient {
   private emitter = new EventEmitter();
@@ -121,7 +127,7 @@ describe('deposits', () => {
   });
 
   test('uses column setting for pretty print', () => {
-    client.dispatch('settings', { containerColumns: 3 });
+    appEventBus.emit('settings', { containerColumns: 3 } as any);
     parse('Twoj depozyt zawiera miecz.');
     expect(prettyPrintContainer).toHaveBeenCalledWith(expect.anything(), 3, 'DEPOZYT', 5, client.contentWidth);
   });

--- a/client/test/magicKeys.test.ts
+++ b/client/test/magicKeys.test.ts
@@ -1,3 +1,14 @@
+jest.mock('../src/dataCatalog/catalogInstance', () => ({
+    dataCatalog: {
+        getMagicKeysStore: () => ({
+            getData: jest.fn(async () => {
+                const response = await (globalThis.fetch as any)('magic_keys');
+                return response.json();
+            }),
+        }),
+    },
+}));
+
 import initMagicKeys, { KEYS_COLOR } from '../src/scripts/magicKeys';
 import { colorTokenInLine } from '../src/Colors';
 

--- a/client/test/magics.test.ts
+++ b/client/test/magics.test.ts
@@ -1,3 +1,14 @@
+jest.mock('../src/dataCatalog/catalogInstance', () => ({
+    dataCatalog: {
+        getMagicsStore: () => ({
+            getData: jest.fn(async () => {
+                const response = await (globalThis.fetch as any)('magics');
+                return response.json();
+            }),
+        }),
+    },
+}));
+
 import initMagics, { MAGICS_COLOR } from '../src/scripts/magics';
 import { colorTokenInLine } from '../src/Colors';
 

--- a/client/tsconfig.jest.json
+++ b/client/tsconfig.jest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "node"
+  }
+}


### PR DESCRIPTION
## Summary
- configure ts-jest to use a Jest-specific tsconfig that supports import.meta and Node-style resolution
- mock data catalog dependencies in the deposit, magics, and magic keys tests to avoid worker usage during Jest runs
- update the magic keys script to await catalog data before registering triggers and adapt the deposit test to emit through the app event bus

## Testing
- yarn --cwd client test deposit
- yarn --cwd client test magics
- yarn --cwd client test magicKeys

------
https://chatgpt.com/codex/tasks/task_e_68eea21410b4832aaa96e9646d303d82