### PR TITLE
Align character settings layout with UI settings

### DIFF
--- a/web-client/src/options/GuildSection.tsx
+++ b/web-client/src/options/GuildSection.tsx
@@ -20,9 +20,9 @@ export default function GuildSection({selected, enemySelected, colors = {}, defa
     const allSelected = selected.length === guilds.length;
     const allEnemySelected = enemySelected.length === guilds.length;
     return (
-        <div className="mb-4 border rounded p-3">
-            <div className="d-flex justify-content-between mb-2">
-                <h5 className="fw-bold">Gildie</h5>
+        <section className="character-settings-section character-settings-section--full">
+            <div className="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-2">
+                <h5 className="character-settings-section-title mb-0">Gildie</h5>
                 <div className="d-flex gap-2">
                     <Form.Check
                         type="checkbox"
@@ -55,6 +55,6 @@ export default function GuildSection({selected, enemySelected, colors = {}, defa
                     />
                 ))}
             </div>
-        </div>
+        </section>
     );
 }

--- a/web-client/src/options/GuildsSettings.tsx
+++ b/web-client/src/options/GuildsSettings.tsx
@@ -105,19 +105,21 @@ function GuildsSettings({ registerSave }: { registerSave: (cb: () => void) => vo
     }, [registerSave, selected, enemySelected, colors]);
 
     return (
-        <div className="p-2">
+        <div className="p-2 h-100">
             <fieldset disabled={locked} className="p-0 border-0 m-0">
-                <GuildSection
-                    selected={selected}
-                    enemySelected={enemySelected}
-                    colors={colors}
-                    defaultColors={defaultColors}
-                    onChange={onChange}
-                    onEnemyChange={onEnemyChange}
-                    onColorChange={onColorChange}
-                    onChangeAll={onChangeAll}
-                    onChangeAllEnemy={onChangeAllEnemy}
-                />
+                <div className="character-settings-layout">
+                    <GuildSection
+                        selected={selected}
+                        enemySelected={enemySelected}
+                        colors={colors}
+                        defaultColors={defaultColors}
+                        onChange={onChange}
+                        onEnemyChange={onEnemyChange}
+                        onColorChange={onColorChange}
+                        onChangeAll={onChangeAll}
+                        onChangeAllEnemy={onChangeAllEnemy}
+                    />
+                </div>
             </fieldset>
         </div>
     );

