### PR TITLE
Allow preserving casing for letter commands

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -345,7 +345,7 @@ export default class Client {
         this.sendCommand('przestan kryc sie za zaslona')
     }
 
-    sendCommand(command: string, echo: boolean = true) {
+    sendCommand(command: string, echo: boolean = true, options?: { preserveCase?: boolean }) {
         if (command) {
             command = stripPolishCharacters(command)
 
@@ -361,7 +361,7 @@ export default class Client {
                     "szepnij",
                     "jszepnij",
                 ]
-                const shouldLowercase = !skipLowercasePrefixes.some(prefix => trimmedCommand.startsWith(prefix))
+                const shouldLowercase = !options?.preserveCase && !skipLowercasePrefixes.some(prefix => trimmedCommand.startsWith(prefix))
                 if (shouldLowercase) {
                     const leadingWhitespaceLength = command.length - trimmedCommand.length
                     const leadingWhitespace = command.slice(0, leadingWhitespaceLength)
@@ -382,7 +382,7 @@ export default class Client {
         if (split.length > 1) {
             split.forEach(part => {
                 if (part !== preparse) {
-                    this.sendCommand(part, echo)
+                    this.sendCommand(part, echo, options)
                 } else {
                     this.sendMovement(part, echo)
                 }

--- a/client/src/scripts/letter.ts
+++ b/client/src/scripts/letter.ts
@@ -396,7 +396,7 @@ export default function initLetter(client: Client, aliases?: { pattern: RegExp; 
             () => {
                 lines.forEach(line => {
                     if (line.length > 0) {
-                        client.sendCommand(line);
+                        client.sendCommand(line, true, { preserveCase: true });
                     }
                 });
                 client.sendCommand("**");
@@ -406,9 +406,9 @@ export default function initLetter(client: Client, aliases?: { pattern: RegExp; 
         );
 
         client.sendCommand("napisz list");
-        client.sendCommand(recipient);
-        client.sendCommand(subjectLine);
-        client.sendCommand(carbonCopy);
+        client.sendCommand(recipient, true, { preserveCase: true });
+        client.sendCommand(subjectLine, true, { preserveCase: true });
+        client.sendCommand(carbonCopy, true, { preserveCase: true });
     });
 
     client.addEventListener("letterComposer.preview", (event: CustomEvent<LetterSubmitPayload>) => {

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -199,6 +199,15 @@ test('sendCommand keeps casing for speech commands', () => {
   });
 });
 
+test('sendCommand preserves casing when requested', () => {
+  const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  parseCommand.mockClear();
+  client.sendCommand('UPPER CASE', true, { preserveCase: true });
+  expect(parseCommand).toHaveBeenCalledTimes(1);
+  expect(parseCommand).toHaveBeenCalledWith('UPPER CASE');
+  expect((global as any).clientAdapterMock.send).toHaveBeenCalledWith('parsed:UPPER CASE', true);
+});
+
 test('sendCommand allows empty command', () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   client.sendCommand('');

--- a/web-client/src/Recorder.ts
+++ b/web-client/src/Recorder.ts
@@ -2,7 +2,7 @@ import { saveRecording, getRecording, getRecordingNames, deleteRecording, Record
 
 export interface RecorderHooks {
     processIncomingData(data: string): void;
-    sendCommand(command: string, echo?: boolean): void;
+    sendCommand(command: string, echo?: boolean, options?: { preserveCase?: boolean }): void;
     emit(event: string, ...args: any[]): void;
 }
 


### PR DESCRIPTION
## Summary
- allow `Client.sendCommand` to accept an option that skips forced lowercasing and propagates through split commands
- update the letter workflow to preserve casing for recipients, subjects, and body lines when sending messages
- add unit coverage for the new option and align the recorder hook typing with the extended signature

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68f01d06cb54832a97cb9b229080e929