### PR TITLE
Centralize command normalization and fix warning actions

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -20,11 +20,12 @@ import { setCurrentCharacter, getItemSync, setItemSync } from "./storage";
 import {color, Colors} from "./Colors";
 import {SKIP_LINE} from "./ControlConstants";
 import {stripPolishCharacters} from "./stripPolishCharacters";
+import {normalizeCommand, CommandOptions} from "./normalizeCommand";
 import eventBus from "./eventBus";
 import { openMapContextMenu } from "./contextMenus";
 
 export interface ClientAdapter {
-    send(text: string, echo?: boolean, options?: { preserveCase?: boolean }): void;
+    send(text: string, echo?: boolean, options?: CommandOptions): void;
 
     output(text?: string, type?: string): void
 
@@ -325,7 +326,7 @@ export default class Client {
         this.eventTarget.removeEventListener(event, listener)
     }
 
-    send(command: string, echo: boolean = true, options?: { preserveCase?: boolean }) {
+    send(command: string, echo: boolean = true, options?: CommandOptions) {
         this.clientAdapter.send(command, echo, options)
     }
 
@@ -345,9 +346,10 @@ export default class Client {
         this.sendCommand('przestan kryc sie za zaslona')
     }
 
-    sendCommand(command: string, echo: boolean = true, options?: { preserveCase?: boolean }) {
+    sendCommand(command: string, echo: boolean = true, options?: CommandOptions) {
         if (command) {
             command = stripPolishCharacters(command)
+            command = normalizeCommand(command, options)
         }
         this.eventTarget.dispatchEvent(new CustomEvent('command', {detail: command}))
 

--- a/client/src/normalizeCommand.ts
+++ b/client/src/normalizeCommand.ts
@@ -1,0 +1,34 @@
+const skipLowercasePrefixes = [
+    "'",
+    'powiedz',
+    "j'",
+    'jpowiedz',
+    'jppowiedz',
+    'krzyknij',
+    'jkrzyknij',
+    'jpkrzyknij',
+    'szepnij',
+    'jszepnij',
+    'jpszepnij',
+];
+
+export interface CommandOptions {
+    preserveCase?: boolean;
+}
+
+export function normalizeCommand(command: string, options?: CommandOptions): string {
+    const trimmedCommand = command.trimStart();
+    if (!trimmedCommand || options?.preserveCase) {
+        return command;
+    }
+
+    const shouldLowercase = !skipLowercasePrefixes.some(prefix => trimmedCommand.startsWith(prefix));
+    if (!shouldLowercase) {
+        return command;
+    }
+
+    const leadingWhitespaceLength = command.length - trimmedCommand.length;
+    const leadingWhitespace = command.slice(0, leadingWhitespaceLength);
+    return leadingWhitespace + trimmedCommand.toLowerCase();
+}
+

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -2,6 +2,7 @@ import {parseAnsiPatterns} from './ansiParser';
 import {RecordedEvent} from './recordingStorage';
 import Recorder from './Recorder';
 import {ClientAdapter} from "@client/src/Client.ts";
+import {normalizeCommand, CommandOptions} from "@client/src/normalizeCommand.ts";
 import eventBus, {ClientEvents} from "@client/src/eventBus.ts";
 import TelnetOptionNegotiation from "./TelnetOptionNegotiation.ts";
 import {md5} from 'js-md5';
@@ -195,7 +196,7 @@ class ArkadiaClient implements ClientAdapter {
     /**
      * Send a message through the WebSocket
      */
-    send(message: string, echo: boolean = true, options?: { preserveCase?: boolean }): void {
+    send(message: string, echo: boolean = true, options?: CommandOptions): void {
         if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
             console.error('WebSocket is not connected');
             return;
@@ -207,28 +208,7 @@ class ArkadiaClient implements ClientAdapter {
             }
             this.passwordCommand = message;
         } else {
-
-            const trimmedCommand = message.trimStart()
-            if (trimmedCommand) {
-                const skipLowercasePrefixes = [
-                    "'",
-                    "powiedz",
-                    "j'",
-                    "jpowiedz",
-                    "jppowiedz",
-                    "krzyknij",
-                    "jkrzyknij",
-                    "jpkrzyknij",
-                    "szepnij",
-                    "jpszepnij",
-                ]
-                const shouldLowercase = !options?.preserveCase && !skipLowercasePrefixes.some(prefix => trimmedCommand.startsWith(prefix))
-                if (shouldLowercase) {
-                    const leadingWhitespaceLength = message.length - trimmedCommand.length
-                    const leadingWhitespace = message.slice(0, leadingWhitespaceLength)
-                    message = leadingWhitespace + trimmedCommand.toLowerCase()
-                }
-            }
+            message = normalizeCommand(message, options)
         }
 
 
@@ -243,6 +223,10 @@ class ArkadiaClient implements ClientAdapter {
             console.error('Error sending message:', error);
             this.emit('error', error);
         }
+    }
+
+    sendCommand(message: string, echo: boolean = true, options?: CommandOptions): void {
+        this.send(message, echo, options);
     }
 
     sendGmcp(path: string, payload: any = {}): void {

--- a/web-client/src/BreakItemWarning.ts
+++ b/web-client/src/BreakItemWarning.ts
@@ -15,7 +15,7 @@ export default class BreakItemWarning {
     if (this.container) {
       this.container.addEventListener("click", () => {
         if (this.command) {
-          this.client.send(this.command);
+          this.client.sendCommand(this.command);
         }
         this.update(null);
       });

--- a/web-client/src/Recorder.ts
+++ b/web-client/src/Recorder.ts
@@ -1,8 +1,9 @@
 import { saveRecording, getRecording, getRecordingNames, deleteRecording, RecordedEvent } from './recordingStorage';
+import {CommandOptions} from "@client/src/normalizeCommand.ts";
 
 export interface RecorderHooks {
     processIncomingData(data: string): void;
-    sendCommand(command: string, echo?: boolean, options?: { preserveCase?: boolean }): void;
+    sendCommand(command: string, echo?: boolean, options?: CommandOptions): void;
     emit(event: string, ...args: any[]): void;
 }
 


### PR DESCRIPTION
## Summary
- extract a shared command normalizer so both Client and ArkadiaClient reuse the same casing rules
- expose sendCommand on ArkadiaClient and have BreakItemWarning invoke it instead of send
- align Recorder hook typing with the shared command options

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68f0a5d8f78c832aa25661c905d42df6