### PR TITLE
Revamp options table styling

### DIFF
--- a/web-client/src/options/Binds.tsx
+++ b/web-client/src/options/Binds.tsx
@@ -576,7 +576,7 @@ function Binds() {
                 <Alert variant="danger" className="mb-0">{importError}</Alert>
             )}
             <fieldset className="p-0 border-0 m-0">
-                <Table bordered size="sm" className="table-zebra mb-2">
+                <Table bordered size="sm" hover className="table-modern table-zebra mb-2">
                     <tbody className="align-middle">
                         <tr>
                             <td className="w-32">Domyślny</td>

--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -117,7 +117,7 @@ function Npc() {
                     style={{width: '100%', maxWidth: '160px'}}
                 />
             </div>
-            <Table bordered size="sm" className="table-zebra">
+            <Table bordered size="sm" hover className="table-modern table-zebra">
                 <tbody className="align-middle">
                 {npcs
                     .filter(item => item.name.toLowerCase().includes(filter.toLowerCase()))

--- a/web-client/src/options/Recordings.tsx
+++ b/web-client/src/options/Recordings.tsx
@@ -181,7 +181,7 @@ function Recordings() {
                     <Button size="sm" onClick={start}>Rozpocznij</Button>
                 )}
             </Form.Group>
-            <Table bordered size="sm" className="table-zebra">
+            <Table bordered size="sm" hover className="table-modern table-zebra">
                 <tbody>
                 {names.map(n => (
                     <tr key={n}>

--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -355,7 +355,7 @@ function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void
                                 </Form.Select>
                             </Form.Group>
                         </div>
-                        <table className="table table-sm mt-3 mb-0">
+                        <table className="table table-modern table-sm table-hover table-zebra mt-3 mb-0">
                             <thead>
                                 <tr>
                                     <th>Alias</th>

--- a/web-client/src/options/Shortcuts.tsx
+++ b/web-client/src/options/Shortcuts.tsx
@@ -81,7 +81,7 @@ function Shortcuts() {
                     </div>
                 </div>
             )}
-            <Table bordered size="sm" className="table-zebra">
+            <Table bordered size="sm" hover className="table-modern table-zebra">
                 <tbody className="align-middle">
                 {list.map(item => (
                     <tr key={item.key}>

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -194,6 +194,69 @@ input::placeholder {
   border-color: #3b82f6;
 }
 
+.table-modern {
+  --table-border-color: var(--surface-border);
+  --table-header-bg: rgba(255, 255, 255, 0.06);
+  --table-header-border: var(--surface-border-strong);
+  --table-row-border: rgba(148, 163, 184, 0.15);
+  --table-hover-bg: rgba(88, 154, 255, 0.16);
+  --bs-table-color: var(--text-primary);
+  --bs-table-bg: transparent;
+  --bs-table-striped-color: var(--text-primary);
+  --bs-table-hover-color: var(--text-primary);
+  --bs-table-border-color: var(--surface-border);
+  background-color: var(--surface-raised);
+  border: 1px solid var(--table-border-color);
+  overflow: hidden;
+  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.25);
+}
+
+.table-modern thead {
+  background: var(--table-header-bg);
+}
+
+.table-modern thead th {
+  border-bottom: 1px solid var(--table-header-border);
+  color: var(--text-secondary);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.table-modern > :not(caption) > * > * {
+  background-color: transparent;
+  border-bottom: 1px solid var(--table-row-border);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.table-modern > :not(caption) > *:last-child > * {
+  border-bottom: 0;
+}
+
+.table-modern.table-bordered > :not(caption) > * > * {
+  border-width: 0;
+}
+
+.table-modern.table-zebra tbody tr:nth-of-type(odd) {
+  background-color: rgba(255, 255, 255, 0.03);
+}
+
+.table-modern.table-zebra tbody tr:nth-of-type(even) {
+  background-color: transparent;
+}
+
+.table-modern.table-hover tbody tr:hover {
+  background-color: var(--table-hover-bg);
+}
+
+.table-modern.table-hover tbody tr:hover > * {
+  color: var(--text-primary);
+}
+
+.table-modern caption {
+  color: var(--text-secondary);
+}
+
 .dropdown-menu {
   background-color: var(--surface-elevated);
   border: 1px solid var(--surface-border);


### PR DESCRIPTION
## Summary
- add a reusable `table-modern` style with themed colors, zebra rows, and hover feedback
- adopt the refreshed table styling in binds, NPC, shortcut, recording, and language alias views
- remove rounded corners from the modern table style to better align with surrounding components

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68f033ce78a8832aa2b64c08af8b0411