### PR TITLE
Add toggle for main window timestamps

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -362,6 +362,10 @@
                                         </button>
                                     </div>
                                 </div>
+                                <div class="form-check">
+                                    <input id="ui-show-timestamps" type="checkbox" class="form-check-input" />
+                                    <label class="form-check-label" for="ui-show-timestamps">Pokaż znaczniki czasu w oknie głównym</label>
+                                </div>
                                 <div>
                                     <label class="form-label" for="ui-footer-mode">Tryb stopki</label>
                                     <select id="ui-footer-mode" class="form-select">

--- a/web-client/src/logBrowser.ts
+++ b/web-client/src/logBrowser.ts
@@ -1,5 +1,6 @@
 import Modal from "bootstrap/js/dist/modal";
 import storage from "@client/src/storage";
+import { formatDateTime, formatTime, splitLines } from "./utils/logFormatting";
 
 interface LogEntry {
   text: string;
@@ -28,23 +29,6 @@ function initLogBrowser(): boolean {
   });
 
   let db: IDBDatabase | null = null;
-
-  function formatTime(ts: number): string {
-    const d = new Date(ts);
-    const h = String(d.getHours()).padStart(2, "0");
-    const m = String(d.getMinutes()).padStart(2, "0");
-    const s = String(d.getSeconds()).padStart(2, "0");
-    const ms = String(d.getMilliseconds()).padStart(3, "0");
-    return `${h}:${m}:${s}.${ms}`;
-  }
-
-  function formatDateTime(ts: number): string {
-    const d = new Date(ts);
-    const y = d.getFullYear();
-    const mo = String(d.getMonth() + 1).padStart(2, "0");
-    const da = String(d.getDate()).padStart(2, "0");
-    return `${y}-${mo}-${da} ${formatTime(ts)}`;
-  }
 
   const modal = new Modal(modalEl);
 
@@ -91,35 +75,6 @@ function initLogBrowser(): boolean {
     } else {
       preview.innerHTML = "";
     }
