### PR TITLE
Add /depozyt_reset alias for clearing stored deposits

### DIFF
--- a/client/src/scripts/deposits.ts
+++ b/client/src/scripts/deposits.ts
@@ -36,6 +36,12 @@ export default function initDeposits(client: Client, aliases?: { pattern: RegExp
         client.port?.postMessage({ type: "SET_STORAGE", key: STORAGE_KEY, value: deposits });
     };
 
+    const clearDeposits = () => {
+        Object.keys(deposits).forEach(key => delete deposits[Number(key)]);
+        persist();
+        client.println("Zapisane depozyty zostaly usuniete.");
+    };
+
     let columns = 1;
     let width = client.contentWidth;
     client.addEventListener('settings', (ev: CustomEvent) => {
@@ -113,6 +119,7 @@ export default function initDeposits(client: Client, aliases?: { pattern: RegExp
     if (aliases) {
         aliases.push({ pattern: /\/depozyt$/, callback: () => client.sendCommand("przejrzyj depozyt") });
         aliases.push({ pattern: /\/depozyty$/, callback: printDeposits });
+        aliases.push({ pattern: /\/depozyt_reset$/, callback: clearDeposits });
     }
 
     window.addEventListener("beforeunload", persist);

--- a/client/test/deposit.test.ts
+++ b/client/test/deposit.test.ts
@@ -34,6 +34,7 @@ describe('deposits', () => {
   let parse: (line: string) => string;
   let refresh: () => void;
   let show: () => void;
+  let reset: () => void;
 
   beforeEach(() => {
     (global as any).Input = { send: jest.fn() };
@@ -44,6 +45,7 @@ describe('deposits', () => {
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
     refresh = aliases[0].callback;
     show = aliases[1].callback;
+    reset = aliases[2].callback;
     Object.keys(deposits).forEach(k => delete deposits[parseInt(k)]);
     jest.clearAllMocks();
   });
@@ -118,6 +120,17 @@ describe('deposits', () => {
     const printed = stripAnsiCodes(client.println.mock.calls[0][0]);
     expect(printed).toContain('  5 | mieczy');
     expect(printed).toContain('wie | monet');
+  });
+
+  test('reset command clears deposits and persists', () => {
+    parse('Twoj depozyt zawiera miecz.');
+    expect(deposits[1]).toBeDefined();
+
+    reset();
+
+    expect(deposits[1]).toBeUndefined();
+    expect(client.port.postMessage).toHaveBeenLastCalledWith({ type: 'SET_STORAGE', key: 'deposits', value: {} });
+    expect(client.println).toHaveBeenCalledWith('Zapisane depozyty zostaly usuniete.');
   });
 
   test('uses column setting for pretty print', () => {


### PR DESCRIPTION
## Summary
- add a /depozyt_reset alias that wipes stored deposit entries and persists the change
- print a confirmation message after clearing deposits
- extend the deposit test suite to cover the reset alias behaviour

## Testing
- yarn --cwd client test
- yarn --cwd web-client test *(fails: Cannot find module '@client/src/normalizeCommand.ts' in Recorder.test.ts)*
- yarn --cwd web-client build


------
https://chatgpt.com/codex/tasks/task_e_68f146d5ebc0832a972c8b532e2b283d