### PR TITLE
Stop logging multibind creation

### DIFF
--- a/client/src/scripts/multibinds.ts
+++ b/client/src/scripts/multibinds.ts
@@ -100,7 +100,6 @@ export default function initMultibinds(client: Client, aliases?: { pattern: RegE
         const normalized = action.trim();
         set(roomId, index, normalized);
         persist();
-        log(`Utworzono bind ${roomId}-${index}: ${normalized}`);
         sendUpdate(getRoomId());
     }
 


### PR DESCRIPTION
## Summary
- remove the success log from multibind creation so the UI update no longer produces extra output that triggers the scroll pane

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68f10649c5a0832a8449fb25d8b2a0e7