### PR TITLE
Add toggle to disable mobile radial menu

### DIFF
--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -35,6 +35,7 @@ export interface RadialCommandSetting {
 }
 
 export interface RadialSettings {
+    enabled: boolean;
     commands: RadialCommandSetting[];
 }
 
@@ -195,6 +196,7 @@ export function createDefaultLayout(): LayoutSettings {
 const emptyButton: ButtonSetting = { macro: 'empty', label: '', color: 'transparent', fontColor: defaultFontColor };
 
 const defaultRadialSettings: RadialSettings = {
+    enabled: true,
     commands: [
         { id: 'radial-1', label: 'dobadz broni', command: 'dobadz wszystkich broni' },
         { id: 'radial-2', label: 'buduj zioła', command: '/ziola_buduj' },
@@ -250,8 +252,9 @@ function parseLayout(set: any, fallback: LayoutSettings = createDefaultLayout())
 
 function parseRadialSettings(raw: any): RadialSettings {
     if (!raw || typeof raw !== 'object') {
-        return { commands: cloneDefaultRadialCommands() };
+        return { enabled: true, commands: cloneDefaultRadialCommands() };
     }
+    const enabled = raw.enabled === false ? false : true;
     const list = Array.isArray(raw.commands) ? raw.commands : [];
     const commands: RadialCommandSetting[] = [];
     const usedIds = new Set<string>();
@@ -276,9 +279,9 @@ function parseRadialSettings(raw: any): RadialSettings {
         commands.push({ id, label, command, color, activeColor, fontColor });
     });
     if (!commands.length) {
-        return { commands: cloneDefaultRadialCommands() };
+        return { enabled, commands: cloneDefaultRadialCommands() };
     }
-    return { commands };
+    return { enabled, commands };
 }
 
 export async function loadSettings(): Promise<Settings> {
@@ -342,7 +345,7 @@ export async function loadSettings(): Promise<Settings> {
         team: createDefaultLayout(),
         leader: createDefaultLayout(),
         locked: false,
-        radial: { commands: cloneDefaultRadialCommands() },
+        radial: { enabled: true, commands: cloneDefaultRadialCommands() },
     };
 }
 

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -90,7 +90,7 @@ function MobileButtons() {
         team: { buttons: {}, order: [...defaultOrder], cols: defaultCols, background: defaultBackground },
         leader: { buttons: {}, order: [...defaultOrder], cols: defaultCols, background: defaultBackground },
         locked: false,
-        radial: { commands: [] },
+        radial: { enabled: true, commands: [] },
     });
     const [syncDirs, setSyncDirs] = useState(true);
     const [active, setActive] = useState<{ set: Mode; id: string } | null>(null);

--- a/web-client/src/options/MobileRadialCommands.tsx
+++ b/web-client/src/options/MobileRadialCommands.tsx
@@ -18,10 +18,26 @@ function createRadialId() {
 
 function MobileRadialCommands() {
     const [settings, setSettings] = useState<Settings | null>(null);
+    const radialEnabled = settings?.radial?.enabled !== false;
 
     useEffect(() => {
         loadSettings().then(setSettings);
     }, []);
+
+    function setRadialEnabled(enabled: boolean) {
+        setSettings(prev => {
+            if (!prev) {
+                return prev;
+            }
+            return {
+                ...prev,
+                radial: {
+                    ...prev.radial,
+                    enabled,
+                },
+            };
+        });
+    }
 
     function addRadialCommand() {
         setSettings(prev => {
@@ -75,6 +91,7 @@ function MobileRadialCommands() {
         if (!settings) {
             return;
         }
+        const enabled = settings.radial?.enabled !== false;
         const normalizedCommands = (settings.radial?.commands || []).reduce<RadialCommandSetting[]>((acc, cmd) => {
             const command = (cmd.command || "").trim();
             if (!command) {
@@ -93,6 +110,7 @@ function MobileRadialCommands() {
             ...settings,
             radial: {
                 ...settings.radial,
+                enabled,
                 commands: normalizedCommands,
             },
         };
@@ -108,6 +126,20 @@ function MobileRadialCommands() {
 
     return (
         <div className="w-100 d-flex flex-column gap-3">
+            <div className="d-flex flex-column gap-2">
+                <Form.Check
+                    type="switch"
+                    id="mobile-radial-enabled"
+                    label="Włącz menu kołowe"
+                    checked={radialEnabled}
+                    onChange={event => setRadialEnabled(event.target.checked)}
+                />
+                {!radialEnabled && (
+                    <p className="text-muted small mb-0">
+                        Menu kołowe jest wyłączone. Włącz je, aby edytować komendy.
+                    </p>
+                )}
+            </div>
             <div>
                 <Form.Label className="mb-2">Komendy menu kołowego</Form.Label>
                 <div className="d-flex flex-column gap-2">
@@ -123,6 +155,7 @@ function MobileRadialCommands() {
                                     type="text"
                                     value={cmd.label}
                                     placeholder="Nazwa przycisku"
+                                    disabled={!radialEnabled}
                                     onChange={e => updateRadialCommand(cmd.id, "label", e.target.value)}
                                 />
                             </Form.Group>
@@ -133,6 +166,7 @@ function MobileRadialCommands() {
                                     type="text"
                                     value={cmd.command}
                                     placeholder="Tekst komendy"
+                                    disabled={!radialEnabled}
                                     onChange={e => updateRadialCommand(cmd.id, "command", e.target.value)}
                                 />
                             </Form.Group>
@@ -140,6 +174,7 @@ function MobileRadialCommands() {
                                 <Button
                                     variant="outline-danger"
                                     size="sm"
+                                    disabled={!radialEnabled}
                                     onClick={() => removeRadialCommand(cmd.id)}
                                 >
                                     Usuń
@@ -148,7 +183,13 @@ function MobileRadialCommands() {
                         </div>
                     ))}
                 </div>
-                <Button variant="secondary" size="sm" className="mt-2" onClick={addRadialCommand}>
+                <Button
+                    variant="secondary"
+                    size="sm"
+                    className="mt-2"
+                    onClick={addRadialCommand}
+                    disabled={!radialEnabled}
+                >
                     Dodaj komendę
                 </Button>
             </div>

--- a/web-client/src/scripts/mobileCommandRadial.ts
+++ b/web-client/src/scripts/mobileCommandRadial.ts
@@ -108,8 +108,19 @@ export default class MobileCommandRadial {
         }).catch(err => console.error('Failed to reload mobile button settings for radial menu', err));
     }
 
+    private isRadialEnabled(): boolean {
+        if (!this.settings) {
+            return true;
+        }
+        return this.settings.radial?.enabled !== false;
+    }
+
     private readonly handleTouchStart = (event: TouchEvent) => {
         if (this.overlay?.classList.contains('mobile-command-radial--visible')) {
+            return;
+        }
+        if (!this.isRadialEnabled()) {
+            this.cancelLongPress();
             return;
         }
         if (event.touches.length !== 1) {
@@ -366,7 +377,7 @@ export default class MobileCommandRadial {
     }
 
     private updateCommands() {
-        if (!this.settings) {
+        if (!this.settings || !this.isRadialEnabled()) {
             this.commands = [];
             this.highlightCommand(null);
             return;

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -64,7 +64,7 @@ export default class MobileDirectionButtons {
         team: { buttons: {}, order: [], cols: 0, background: defaultBackground },
         leader: { buttons: {}, order: [], cols: 0, background: defaultBackground },
         locked: false,
-        radial: { commands: [] },
+        radial: { enabled: true, commands: [] },
     };
     private buttonSettings: Record<string, ButtonSetting> = {};
     private teamMode = false;


### PR DESCRIPTION
## Summary
- add a switch to enable or disable the mobile radial menu from its configuration page and disable editing when it is off
- persist the radial menu enabled flag with settings and prevent the radial overlay from activating when disabled

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68f4cade06d4832a9bd30231720737a4