### PR TITLE
Prevent mobile keyboard from shrinking viewport layout

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -51,6 +51,7 @@ body {
   margin: 0;
   min-width: 100vw;
   min-height: 100vh;
+  height: 100vh;
   overflow: hidden;
   -webkit-tap-highlight-color: transparent;
 }
@@ -58,6 +59,7 @@ body {
 @supports (height: 100lvh) {
   body {
     min-height: 100lvh;
+    height: 100lvh;
   }
 }
 
@@ -354,12 +356,14 @@ h1 {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  height: 100vh;
   width: 100vw;
 }
 
 @supports (height: 100lvh) {
   #main-container {
     min-height: 100lvh;
+    height: 100lvh;
   }
 }
 
@@ -1293,11 +1297,13 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   @supports (-webkit-touch-callout: none) {
     #main-container {
       min-height: 100vh;
+      height: 100vh;
     }
 
     @supports (height: 100lvh) {
       #main-container {
         min-height: 100lvh;
+        height: 100lvh;
       }
     }
   }


### PR DESCRIPTION
## Summary
- ensure the page body and main container reserve the full viewport height instead of using dynamic viewport units that shrink with the on-screen keyboard
- provide large viewport fallbacks, including iOS-specific handling, so fixed buttons are not displaced when the keyboard opens

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68f0df8f6974832a95229ace0c0af9d1