### PR TITLE
Normalize outgoing commands except speech

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -351,7 +351,16 @@ export default class Client {
 
             const trimmedCommand = command.trimStart()
             if (trimmedCommand) {
-                const skipLowercasePrefixes = ["'", "powiedz", "j'", "jpowiedz"]
+                const skipLowercasePrefixes = [
+                    "'",
+                    "powiedz",
+                    "j'",
+                    "jpowiedz",
+                    "krzyknij",
+                    "jkrzyknij",
+                    "szepnij",
+                    "jszepnij",
+                ]
                 const shouldLowercase = !skipLowercasePrefixes.some(prefix => trimmedCommand.startsWith(prefix))
                 if (shouldLowercase) {
                     const leadingWhitespaceLength = command.length - trimmedCommand.length

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -180,10 +180,23 @@ test('sendCommand lowercases non speech commands', () => {
 
 test('sendCommand keeps casing for speech commands', () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
-  parseCommand.mockClear();
-  client.sendCommand("'SHOUT");
-  expect(parseCommand).toHaveBeenCalledTimes(1);
-  expect(parseCommand).toHaveBeenCalledWith("'SHOUT");
+  const speechCommands = [
+    "'SHOUT",
+    'powiedz HELLO',
+    "j'HELLO",
+    'jpowiedz HELLO',
+    'krzyknij HELLO',
+    'jkrzyknij HELLO',
+    'szepnij HELLO',
+    'jszepnij HELLO',
+  ];
+
+  speechCommands.forEach((command) => {
+    parseCommand.mockClear();
+    client.sendCommand(command);
+    expect(parseCommand).toHaveBeenCalledTimes(1);
+    expect(parseCommand).toHaveBeenCalledWith(command);
+  });
 });
 
 test('sendCommand allows empty command', () => {


### PR DESCRIPTION
## Summary
- normalize outgoing commands to lowercase unless they begin with speech prefixes like `'`, `powiedz`, `j'`, or `jpowiedz`
- add Client tests covering the new normalization behaviour and speech exceptions

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68ef67e5253c832a8afecff8b8dd110c