--- a/web-client/src/options/LuaGagsSettings.tsx
+++ b/web-client/src/options/LuaGagsSettings.tsx
@@ -90,35 +90,37 @@ function LuaGagsSettings({ registerSave }: { registerSave: RegisterSave }) {
     };
 
     return (
-        <div className="p-2">
+        <div className="p-2 h-100">
             <fieldset disabled={locked} className="p-0 border-0 m-0">
-                <div className="mb-4 border rounded p-3">
-                    <h5 className="fw-bold mb-3">Ustawienia walki</h5>
-                    <div className="d-flex flex-column gap-3">
-                        {LUA_GAG_LINE_TYPES.map(key => (
-                            <Form.Group
-                                key={key}
-                                className="d-flex flex-wrap align-items-center justify-content-between gap-2"
-                                controlId={`luaGag-${key}`}
-                            >
-                                <Form.Label className="mb-0 me-2">{labels[key]}</Form.Label>
-                                <Form.Select
-                                    size="sm"
-                                    className="w-auto"
-                                    value={deleteLines[key]}
-                                    onChange={event =>
-                                        handleChange(key, Number(event.target.value) as LuaGagDeleteMode)
-                                    }
+                <div className="character-settings-layout">
+                    <section className="character-settings-section character-settings-section--full">
+                        <h5 className="character-settings-section-title">Ustawienia walki</h5>
+                        <div className="character-settings-stack">
+                            {LUA_GAG_LINE_TYPES.map(key => (
+                                <Form.Group
+                                    key={key}
+                                    className="d-flex flex-wrap align-items-center justify-content-between gap-2"
+                                    controlId={`luaGag-${key}`}
                                 >
-                                    {selectOptions.map(option => (
-                                        <option key={option.value} value={option.value}>
-                                            {option.label}
-                                        </option>
-                                    ))}
-                                </Form.Select>
-                            </Form.Group>
-                        ))}
-                    </div>
+                                    <Form.Label className="mb-0 me-2">{labels[key]}</Form.Label>
+                                    <Form.Select
+                                        size="sm"
+                                        className="w-auto"
+                                        value={deleteLines[key]}
+                                        onChange={event =>
+                                            handleChange(key, Number(event.target.value) as LuaGagDeleteMode)
+                                        }
+                                    >
+                                        {selectOptions.map(option => (
+                                            <option key={option.value} value={option.value}>
+                                                {option.label}
+                                            </option>
+                                        ))}
+                                    </Form.Select>
+                                </Form.Group>
+                            ))}
+                        </div>
+                    </section>
                 </div>
             </fieldset>
         </div>

--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -115,302 +115,330 @@ function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void
     }, []);
 
     return (
-        <div className="p-2">
+        <div className="p-2 h-100">
             <fieldset disabled={locked} className="p-0 border-0 m-0">
-            <div className="mb-4 border rounded p-3">
-                <h5 className="fw-bold mb-2">Pozostałe opcje</h5>
-                <div className="d-flex flex-wrap gap-3 align-items-center">
-                    <Form.Check
-                        type="checkbox"
-                        id="packageHelper"
-                        label="Asystent paczek"
-                        checked={settings.packageHelper}
-                        onChange={e => onChangeSetting(s => s.packageHelper = e.target.checked)}
-                        className="me-2"
-                    />
-                    <Form.Check
-                        type="checkbox"
-                        id="inlineCompassRose"
-                        label="Róża wiatrów"
-                        checked={settings.inlineCompassRose}
-                        onChange={e => onChangeSetting(s => s.inlineCompassRose = e.target.checked)}
-                        className="me-2"
-                    />
-                    <Form.Check
-                        type="checkbox"
-                        id="shortenExits"
-                        label="Skrócone wyjścia"
-                        checked={settings.shortenExits}
-                        onChange={e => onChangeSetting(s => s.shortenExits = e.target.checked)}
-                        className="me-2"
-                    />
-                    <Form.Check
-                        type="checkbox"
-                        id="fullHpMessage"
-                        label="Informacja o pelnym zdrowiu"
-                        checked={settings.fullHpMessage}
-                        onChange={e => onChangeSetting(s => s.fullHpMessage = e.target.checked)}
-                        className="me-2"
-                    />
-                    <Form.Group className="d-flex align-items-center me-2">
-                        <Form.Label className="me-1 mb-0" htmlFor="letterLineWidth">Szerokosc linii listu:</Form.Label>
-                        <Form.Control
-                            type="number"
-                            min={LETTER_LINE_WIDTH_MIN}
-                            max={LETTER_LINE_WIDTH_MAX}
-                            id="letterLineWidth"
-                            value={settings.letterLineWidth}
-                            onChange={ev => {
-                                const parsed = parseInt(ev.target.value, 10);
-                                const fallback = defaultSettings.letterLineWidth;
-                                const clamped = Math.min(
-                                    LETTER_LINE_WIDTH_MAX,
-                                    Math.max(LETTER_LINE_WIDTH_MIN, Number.isFinite(parsed) ? parsed : fallback)
-                                );
-                                onChangeSetting(s => s.letterLineWidth = clamped);
-                            }}
-                            style={{ width: '100%', maxWidth: '5rem' }}
-                        />
-                    </Form.Group>
-                    <Form.Group className="d-flex align-items-center me-2">
-                        <Form.Label className="me-1 mb-0" htmlFor="lowHpAlert">Alarm niskiego zdrowia:</Form.Label>
-                        <Form.Select
-                            size="sm"
-                            id="lowHpAlert"
-                            value={settings.lowHpAlert}
-                            onChange={e => onChangeSetting(s => s.lowHpAlert = parseInt(e.target.value) || 0)}
-                            className="w-auto"
-                        >
-                            {lowHpAlertOptions.map(option => (
-                                <option value={option.value} key={option.value}>{option.label}</option>
-                            ))}
-                        </Form.Select>
-                    </Form.Group>
-                </div>
-            </div>
-            <div className="mb-4 border rounded p-3">
-                <h5 className="fw-bold mb-2">Pojemniki</h5>
-                <div className="d-flex flex-wrap gap-3 align-items-center">
-                    <Form.Check
-                        type="checkbox"
-                        id="prettyContainers"
-                        label="Formatuj pojemniki"
-                        checked={settings.prettyContainers}
-                        onChange={e => onChangeSetting(s => s.prettyContainers = e.target.checked)}
-                        className="me-2"
-                    />
-                    <Form.Group className="d-flex align-items-center me-2">
-                        <Form.Label className="me-1 mb-0">Kolumny:</Form.Label>
-                        <Form.Control
-                            type="number"
-                            min={1}
-                            max={4}
-                            id="containerColumns"
-                            value={settings.containerColumns}
-                            onChange={ev => onChangeSetting(s => s.containerColumns = parseInt(ev.target.value) || 1)}
-                            style={{width: '100%', maxWidth: '4rem'}}
-                        />
-                    </Form.Group>
-                </div>
-            </div>
-            <div className="mb-4 border rounded p-3">
-                <h5 className="fw-bold mb-2">Zbieranie przedmiotów</h5>
-                <div className="d-flex flex-column gap-2">
-                    <Form.Group className="d-flex align-items-center">
-                        <Form.Label className="me-1 mb-0">Tryb zbierania:</Form.Label>
-                        <Form.Select
-                            size="sm"
-                            value={settings.collectMode}
-                            onChange={e => onChangeSetting(s => s.collectMode = parseInt(e.target.value))}
-                            className="w-auto"
-                        >
-                            {collectModeOptions.map((label, i) => (
-                                <option value={i + 1} key={i + 1}>{`${i + 1} - ${label}`}</option>
-                            ))}
-                        </Form.Select>
-                    </Form.Group>
-                    <Form.Group className="d-flex align-items-center">
-                        <Form.Label className="me-1 mb-0">Rodzaj monet:</Form.Label>
-                        <Form.Select
-                            size="sm"
-                            value={settings.collectMoneyType}
-                            onChange={e => onChangeSetting(s => s.collectMoneyType = parseInt(e.target.value))}
-                            className="w-auto"
-                        >
-                            {collectMoneyOptions.map((label, i) => (
-                                <option value={i + 1} key={i + 1}>{`${i + 1} - ${label}`}</option>
-                            ))}
-                        </Form.Select>
-                    </Form.Group>
-                    <Form.Group>
-                        <Form.Label className="me-1">Dodatkowe przedmioty:</Form.Label>
-                        <Form.Control
-                            id="extraItem"
-                            type="text"
-                            size="sm"
-                            value={extraInput}
-                            onChange={e => setExtraInput(e.target.value)}
-                            onKeyDown={e => {
-                                if (e.key === 'Enter') {
-                                    e.preventDefault();
-                                    if (extraInput.trim()) {
-                                        onChangeSetting(s => s.collectExtra = [...s.collectExtra, extraInput.trim()]);
-                                        setExtraInput('');
-                                    }
-                                }
-                            }}
-                            className="d-inline-block me-1 w-auto"
-                            style={{width: '100%', maxWidth: '10rem'}}
-                        />
-                        <Button
-                            size="sm"
-                            onClick={() => {
-                                if (extraInput.trim()) {
-                                    onChangeSetting(s => s.collectExtra = [...s.collectExtra, extraInput.trim()]);
-                                    setExtraInput('');
-                                }
-                            }}
-                        >
-                            Dodaj
-                        </Button>
-                    </Form.Group>
-                    <ul className="list-unstyled ms-3">
-                        {settings.collectExtra.map(item => (
-                            <li key={item} className="d-flex align-items-center gap-2">
-                                <span>{item}</span>
-                                <Button size="sm" variant="secondary" onClick={() => onChangeSetting(s => s.collectExtra = s.collectExtra.filter(i => i !== item))}>Usuń</Button>
-                            </li>
-                        ))}
-                    </ul>
-                    {settings.collectExtra.length > 0 && (
-                        <Button size="sm" variant="secondary" className="mt-1" onClick={() => onChangeSetting(s => s.collectExtra = [])}>Wyczyść wszystko</Button>
-                    )}
-                </div>
-            </div>
-            <div className="mb-4 border rounded p-3">
-                <h5 className="fw-bold mb-2">Zioła</h5>
-                <div className="d-flex flex-column gap-2">
-                    <Form.Group>
-                        <Form.Label className="me-1 mb-0">Komendy przed użyciem:</Form.Label>
-                        <Form.Control
-                            type="text"
-                            size="sm"
-                            value={settings.herbPreUseCommand}
-                            onChange={e => onChangeSetting(s => s.herbPreUseCommand = e.target.value)}
-                            style={{width: '100%', maxWidth: '20rem'}}
-                        />
-                        <Form.Text className="text-muted">Oddziel komendy średnikiem (;)</Form.Text>
-                    </Form.Group>
-                    <Form.Group>
-                        <Form.Label className="me-1 mb-0">Komendy po użyciu:</Form.Label>
-                        <Form.Control
-                            type="text"
-                            size="sm"
-                            value={settings.herbPostUseCommand}
-                            onChange={e => onChangeSetting(s => s.herbPostUseCommand = e.target.value)}
-                            style={{width: '100%', maxWidth: '20rem'}}
-                        />
-                        <Form.Text className="text-muted">Oddziel komendy średnikiem (;)</Form.Text>
-                    </Form.Group>
-                </div>
-            </div>
-            <div className="mb-4 border rounded p-3">
-                <h5 className="fw-bold mb-2">Język</h5>
-                <div className="d-flex flex-wrap gap-3 align-items-center">
-                    <Form.Group className="d-flex align-items-center">
-                        <Form.Label className="me-1 mb-0">Przymiotnik:</Form.Label>
-                        <Form.Control
-                            type="text"
-                            size="sm"
-                            value={settings.languageAdjective}
-                            onChange={e => onChangeSetting(s => s.languageAdjective = e.target.value)}
-                            style={{width: '100%', maxWidth: '10rem'}}
-                        />
-                    </Form.Group>
-                    <Form.Group className="d-flex align-items-center">
-                        <Form.Label className="me-1 mb-0">Domyślny język:</Form.Label>
-                        <Form.Select
-                            size="sm"
-                            value={settings.language}
-                            onChange={e => onChangeSetting(s => s.language = e.target.value)}
-                            className="w-auto"
-                        >
-                            {languageOptions.map(lang => (
-                                <option key={lang} value={lang}>{lang}</option>
-                            ))}
-                        </Form.Select>
-                    </Form.Group>
-                </div>
-                <table className="table table-sm mt-3 mb-0">
-                    <thead>
-                        <tr>
-                            <th>Alias</th>
-                            <th>Przymiotnik</th>
-                            <th>Język</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {settings.languageAliases.map(item => (
-                            <tr key={item.alias}>
-                                <td>{item.alias}</td>
-                                <td>{item.adjective}</td>
-                                <td>{item.language}</td>
-                                <td>
-                                    <Button size="sm" variant="secondary" onClick={() => onChangeSetting(s => s.languageAliases = s.languageAliases.filter(a => a !== item))}>Usuń</Button>
-                                </td>
-                            </tr>
-                        ))}
-                        <tr>
-                            <td>
+                <div className="character-settings-layout">
+                    <section className="character-settings-section">
+                        <h5 className="character-settings-section-title">Pozostałe opcje</h5>
+                        <div className="d-flex flex-wrap gap-3 align-items-center">
+                            <Form.Check
+                                type="checkbox"
+                                id="packageHelper"
+                                label="Asystent paczek"
+                                checked={settings.packageHelper}
+                                onChange={e => onChangeSetting(s => s.packageHelper = e.target.checked)}
+                                className="me-2"
+                            />
+                            <Form.Check
+                                type="checkbox"
+                                id="inlineCompassRose"
+                                label="Róża wiatrów"
+                                checked={settings.inlineCompassRose}
+                                onChange={e => onChangeSetting(s => s.inlineCompassRose = e.target.checked)}
+                                className="me-2"
+                            />
+                            <Form.Check
+                                type="checkbox"
+                                id="shortenExits"
+                                label="Skrócone wyjścia"
+                                checked={settings.shortenExits}
+                                onChange={e => onChangeSetting(s => s.shortenExits = e.target.checked)}
+                                className="me-2"
+                            />
+                            <Form.Check
+                                type="checkbox"
+                                id="fullHpMessage"
+                                label="Informacja o pelnym zdrowiu"
+                                checked={settings.fullHpMessage}
+                                onChange={e => onChangeSetting(s => s.fullHpMessage = e.target.checked)}
+                                className="me-2"
+                            />
+                            <Form.Group className="d-flex align-items-center me-2">
+                                <Form.Label className="me-1 mb-0" htmlFor="letterLineWidth">Szerokosc linii listu:</Form.Label>
                                 <Form.Control
-                                    type="text"
-                                    size="sm"
-                                    value={aliasInput}
-                                    onChange={e => setAliasInput(e.target.value)}
-                                    style={{width: '100%', maxWidth: '6rem'}}
+                                    type="number"
+                                    min={LETTER_LINE_WIDTH_MIN}
+                                    max={LETTER_LINE_WIDTH_MAX}
+                                    id="letterLineWidth"
+                                    value={settings.letterLineWidth}
+                                    onChange={ev => {
+                                        const parsed = parseInt(ev.target.value, 10);
+                                        const fallback = defaultSettings.letterLineWidth;
+                                        const clamped = Math.min(
+                                            LETTER_LINE_WIDTH_MAX,
+                                            Math.max(LETTER_LINE_WIDTH_MIN, Number.isFinite(parsed) ? parsed : fallback)
+                                        );
+                                        onChangeSetting(s => s.letterLineWidth = clamped);
+                                    }}
+                                    style={{ width: '100%', maxWidth: '5rem' }}
                                 />
-                            </td>
-                            <td>
-                                <Form.Control
-                                    type="text"
-                                    size="sm"
-                                    value={aliasAdjInput}
-                                    onChange={e => setAliasAdjInput(e.target.value)}
-                                    style={{width: '100%', maxWidth: '10rem'}}
-                                />
-                            </td>
-                            <td>
+                            </Form.Group>
+                            <Form.Group className="d-flex align-items-center me-2">
+                                <Form.Label className="me-1 mb-0" htmlFor="lowHpAlert">Alarm niskiego zdrowia:</Form.Label>
                                 <Form.Select
                                     size="sm"
-                                    value={aliasLangInput}
-                                    onChange={e => setAliasLangInput(e.target.value)}
+                                    id="lowHpAlert"
+                                    value={settings.lowHpAlert}
+                                    onChange={e => onChangeSetting(s => s.lowHpAlert = parseInt(e.target.value) || 0)}
+                                    className="w-auto"
+                                >
+                                    {lowHpAlertOptions.map(option => (
+                                        <option value={option.value} key={option.value}>{option.label}</option>
+                                    ))}
+                                </Form.Select>
+                            </Form.Group>
+                        </div>
+                    </section>
+                    <section className="character-settings-section">
+                        <h5 className="character-settings-section-title">Pojemniki</h5>
+                        <div className="d-flex flex-wrap gap-3 align-items-center">
+                            <Form.Check
+                                type="checkbox"
+                                id="prettyContainers"
+                                label="Formatuj pojemniki"
+                                checked={settings.prettyContainers}
+                                onChange={e => onChangeSetting(s => s.prettyContainers = e.target.checked)}
+                                className="me-2"
+                            />
+                            <Form.Group className="d-flex align-items-center me-2">
+                                <Form.Label className="me-1 mb-0">Kolumny:</Form.Label>
+                                <Form.Control
+                                    type="number"
+                                    min={1}
+                                    max={4}
+                                    id="containerColumns"
+                                    value={settings.containerColumns}
+                                    onChange={ev => onChangeSetting(s => s.containerColumns = parseInt(ev.target.value) || 1)}
+                                    style={{ width: '100%', maxWidth: '4rem' }}
+                                />
+                            </Form.Group>
+                        </div>
+                    </section>
+                    <section className="character-settings-section">
+                        <h5 className="character-settings-section-title">Zbieranie przedmiotów</h5>
+                        <div className="character-settings-stack">
+                            <Form.Group className="d-flex align-items-center">
+                                <Form.Label className="me-1 mb-0">Tryb zbierania:</Form.Label>
+                                <Form.Select
+                                    size="sm"
+                                    value={settings.collectMode}
+                                    onChange={e => onChangeSetting(s => s.collectMode = parseInt(e.target.value))}
+                                    className="w-auto"
+                                >
+                                    {collectModeOptions.map((label, i) => (
+                                        <option value={i + 1} key={i + 1}>{`${i + 1} - ${label}`}</option>
+                                    ))}
+                                </Form.Select>
+                            </Form.Group>
+                            <Form.Group className="d-flex align-items-center">
+                                <Form.Label className="me-1 mb-0">Rodzaj monet:</Form.Label>
+                                <Form.Select
+                                    size="sm"
+                                    value={settings.collectMoneyType}
+                                    onChange={e => onChangeSetting(s => s.collectMoneyType = parseInt(e.target.value))}
+                                    className="w-auto"
+                                >
+                                    {collectMoneyOptions.map((label, i) => (
+                                        <option value={i + 1} key={i + 1}>{`${i + 1} - ${label}`}</option>
+                                    ))}
+                                </Form.Select>
+                            </Form.Group>
+                            <Form.Group>
+                                <Form.Label className="me-1">Dodatkowe przedmioty:</Form.Label>
+                                <Form.Control
+                                    id="extraItem"
+                                    type="text"
+                                    size="sm"
+                                    value={extraInput}
+                                    onChange={e => setExtraInput(e.target.value)}
+                                    onKeyDown={e => {
+                                        if (e.key === 'Enter') {
+                                            e.preventDefault();
+                                            if (extraInput.trim()) {
+                                                onChangeSetting(s => s.collectExtra = [...s.collectExtra, extraInput.trim()]);
+                                                setExtraInput('');
+                                            }
+                                        }
+                                    }}
+                                    className="d-inline-block me-1 w-auto"
+                                    style={{ width: '100%', maxWidth: '10rem' }}
+                                />
+                                <Button
+                                    size="sm"
+                                    onClick={() => {
+                                        if (extraInput.trim()) {
+                                            onChangeSetting(s => s.collectExtra = [...s.collectExtra, extraInput.trim()]);
+                                            setExtraInput('');
+                                        }
+                                    }}
+                                >
+                                    Dodaj
+                                </Button>
+                            </Form.Group>
+                            <ul className="list-unstyled ms-3">
+                                {settings.collectExtra.map(item => (
+                                    <li key={item} className="d-flex align-items-center gap-2">
+                                        <span>{item}</span>
+                                        <Button
+                                            size="sm"
+                                            variant="secondary"
+                                            onClick={() => onChangeSetting(s => s.collectExtra = s.collectExtra.filter(i => i !== item))}
+                                        >
+                                            Usuń
+                                        </Button>
+                                    </li>
+                                ))}
+                            </ul>
+                            {settings.collectExtra.length > 0 && (
+                                <Button
+                                    size="sm"
+                                    variant="secondary"
+                                    className="mt-1"
+                                    onClick={() => onChangeSetting(s => s.collectExtra = [])}
+                                >
+                                    Wyczyść wszystko
+                                </Button>
+                            )}
+                        </div>
+                    </section>
+                    <section className="character-settings-section">
+                        <h5 className="character-settings-section-title">Zioła</h5>
+                        <div className="character-settings-stack">
+                            <Form.Group>
+                                <Form.Label className="me-1 mb-0">Komendy przed użyciem:</Form.Label>
+                                <Form.Control
+                                    type="text"
+                                    size="sm"
+                                    value={settings.herbPreUseCommand}
+                                    onChange={e => onChangeSetting(s => s.herbPreUseCommand = e.target.value)}
+                                    style={{ width: '100%', maxWidth: '20rem' }}
+                                />
+                                <Form.Text className="text-muted">Oddziel komendy średnikiem (;)</Form.Text>
+                            </Form.Group>
+                            <Form.Group>
+                                <Form.Label className="me-1 mb-0">Komendy po użyciu:</Form.Label>
+                                <Form.Control
+                                    type="text"
+                                    size="sm"
+                                    value={settings.herbPostUseCommand}
+                                    onChange={e => onChangeSetting(s => s.herbPostUseCommand = e.target.value)}
+                                    style={{ width: '100%', maxWidth: '20rem' }}
+                                />
+                                <Form.Text className="text-muted">Oddziel komendy średnikiem (;)</Form.Text>
+                            </Form.Group>
+                        </div>
+                    </section>
+                    <section className="character-settings-section character-settings-section--full">
+                        <h5 className="character-settings-section-title">Język</h5>
+                        <div className="d-flex flex-wrap gap-3 align-items-center">
+                            <Form.Group className="d-flex align-items-center">
+                                <Form.Label className="me-1 mb-0">Przymiotnik:</Form.Label>
+                                <Form.Control
+                                    type="text"
+                                    size="sm"
+                                    value={settings.languageAdjective}
+                                    onChange={e => onChangeSetting(s => s.languageAdjective = e.target.value)}
+                                    style={{ width: '100%', maxWidth: '10rem' }}
+                                />
+                            </Form.Group>
+                            <Form.Group className="d-flex align-items-center">
+                                <Form.Label className="me-1 mb-0">Domyślny język:</Form.Label>
+                                <Form.Select
+                                    size="sm"
+                                    value={settings.language}
+                                    onChange={e => onChangeSetting(s => s.language = e.target.value)}
                                     className="w-auto"
                                 >
                                     {languageOptions.map(lang => (
                                         <option key={lang} value={lang}>{lang}</option>
                                     ))}
                                 </Form.Select>
-                            </td>
-                            <td>
-                                <Button
-                                    size="sm"
-                                    onClick={() => {
-                                        if (aliasInput.trim()) {
-                                            onChangeSetting(s => s.languageAliases = [...s.languageAliases, { alias: aliasInput.trim(), adjective: aliasAdjInput.trim(), language: aliasLangInput }]);
-                                            setAliasInput('');
-                                            setAliasAdjInput('');
-                                            setAliasLangInput('potoczna');
-                                        }
-                                    }}
-                                >
-                                    Dodaj
-                                </Button>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+                            </Form.Group>
+                        </div>
+                        <table className="table table-sm mt-3 mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Alias</th>
+                                    <th>Przymiotnik</th>
+                                    <th>Język</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {settings.languageAliases.map(item => (
+                                    <tr key={item.alias}>
+                                        <td>{item.alias}</td>
+                                        <td>{item.adjective}</td>
+                                        <td>{item.language}</td>
+                                        <td>
+                                            <Button
+                                                size="sm"
+                                                variant="secondary"
+                                                onClick={() => onChangeSetting(s => s.languageAliases = s.languageAliases.filter(a => a !== item))}
+                                            >
+                                                Usuń
+                                            </Button>
+                                        </td>
+                                    </tr>
+                                ))}
+                                <tr>
+                                    <td>
+                                        <Form.Control
+                                            type="text"
+                                            size="sm"
+                                            value={aliasInput}
+                                            onChange={e => setAliasInput(e.target.value)}
+                                            style={{ width: '100%', maxWidth: '6rem' }}
+                                        />
+                                    </td>
+                                    <td>
+                                        <Form.Control
+                                            type="text"
+                                            size="sm"
+                                            value={aliasAdjInput}
+                                            onChange={e => setAliasAdjInput(e.target.value)}
+                                            style={{ width: '100%', maxWidth: '10rem' }}
+                                        />
+                                    </td>
+                                    <td>
+                                        <Form.Select
+                                            size="sm"
+                                            value={aliasLangInput}
+                                            onChange={e => setAliasLangInput(e.target.value)}
+                                            className="w-auto"
+                                        >
+                                            {languageOptions.map(lang => (
+                                                <option key={lang} value={lang}>{lang}</option>
+                                            ))}
+                                        </Form.Select>
+                                    </td>
+                                    <td>
+                                        <Button
+                                            size="sm"
+                                            onClick={() => {
+                                                if (aliasInput.trim()) {
+                                                    onChangeSetting(s => s.languageAliases = [
+                                                        ...s.languageAliases,
+                                                        {
+                                                            alias: aliasInput.trim(),
+                                                            adjective: aliasAdjInput.trim(),
+                                                            language: aliasLangInput,
+                                                        },
+                                                    ]);
+                                                    setAliasInput('');
+                                                    setAliasAdjInput('');
+                                                    setAliasLangInput('potoczna');
+                                                }
+                                            }}
+                                        >
+                                            Dodaj
+                                        </Button>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </section>
+                </div>
             </fieldset>
         </div>
     );

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -1260,14 +1260,17 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   margin-bottom: 5vh;
 }
 
