### PR TITLE
Fix localizers tests

### DIFF
--- a/client/test/localizers.test.ts
+++ b/client/test/localizers.test.ts
@@ -1,5 +1,6 @@
 import initLocalizers from '../src/scripts/localizers';
 import Triggers from '../src/Triggers';
+import appEventBus from '../src/events/app-event-bus';
 
 class FakeClient {
   Triggers = new Triggers({} as unknown as any);
@@ -10,23 +11,29 @@ class FakeClient {
 describe('localizers triggers', () => {
   let client: FakeClient;
   let parse: (line: string) => string;
+  let emitSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    appEventBus.clear();
     client = new FakeClient();
+    emitSpy = jest.spyOn(appEventBus, 'emit');
     initLocalizers(client as unknown as any);
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
-    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    emitSpy.mockRestore();
   });
 
   test('single line localizer sets map location', () => {
     parse('Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, placyk w Grabowej Buchcie');
     expect(client.Map.setMapRoomById).toHaveBeenCalledWith(3525);
-    expect(client.sendEvent).toHaveBeenCalledWith('notify', { text: 'Map Sync: localizer 3525' });
+    expect(appEventBus.emit).toHaveBeenCalledWith('notify', { text: 'Map Sync: localizer 3525' });
   });
 
   test('single line localizer without proper parent does not move map', () => {
     parse('Postoj, placyk w Grabowej Buchcie');
     expect(client.Map.setMapRoomById).not.toHaveBeenCalled();
-    expect(client.sendEvent).not.toHaveBeenCalled();
+    expect(appEventBus.emit).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- update the localizers test to spy on the app event bus emit call
- ensure the event bus is cleared between tests to avoid cross-test pollution

## Testing
- yarn --cwd client test localizers

------
https://chatgpt.com/codex/tasks/task_e_68eea79093a4832abef72d8427307297