### PR TITLE
Preserve command casing before processing

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -346,52 +346,58 @@ export default class Client {
     }
 
     sendCommand(command: string, echo: boolean = true, options?: { preserveCase?: boolean }) {
-        if (command) {
-            command = stripPolishCharacters(command)
+        const skipLowercasePrefixes = [
+            "'",
+            "powiedz",
+            "j'",
+            "jpowiedz",
+            "krzyknij",
+            "jkrzyknij",
+            "szepnij",
+            "jszepnij",
+        ]
 
-            const trimmedCommand = command.trimStart()
-            if (trimmedCommand) {
-                const skipLowercasePrefixes = [
-                    "'",
-                    "powiedz",
-                    "j'",
-                    "jpowiedz",
-                    "krzyknij",
-                    "jkrzyknij",
-                    "szepnij",
-                    "jszepnij",
-                ]
-                const shouldLowercase = !options?.preserveCase && !skipLowercasePrefixes.some(prefix => trimmedCommand.startsWith(prefix))
-                if (shouldLowercase) {
-                    const leadingWhitespaceLength = command.length - trimmedCommand.length
-                    const leadingWhitespace = command.slice(0, leadingWhitespaceLength)
-                    command = leadingWhitespace + trimmedCommand.toLowerCase()
-                }
+        command = command ? stripPolishCharacters(command) : ''
+
+        const trimmedCommand = command.trimStart()
+        const lowerTrimmedCommand = trimmedCommand.toLowerCase()
+        const shouldLowercase = Boolean(trimmedCommand) && !options?.preserveCase && !skipLowercasePrefixes.some(prefix => lowerTrimmedCommand.startsWith(prefix))
+
+        const applyLowercase = (value: string) => {
+            if (!shouldLowercase) {
+                return value
             }
+            const valueTrimmed = value.trimStart()
+            const leadingWhitespaceLength = value.length - valueTrimmed.length
+            const leadingWhitespace = value.slice(0, leadingWhitespaceLength)
+            return leadingWhitespace + valueTrimmed.toLowerCase()
         }
+
         this.eventTarget.dispatchEvent(new CustomEvent('command', {detail: command}))
 
-        let preparse = command
-        command = this.Map.parseCommand(command)
-        command = this.expandObjectShortcuts(command)
-        if (command.startsWith('echo ')) {
-            this.print(mudletColorLine(command.substring(5)))
+        const preparse = command
+        let processedCommand = this.Map.parseCommand(command)
+        processedCommand = this.expandObjectShortcuts(processedCommand)
+
+        const trimmedProcessedCommand = processedCommand.trimStart()
+        if (trimmedProcessedCommand.toLowerCase().startsWith('echo ')) {
+            this.print(mudletColorLine(trimmedProcessedCommand.substring(5)))
             return
         }
-        const split = command.split(/[#;]/)
+        const split = processedCommand.split(/[#;]/)
         if (split.length > 1) {
             split.forEach(part => {
                 if (part !== preparse) {
                     this.sendCommand(part, echo, options)
                 } else {
-                    this.sendMovement(part, echo)
+                    this.sendMovement(applyLowercase(part), echo)
                 }
             })
             return
         }
 
         const isAlias = this.aliases.find(alias => {
-            const matches = command.match(alias.pattern)
+            const matches = processedCommand.match(alias.pattern)
             if (matches) {
                 alias.callback(matches)
                 return true
@@ -399,11 +405,11 @@ export default class Client {
             return false
         })
         if (!isAlias) {
-            if (command.trim().startsWith('/')) {
-                this.print(mudletColorLine(`--- <tomato>Nieznany alias<reset>: ${command}`))
+            if (processedCommand.trim().startsWith('/')) {
+                this.print(mudletColorLine(`--- <tomato>Nieznany alias<reset>: ${processedCommand}`))
                 return
             }
-            this.sendMovement(command, echo)
+            this.sendMovement(applyLowercase(processedCommand), echo)
         }
     }
 

--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -138,7 +138,9 @@ export default class MapHelper {
     }
 
     parseCommand(command: string): string | null {
-        if (command.trim() === "idz") {
+        const trimmed = command.trim()
+        const lowerTrimmed = trimmed.toLowerCase()
+        if (lowerTrimmed === "idz") {
             this.refreshPosition = true;
             if (this.currentRoom) {
                 const allExits = Object.assign(
@@ -160,8 +162,9 @@ export default class MapHelper {
         if (this.currentRoom) {
             if (this.currentRoom.userData.dir_bind) {
                 const dirBinds = Object.fromEntries(this.currentRoom.userData.dir_bind.split("&").map((item: string) => item.split("=")))
-                if (dirBinds[getLongDir(command)]) {
-                    return dirBinds[getLongDir(command)]
+                const longDir = getLongDir(trimmed)
+                if (dirBinds[longDir]) {
+                    return dirBinds[longDir]
                 }
             }
         }

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -174,7 +174,7 @@ test('sendCommand lowercases non speech commands', () => {
   parseCommand.mockClear();
   client.sendCommand('LOOK AROUND');
   expect(parseCommand).toHaveBeenCalledTimes(1);
-  expect(parseCommand).toHaveBeenCalledWith('look around');
+  expect(parseCommand).toHaveBeenCalledWith('LOOK AROUND');
   expect((global as any).clientAdapterMock.send).toHaveBeenCalledWith('parsed:look around', true);
 });
 


### PR DESCRIPTION
## Summary
- keep client command processing working with the original casing while lowercasing only what is sent to the server
- make map command parsing robust to mixed command casing
- update the client tests to reflect the new command casing behavior

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68f044c3e3ec832a942303d55c67e6d4