-.ui-settings-layout {
+
+.ui-settings-layout,
+.character-settings-layout {
   display: grid;
   gap: 1rem;
   grid-template-columns: minmax(0, 1fr);
 }
 
 @media (min-width: 992px) {
-  .ui-settings-layout {
+  .ui-settings-layout,
+  .character-settings-layout {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -1277,7 +1280,8 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   }
 }
 
-.ui-settings-section {
+.ui-settings-section,
+.character-settings-section {
   background-color: var(--surface-raised);
   border: 1px solid var(--surface-border);
   border-radius: 0.5rem;
@@ -1288,19 +1292,26 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.25);
 }
 
-.ui-settings-section-title {
+.ui-settings-section-title,
+.character-settings-section-title {
   font-size: 1rem;
   font-weight: 600;
   margin: 0;
 }
 
-.ui-settings-stack {
+.ui-settings-stack,
+.character-settings-stack {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
 }
 
-.ui-settings-section .form-check {
+.character-settings-section--full {
+  grid-column: 1 / -1;
+}
+
+.ui-settings-section .form-check,
+.character-settings-section .form-check {
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary
- restyle character-specific options to use the same card grid layout as the UI settings
- update guild and fight tabs to match the new container styling
- extend the shared stylesheet with reusable character settings helpers

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68efc06fd368832aa63001fc9424a04f