### PR TITLE
Fix radial menu command for deliona

### DIFF
--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -198,7 +198,7 @@ const defaultRadialSettings: RadialSettings = {
     commands: [
         { id: 'radial-1', label: 'dobadz broni', command: 'dobadz wszystkich broni' },
         { id: 'radial-2', label: 'buduj zioła', command: '/ziola_buduj' },
-        { id: 'radial-3', label: 'deliona', command: '/z_zjedz deliona' },
+        { id: 'radial-3', label: 'deliona', command: '/zi zjedz deliona' },
         { id: 'radial-4', label: '+k', command: '+k' },
         { id: 'radial-5', label: '/list', command: '/list' },
         { id: 'radial-6', label: 'otul', command: 'otul sie plaszczem' },


### PR DESCRIPTION
## Summary
- update the default radial menu command for deliona to `/zi zjedz deliona`

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68f19138c7e8832a920b574763579402