### PR TITLE
Fix deposit storage per character

### DIFF
--- a/client/src/scripts/deposits.ts
+++ b/client/src/scripts/deposits.ts
@@ -22,8 +22,11 @@ function isBankRoom(room: any): boolean {
 
 export default function initDeposits(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
     client.addEventListener("storage", (event: CustomEvent) => {
-        if (event.detail.key === STORAGE_KEY && event.detail.value) {
-            Object.assign(deposits, event.detail.value);
+        if (event.detail.key === STORAGE_KEY) {
+            Object.keys(deposits).forEach(key => delete deposits[Number(key)]);
+            if (event.detail.value) {
+                Object.assign(deposits, event.detail.value);
+            }
         }
     });
 

--- a/client/test/deposit.test.ts
+++ b/client/test/deposit.test.ts
@@ -125,4 +125,24 @@ describe('deposits', () => {
     parse('Twoj depozyt zawiera miecz.');
     expect(prettyPrintContainer).toHaveBeenCalledWith(expect.anything(), 3, 'DEPOZYT', 5, client.contentWidth);
   });
+
+  test('replaces stored deposits when storage updates', () => {
+    parse('Twoj depozyt zawiera miecz.');
+    expect(deposits[1]?.items).toEqual([
+      { count: 1, name: 'miecz' }
+    ]);
+
+    client.dispatch('storage', {
+      key: 'deposits',
+      value: {
+        2: { name: 'Inny bank', items: [{ count: 3, name: 'klejnoty' }] }
+      }
+    });
+
+    expect(deposits[1]).toBeUndefined();
+    expect(deposits[2]).toEqual({
+      name: 'Inny bank',
+      items: [{ count: 3, name: 'klejnoty' }]
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- reset cached deposit entries before loading values from storage events so characters do not share deposits
- add a regression test that confirms storage updates replace existing deposits

## Testing
- yarn --cwd client test *(fails: existing expectations in Client.test.ts about command normalization)*

------
https://chatgpt.com/codex/tasks/task_e_68f13b1188c8832a81d5536c03f17979