### PR TITLE
Adjust object list drag guard for touch interactions

### DIFF
--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -97,7 +97,13 @@ export default class ObjectList {
     private onPointerDown = (e: PointerEvent) => {
         if (!this.container) return;
         const target = e.target as HTMLElement | null;
-        if (target?.closest(".object-num, .object-desc, .objects-list-controls")) {
+        const pointerType = e.pointerType || "";
+        const isMousePointer =
+            pointerType === "mouse" || (pointerType === "" && !this.isMobile);
+        if (
+            isMousePointer &&
+            target?.closest(".object-num, .object-desc, .objects-list-controls")
+        ) {
             return;
         }
         this.isDragging = true;


### PR DESCRIPTION
## Summary
- only block drag initiation from object list controls when the pointer is a mouse
- keep touch pointers free to start dragging even when tapping on list entries

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68f4ec65158c832a8514d69ef081524b