-  }
-
-  function splitLines(html: string): string[] {
-    const lines: string[] = [];
-    const stack: { open: string; close: string }[] = [];
-    let line = "";
-    const regex = /(<[^>]+>|\r?\n)/g;
-    let last = 0;
-    let match: RegExpExecArray | null;
-    while ((match = regex.exec(html)) !== null) {
-      const token = match[0];
-      line += html.slice(last, match.index);
-      if (token === "\n" || token === "\r\n") {
-        lines.push(line + stack.map(s => s.close).reverse().join(""));
-        line = stack.map(s => s.open).join("");
-      } else {
-        line += token;
-        if (token.startsWith("<") && !token.startsWith("</") && !token.endsWith("/>") && !token.startsWith("<!")) {
-          const tag = token.match(/^<([a-zA-Z0-9:-]+)/);
-          if (tag) stack.push({ open: token, close: `</${tag[1]}>` });
-        } else if (token.startsWith("</")) {
-          stack.pop();
-        }
-      }
-      last = regex.lastIndex;
-    }
-    line += html.slice(last);
-    lines.push(line);
-    return lines;
   }
 
   function loadPreview(storeName: string) {

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -44,6 +44,7 @@ import {
 import "./triggerTester"
 import "./triggerFinder"
 import { getItemSync } from "@client/src/storage"
+import { formatTime, splitLines } from "./utils/logFormatting"
 
 initSessionLogger(arkadiaClient).catch(err => console.error('Logger init failed', err));
 
@@ -169,6 +170,82 @@ const stickyArea = document.getElementById('sticky-area') as HTMLElement;
 let isSplitView = false;
 const STICKY_LINES = 15;
 
+let showTimestamps = false;
+const storedUiSettings = getItemSync('uiSettings');
+if (typeof storedUiSettings?.uiSettings?.showTimestamps === 'boolean') {
+    showTimestamps = storedUiSettings.uiSettings.showTimestamps;
+}
+
+function applyMessageContent(target: HTMLElement, messageHtml: string, timestamp: number, withTimestamps: boolean) {
+    target.innerHTML = '';
+    if (withTimestamps) {
+        target.classList.add('with-timestamps');
+        target.style.whiteSpace = '';
+        const lines = splitLines(messageHtml);
+        for (const line of lines) {
+            const timeSpan = document.createElement('span');
+            timeSpan.classList.add('log-time', 'output-msg-time');
+            timeSpan.textContent = formatTime(timestamp);
+            const contentSpan = document.createElement('span');
+            contentSpan.classList.add('output-msg-content');
+            contentSpan.innerHTML = line;
+            target.appendChild(timeSpan);
+            target.appendChild(contentSpan);
+        }
+    } else {
+        target.classList.remove('with-timestamps');
+        target.style.whiteSpace = 'pre-wrap';
+        target.innerHTML = messageHtml;
+    }
+}
+
+function updateWrapperContent(wrapper: HTMLElement, messageHtml: string, timestamp: number, withTimestamps: boolean) {
+    const messageDiv = wrapper.querySelector('.output_msg_text') as HTMLElement | null;
+    if (!messageDiv) {
+        return;
+    }
+    wrapper.dataset.rawMessage = messageHtml;
+    wrapper.dataset.timestamp = String(timestamp);
+    applyMessageContent(messageDiv, messageHtml, timestamp, withTimestamps);
+}
+
+function rerenderContainer(container: HTMLElement | null, withTimestamps: boolean, skip?: Element | null) {
+    if (!container) {
+        return;
+    }
+    Array.from(container.children).forEach(child => {
+        if (skip && child === skip) {
+            return;
+        }
+        const element = child as HTMLElement;
+        const raw = element.dataset.rawMessage;
+        const ts = element.dataset.timestamp;
+        if (!raw || !ts) {
+            return;
+        }
+        const parsedTs = Number(ts);
+        if (!Number.isFinite(parsedTs)) {
+            return;
+        }
+        const messageDiv = element.querySelector('.output_msg_text') as HTMLElement | null;
+        if (!messageDiv) {
+            return;
+        }
+        applyMessageContent(messageDiv, raw, parsedTs, withTimestamps);
+    });
+}
+
+function setShowTimestamps(value: boolean) {
+    showTimestamps = value;
+    if (outputWrapper) {
+        outputWrapper.classList.toggle('show-timestamps', showTimestamps);
+    }
+    rerenderContainer(outputWrapper, showTimestamps, splitBottom);
+    rerenderContainer(stickyArea, showTimestamps);
+}
+
+setShowTimestamps(showTimestamps);
+
 function processSticky(count: number) {
     const handler: any = (window as any).clientExtension?.OutputHandler;
     if (handler && typeof handler.processOutput === 'function') {
@@ -251,7 +328,7 @@ Promise.all([mapDataPromise, colorsPromise])
 
 // Set up message event listener for UI updates
 arkadiaClient.on('message', (message: string, type?: string) => {
-    if (message === "") {
+    if (typeof message !== 'string' || message === "") {
         return; //TODO investigate
     }
     const wrapper = document.createElement('div');
@@ -262,11 +339,12 @@ arkadiaClient.on('message', (message: string, type?: string) => {
     }
 
     const messageDiv = document.createElement('div');
-    messageDiv.innerHTML = message;
     messageDiv.classList.add('output_msg_text');
-    messageDiv.style.whiteSpace = 'pre-wrap';
-
     wrapper.appendChild(messageDiv);
+
+    const timestamp = Date.now();
+    updateWrapperContent(wrapper, message, timestamp, showTimestamps);
+
     outputWrapper.insertBefore(wrapper, splitBottom);
 
     const maxElements = 1000;
@@ -454,8 +532,13 @@ document.addEventListener('DOMContentLoaded', () => {
     let clearInputOnSend = !!uiSettingsData?.uiSettings?.clearInputOnSend;
     client.eventTarget.addEventListener('uiSettings', (ev: Event) => {
         const detail = (ev as CustomEvent).detail;
-        if (detail && typeof detail.clearInputOnSend === 'boolean') {
-            clearInputOnSend = detail.clearInputOnSend;
+        if (detail) {
+            if (typeof detail.clearInputOnSend === 'boolean') {
+                clearInputOnSend = detail.clearInputOnSend;
+            }
+            if (typeof detail.showTimestamps === 'boolean') {
+                setShowTimestamps(detail.showTimestamps);
+            }
         }
     });
     const historyUpButton = document.getElementById('history-up-button') as HTMLButtonElement | null;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -329,6 +329,23 @@ h1 {
   padding-right: 0.5rem;
 }
 
+#main_text_output_msg_wrapper.show-timestamps .output_msg_text.with-timestamps {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 0.5rem;
+  align-items: start;
+}
+
+#main_text_output_msg_wrapper.show-timestamps .output-msg-time {
+  color: darkorange;
+  padding-right: 0.5rem;
+  white-space: nowrap;
+}
+
+#main_text_output_msg_wrapper.show-timestamps .output-msg-content {
+  white-space: pre-wrap;
+}
+
 #split-bottom {
   position: sticky;
   bottom: 0px;

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -34,6 +34,7 @@ interface UiSettings {
     transparentLabels: boolean;
     outputBackground: string;
     clearInputOnSend: boolean;
+    showTimestamps: boolean;
 }
 
 const defaultSettings: UiSettings = {
@@ -56,6 +57,7 @@ const defaultSettings: UiSettings = {
     transparentLabels: true,
     outputBackground: '#242424',
     clearInputOnSend: false,
+    showTimestamps: false,
 };
 
 function apply(settings: UiSettings) {
@@ -71,6 +73,7 @@ function apply(settings: UiSettings) {
     if (content) {
         content.style.fontSize = settings.contentFontSize + 'rem';
         content.style.backgroundColor = settings.outputBackground;
+        content.classList.toggle('show-timestamps', settings.showTimestamps);
     }
     const charState = document.getElementById('char-state');
     if (charState) {
@@ -148,6 +151,7 @@ function apply(settings: UiSettings) {
                     footerMode: settings.footerMode,
                     fightTitleIcon: settings.fightTitleIcon,
                     clearInputOnSend: settings.clearInputOnSend,
+                    showTimestamps: settings.showTimestamps,
                 },
             })
         );
@@ -198,6 +202,9 @@ async function load(): Promise<UiSettings> {
             const clearInputOnSend = typeof parsed.clearInputOnSend === 'boolean'
                 ? parsed.clearInputOnSend
                 : defaultSettings.clearInputOnSend;
+            const showTimestamps = typeof parsed.showTimestamps === 'boolean'
+                ? parsed.showTimestamps
+                : defaultSettings.showTimestamps;
             return {
                 ...defaultSettings,
                 ...parsed,
@@ -215,6 +222,7 @@ async function load(): Promise<UiSettings> {
                 labelRenderMode: effectiveLabelRenderMode,
                 outputBackground,
                 clearInputOnSend,
+                showTimestamps,
             };
         }
     } catch {
@@ -254,6 +262,7 @@ export default async function initUiSettings() {
     const outputBackgroundInput = modalEl.querySelector('#ui-output-background') as HTMLInputElement;
     const outputBackgroundReset = modalEl.querySelector('#ui-output-background-reset') as HTMLButtonElement | null;
     const clearInputOnSendInput = modalEl.querySelector('#ui-clear-input') as HTMLInputElement;
+    const showTimestampsInput = modalEl.querySelector('#ui-show-timestamps') as HTMLInputElement;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
 
     let current = await load();
@@ -276,6 +285,7 @@ export default async function initUiSettings() {
     transparentLabelsInput.checked = current.transparentLabels;
     outputBackgroundInput.value = current.outputBackground;
     clearInputOnSendInput.checked = current.clearInputOnSend;
+    showTimestampsInput.checked = current.showTimestamps;
     const updateLabelRenderModeState = () => {
         if (transparentLabelsInput.checked) {
             labelRenderModeInput.value = 'data';
@@ -355,6 +365,7 @@ export default async function initUiSettings() {
             transparentLabels: transparentLabelsInput.checked,
             outputBackground: backgroundValue,
             clearInputOnSend: clearInputOnSendInput.checked,
+            showTimestamps: showTimestampsInput.checked,
         };
     }
 

--- a/web-client/src/utils/logFormatting.ts
+++ b/web-client/src/utils/logFormatting.ts
@@ -1,0 +1,45 @@
+export function formatTime(ts: number): string {
+  const d = new Date(ts);
+  const h = String(d.getHours()).padStart(2, "0");
+  const m = String(d.getMinutes()).padStart(2, "0");
+  const s = String(d.getSeconds()).padStart(2, "0");
+  const ms = String(d.getMilliseconds()).padStart(3, "0");
+  return `${h}:${m}:${s}.${ms}`;
+}
+
+export function formatDateTime(ts: number): string {
+  const d = new Date(ts);
+  const y = d.getFullYear();
+  const mo = String(d.getMonth() + 1).padStart(2, "0");
+  const da = String(d.getDate()).padStart(2, "0");
+  return `${y}-${mo}-${da} ${formatTime(ts)}`;
+}
+
+export function splitLines(html: string): string[] {
+  const lines: string[] = [];
+  const stack: { open: string; close: string }[] = [];
+  let line = "";
+  const regex = /(<[^>]+>|\r?\n)/g;
+  let last = 0;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(html)) !== null) {
+    const token = match[0];
+    line += html.slice(last, match.index);
+    if (token === "\n" || token === "\r\n") {
+      lines.push(line + stack.map(s => s.close).reverse().join(""));
+      line = stack.map(s => s.open).join("");
+    } else {
+      line += token;
+      if (token.startsWith("<") && !token.startsWith("</") && !token.endsWith("/>") && !token.startsWith("<!")) {
+        const tag = token.match(/^<([a-zA-Z0-9:-]+)/);
+        if (tag) stack.push({ open: token, close: `</${tag[1]}>` });
+      } else if (token.startsWith("</")) {
+        stack.pop();
+      }
+    }
+    last = regex.lastIndex;
+  }
+  line += html.slice(last);
+  lines.push(line);
+  return lines;
+}


### PR DESCRIPTION
## Summary
- add a UI toggle that lets players enable timestamps in the main output window and persist the preference
- share log formatting utilities across the app and update the log browser to use them
- render timestamps in the live output when enabled and style the layout to match stored logs

## Testing
- yarn --cwd web-client test
- yarn --cwd client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ef821391fc832aaf8827ff8acc54f8