### PR TITLE
Refine data catalog listener change detection

### DIFF
--- a/client/src/dataCatalog/DataCatalogEntry.ts
+++ b/client/src/dataCatalog/DataCatalogEntry.ts
@@ -30,7 +30,6 @@ interface CollectionIndexRecord {
 }
 
 const COLLECTION_INDEX_SUFFIX = '__collection_index__';
-
 export class DataCatalogEntry<T, Persisted = T> {
   private data: T | null = null;
   private timestamp = 0;
@@ -39,12 +38,15 @@ export class DataCatalogEntry<T, Persisted = T> {
   private readonly persistenceKey: string;
   private loadProgressListeners: Set<DataStoreProgressListener> | null = null;
   private currentProgress = 0;
+  private lastDataSnapshot: string | null = null;
+  private hasComparableSnapshot = false;
 
   constructor(private readonly options: DataCatalogEntryOptions<T, Persisted>) {
     this.persistenceKey = options.persistenceKey ?? options.key;
     if (options.initialData !== undefined) {
       this.data = options.initialData ?? null;
       this.timestamp = Date.now();
+      this.updateSnapshotState(this.data);
     }
   }
 
@@ -177,14 +179,14 @@ export class DataCatalogEntry<T, Persisted = T> {
 
   async storeData(data: T, options?: { persist?: boolean; timestamp?: number }): Promise<void> {
     const timestamp = options?.timestamp ?? Date.now();
-    this.updateMemory(data, timestamp);
+    this.commitData(data, timestamp);
     if (options?.persist === false) {
       return;
     }
 
     const persistedData = await this.persist(data, timestamp);
     if (persistedData !== data) {
-      this.updateMemory(persistedData, timestamp);
+      this.commitData(persistedData, timestamp);
     }
   }
 
@@ -193,6 +195,7 @@ export class DataCatalogEntry<T, Persisted = T> {
     this.timestamp = 0;
     this.loadingPromise = null;
     this.clearProgressListeners();
+    this.resetSnapshotState();
     if (!this.options.collection) {
       await this.options.persistenceAdapter.delete(this.options.storeName, this.persistenceKey);
       return;
@@ -218,7 +221,7 @@ export class DataCatalogEntry<T, Persisted = T> {
 
     const freshData = await this.safeLoadFromSource(onProgress);
     const persistedData = await this.persist(freshData);
-    this.updateMemory(persistedData);
+    this.commitData(persistedData);
     return persistedData;
   }
 
@@ -242,7 +245,7 @@ export class DataCatalogEntry<T, Persisted = T> {
         return null;
       }
 
-      this.updateMemory(record.data, record.timestamp);
+      this.commitData(record.data, record.timestamp);
       onProgress?.(1);
       return record.data;
     } catch (error) {
@@ -285,10 +288,18 @@ export class DataCatalogEntry<T, Persisted = T> {
     return data;
   }
 
-  private updateMemory(data: T, timestamp: number = Date.now()): void {
+  private commitData(data: T, timestamp: number = Date.now()): void {
+    const snapshotInfo = this.createSnapshot(data);
+    const shouldNotify = snapshotInfo.shouldNotify;
+
+    this.updateSnapshotStateFromSnapshotInfo(snapshotInfo);
+
     this.data = data;
     this.timestamp = timestamp;
-    this.notifyListeners(data);
+
+    if (shouldNotify) {
+      this.notifyListeners(data);
+    }
   }
 
   private isExpired(): boolean {
@@ -307,6 +318,61 @@ export class DataCatalogEntry<T, Persisted = T> {
         console.error(`Data listener for ${this.options.key} failed`, error);
       }
     }
+  }
+
+  private createSnapshot(
+    data: T,
+  ): { comparable: true; snapshot: string; shouldNotify: boolean } | { comparable: false; shouldNotify: boolean } {
+    try {
+      const snapshot = JSON.stringify(data);
+      if (typeof snapshot === 'string') {
+        if (!this.hasComparableSnapshot) {
+          return { comparable: true, snapshot, shouldNotify: true };
+        }
+
+        return {
+          comparable: true,
+          snapshot,
+          shouldNotify: snapshot !== this.lastDataSnapshot,
+        };
+      }
+    } catch (error) {
+      console.warn(`Failed to snapshot data for ${this.options.key}`, error);
+    }
+
+    return {
+      comparable: false,
+      shouldNotify: !Object.is(this.data, data),
+    };
+  }
+
+  private updateSnapshotStateFromSnapshotInfo(
+    snapshotInfo:
+      | { comparable: true; snapshot: string; shouldNotify: boolean }
+      | { comparable: false; shouldNotify: boolean },
+  ): void {
+    if (snapshotInfo.comparable) {
+      this.hasComparableSnapshot = true;
+      this.lastDataSnapshot = snapshotInfo.snapshot;
+      return;
+    }
+
+    this.resetSnapshotState();
+  }
+
+  private updateSnapshotState(data: T | null): void {
+    if (data === null) {
+      this.resetSnapshotState();
+      return;
+    }
+
+    const snapshotInfo = this.createSnapshot(data);
+    this.updateSnapshotStateFromSnapshotInfo(snapshotInfo);
+  }
+
+  private resetSnapshotState(): void {
+    this.hasComparableSnapshot = false;
+    this.lastDataSnapshot = null;
   }
 
   private getCollectionIndexKey(): string {
@@ -340,7 +406,7 @@ export class DataCatalogEntry<T, Persisted = T> {
 
       const items = await this.loadPersistedCollectionItems<Persisted>(keys);
       const data = options.fromPersistenceItems(items);
-      this.updateMemory(data, indexRecord.timestamp);
+      this.commitData(data, indexRecord.timestamp);
       onProgress?.(1);
       return data;
     } catch (error) {

--- a/client/test/dataCatalogEntryListeners.test.ts
+++ b/client/test/dataCatalogEntryListeners.test.ts
@@ -1,0 +1,76 @@
+import { DataCatalogEntry } from '../src/dataCatalog/DataCatalogEntry';
+import { IndexedDBPersistenceAdapter } from '../src/dataCatalog/IndexedDBPersistenceAdapter';
+
+describe('DataCatalogEntry listeners', () => {
+  test('does not notify listeners when reloading identical data', async () => {
+    const adapter = new IndexedDBPersistenceAdapter(`TestDB-${Date.now()}-${Math.random()}`);
+    const data = { value: 1 };
+    const load = jest.fn(async () => data);
+
+    const entry = new DataCatalogEntry<{ value: number }>({
+      key: 'test',
+      ttl: 60_000,
+      storeName: 'store',
+      persistenceAdapter: adapter,
+      dataSource: { load },
+    });
+
+    const listener = jest.fn();
+    entry.addListener(listener);
+
+    await entry.getData();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    await entry.getData({ forceReload: true });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  test('notifies listeners when data changes on reload', async () => {
+    const adapter = new IndexedDBPersistenceAdapter(`TestDB-${Date.now()}-${Math.random()}`);
+    const load = jest
+      .fn()
+      .mockResolvedValueOnce({ value: 1 })
+      .mockResolvedValueOnce({ value: 2 });
+
+    const entry = new DataCatalogEntry<{ value: number }>({
+      key: 'test',
+      ttl: 60_000,
+      storeName: 'store',
+      persistenceAdapter: adapter,
+      dataSource: { load },
+    });
+
+    const listener = jest.fn();
+    entry.addListener(listener);
+
+    await entry.getData();
+    await entry.getData({ forceReload: true });
+
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  test('notifies listeners when data mutates in place', async () => {
+    const adapter = new IndexedDBPersistenceAdapter(`TestDB-${Date.now()}-${Math.random()}`);
+
+    const entry = new DataCatalogEntry<{ value: number }>({
+      key: 'test',
+      ttl: 60_000,
+      storeName: 'store',
+      persistenceAdapter: adapter,
+    });
+
+    const listener = jest.fn();
+    entry.addListener(listener);
+
+    const data = { value: 1 };
+    await entry.storeData(data, { persist: false });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    data.value = 2;
+    await entry.storeData(data, { persist: false });
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    await entry.storeData({ value: 2 }, { persist: false });
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- rework DataCatalogEntry change detection to update snapshots during data operations without storing previous references
- reset snapshot state when clearing data and fall back to reference checks when serialization fails
- extend listener tests to cover in-place data mutations

## Testing
- yarn --cwd client test dataCatalogEntryListeners.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ef58c63e3c832a823a1e78dec7d63c