### PR TITLE
Handle Android bracket key for functional bind

### DIFF
--- a/client/src/scripts/functionalBind.ts
+++ b/client/src/scripts/functionalBind.ts
@@ -32,6 +32,23 @@ export function formatLabel(options: FunctionalBindOptions) {
     return parts.join('+');
 }
 
+function matchesKey(event: KeyboardEvent, expectedKey: string) {
+    if (event.code === expectedKey || event.key === expectedKey) {
+        return true;
+    }
+
+    switch (expectedKey) {
+        case 'BracketRight':
+            return event.key === ']';
+        case 'BracketLeft':
+            return event.key === '[';
+        case 'Backquote':
+            return event.key === '`';
+        default:
+            return false;
+    }
+}
+
 export class FunctionalBind {
 
     private client: Client;
@@ -55,7 +72,7 @@ export class FunctionalBind {
         this.shift = !!options.shift;
         window.addEventListener('keydown', (ev) => {
             if (
-                (ev.code === this.key || ev.key === this.key) &&
+                matchesKey(ev, this.key) &&
                 (!!this.ctrl === ev.ctrlKey) &&
                 (!!this.alt === ev.altKey) &&
                 (!!this.shift === ev.shiftKey)


### PR DESCRIPTION
## Summary
- add a helper to normalize keyboard events to the configured functional bind key
- ensure the default BracketRight bind still fires when Android keyboards report only the literal character

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68f022c96d50832a815568f136503196