### PR TITLE
Adjust radial command font size

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -1377,7 +1377,9 @@ body[data-map-position="right"] #content-area #main_text_output_msg_wrapper {
   align-items: center;
   justify-content: center;
   text-align: center;
-  font-size: 0.85rem;
+  padding: 2px;
+  box-sizing: border-box;
+  font-size: 0.8rem;
   font-weight: 600;
   color: #f1f5f9;
   box-shadow: 0 6px 18px rgba(15, 23, 42, 0.55);


### PR DESCRIPTION
## Summary
- set mobile radial command button font size to 0.8rem to keep labels away from the edge while preserving padding adjustments

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68f0e36899b0832ab85b5e13c89cd06e