### PR TITLE
Adjust object list pointer handling for touch dragging

### DIFF
--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -96,8 +96,13 @@ export default class ObjectList {
 
     private onPointerDown = (e: PointerEvent) => {
         if (!this.container) return;
-        const target = e.target as HTMLElement | null;
-        if (target?.closest(".object-num, .object-desc, .objects-list-controls")) {
+        const target = this.getEventTargetElement(e.target);
+        if (target?.closest(".objects-list-controls")) {
+            return;
+        }
+        const pointerType = e.pointerType || (this.isMobile ? "touch" : "mouse");
+        const isMouseLikePointer = pointerType === "mouse" || pointerType === "pen";
+        if (isMouseLikePointer && target?.closest(".object-num, .object-desc")) {
             return;
         }
         this.isDragging = true;


### PR DESCRIPTION
## Summary
- allow touch drags to start on object numbers and descriptions while keeping mouse safeguards
- continue to block pointer interactions on control buttons from initiating drags

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68f4f1773a80832aad480aba06c94e8c