### PR TITLE
Move clear command toggle to UI settings

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -343,6 +343,15 @@
                             </div>
                         </section>
                         <section class="ui-settings-section">
+                            <h6 class="ui-settings-section-title">Pole komendy</h6>
+                            <div class="ui-settings-stack">
+                                <div class="form-check">
+                                    <input id="ui-clear-input-after-send" type="checkbox" class="form-check-input" />
+                                    <label class="form-check-label" for="ui-clear-input-after-send">Czysc pole komendy po wyslaniu</label>
+                                </div>
+                            </div>
+                        </section>
+                        <section class="ui-settings-section">
                             <h6 class="ui-settings-section-title">Wygląd</h6>
                             <div class="ui-settings-stack">
                                 <div>

--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -325,6 +325,15 @@
                             </div>
                         </section>
                         <section class="ui-settings-section">
+                            <h6 class="ui-settings-section-title">Pole komendy</h6>
+                            <div class="ui-settings-stack">
+                                <div class="form-check">
+                                    <input id="ui-clear-input-after-send" type="checkbox" class="form-check-input" />
+                                    <label class="form-check-label" for="ui-clear-input-after-send">Czysc pole komendy po wyslaniu</label>
+                                </div>
+                            </div>
+                        </section>
+                        <section class="ui-settings-section">
                             <h6 class="ui-settings-section-title">Wygląd</h6>
                             <div class="ui-settings-stack">
                                 <div>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -52,6 +52,8 @@ registerScripts(client)
 
 appEventBus.emit('settings', Object.assign(defaultSettings, getItemSync('settings')))
 
+let clearInputAfterSend = false
+
 const locationParam = new URLSearchParams(window.location.search).get('locationId');
 const initialLocationId = locationParam ? parseInt(locationParam) : NaN;
 if (!isNaN(initialLocationId)) {
@@ -117,6 +119,10 @@ appEventBus.on('settings', (settings) => {
     if (settings.binds.directions) {
         applyDirectionBinds(settings.binds.directions);
     }
+});
+
+appEventBus.on('uiSettings', (settings) => {
+    clearInputAfterSend = !!settings.clearInputAfterSend;
 });
 
 
@@ -923,6 +929,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function sendMessage(focus = true) {
         const message = messageInput.value.trim();
+        const applyPostSend = () => {
+            if (clearInputAfterSend) {
+                messageInput.value = '';
+                if (focus) {
+                    messageInput.focus();
+                }
+            } else if (focus) {
+                messageInput.select();
+            }
+        };
         if (message) {
             // Only add command to history if we've received the first GMCP event
             if (arkadiaClient.hasReceivedFirstGmcp()) {
@@ -935,15 +951,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 currentInput = '';
 
                 client.sendCommand(message);
-                if (focus) messageInput.select();
+                applyPostSend();
             } else {
                 // If we haven't received the first GMCP event yet, clear the input field
                 client.sendCommand(message);
                 messageInput.value = '';
+                if (clearInputAfterSend && focus) {
+                    messageInput.focus();
+                }
             }
         } else {
             client.sendCommand('');
-            if (focus) messageInput.select();
+            applyPostSend();
         }
     }
 

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -23,6 +23,7 @@ export interface UiSettings {
     buttonSize: number;
     mapScale: number;
     showButtons: boolean;
+    clearInputAfterSend: boolean;
     hapticFeedback: boolean;
     mapHeight: number;
     mapPosition: MapPosition;
@@ -46,6 +47,7 @@ const defaultSettings: UiSettings = {
     buttonSize: 1,
     mapScale: 0.30,
     showButtons: true,
+    clearInputAfterSend: false,
     hapticFeedback: true,
     mapHeight: typeof window !== 'undefined' && window.innerWidth < 768 ? 25 : 30,
     mapPosition: 'top-overlay',
@@ -179,6 +181,9 @@ async function load(): Promise<UiSettings> {
             const highlightCurrentRoom = typeof parsed.highlightCurrentRoom === 'boolean'
                 ? parsed.highlightCurrentRoom
                 : defaultSettings.highlightCurrentRoom;
+            const clearInputAfterSend = typeof parsed.clearInputAfterSend === 'boolean'
+                ? parsed.clearInputAfterSend
+                : defaultSettings.clearInputAfterSend;
             const outputBackground = typeof parsed.outputBackground === 'string'
                 && /^#[0-9a-f]{6}$/i.test(parsed.outputBackground.trim())
                     ? parsed.outputBackground.trim()
@@ -196,6 +201,7 @@ async function load(): Promise<UiSettings> {
                 hapticFeedback,
                 instantMove,
                 highlightCurrentRoom,
+                clearInputAfterSend,
                 transparentLabels,
                 labelRenderMode: effectiveLabelRenderMode,
                 outputBackground,
@@ -226,6 +232,7 @@ export default async function initUiSettings() {
     const explorationInput = modalEl.querySelector('#ui-exploration-mode') as HTMLInputElement;
     const explorationStats = modalEl.querySelector('#ui-exploration-stats') as HTMLElement | null;
     const showButtonsInput = modalEl.querySelector('#ui-show-buttons') as HTMLInputElement;
+    const clearInputAfterSendInput = modalEl.querySelector('#ui-clear-input-after-send') as HTMLInputElement;
     const hapticFeedbackInput = modalEl.querySelector('#ui-haptic-feedback') as HTMLInputElement;
     const emojiLabelsInput = modalEl.querySelector('#ui-emoji-labels') as HTMLInputElement;
     const fightTitleIconInput = modalEl.querySelector('#ui-fight-title-icon') as HTMLInputElement;
@@ -248,6 +255,7 @@ export default async function initUiSettings() {
     mapPositionInput.value = current.mapPosition;
     explorationInput.checked = current.explorationMode;
     showButtonsInput.checked = current.showButtons;
+    clearInputAfterSendInput.checked = current.clearInputAfterSend;
     hapticFeedbackInput.checked = current.hapticFeedback;
     emojiLabelsInput.checked = current.emojiLabels;
     fightTitleIconInput.checked = current.fightTitleIcon;
@@ -325,6 +333,7 @@ export default async function initUiSettings() {
             mapHeight: parseFloat(mapHeightInput.value) || defaultSettings.mapHeight,
             mapPosition: (mapPositionInput.value as MapPosition) || defaultSettings.mapPosition,
             showButtons: showButtonsInput.checked,
+            clearInputAfterSend: clearInputAfterSendInput.checked,
             hapticFeedback: hapticFeedbackInput.checked,
             emojiLabels: emojiLabelsInput.checked,
             fightTitleIcon: fightTitleIconInput.checked,


### PR DESCRIPTION
## Summary
- add a UI settings checkbox for clearing the command input after sending a message
- remove the per-character setting and wire the main input handler to the uiSettings event

## Testing
- yarn --cwd client test *(fails: improveCounter.test.ts assertions about recorded improvements)*
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ef6c9badc0832a984102910f12914e