### PR TITLE
Update kill counter tests for new event bus

### DIFF
--- a/client/test/kill.test.ts
+++ b/client/test/kill.test.ts
@@ -1,35 +1,27 @@
 import { initKillCounter, parseName, formatSessionTable, formatLifetimeTable } from '../src/scripts/kill';
 import Triggers, { stripAnsiCodes } from '../src/Triggers';
 
-import { EventEmitter } from 'events';
+import appEventBus from '../src/events/app-event-bus';
+import { setItemSync } from '../src/storage';
 
 class FakeClient {
-  private emitter = new EventEmitter();
   Triggers = new Triggers(({} as unknown) as any);
   TeamManager = { isInTeam: jest.fn() };
   prefix = (line: string, prefix: string) => prefix + line;
   print = jest.fn();
   port = { postMessage: jest.fn() } as any;
-
-  addEventListener(event: string, cb: any) {
-    this.emitter.on(event, cb);
-  }
-  removeEventListener(event: string, cb: any) {
-    this.emitter.off(event, cb);
-  }
-  dispatch(event: string, detail: any) {
-    this.emitter.emit(event, { detail });
-  }
 }
 
 describe('kill counter team kills', () => {
   let client: FakeClient;
 
   beforeEach(() => {
+    appEventBus.clear();
+    localStorage.clear();
+    setItemSync('kill_counter', {});
+    setItemSync('kill_counter_session', {});
     client = new FakeClient();
     initKillCounter((client as unknown) as any, []);
-    client.dispatch('storage', { key: 'kill_counter', value: {} });
-    client.dispatch('storage', { key: 'kill_counter_session', value: {} });
   });
 
   const parse = (line: string) => {
@@ -61,7 +53,7 @@ describe('kill counter team kills', () => {
     let result = parse('> Eamon zabil smoka chaosu.');
     expect(stripAnsiCodes(result)).toContain('(0 / 1)');
 
-    client.dispatch('storage', { key: 'kill_counter', value: { 'smoka chaosu': 1 } });
+    setItemSync('kill_counter', { 'smoka chaosu': 1 });
 
     result = parse('> Eamon zabil smoka chaosu.');
     expect(stripAnsiCodes(result)).toContain('(0 / 2)');
@@ -75,11 +67,13 @@ describe('kill counter scenario', () => {
   let aliases: { pattern: RegExp; callback: () => void }[];
 
   beforeEach(() => {
+    appEventBus.clear();
+    localStorage.clear();
+    setItemSync('kill_counter', {});
+    setItemSync('kill_counter_session', {});
     aliases = [];
     client = new FakeClient();
     initKillCounter((client as unknown) as any, aliases);
-    client.dispatch('storage', { key: 'kill_counter', value: {} });
-    client.dispatch('storage', { key: 'kill_counter_session', value: {} });
     parse = (line: string) =>
       Triggers.prototype.parseLine.call(client.Triggers, line, '');
     // alias[0] corresponds to the /zabici command which prints
@@ -118,7 +112,7 @@ describe('kill counter scenario', () => {
     parse('Zabiles smoka chaosu.');
     printSessionTable();
     client.print.mockClear();
-    client.dispatch('reset', undefined);
+    appEventBus.emit('reset');
     printSessionTable();
     const printed = stripAnsiCodes(client.print.mock.calls.pop()[0]);
     expect(printed).not.toMatch(/smoka chaosu/);


### PR DESCRIPTION
## Summary
- reset kill counter tests to clear shared state before each run
- replace custom event target usage with app event bus and storage helpers

## Testing
- yarn --cwd client test kill

------
https://chatgpt.com/codex/tasks/task_e_68eecc71ba78832a9024de9cad2f394d