### PR TITLE
Fix event bus integration for client tests

### DIFF
--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -93,8 +93,9 @@ export default function initObjectAliases(
     });
 
     let attackMode: 'A' | 'AW' | 'AWR' = getItemSync('attack_mode')?.attack_mode ?? 'A';
-    appEventBus.on('attackMode', (attackMode) => {;
-        setItemSync('attack_mode', attackMode);
+    appEventBus.on('attackMode', (mode) => {
+        attackMode = mode;
+        setItemSync('attack_mode', mode);
     });
     appEventBus.emit('attackMode', attackMode);
 

--- a/client/test/idleFullHp.test.ts
+++ b/client/test/idleFullHp.test.ts
@@ -1,55 +1,50 @@
 import initIdleFullHp from '../src/scripts/idleFullHp';
-import { EventEmitter } from 'events';
+import appEventBus from '../src/events/app-event-bus';
 
 describe('idle full hp notification', () => {
   class FakeClient {
-    private emitter = new EventEmitter();
     notify = jest.fn();
-    sendEvent(type: string, detail?: any) {
-      this.emitter.emit(type, { detail });
-    }
-    addEventListener(event: string, cb: any) {
-      this.emitter.on(event, cb);
-    }
   }
 
   beforeEach(() => {
+    appEventBus.clear();
     jest.useFakeTimers();
     jest.setSystemTime(0);
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    appEventBus.clear();
   });
 
   test('notifies when reaching full hp after idle', () => {
     const client = new FakeClient();
     initIdleFullHp((client as unknown) as any);
-    client.sendEvent('gmcp.char.state', { hp: 5 });
+    appEventBus.emit('gmcp.char.state', { hp: 5 });
     jest.setSystemTime(120000);
-    client.sendEvent('gmcp.char.state', { hp: 6 });
+    appEventBus.emit('gmcp.char.state', { hp: 6 });
     expect(client.notify).toHaveBeenCalledWith('Masz pelne zycie');
   });
 
   test('does not notify before idle threshold', () => {
     const client = new FakeClient();
     initIdleFullHp((client as unknown) as any);
-    client.sendEvent('gmcp.char.state', { hp: 5 });
+    appEventBus.emit('gmcp.char.state', { hp: 5 });
     jest.setSystemTime(119000);
-    client.sendEvent('gmcp.char.state', { hp: 6 });
+    appEventBus.emit('gmcp.char.state', { hp: 6 });
     expect(client.notify).not.toHaveBeenCalled();
   });
 
   test('command resets idle timer', () => {
     const client = new FakeClient();
     initIdleFullHp((client as unknown) as any);
-    client.sendEvent('gmcp.char.state', { hp: 5 });
+    appEventBus.emit('gmcp.char.state', { hp: 5 });
     jest.setSystemTime(90000);
-    client.sendEvent('command', 'look');
+    appEventBus.emit('command', 'look');
     jest.setSystemTime(180000);
-    client.sendEvent('gmcp.char.state', { hp: 5 });
+    appEventBus.emit('gmcp.char.state', { hp: 5 });
     jest.setSystemTime(210000);
-    client.sendEvent('gmcp.char.state', { hp: 6 });
+    appEventBus.emit('gmcp.char.state', { hp: 6 });
     expect(client.notify).toHaveBeenCalledWith('Masz pelne zycie');
   });
 });

--- a/client/test/leaderAttackWarning.test.ts
+++ b/client/test/leaderAttackWarning.test.ts
@@ -1,9 +1,8 @@
 import initLeaderAttackWarning from '../src/scripts/leaderAttackWarning';
 import { stripAnsiCodes } from '../src/Triggers';
-import { EventEmitter } from 'events';
+import appEventBus from '../src/events/app-event-bus';
 
 class FakeClient {
-  private emitter = new EventEmitter();
   TeamManager = {
     getAttackTargetId: jest.fn(),
     getAvatarAttackTargetId: jest.fn(),
@@ -11,21 +10,13 @@ class FakeClient {
   supportBind = { key: 'KeyQ', ctrl: true };
   attackBind = { key: 'Digit1', ctrl: true };
   println = jest.fn();
-  addEventListener(event: string, cb: any) {
-    this.emitter.on(event, cb);
-  }
-  removeEventListener(event: string, cb: any) {
-    this.emitter.off(event, cb);
-  }
-  sendEvent(type: string, detail?: any) {
-    this.emitter.emit(type, { detail });
-  }
 }
 
 describe('leader attack warning', () => {
   let client: FakeClient;
 
   beforeEach(() => {
+    appEventBus.clear();
     client = new FakeClient();
     jest.useFakeTimers();
     initLeaderAttackWarning((client as unknown) as any);
@@ -33,12 +24,13 @@ describe('leader attack warning', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    appEventBus.clear();
   });
 
   test('suggests attacking when leader hits attack target', () => {
     client.TeamManager.getAttackTargetId.mockReturnValue('1');
     client.TeamManager.getAvatarAttackTargetId.mockReturnValue(undefined);
-    client.sendEvent('teamLeaderTargetNoAvatar', '1');
+    appEventBus.emit('teamLeaderTargetNoAvatar', '1');
     const text = stripAnsiCodes(client.println.mock.calls[0][0]);
     expect(text).toContain('Zaatakuj cel ataku');
     expect(text).toContain('CTRL+1');
@@ -47,7 +39,7 @@ describe('leader attack warning', () => {
   test('suggests support when leader hits different target', () => {
     client.TeamManager.getAttackTargetId.mockReturnValue('2');
     client.TeamManager.getAvatarAttackTargetId.mockReturnValue(undefined);
-    client.sendEvent('teamLeaderTargetNoAvatar', '1');
+    appEventBus.emit('teamLeaderTargetNoAvatar', '1');
     const text = stripAnsiCodes(client.println.mock.calls[0][0]);
     expect(text).toContain('wesprzyj');
     expect(text).toContain('CTRL+Q');
@@ -56,7 +48,7 @@ describe('leader attack warning', () => {
   test('prints nothing when avatar attacks attack target', () => {
     client.TeamManager.getAttackTargetId.mockReturnValue('3');
     client.TeamManager.getAvatarAttackTargetId.mockReturnValue('3');
-    client.sendEvent('teamLeaderTargetNoAvatar', '1');
+    appEventBus.emit('teamLeaderTargetNoAvatar', '1');
     expect(client.println).not.toHaveBeenCalled();
   });
 });

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -1,5 +1,6 @@
 import initObjectAliases from '../src/scripts/objectAliases';
 import { gmcp } from '../src/gmcp';
+import appEventBus from '../src/events/app-event-bus';
 
 jest.mock('../src/storage', () => ({
   getItemSync: jest.fn(() => ({})),
@@ -44,9 +45,9 @@ describe('object aliases', () => {
   let orderShieldTarget: () => void;
   let markAttack: (m: RegExpMatchArray) => void;
   let markDefense: (m: RegExpMatchArray) => void;
-  let setAttackMode: (ev: { detail: 'A' | 'AW' | 'AWR' }) => void;
 
   beforeEach(() => {
+    appEventBus.clear();
     client = new FakeClient();
     const aliases: { pattern: RegExp; callback: (m: RegExpMatchArray) => void }[] = [];
     initObjectAliases((client as unknown) as any, aliases);
@@ -71,9 +72,6 @@ describe('object aliases', () => {
     gmcp.char = { options: { group_cover: 1 } } as any;
 
     (setItemSync as jest.Mock).mockClear();
-
-    const attackModeCall = client.addEventListener.mock.calls.find(c => c[0] === 'attackMode');
-    setAttackMode = attackModeCall && attackModeCall[1];
   });
 
   test('kill alias sends zabij with object number', () => {
@@ -84,7 +82,7 @@ describe('object aliases', () => {
 
   test('kill alias in AW mode marks target', () => {
     client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 5, shortcut: '1' }]);
-    setAttackMode({ detail: 'AW' });
+    appEventBus.emit('attackMode', 'AW');
     expect(setItemSync).toHaveBeenLastCalledWith('attack_mode', 'AW');
     kill(['', '1'] as unknown as RegExpMatchArray);
     expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'zabij ob_5');
@@ -93,7 +91,7 @@ describe('object aliases', () => {
 
   test('kill alias in AWR mode orders attack', () => {
     client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 5, shortcut: '1' }]);
-    setAttackMode({ detail: 'AWR' });
+    appEventBus.emit('attackMode', 'AWR');
     expect(setItemSync).toHaveBeenLastCalledWith('attack_mode', 'AWR');
     kill(['', '1'] as unknown as RegExpMatchArray);
     expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'zabij ob_5');
@@ -104,7 +102,7 @@ describe('object aliases', () => {
   test('kill alias in AW mode without leadership only sends zabij', () => {
     client.TeamManager.isLeader.mockReturnValue(false);
     client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 5, shortcut: '1' }]);
-    setAttackMode({ detail: 'AW' });
+    appEventBus.emit('attackMode', 'AW');
     client.sendCommand.mockClear();
     kill(['', '1'] as unknown as RegExpMatchArray);
     expect(client.sendCommand).toHaveBeenCalledTimes(1);
@@ -113,7 +111,7 @@ describe('object aliases', () => {
 
   test('kill alias resumes extra commands when becoming leader again', () => {
     client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 5, shortcut: '1' }]);
-    setAttackMode({ detail: 'AWR' });
+    appEventBus.emit('attackMode', 'AWR');
     client.TeamManager.isLeader.mockReturnValue(false);
     kill(['', '1'] as unknown as RegExpMatchArray);
     expect(client.sendCommand).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- update object alias logic to retain the latest attack mode from the event bus
- adjust object alias, leader attack warning, and idle full HP tests to emit events via the shared app event bus

## Testing
- yarn --cwd client test objectAliases.test.ts
- yarn --cwd client test leaderAttackWarning.test.ts idleFullHp.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68eece38e0b0832ab1ef3e6b7b157cf9