### PR TITLE
Enhance objects list PiP with status header and footer

### DIFF
--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -507,14 +507,23 @@ export default class ObjectList {
         const styleEl = this.pipDocument.createElement("style");
         styleEl.setAttribute("data-objects-list-pip", "true");
         styleEl.textContent = `:root { color-scheme: dark; }
-body {
+html, body {
     margin: 0;
+    height: 100%;
 }
 #objects-list-pip {
     white-space: pre;
     box-sizing: border-box;
     max-width: 100vw;
     overflow-x: hidden;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+#objects-list-pip .objects-list-pip-body {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    white-space: inherit;
 }
 #objects-list-pip .objects-list-pip-header {
     display: block;
@@ -525,6 +534,9 @@ body {
     display: block;
     margin-top: 0.35rem;
     color: #d0d0d0;
+}
+#objects-list-pip .objects-list-pip-footer-content {
+    display: block;
 }
 #objects-list-pip .object-num,
 #objects-list-pip .object-desc {
@@ -603,17 +615,17 @@ body {
             }
             return;
         }
-        let lastHtml = "";
-        for (let i = wrapper.children.length - 1; i >= 0; i--) {
+        const outputs: string[] = [];
+        for (let i = wrapper.children.length - 1; i >= 0 && outputs.length < 2; i--) {
             const child = wrapper.children[i] as HTMLElement;
             if (child && child.classList && child.classList.contains("output_msg")) {
                 const textEl = child.querySelector<HTMLElement>(".output_msg_text");
                 if (textEl) {
-                    lastHtml = textEl.innerHTML;
+                    outputs.unshift(textEl.innerHTML);
                 }
-                break;
             }
         }
+        const lastHtml = outputs.join("<br>");
         if (lastHtml === this.pipLastOutputHtml) {
             return;
         }
@@ -631,18 +643,21 @@ body {
 
     private buildPictureInPictureHtml() {
         const lines = [...this.objectLines];
-        const header = this.buildPipHeaderLine();
-        const footer = this.buildPipFooterLine();
+        const header = this.buildPipHeaderHtml();
+        const footer = this.buildPipFooterHtml();
+        const body = `<div class="objects-list-pip-body">${lines.join("<br>")}</div>`;
+        const parts = [] as string[];
         if (header) {
-            lines.unshift(header);
+            parts.push(header);
         }
+        parts.push(body);
         if (footer) {
-            lines.push(footer);
+            parts.push(footer);
         }
-        return lines.join("<br>");
+        return parts.join("");
     }
 
-    private buildPipHeaderLine() {
+    private buildPipHeaderHtml() {
         const parts = [] as string[];
         if (this.pipLocationText) {
             parts.push(this.escapeHtml(this.pipLocationText));
@@ -654,14 +669,14 @@ body {
             return "";
         }
         const content = parts.join("&nbsp;&bull;&nbsp;");
-        return `<span class="objects-list-pip-header">${content}</span>`;
+        return `<div class="objects-list-pip-header">${content}</div>`;
     }
 
-    private buildPipFooterLine() {
+    private buildPipFooterHtml() {
         if (!this.pipLastOutputHtml) {
             return "";
         }
-        return `<span class="objects-list-pip-footer">${this.pipLastOutputHtml}</span>`;
+        return `<div class="objects-list-pip-footer"><div class="objects-list-pip-footer-content">${this.pipLastOutputHtml}</div></div>`;
     }
 
     private escapeHtml(text: string) {

--- a/web-client/test/ObjectList.test.ts
+++ b/web-client/test/ObjectList.test.ts
@@ -373,26 +373,29 @@ describe('ObjectList', () => {
 
     const pipRoot = pipDoc.body.querySelector('#objects-list-pip') as HTMLElement;
     expect(pipRoot).toBeTruthy();
-    let lines = pipRoot.innerHTML.split('<br>');
-    expect(lines[0]).toContain('objects-list-pip-header');
-    expect(lines[0]).toContain('#101 Northern Gate');
-    expect(lines[0]).toContain('Zas: 1.50');
-    const footerLine = lines[lines.length - 1];
-    expect(footerLine).toContain('objects-list-pip-footer');
-    expect(footerLine).toContain('Enemies incoming');
-    expect(footerLine).toContain('span class="ansi"');
+    const getHeaderHtml = () =>
+      (pipRoot.querySelector('.objects-list-pip-header') as HTMLElement | null)?.innerHTML || '';
+    const getFooterHtml = () =>
+      (pipRoot.querySelector('.objects-list-pip-footer-content') as HTMLElement | null)?.innerHTML || '';
+    const getBodyHtml = () =>
+      (pipRoot.querySelector('.objects-list-pip-body') as HTMLElement | null)?.innerHTML || '';
+
+    expect(getHeaderHtml()).toContain('#101 Northern Gate');
+    expect(getHeaderHtml()).toContain('Zas: 1.50');
+    expect(getBodyHtml()).toContain('Goblin');
+    const initialFooterHtml = getFooterHtml();
+    expect(initialFooterHtml).toContain('Enemies incoming');
+    expect(initialFooterHtml).toContain('span class="ansi"');
 
     const locationEl = document.getElementById('location-text')!;
     locationEl.textContent = '#202 Southern Gate';
     await Promise.resolve();
-    lines = pipRoot.innerHTML.split('<br>');
-    expect(lines[0]).toContain('#202 Southern Gate');
+    expect(getHeaderHtml()).toContain('#202 Southern Gate');
 
     const coverEl = document.getElementById('cover-timer')!;
     coverEl.textContent = 'Zas: OK';
     await Promise.resolve();
-    lines = pipRoot.innerHTML.split('<br>');
-    expect(lines[0]).toContain('Zas: OK');
+    expect(getHeaderHtml()).toContain('Zas: OK');
 
     const wrapper = document.getElementById('main_text_output_msg_wrapper')!;
     const msg = document.createElement('div');
@@ -403,8 +406,10 @@ describe('ObjectList', () => {
     msg.appendChild(msgText);
     wrapper.insertBefore(msg, document.getElementById('split-bottom'));
     (objectList as any).handleOutputUpdate();
-    lines = pipRoot.innerHTML.split('<br>');
-    expect(lines[lines.length - 1]).toContain('All clear');
+    const footerHtml = getFooterHtml();
+    expect(footerHtml).toContain('Enemies incoming');
+    expect(footerHtml).toContain('All clear');
+    expect(footerHtml.split('<br>').length).toBe(2);
 
     delete (window as any).documentPictureInPicture;
   });


### PR DESCRIPTION
## Summary
- add location and cover timer header plus main output footer to the picture-in-picture objects list
- keep PiP status lines in sync via DOM observers and output events
- cover the new behaviour with dedicated ObjectList unit tests

## Testing
- yarn --cwd web-client test ObjectList
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68efc7ca970c832a8863739728bab2de