### PR TITLE
feat: bootstrap runtime providers

### DIFF
--- a/client/src/runtime/embeddedMapBridge.ts
+++ b/client/src/runtime/embeddedMapBridge.ts
@@ -1,0 +1,58 @@
+export type LabelRenderModeOption = 'image' | 'data';
+
+export interface EmbeddedMapApi {
+    setZoom(zoom: number): void;
+    refresh(): void;
+    setExplorationMode(on: boolean): void;
+    setTransparentLabels(on: boolean): void;
+    setLabelRenderMode(mode: LabelRenderModeOption): void;
+    setInstantMove(on: boolean): void;
+    setHighlightCurrentRoom(on: boolean): void;
+    getVisitedCount(): number;
+    getRoomCount(): number;
+    getDestinations(): readonly number[];
+    getPrimaryDestination(): number | null;
+}
+
+type EmbeddedMapSubscriber = (map: EmbeddedMapApi | null) => void;
+
+let embeddedMapInstance: EmbeddedMapApi | null = null;
+const subscribers = new Set<EmbeddedMapSubscriber>();
+
+function notifySubscribers() {
+    subscribers.forEach(listener => {
+        try {
+            listener(embeddedMapInstance);
+        } catch (err) {
+            console.error('embeddedMapBridge subscriber failed', err);
+        }
+    });
+}
+
+export function setEmbeddedMapBridge(map: EmbeddedMapApi | null) {
+    embeddedMapInstance = map;
+    notifySubscribers();
+}
+
+export function clearEmbeddedMapBridge() {
+    setEmbeddedMapBridge(null);
+}
+
+export function getEmbeddedMap(): EmbeddedMapApi {
+    if (!embeddedMapInstance) {
+        throw new Error('Embedded map has not been initialised.');
+    }
+    return embeddedMapInstance;
+}
+
+export function peekEmbeddedMap(): EmbeddedMapApi | null {
+    return embeddedMapInstance;
+}
+
+export function subscribeEmbeddedMap(listener: EmbeddedMapSubscriber): () => void {
+    subscribers.add(listener);
+    listener(embeddedMapInstance);
+    return () => {
+        subscribers.delete(listener);
+    };
+}

--- a/client/src/scripts/herbCounter.ts
+++ b/client/src/scripts/herbCounter.ts
@@ -140,7 +140,7 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
         }
     });
     client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
-    window.addEventListener('request-herb-counts', requestBagsIfNeeded);
+    client.addEventListener('request-herb-counts', requestBagsIfNeeded as any);
 
     let preUseCommands: string[] = [];
     let postUseCommands: string[] = [];

--- a/client/src/scripts/idz.ts
+++ b/client/src/scripts/idz.ts
@@ -1,6 +1,7 @@
 import Client from "../Client";
 import { longToShort } from "../MapHelper";
 import { getShortcut } from "./shortcuts";
+import { peekEmbeddedMap } from "../runtime/embeddedMapBridge";
 
 
 export default function initIdz(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
@@ -116,9 +117,9 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
     const resumeWalk = (d?: number) => {
         if (target === null) {
             const current: any = client.Map.currentRoom;
-            const dest = (window as any).embedded?.destinations?.[0];
-            if (!current || !dest) return;
-            const p = client.Map.findPath(current.id, parseInt(dest));
+            const dest = peekEmbeddedMap()?.getPrimaryDestination();
+            if (!current || typeof dest !== 'number') return;
+            const p = client.Map.findPath(current.id, dest);
             if (!p || p.length < 2) return;
             path = p.map((n) => parseInt(n as any, 10)).filter(n => !isNaN(n));
             if (path.length < 2) {
@@ -126,7 +127,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
                 return;
             }
             index = 0;
-            target = parseInt(dest);
+            target = dest;
         }
         startWalk(target, d, 'resume');
     };

--- a/client/src/scripts/mapAliases.ts
+++ b/client/src/scripts/mapAliases.ts
@@ -1,6 +1,7 @@
 import Client from "../Client";
 import {longToShort} from "../MapHelper";
 import {getShortcut} from "./shortcuts";
+import {peekEmbeddedMap} from "../runtime/embeddedMapBridge";
 
 export default function initMapAliases(client: Client, aliases: { pattern: RegExp; callback: Function }[]) {
     aliases.push(
@@ -38,10 +39,10 @@ export default function initMapAliases(client: Client, aliases: { pattern: RegEx
         {
             pattern: /\/go$/,
             callback: () => {
-                const embedded: any = (window as any).embedded;
+                const embedded = peekEmbeddedMap();
                 const room: any = client.Map.currentRoom;
-                if (!embedded?.destinations?.length || !room) return;
-                const target = parseInt(embedded.destinations[0]);
+                const target = embedded?.getDestinations()?.[0];
+                if (typeof target !== 'number' || !room) return;
                 const path = client.Map.findPath(room.id, target);
                 if (!path || path.length < 2) return;
                 const next = path[1];

--- a/web-client/jest.setup.js
+++ b/web-client/jest.setup.js
@@ -34,3 +34,27 @@ if (typeof globalThis.fetch !== 'function') {
     });
   }
 }
+
+if (typeof globalThis.pako === 'undefined') {
+  class MockInflate {
+    constructor() {
+      this.result = [];
+      this.err = 0;
+      this.msg = '';
+      this.chunks = [];
+      this.ended = false;
+    }
+
+    push() {
+      this.result = [];
+      this.chunks = [];
+      this.ended = false;
+    }
+  }
+
+  globalThis.pako = {
+    Inflate: MockInflate,
+    inflate: (input) => input,
+    ungzip: (input) => input,
+  };
+}

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -7,6 +7,7 @@ import TelnetOptionNegotiation from "./TelnetOptionNegotiation.ts";
 import {md5} from 'js-md5';
 import {uncompress} from "./compression.ts";
 import {CommandOptions, normalizeCommand} from "@client/src/scripts/commandPreserveCaseMode.ts";
+import {peekClient} from "./runtime/clientProvider";
 
 type Params<T> = T extends void ? [] : T extends any[] ? T : [T];
 type EventListener<K extends keyof ClientEvents> = (...args: Params<ClientEvents[K]>) => void;
@@ -363,7 +364,10 @@ class ArkadiaClient implements ClientAdapter {
     }
 
     private sendLine(text: string, type: string, i: number) {
-        text = window.clientExtension.onLine(text, type)
+        const client = peekClient();
+        if (client) {
+            text = client.onLine(text, type);
+        }
         eventBus.on('output-sent', () => this.emit(`gmcp_msg.${type}`, text), {once: true})
         Output.send(parseAnsiPatterns(text), type);
         this.emit('line-sent')

--- a/web-client/src/AttackMode.ts
+++ b/web-client/src/AttackMode.ts
@@ -1,5 +1,6 @@
 import ArkadiaClient from "./ArkadiaClient.ts";
 import { getItemSync } from "@client/src/storage.ts";
+import { getClient } from "./runtime/clientProvider";
 
 const MODES = ["A", "AW", "AWR"] as const;
 type Mode = typeof MODES[number];
@@ -37,7 +38,7 @@ export default class AttackMode {
 
   private updateVisibility() {
     if (!this.container) return;
-    const leader = !!(window as any).clientExtension?.TeamManager?.isLeader?.();
+    const leader = !!getClient().TeamManager?.isLeader?.();
     this.container.style.display = leader ? 'block' : 'none';
   }
 }

--- a/web-client/src/CharState.ts
+++ b/web-client/src/CharState.ts
@@ -1,5 +1,6 @@
 import ArkadiaClient from "./ArkadiaClient.ts";
 import { COLOR_BAR_CLASS, COLOR_TEXT, getColorLevel } from "./colors.ts";
+import { getEventHub } from "./runtime/clientProvider";
 
 export interface CharStateData {
   hp: number;
@@ -169,17 +170,15 @@ export default class CharState {
       }
     });
 
-    const ext: any = (window as any).clientExtension;
-    if (ext?.addEventListener) {
-      ext.addEventListener('uiSettings', (ev: CustomEvent) => {
-        if (typeof ev.detail?.emojiLabels === 'boolean') {
-          this.applyLabelMode(ev.detail.emojiLabels);
-        }
-        if (typeof ev.detail?.footerMode === 'number') {
-          this.applyMode(ev.detail.footerMode);
-        }
-      });
-    }
+    const eventHub = getEventHub();
+    eventHub.on('uiSettings', (settings: any) => {
+      if (typeof settings?.emojiLabels === 'boolean') {
+        this.applyLabelMode(settings.emojiLabels);
+      }
+      if (typeof settings?.footerMode === 'number') {
+        this.applyMode(settings.footerMode);
+      }
+    });
 
     this.client.on(
       "gmcp.char.state",

--- a/web-client/src/FightTitle.ts
+++ b/web-client/src/FightTitle.ts
@@ -1,4 +1,5 @@
 import ArkadiaClient from "./ArkadiaClient.ts";
+import { getEventHub } from "./runtime/clientProvider";
 
 export default class FightTitle {
   private baseTitle: string;
@@ -18,12 +19,13 @@ export default class FightTitle {
     client.on("gmcp.char.info", (info: any) => this.handleCharInfo(info));
     client.on("gmcp.objects.data", (data: Record<string, any>) => this.handleObjectsData(data));
     client.on("client.disconnect", () => this.reset());
-    (window as any).clientExtension?.eventTarget.addEventListener("uiSettings", (ev: CustomEvent) => {
-      if (typeof ev.detail?.fightTitleIcon === "boolean") {
-        this.enabled = ev.detail.fightTitleIcon;
+    const handleUiSettings = (settings: any) => {
+      if (typeof settings?.fightTitleIcon === "boolean") {
+        this.enabled = settings.fightTitleIcon;
         this.updateTitle(this.isFighting, true);
       }
-    });
+    };
+    getEventHub().on("uiSettings", handleUiSettings);
   }
 
   private handleCharInfo(info: any) {

--- a/web-client/src/Recorder.ts
+++ b/web-client/src/Recorder.ts
@@ -1,5 +1,6 @@
 import { saveRecording, getRecording, getRecordingNames, deleteRecording, RecordedEvent } from './recordingStorage';
 import { CommandOptions } from "@client/src/scripts/commandPreserveCaseMode.ts";
+import { peekClient } from "./runtime/clientProvider";
 
 export interface RecorderHooks {
     processIncomingData(data: string): void;
@@ -172,7 +173,7 @@ export default class Recorder {
             this.hooks.processIncomingData(ev.message);
         } else {
             Output.send('→ ' + ev.message);
-            window.clientExtension.sendCommand(ev.message, false);
+            peekClient()?.sendCommand(ev.message, false);
             this.hooks.sendCommand(ev.message, false);
         }
     }

--- a/web-client/src/debug.ts
+++ b/web-client/src/debug.ts
@@ -1,4 +1,5 @@
 import Modal from "bootstrap/js/dist/modal";
+import { getCommandDispatcher, peekClient } from "./runtime/clientProvider";
 
 function initDebug() {
   const debugButton = document.getElementById("debug-button") as HTMLButtonElement | null;
@@ -40,13 +41,15 @@ function initDebug() {
 
   if (scheduleButton) {
     scheduleButton.addEventListener("click", () => {
-      const client = (window as any).clientExtension;
+      const client = peekClient();
       if (!client) return;
       client.enableNotifications?.();
-      client.sendEvent?.("notify", { text: "Powiadomienie za 5s" });
+      const dispatcher = getCommandDispatcher();
+      dispatcher.sendEvent("notify", { text: "Powiadomienie za 5s" });
       setTimeout(() => {
-        client.notify?.("Test notification");
-        client.sendEvent?.("notify", { text: "Test notification" });
+        const latestClient = peekClient();
+        latestClient?.notify?.("Test notification");
+        dispatcher.sendEvent("notify", { text: "Test notification" });
       }, 5000);
     });
   }

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -256,6 +256,14 @@ export class EmbeddedMap {
         return this.totalRooms;
     }
 
+    getDestinations(): readonly number[] {
+        return this.destinations;
+    }
+
+    getPrimaryDestination(): number | null {
+        return this.destinations.length > 0 ? this.destinations[0] : null;
+    }
+
     setExplorationMode(on: boolean) {
         this.explorationMode = on;
         if (this.explorationMode) {
@@ -311,7 +319,7 @@ export class EmbeddedMap {
         if (id) {
             this.destinations = [parseInt(id)];
         } else {
-            this.destinations = [];6
+            this.destinations = [];
         }
         this.refresh();
     }

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -1,5 +1,6 @@
 import {MapReader, Renderer, PathFinder, Settings, RoomContextMenuEventDetail, LabelRenderMode} from "mudlet-map-renderer";
 import {getCurrentCharacter, getItemSync, setItemSync} from "@client/src/storage";
+import { getClient } from "./runtime/clientProvider";
 
 const STORAGE_KEY = 'mapperRoomId';
 const VISITED_DB_NAME = 'ArkadiaVisitedRoomsDB';
@@ -194,8 +195,8 @@ export class EmbeddedMap {
 
         const room = ev.detail.roomId
         if (room) {
-            const client: any = (window as any).clientExtension;
-            client?.openMapContextMenu?.(room, ev.detail.position.x, ev.detail.position.y);
+            const client = getClient();
+            client.openMapContextMenu?.(room, ev.detail.position.x, ev.detail.position.y);
         }
     }
 

--- a/web-client/src/herbs/HerbManager.tsx
+++ b/web-client/src/herbs/HerbManager.tsx
@@ -4,7 +4,7 @@ import { getItemSync } from "@client/src/storage";
 import type { HerbBagsState, HerbManagerApi, HerbMoveOptions } from "@client/src/types/herbs";
 import { openHerbContextMenu } from "@client/src/contextMenus";
 import loadHerbs, { type HerbsData } from "@client/src/scripts/herbsLoader";
-import type Client from "@client/src/Client";
+import { getCommandDispatcher, getEventHub, peekClient } from "../runtime/clientProvider";
 
 type HerbCounts = Record<string | number, Record<string, number>>;
 
@@ -191,12 +191,13 @@ const getHerbStyle = (herbId: string): HerbPillStyle => {
 };
 
 const HerbManager = () => {
+    const commandDispatcher = getCommandDispatcher();
     const idCounter = useRef(0);
-    const nextInstanceId = () => `stack-${idCounter.current++}`;
-    const rebuildBags = (counts?: HerbCounts) => {
+    const nextInstanceId = useCallback(() => `stack-${idCounter.current++}`, []);
+    const rebuildBags = useCallback((counts?: HerbCounts) => {
         idCounter.current = 0;
         return buildBags(counts, nextInstanceId);
-    };
+    }, [nextInstanceId]);
 
     const [bags, setBags] = useState<HerbBag[]>(() => rebuildBags(getInitialCounts()));
     const [activeBag, setActiveBag] = useState<number | null>(null);
@@ -230,7 +231,7 @@ const HerbManager = () => {
     }, []);
 
     const closeContextMenu = useCallback(() => {
-        const client = (window as any).clientExtension as Client | undefined;
+        const client = peekClient();
         const outputHandler = client?.OutputHandler
         outputHandler?.hideContextMenu?.();
     }, []);
@@ -241,7 +242,7 @@ const HerbManager = () => {
     }, [closeContextMenu]);
 
     useEffect(() => {
-        const client = (window as any).clientExtension as Client | undefined;
+        const client = peekClient();
         if (!client) {
             return;
         }
@@ -259,22 +260,22 @@ const HerbManager = () => {
     }, []);
 
     useEffect(() => {
-        const handler = (ev: Event) => {
-            const detail = (ev as CustomEvent<HerbBagsState>).detail;
+        const eventHub = getEventHub();
+        const handler = (detail: unknown) => {
             if (detail && typeof detail === "object") {
                 setError(null);
-                setBags(rebuildBags(detail));
+                setBags(rebuildBags(detail as HerbBagsState));
             }
         };
-        window.addEventListener("herbCounts", handler as EventListener);
-        return () => window.removeEventListener("herbCounts", handler as EventListener);
-    }, []);
+        eventHub.on("herbCounts", handler);
+        return () => eventHub.off("herbCounts", handler);
+    }, [rebuildBags]);
 
     useEffect(() => {
         if (!isOpen) {
             return;
         }
-        window.dispatchEvent(new Event("request-herb-counts"));
+        commandDispatcher.sendEvent("request-herb-counts");
         panelRef.current?.focus();
     }, [isOpen]);
 
@@ -460,7 +461,7 @@ const HerbManager = () => {
         setError(null);
         setBags(moveResult.next);
         setBusy(true);
-        const manager = (window as any).clientExtension?.herbManager as HerbManagerApi | undefined;
+        const manager = peekClient()?.herbManager as HerbManagerApi | undefined;
         const payload: HerbMoveOptions = {
             herbId: moveResult.moved.herbId,
             amount: moveResult.moved.count,
@@ -470,14 +471,14 @@ const HerbManager = () => {
         if (!manager) {
             setError("Brak połączenia z licznikiem ziół.");
             setBusy(false);
-            window.dispatchEvent(new Event("request-herb-counts"));
+            commandDispatcher.sendEvent("request-herb-counts");
             return;
         }
         Promise.resolve(manager.move(payload))
             .catch(err => {
                 const message = err instanceof Error ? err.message : "Nie udało się przenieść ziół.";
                 setError(message);
-                window.dispatchEvent(new Event("request-herb-counts"));
+                commandDispatcher.sendEvent("request-herb-counts");
             })
             .finally(() => {
                 setBusy(false);
@@ -534,7 +535,7 @@ const HerbManager = () => {
     const handleContextMenu = (stack: HerbStack) => async (event: React.MouseEvent<HTMLButtonElement>) => {
         event.preventDefault();
         const { pageX, pageY } = event;
-        const client = (window as any).clientExtension as Client | undefined;
+        const client = peekClient();
         if (!client) {
             return;
         }

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -170,7 +170,7 @@ let isSplitView = false;
 const STICKY_LINES = 15;
 
 function processSticky(count: number) {
-    const handler: any = (window as any).clientExtension?.OutputHandler;
+    const handler = client.OutputHandler;
     if (handler && typeof handler.processOutput === 'function') {
         const prev = handler.output;
         handler.output = stickyArea;
@@ -354,7 +354,7 @@ arkadiaClient.on('client.connect', () => {
     isConnected = true;
     isConnecting = false;
     updateConnectButtons();
-    window.clientExtension.sendEvent('refreshPositionWhenAble');
+    client.sendEvent('refreshPositionWhenAble');
     console.log('Client connected to Arkadia server.');
 });
 
@@ -425,10 +425,10 @@ document.addEventListener('keydown', (e) => {
     if (direction) {
         e.preventDefault();
         if (direction === 'special') {
-            const exits = (window as any).clientExtension?.Map.currentRoom?.specialExits ?? {};
+            const exits = client.Map.currentRoom?.specialExits ?? {};
             const first = Object.keys(exits)[0];
             if (first) {
-                (window as any).clientExtension.sendCommand(first);
+                client.sendCommand(first);
             }
         } else {
             client.sendCommand(direction);
@@ -679,7 +679,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (shareLocationButton && locationQrImage && locationShareModal) {
         shareLocationButton.addEventListener('click', () => {
-            const roomId = (window as any).clientExtension?.Map?.currentRoom?.id;
+            const roomId = client.Map?.currentRoom?.id;
             if (!roomId) {
                 return;
             }

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -22,7 +22,6 @@ import "@client/src/main.ts"
 import NoSleep from 'nosleep.js';
 import {loadMapData, loadColors} from "./mapDataLoader.ts";
 import {loadNpcData} from "./npcDataLoader.ts";
-import {EmbeddedMap} from "./embed.ts"
 import {createElement} from 'react'
 import {createRoot} from 'react-dom/client'
 import Binds from "./options/Binds.tsx"
@@ -48,7 +47,7 @@ import "./triggerTester"
 import "./triggerFinder"
 import {getItemSync} from "@client/src/storage"
 import {initRuntime} from "./runtime/compositionRoot";
-import {setEmbeddedMap} from "./runtime/mapProvider";
+import {initializeEmbeddedMap} from "./runtime/mapProvider";
 
 const {client} = await initRuntime();
 
@@ -241,7 +240,7 @@ Promise.all([mapDataPromise, colorsPromise])
         console.log('Map data and colors loaded successfully');
         progressContainer.style.display = 'none';
         const {startId, reader, pathFinder} = client.Map.initialize(mapData, colors);
-        setEmbeddedMap(new EmbeddedMap(reader, pathFinder, startId));
+        initializeEmbeddedMap({ reader, pathFinder, startId });
     })
     .catch(error => {
         progressContainer.style.display = 'none';

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -16,11 +16,9 @@ import ReleaseGuard from "./ReleaseGuard";
 import AttackMode from "./AttackMode";
 import FightTitle from "./FightTitle";
 import HpTitle from "./HpTitle";
-import initSessionLogger from "./sessionLogger";
 import LetterComposer from "./LetterComposer";
 
 import "@client/src/main.ts"
-import MockPort from "./MockPort.ts";
 import NoSleep from 'nosleep.js';
 import {loadMapData, loadColors} from "./mapDataLoader.ts";
 import {loadNpcData} from "./npcDataLoader.ts";
@@ -39,6 +37,9 @@ import Shortcuts from "./options/Shortcuts.tsx"
 import MobileButtons from "./options/MobileButtons.tsx"
 import MobileRadialCommands from "./options/MobileRadialCommands.tsx"
 import HerbManager from "./herbs/HerbManager";
+import MobileDirectionButtons from "./scripts/mobileDirectionButtons"
+import MobileCommandRadial from "./scripts/mobileCommandRadial"
+import initUiSettings from "./uiSettings"
 import {
     loadSettings as loadMobileButtonSettings,
     applySettings as applyMobileButtonSettings
@@ -46,13 +47,10 @@ import {
 import "./triggerTester"
 import "./triggerFinder"
 import {getItemSync} from "@client/src/storage"
+import {initRuntime} from "./runtime/compositionRoot";
+import {setEmbeddedMap} from "./runtime/mapProvider";
 
-initSessionLogger(arkadiaClient).catch(err => console.error('Logger init failed', err));
-
-const client = new Client(arkadiaClient, new MockPort())
-window.clientExtension = client;
-registerScripts(client)
-client.connect(client.port, true)
+const {client} = await initRuntime();
 
 
 const locationParam = new URLSearchParams(window.location.search).get('locationId');
@@ -243,7 +241,7 @@ Promise.all([mapDataPromise, colorsPromise])
         console.log('Map data and colors loaded successfully');
         progressContainer.style.display = 'none';
         const {startId, reader, pathFinder} = client.Map.initialize(mapData, colors);
-        (window as any).embedded = new EmbeddedMap(reader, pathFinder, startId);
+        setEmbeddedMap(new EmbeddedMap(reader, pathFinder, startId));
     })
     .catch(error => {
         progressContainer.style.display = 'none';
@@ -1091,13 +1089,4 @@ window.addEventListener('resize', () => {
     }
 });
 
-// @ts-ignore
-window.client = arkadiaClient
-
 // background communication disabled
-
-import MobileDirectionButtons from "./scripts/mobileDirectionButtons"
-import MobileCommandRadial from "./scripts/mobileCommandRadial"
-import initUiSettings from "./uiSettings";
-import Client from "@client/src/Client.ts";
-import {registerScripts} from "@client/src/main.ts";

--- a/web-client/src/mobileButtonSettings.ts
+++ b/web-client/src/mobileButtonSettings.ts
@@ -1,4 +1,5 @@
 import storage from "@client/src/storage";
+import { getEventHub } from "./runtime/clientProvider";
 
 export type MacroType =
     | 'functional'
@@ -434,11 +435,7 @@ export function applySettings(settings: Settings, inTeam = false, isLeader = fal
             div.style.gridAutoRows = baseRow * sizeRatio + 'px';
         });
     }
-    if ((window as any).clientExtension?.eventTarget) {
-        (window as any).clientExtension.eventTarget.dispatchEvent(
-            new CustomEvent('mobileButtonsSettings', { detail: set.buttons })
-        );
-    }
+    getEventHub().emit('mobileButtonsSettings', set.buttons);
 }
 
 

--- a/web-client/src/options/Binds.tsx
+++ b/web-client/src/options/Binds.tsx
@@ -3,6 +3,7 @@ import {Alert, Button, Form, Modal, ProgressBar, Spinner, Table} from 'react-boo
 import storage from "@client/src/storage";
 import { parseMultibindsDatabase, type MultibindImportRow } from "./multibindImport";
 import { readMultibinds, replaceMultibinds, type StoredMultibindRecord } from "../multibindStorage";
+import { getClient, getEventHub } from "../runtime/clientProvider";
 
 interface Bind {
     key: string;
@@ -207,15 +208,15 @@ function Binds() {
                 setMultibinds(list);
             }
         });
-        const handler = (ev: Event) => {
-            const detail = (ev as CustomEvent).detail;
+        const eventHub = getEventHub();
+        const handler = (detail: unknown) => {
             setMultibinds(normalizeMultibinds(detail));
         };
-        window.addEventListener('multibindsStorage', handler as EventListener);
-        window.clientExtension?.port?.postMessage?.({ type: 'MULTIBINDS_LOAD' });
+        eventHub.on('multibindsStorage', handler);
+        getClient().port?.postMessage?.({ type: 'MULTIBINDS_LOAD' });
         return () => {
             active = false;
-            window.removeEventListener('multibindsStorage', handler as EventListener);
+            eventHub.off('multibindsStorage', handler);
         };
     }, []);
 
@@ -357,27 +358,29 @@ function Binds() {
         }
         const finalList = Array.from(finalMap.values()).sort((a, b) => (a.roomId - b.roomId) || (a.index - b.index));
         try {
-            if (window.clientExtension?.port) {
+            const eventHub = getEventHub();
+            const client = getClient();
+            if (client.port) {
                 await new Promise<void>((resolve) => {
                     let settled = false;
                     const handler = () => {
                         if (settled) return;
                         settled = true;
-                        window.removeEventListener('multibindsStorage', handler as EventListener);
+                        eventHub.off('multibindsStorage', handler);
                         resolve();
                     };
-                    window.addEventListener('multibindsStorage', handler as EventListener, { once: true });
-                    window.clientExtension.port.postMessage({ type: 'MULTIBINDS_SAVE', value: finalList });
+                    eventHub.on('multibindsStorage', handler);
+                    client.port.postMessage({ type: 'MULTIBINDS_SAVE', value: finalList });
                     setTimeout(() => {
                         if (settled) return;
                         settled = true;
-                        window.removeEventListener('multibindsStorage', handler as EventListener);
+                        eventHub.off('multibindsStorage', handler);
                         resolve();
                     }, 1500);
                 });
             } else {
                 await replaceMultibinds(finalList);
-                window.dispatchEvent(new CustomEvent('multibindsStorage', { detail: finalList }));
+                eventHub.emit('multibindsStorage', finalList);
             }
             setMultibinds(finalList);
             setImportResult({

--- a/web-client/src/options/MobileButtons.tsx
+++ b/web-client/src/options/MobileButtons.tsx
@@ -14,6 +14,7 @@ import {
     defaultBackground,
     defaultFontColor,
 } from "../mobileButtonSettings";
+import { getClient } from "../runtime/clientProvider";
 
 import ButtonGrid, { Mode } from "./ButtonGrid";
 
@@ -306,8 +307,9 @@ function MobileButtons() {
 
     function save() {
         saveSettings(settings);
-        const teamActive = !!(window as any).clientExtension?.TeamManager?.isInAnyTeam?.();
-        const leaderActive = !!(window as any).clientExtension?.TeamManager?.isLeader?.();
+        const client = getClient();
+        const teamActive = !!client.TeamManager?.isInAnyTeam?.();
+        const leaderActive = !!client.TeamManager?.isLeader?.();
         applySettings(settings, teamActive, leaderActive);
         window.dispatchEvent(new Event('close-options'));
     }

--- a/web-client/src/options/MobileRadialCommands.tsx
+++ b/web-client/src/options/MobileRadialCommands.tsx
@@ -7,6 +7,7 @@ import {
     Settings,
     RadialCommandSetting,
 } from "../mobileButtonSettings";
+import { getClient } from "../runtime/clientProvider";
 
 function createRadialId() {
     const globalCrypto = typeof crypto !== "undefined" ? crypto : undefined;
@@ -116,8 +117,9 @@ function MobileRadialCommands() {
         };
         setSettings(normalizedSettings);
         saveSettings(normalizedSettings);
-        const teamActive = !!(window as any).clientExtension?.TeamManager?.isInAnyTeam?.();
-        const leaderActive = !!(window as any).clientExtension?.TeamManager?.isLeader?.();
+        const client = getClient();
+        const teamActive = !!client.TeamManager?.isInAnyTeam?.();
+        const leaderActive = !!client.TeamManager?.isLeader?.();
         applySettings(normalizedSettings, teamActive, leaderActive);
         window.dispatchEvent(new Event("close-options"));
     }

--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -4,6 +4,7 @@ import {Button, Form, Table} from 'react-bootstrap';
 import {clearIndexedDB, updateIndexedDB} from "@client/src/utils/dataCache.ts";
 import {TiDelete} from "react-icons/ti";
 import {loadNpcData} from "../npcDataLoader.ts";
+import { getCommandDispatcher, getEventHub } from "../runtime/clientProvider";
 
 const DB_CONFIG = { dbName: 'ArkadiaNpcDB', storeName: 'npcData', key: 'npc' } as const;
 const NPC_URL = 'https://delwing.github.io/arkadia-mapa/data/npc.json';
@@ -15,6 +16,7 @@ interface NpcProps {
 
 function Npc() {
 
+    const { sendEvent } = getCommandDispatcher();
     const [npcs, setNpcs] = useState<NpcProps[]>([])
     const [filter, setFilter] = useState<string>('')
 
@@ -25,15 +27,15 @@ function Npc() {
     }, []);
 
     useEffect(() => {
-        const handler = (ev: Event) => {
-            const detail = (ev as CustomEvent).detail
+        const eventHub = getEventHub();
+        const handler = (detail: unknown) => {
             if (Array.isArray(detail)) {
                 setNpcs(detail)
             }
         }
-        window.addEventListener('npc', handler as EventListener)
+        eventHub.on('npc', handler)
         return () => {
-            window.removeEventListener('npc', handler as EventListener)
+            eventHub.off('npc', handler)
         }
     }, [])
 
@@ -41,7 +43,7 @@ function Npc() {
         updateIndexedDB<NpcProps[]>(DB_CONFIG, NPC_URL)
             .then(data => {
                 setNpcs(data)
-                ;(window as any).clientExtension?.sendEvent('npc', data)
+                sendEvent('npc', data)
             })
             .catch(e => console.error('Failed to update NPC data:', e));
     }
@@ -50,7 +52,7 @@ function Npc() {
         clearIndexedDB(DB_CONFIG)
             .then(() => {
                 setNpcs([])
-                ;(window as any).clientExtension?.sendEvent('npc', [])
+                sendEvent('npc', [])
             })
             .catch(e => console.error('Failed to clear NPC data:', e));
     }
@@ -70,7 +72,7 @@ function Npc() {
         const updated = npcs.filter(n => !(n.name === npc.name && n.loc === npc.loc))
         setNpcs(updated)
         saveNpcs(updated)
-        ;(window as any).clientExtension?.sendEvent('npc', updated)
+        sendEvent('npc', updated)
     }
 
     async function saveNpcs(list: NpcProps[]) {

--- a/web-client/src/options/Shortcuts.tsx
+++ b/web-client/src/options/Shortcuts.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Button, Form, Table } from 'react-bootstrap';
 import { TiDelete } from 'react-icons/ti';
 import storage from "@client/src/storage";
+import { getClient, getCommandDispatcher } from "../runtime/clientProvider";
 
 interface ShortcutEntry {
     key: string;
@@ -15,6 +16,7 @@ function Shortcuts() {
     const [key, setKey] = useState('');
     const [loc, setLoc] = useState('');
     const [label, setLabel] = useState('');
+    const { sendEvent } = getCommandDispatcher();
 
     useEffect(() => {
         storage.getItem('shortcuts').then(res => {
@@ -51,7 +53,7 @@ function Shortcuts() {
     }
 
     function useCurrent() {
-        const id = (window as any).clientExtension?.Map?.currentRoom?.id;
+        const id = getClient().Map?.currentRoom?.id;
         if (id) {
             setLoc(String(id));
         }
@@ -89,7 +91,7 @@ function Shortcuts() {
                         <td>{item.id}</td>
                         <td>{item.label}</td>
                         <td className="d-flex gap-2">
-                            <Button size="sm" onClick={() => (window as any).clientExtension?.sendEvent('leadTo', item.id)}>Prowadź</Button>
+                            <Button size="sm" onClick={() => sendEvent('leadTo', item.id)}>Prowadź</Button>
                             <Button size="sm" variant="danger" onClick={() => remove(item.key)}><TiDelete /></Button>
                         </td>
                     </tr>

--- a/web-client/src/runtime/clientProvider.ts
+++ b/web-client/src/runtime/clientProvider.ts
@@ -1,0 +1,59 @@
+import type Client from '@client/src/Client';
+import type { ClientEvents, EventBus } from '@client/src/eventBus';
+
+type CommandOptions = Parameters<Client['sendCommand']>[2];
+
+type CommandDispatcher = {
+    sendCommand: (command: string, echo?: boolean, options?: CommandOptions) => void;
+    sendEvent: (type: string, payload?: any) => void;
+};
+
+let clientInstance: Client | null = null;
+let eventHubInstance: EventBus<ClientEvents> | null = null;
+
+const commandDispatcher: CommandDispatcher = {
+    sendCommand(command: string, echo?: boolean, options?: CommandOptions) {
+        getClient().sendCommand(command, echo, options);
+    },
+    sendEvent(type: string, payload?: any) {
+        getClient().sendEvent(type, payload);
+    },
+};
+
+export function setClientInstance(client: Client) {
+    clientInstance = client;
+    eventHubInstance = client.eventTarget as EventBus<ClientEvents>;
+    (globalThis as any).clientExtension = client;
+}
+
+export function clearClientInstance() {
+    clientInstance = null;
+    eventHubInstance = null;
+    if ((globalThis as any).clientExtension) {
+        delete (globalThis as any).clientExtension;
+    }
+}
+
+export function getClient(): Client {
+    if (!clientInstance) {
+        throw new Error('Client runtime has not been initialised. Call initRuntime() first.');
+    }
+    return clientInstance;
+}
+
+export function peekClient(): Client | null {
+    return clientInstance;
+}
+
+export function getEventHub(): EventBus<ClientEvents> {
+    if (!eventHubInstance) {
+        throw new Error('Event hub has not been initialised. Call initRuntime() first.');
+    }
+    return eventHubInstance;
+}
+
+export function getCommandDispatcher(): CommandDispatcher {
+    return commandDispatcher;
+}
+
+export type { CommandDispatcher };

--- a/web-client/src/runtime/compositionRoot.ts
+++ b/web-client/src/runtime/compositionRoot.ts
@@ -1,0 +1,93 @@
+import Client from '@client/src/Client';
+import { registerScripts } from '@client/src/main';
+import type { ClientEvents, EventBus } from '@client/src/eventBus';
+
+import arkadiaClient from '../ArkadiaClient';
+import MockPort from '../MockPort';
+import initSessionLogger from '../sessionLogger';
+import { clearClientInstance, getEventHub, setClientInstance } from './clientProvider';
+import { clearEmbeddedMap } from './mapProvider';
+import {
+    SettingsService,
+    clearSettingsService,
+    createSettingsService,
+    setSettingsService,
+} from './settingsService';
+
+type RuntimeContext = {
+    client: Client;
+    eventHub: EventBus<ClientEvents>;
+    settingsService: SettingsService;
+};
+
+type RuntimeOptions = {
+    enableSessionLogger?: boolean;
+};
+
+let runtimeContext: RuntimeContext | null = null;
+let initPromise: Promise<RuntimeContext> | null = null;
+
+export async function initRuntime(options: RuntimeOptions = {}): Promise<RuntimeContext> {
+    if (runtimeContext) {
+        return runtimeContext;
+    }
+    if (!initPromise) {
+        initPromise = bootstrap(options).catch(err => {
+            initPromise = null;
+            throw err;
+        });
+    }
+    runtimeContext = await initPromise;
+    return runtimeContext;
+}
+
+async function bootstrap(options: RuntimeOptions): Promise<RuntimeContext> {
+    const { enableSessionLogger = true } = options;
+    const port = new MockPort();
+    const client = new Client(arkadiaClient, port);
+    setClientInstance(client);
+    (globalThis as any).client = arkadiaClient;
+
+    registerScripts(client);
+
+    if (enableSessionLogger) {
+        try {
+            await initSessionLogger(arkadiaClient);
+        } catch (err) {
+            console.error('Logger init failed', err);
+        }
+    }
+
+    client.connect(port, true);
+
+    const settingsService = createSettingsService();
+    setSettingsService(settingsService);
+
+    const eventHub = getEventHub();
+    client.sendEvent('settings.updated', settingsService.snapshot);
+    settingsService.onChange(settings => {
+        client.sendEvent('settings.updated', settings);
+    });
+
+    return { client, eventHub, settingsService };
+}
+
+export function getRuntimeContext(): RuntimeContext {
+    if (!runtimeContext) {
+        throw new Error('Runtime has not been initialised.');
+    }
+    return runtimeContext;
+}
+
+export function resetRuntimeForTests() {
+    runtimeContext = null;
+    initPromise = null;
+    clearSettingsService();
+    clearEmbeddedMap();
+    clearClientInstance();
+    if ((globalThis as any).client) {
+        delete (globalThis as any).client;
+    }
+}
+
+export type { RuntimeContext, RuntimeOptions };

--- a/web-client/src/runtime/compositionRoot.ts
+++ b/web-client/src/runtime/compositionRoot.ts
@@ -64,7 +64,6 @@ async function bootstrap(options: RuntimeOptions): Promise<RuntimeContext> {
     setSettingsService(settingsService);
 
     const eventHub = getEventHub();
-    client.sendEvent('settings.updated', settingsService.snapshot);
     settingsService.onChange(settings => {
         client.sendEvent('settings.updated', settings);
     });

--- a/web-client/src/runtime/mapProvider.ts
+++ b/web-client/src/runtime/mapProvider.ts
@@ -1,14 +1,50 @@
-import type { EmbeddedMap } from '../embed';
+import type { MapReader, PathFinder } from 'mudlet-map-renderer';
+import { EmbeddedMap } from '../embed';
+import {
+    clearEmbeddedMapBridge,
+    setEmbeddedMapBridge,
+} from '@client/src/runtime/embeddedMapBridge';
 
 let embeddedMapInstance: EmbeddedMap | null = null;
+type EmbeddedMapSubscriber = (map: EmbeddedMap | null) => void;
+const subscribers = new Set<EmbeddedMapSubscriber>();
 
-export function setEmbeddedMap(map: EmbeddedMap | null) {
+function notifySubscribers() {
+    subscribers.forEach(listener => {
+        try {
+            listener(embeddedMapInstance);
+        } catch (err) {
+            console.error('mapProvider subscriber failed', err);
+        }
+    });
+}
+
+function assignEmbeddedMap(map: EmbeddedMap | null) {
     embeddedMapInstance = map;
     if (map) {
-        (globalThis as any).embedded = map;
-    } else if ((globalThis as any).embedded) {
-        delete (globalThis as any).embedded;
+        setEmbeddedMapBridge(map);
+    } else {
+        clearEmbeddedMapBridge();
     }
+    notifySubscribers();
+}
+
+export function initializeEmbeddedMap({
+    reader,
+    pathFinder,
+    startId,
+}: {
+    reader: MapReader;
+    pathFinder: PathFinder;
+    startId?: number;
+}): EmbeddedMap {
+    const map = new EmbeddedMap(reader, pathFinder, startId);
+    assignEmbeddedMap(map);
+    return map;
+}
+
+export function setEmbeddedMap(map: EmbeddedMap | null) {
+    assignEmbeddedMap(map);
 }
 
 export function getEmbeddedMap(): EmbeddedMap {
@@ -22,6 +58,14 @@ export function peekEmbeddedMap(): EmbeddedMap | null {
     return embeddedMapInstance;
 }
 
+export function subscribeEmbeddedMap(listener: EmbeddedMapSubscriber): () => void {
+    subscribers.add(listener);
+    listener(embeddedMapInstance);
+    return () => {
+        subscribers.delete(listener);
+    };
+}
+
 export function clearEmbeddedMap() {
-    setEmbeddedMap(null);
+    assignEmbeddedMap(null);
 }

--- a/web-client/src/runtime/mapProvider.ts
+++ b/web-client/src/runtime/mapProvider.ts
@@ -1,0 +1,27 @@
+import type { EmbeddedMap } from '../embed';
+
+let embeddedMapInstance: EmbeddedMap | null = null;
+
+export function setEmbeddedMap(map: EmbeddedMap | null) {
+    embeddedMapInstance = map;
+    if (map) {
+        (globalThis as any).embedded = map;
+    } else if ((globalThis as any).embedded) {
+        delete (globalThis as any).embedded;
+    }
+}
+
+export function getEmbeddedMap(): EmbeddedMap {
+    if (!embeddedMapInstance) {
+        throw new Error('Embedded map has not been initialised.');
+    }
+    return embeddedMapInstance;
+}
+
+export function peekEmbeddedMap(): EmbeddedMap | null {
+    return embeddedMapInstance;
+}
+
+export function clearEmbeddedMap() {
+    setEmbeddedMap(null);
+}

--- a/web-client/src/runtime/settingsService.ts
+++ b/web-client/src/runtime/settingsService.ts
@@ -42,6 +42,7 @@ class SettingsService {
             listener((ev as CustomEvent<Settings>).detail);
         };
         this.target.addEventListener('change', handler);
+        listener(this.snapshot);
         return () => this.target.removeEventListener('change', handler);
     }
 

--- a/web-client/src/runtime/settingsService.ts
+++ b/web-client/src/runtime/settingsService.ts
@@ -1,0 +1,85 @@
+import { defaultSettings, type Settings } from '@client/src/defaultSettings';
+import storage, { getItemSync, setItemSync } from '@client/src/storage';
+
+type SettingsListener = (settings: Settings) => void;
+
+function normalizeSettings(raw: unknown): Settings {
+    if (!raw || typeof raw !== 'object') {
+        return { ...defaultSettings };
+    }
+    return { ...defaultSettings, ...(raw as Partial<Settings>) };
+}
+
+class SettingsService {
+    private current: Settings;
+    private readonly target = new EventTarget();
+    private readonly storageListener = (changes: { [key: string]: { oldValue: any; newValue: any } }) => {
+        const change = changes.settings;
+        if (!change) {
+            return;
+        }
+        this.current = normalizeSettings(change.newValue);
+        this.emit();
+    };
+
+    constructor(initial: Settings) {
+        this.current = { ...initial };
+        storage.onChanged?.addListener(this.storageListener);
+    }
+
+    get snapshot(): Settings {
+        return { ...this.current };
+    }
+
+    update(patch: Partial<Settings>) {
+        this.current = { ...this.current, ...patch };
+        setItemSync('settings', this.current);
+        this.emit();
+    }
+
+    onChange(listener: SettingsListener): () => void {
+        const handler = (ev: Event) => {
+            listener((ev as CustomEvent<Settings>).detail);
+        };
+        this.target.addEventListener('change', handler);
+        return () => this.target.removeEventListener('change', handler);
+    }
+
+    dispose() {
+        storage.onChanged?.removeListener?.(this.storageListener);
+    }
+
+    private emit() {
+        this.target.dispatchEvent(new CustomEvent<Settings>('change', { detail: this.snapshot }));
+    }
+}
+
+let settingsServiceInstance: SettingsService | null = null;
+
+export function createSettingsService(): SettingsService {
+    if (settingsServiceInstance) {
+        return settingsServiceInstance;
+    }
+    const stored = getItemSync('settings');
+    const initial = normalizeSettings(stored?.settings);
+    settingsServiceInstance = new SettingsService(initial);
+    return settingsServiceInstance;
+}
+
+export function setSettingsService(service: SettingsService) {
+    settingsServiceInstance = service;
+}
+
+export function getSettingsService(): SettingsService {
+    if (!settingsServiceInstance) {
+        throw new Error('Settings service has not been initialised.');
+    }
+    return settingsServiceInstance;
+}
+
+export function clearSettingsService() {
+    settingsServiceInstance?.dispose();
+    settingsServiceInstance = null;
+}
+
+export { SettingsService };

--- a/web-client/src/sandbox.ts
+++ b/web-client/src/sandbox.ts
@@ -1,5 +1,6 @@
 import './sandbox.css';
 import arkadiaClient from "./ArkadiaClient.ts";
+import { peekClient } from "./runtime/clientProvider";
 
 // Disable real network and echo commands locally
 arkadiaClient.connect = () => {
@@ -20,7 +21,10 @@ arkadiaClient.send = (message: string, echo: boolean = true) => {
 (arkadiaClient as any).receivedFirstGmcp = true;
 
 window.addEventListener('load', () => {
-    const client: any = (window as any).clientExtension;
+    const client = peekClient();
+    if (!client) {
+        return;
+    }
     arkadiaClient.emit('client.connect');
     const memberInput = document.getElementById('sandbox-member-name') as HTMLInputElement | null;
     const addMemberButton = document.getElementById('sandbox-add-member') as HTMLButtonElement | null;

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -735,7 +735,7 @@ export default class MobileDirectionButtons {
     private renderList(target: HTMLDivElement | null, regex: RegExp, prefix: string) {
         if (!target) return;
         target.innerHTML = '';
-        const objects = (window as any).clientExtension?.ObjectManager?.getObjectsOnLocation?.() || [];
+        const objects = this.client.ObjectManager?.getObjectsOnLocation?.() ?? [];
         const values = Array.from(new Set(objects
             .filter((o: any) => regex.test(o.shortcut))
             .map((o: any) => o.shortcut)));

--- a/web-client/src/triggerFinder.ts
+++ b/web-client/src/triggerFinder.ts
@@ -2,6 +2,7 @@ import Modal from "bootstrap/js/dist/modal";
 import { stripAnsiCodes } from "@client/src/stripAnsiCodes";
 import type { Trigger } from "@client/src/Triggers";
 import { getMatchingPatterns, matchTrigger, patternToString } from "./triggerUtils";
+import { peekClient } from "./runtime/clientProvider";
 
 type TriggerSource = "regular" | "multiline" | "token";
 
@@ -29,8 +30,7 @@ function initTriggerFinder() {
     });
 
     runBtn.addEventListener("click", () => {
-        // @ts-ignore
-        const manager = (window as any).clientExtension?.Triggers;
+        const manager = peekClient()?.Triggers;
         if (!manager) {
             outputEl.textContent = "No trigger manager.";
             return;

--- a/web-client/src/triggerTester.ts
+++ b/web-client/src/triggerTester.ts
@@ -1,6 +1,7 @@
 import Modal from "bootstrap/js/dist/modal";
 import type { Trigger } from "@client/src/Triggers";
 import { matchTrigger, patternToString } from "./triggerUtils";
+import { peekClient } from "./runtime/clientProvider";
 
 function initTriggerTester() {
     const button = document.getElementById('trigger-tester-button') as HTMLButtonElement | null;
@@ -31,8 +32,7 @@ function initTriggerTester() {
         selectedPath = null;
         selectedEl = null;
         treeEl.innerHTML = '';
-        // @ts-ignore
-        const manager = (window as any).clientExtension?.Triggers;
+        const manager = peekClient()?.Triggers;
         if (!manager) return;
         const roots: Trigger[] = [
             ...Array.from(manager.triggers.values()),
@@ -77,8 +77,7 @@ function initTriggerTester() {
         const line = lineInput.value;
         const type = typeInput.value.trim();
         outputEl.textContent = '';
-        // @ts-ignore
-        const triggers = (window as any).clientExtension?.Triggers;
+        const triggers = peekClient()?.Triggers;
         if (!triggers) {
             outputEl.textContent = 'No trigger manager.';
             return;

--- a/web-client/src/types/globals.d.ts
+++ b/web-client/src/types/globals.d.ts
@@ -47,7 +47,6 @@ declare global {
         Text: ClientText;
         Conf: ClientConf
         Gmcp: ClientGmcp;
-        clientExtension: Client
     }
 
     declare var Input: ClientInput;

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -1,7 +1,13 @@
 import Modal from "bootstrap/js/dist/modal";
 import {Settings} from "mudlet-map-renderer";
 import {peekClient} from "./runtime/clientProvider";
-import {peekEmbeddedMap} from "./runtime/mapProvider";
+import {subscribeEmbeddedMap} from "./runtime/mapProvider";
+import type { EmbeddedMap } from "./embed";
+
+let embeddedMapRef: EmbeddedMap | null = null;
+subscribeEmbeddedMap(map => {
+    embeddedMapRef = map;
+});
 
 const mapPositions = [
     'top-overlay',
@@ -125,8 +131,8 @@ function apply(settings: UiSettings) {
         const baseRow = 36; // default row height in px
         div.style.gridAutoRows = baseRow * settings.buttonSize + 'px';
     });
-    const embedded = peekEmbeddedMap();
-    if (embedded && (embedded as any).renderer) {
+    const embedded = embeddedMapRef;
+    if (embedded) {
         embedded.setZoom(settings.mapScale);
         embedded.setExplorationMode(settings.explorationMode);
         embedded.refresh();
@@ -321,7 +327,7 @@ export default async function initUiSettings() {
     storage.onChanged?.addListener(handleStorageChange);
 
     function refreshExplorationStats() {
-        const map = peekEmbeddedMap();
+        const map = embeddedMapRef;
         if (map?.getVisitedCount && map?.getRoomCount && explorationStats) {
             const visited = map.getVisitedCount();
             const total = map.getRoomCount();

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -1,5 +1,7 @@
 import Modal from "bootstrap/js/dist/modal";
 import {Settings} from "mudlet-map-renderer";
+import {peekClient} from "./runtime/clientProvider";
+import {peekEmbeddedMap} from "./runtime/mapProvider";
 
 const mapPositions = [
     'top-overlay',
@@ -123,35 +125,39 @@ function apply(settings: UiSettings) {
         const baseRow = 36; // default row height in px
         div.style.gridAutoRows = baseRow * settings.buttonSize + 'px';
     });
-    if ((window as any).embedded?.renderer) {
-        (window as any).embedded.setZoom?.(settings.mapScale);
-        (window as any).embedded.setExplorationMode?.(settings.explorationMode);
-        (window as any).embedded.refresh();
+    const embedded = peekEmbeddedMap();
+    if (embedded && (embedded as any).renderer) {
+        embedded.setZoom(settings.mapScale);
+        embedded.setExplorationMode(settings.explorationMode);
+        embedded.refresh();
     }
     Settings.transparentLabels = settings.transparentLabels;
     const labelRenderMode = settings.transparentLabels ? 'data' : settings.labelRenderMode;
     Settings.labelRenderMode = labelRenderMode;
-    (window as any).embedded?.setTransparentLabels?.(settings.transparentLabels);
-    (window as any).embedded?.setLabelRenderMode?.(labelRenderMode);
-    Settings.instantMapMove = settings.instantMove;
-    (window as any).embedded?.setInstantMove?.(settings.instantMove);
-    Settings.highlightCurrentRoom = settings.highlightCurrentRoom;
-    (window as any).embedded?.setHighlightCurrentRoom?.(settings.highlightCurrentRoom);
-    if ((window as any).clientExtension?.eventTarget) {
-        (window as any).clientExtension.eventTarget.dispatchEvent(
-            new CustomEvent('uiSettings', {
-                detail: {
-                    mobileDirectionButtons: settings.showButtons,
-                    hapticFeedback: settings.hapticFeedback,
-                    emojiLabels: settings.emojiLabels,
-                    xtermPalette: settings.xtermPalette,
-                    footerMode: settings.footerMode,
-                    fightTitleIcon: settings.fightTitleIcon,
-                    clearInputOnSend: settings.clearInputOnSend,
-                },
-            })
-        );
+    if (embedded) {
+        embedded.setTransparentLabels(settings.transparentLabels);
+        embedded.setLabelRenderMode(labelRenderMode);
+        Settings.instantMapMove = settings.instantMove;
+        embedded.setInstantMove(settings.instantMove);
+        Settings.highlightCurrentRoom = settings.highlightCurrentRoom;
+        embedded.setHighlightCurrentRoom(settings.highlightCurrentRoom);
+    } else {
+        Settings.instantMapMove = settings.instantMove;
+        Settings.highlightCurrentRoom = settings.highlightCurrentRoom;
     }
+    peekClient()?.eventTarget.dispatchEvent(
+        new CustomEvent('uiSettings', {
+            detail: {
+                mobileDirectionButtons: settings.showButtons,
+                hapticFeedback: settings.hapticFeedback,
+                emojiLabels: settings.emojiLabels,
+                xtermPalette: settings.xtermPalette,
+                footerMode: settings.footerMode,
+                fightTitleIcon: settings.fightTitleIcon,
+                clearInputOnSend: settings.clearInputOnSend,
+            },
+        })
+    );
     if (typeof window !== 'undefined') {
         window.dispatchEvent(new CustomEvent('map-position-change'));
     }
@@ -315,7 +321,7 @@ export default async function initUiSettings() {
     storage.onChanged?.addListener(handleStorageChange);
 
     function refreshExplorationStats() {
-        const map = (window as any).embedded;
+        const map = peekEmbeddedMap();
         if (map?.getVisitedCount && map?.getRoomCount && explorationStats) {
             const visited = map.getVisitedCount();
             const total = map.getRoomCount();

--- a/web-client/test/AttackMode.test.ts
+++ b/web-client/test/AttackMode.test.ts
@@ -1,9 +1,14 @@
 import AttackMode from '../src/AttackMode';
+import { getClient } from '../src/runtime/clientProvider';
 
 jest.mock('@client/src/storage.ts', () => ({
   getItemSync: jest.fn(() => ({})),
 }));
 import { getItemSync } from '@client/src/storage.ts';
+
+jest.mock('../src/runtime/clientProvider', () => ({
+  getClient: jest.fn(),
+}));
 
 class MockClient {
   private events: Record<string, Function[]> = {};
@@ -18,13 +23,15 @@ class MockClient {
 describe('AttackMode', () => {
   let container: HTMLElement;
   let client: MockClient;
+  let teamManager: { isLeader: jest.Mock };
 
   beforeEach(() => {
     document.body.innerHTML = '<span id="attack-mode"></span>';
     container = document.getElementById('attack-mode')!;
     client = new MockClient();
     (getItemSync as jest.Mock).mockReturnValue({ attack_mode: 'A' });
-    (window as any).clientExtension = { TeamManager: { isLeader: jest.fn(() => true) } };
+    teamManager = { isLeader: jest.fn(() => true) };
+    (getClient as jest.Mock).mockReturnValue({ TeamManager: teamManager });
     new AttackMode(client as any);
   });
 
@@ -56,10 +63,11 @@ describe('AttackMode', () => {
     document.body.innerHTML = '<span id="attack-mode"></span>';
     container = document.getElementById('attack-mode')!;
     client = new MockClient();
-    (window as any).clientExtension = { TeamManager: { isLeader: jest.fn(() => false) } };
+    teamManager = { isLeader: jest.fn(() => false) };
+    (getClient as jest.Mock).mockReturnValue({ TeamManager: teamManager });
     new AttackMode(client as any);
     expect(container.style.display).toBe('none');
-    (window as any).clientExtension.TeamManager.isLeader.mockReturnValue(true);
+    teamManager.isLeader.mockReturnValue(true);
     client.emit('teamChange');
     expect(container.style.display).toBe('block');
   });

--- a/web-client/test/CharState.test.ts
+++ b/web-client/test/CharState.test.ts
@@ -1,5 +1,13 @@
 import CharState from '../src/CharState';
 
+jest.mock('../src/runtime/clientProvider', () => ({
+  getEventHub: jest.fn(() => ({
+    on: jest.fn(),
+    off: jest.fn(),
+    emit: jest.fn(),
+  })),
+}));
+
 class MockClient {
   private events: Record<string, Function[]> = {};
   on(event: string, listener: Function) {

--- a/web-client/test/Recorder.test.ts
+++ b/web-client/test/Recorder.test.ts
@@ -1,4 +1,9 @@
 import Recorder from '../src/Recorder';
+import { peekClient } from '../src/runtime/clientProvider';
+
+jest.mock('../src/runtime/clientProvider', () => ({
+  peekClient: jest.fn(),
+}));
 
 describe('Recorder playback', () => {
   test('replayRecordedMessagesTimed echoes outgoing commands', () => {
@@ -8,7 +13,8 @@ describe('Recorder playback', () => {
       emit: jest.fn(),
     };
     const recorder = new Recorder(hooks as any);
-    (window as any).clientExtension = { sendCommand: jest.fn() };
+    const sendCommand = jest.fn();
+    (peekClient as jest.Mock).mockReturnValue({ sendCommand });
     (window as any).Output = { send: jest.fn() };
     recorder.setRecordedMessages([
       { message: 'look', timestamp: 0, direction: 'out' },
@@ -17,5 +23,6 @@ describe('Recorder playback', () => {
     recorder.replayRecordedMessagesTimed();
     jest.runAllTimers();
     expect((window as any).Output.send).toHaveBeenCalledWith('→ look');
+    expect(sendCommand).toHaveBeenCalledWith('look', false);
   });
 });

--- a/web-client/test/runtime/compositionRoot.test.ts
+++ b/web-client/test/runtime/compositionRoot.test.ts
@@ -1,0 +1,99 @@
+jest.mock('mudlet-map-renderer', () => ({
+    MapReader: class {},
+    PathFinder: class {},
+    Renderer: class {},
+    Settings: {},
+}));
+
+jest.mock('@client/src/main', () => ({
+    registerScripts: jest.fn(),
+}));
+
+jest.mock('@client/src/Client', () => {
+    const eventBus = jest.requireActual('@client/src/eventBus').default;
+
+    return class MockClient {
+        eventTarget = eventBus;
+        clientAdapter: any;
+        port: any;
+
+        constructor(clientAdapter: any, port: any) {
+            this.clientAdapter = clientAdapter;
+            this.port = port;
+        }
+
+        connect(port: any) {
+            this.port = port;
+            this.eventTarget.dispatchEvent(new CustomEvent('port-connected'));
+        }
+
+        addEventListener(event: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) {
+            this.eventTarget.addEventListener(event, listener, options);
+        }
+
+        removeEventListener(event: string, listener: EventListenerOrEventListenerObject | null) {
+            this.eventTarget.removeEventListener(event, listener);
+        }
+
+        sendEvent(type: string, payload?: any) {
+            this.eventTarget.dispatchEvent(new CustomEvent(type, { detail: payload }));
+        }
+
+        sendCommand(command: string, echo: boolean = true, options?: any) {
+            this.eventTarget.dispatchEvent(new CustomEvent('command', { detail: command }));
+            this.clientAdapter?.send?.(command, echo, options);
+        }
+    };
+});
+
+import arkadiaClient from '../../src/ArkadiaClient';
+import { getCommandDispatcher, getEventHub } from '../../src/runtime/clientProvider';
+import { initRuntime, resetRuntimeForTests } from '../../src/runtime/compositionRoot';
+
+describe('runtime composition', () => {
+    beforeEach(() => {
+        resetRuntimeForTests();
+    });
+
+    test('initRuntime provides the client through the provider', async () => {
+        const runtime = await initRuntime({ enableSessionLogger: false });
+
+        expect(runtime.client).toBeDefined();
+        expect(getEventHub()).toBe(runtime.eventHub);
+    });
+
+    test('transport events flow through the exported event hub', async () => {
+        await initRuntime({ enableSessionLogger: false });
+
+        const eventHub = getEventHub();
+        const handler = jest.fn();
+        eventHub.addEventListener('gmcp.room.info', (event) => {
+            handler((event as CustomEvent).detail);
+        }, { once: true });
+
+        const payload = { room: { id: 123 } };
+        arkadiaClient.emit('gmcp.room.info', payload);
+
+        expect(handler).toHaveBeenCalledWith(payload);
+    });
+
+    test('command dispatcher delegates to client sendCommand', async () => {
+        await initRuntime({ enableSessionLogger: false });
+
+        const eventHub = getEventHub();
+        const handler = jest.fn();
+        eventHub.addEventListener('command', (event) => {
+            handler((event as CustomEvent).detail);
+        }, { once: true });
+
+        const dispatcher = getCommandDispatcher();
+        const sendSpy = jest.spyOn(arkadiaClient, 'send').mockImplementation(() => undefined);
+
+        dispatcher.sendCommand('test-command');
+
+        expect(handler).toHaveBeenCalledWith('test-command');
+        expect(sendSpy).toHaveBeenCalledWith('test-command', true, undefined);
+
+        sendSpy.mockRestore();
+    });
+});

--- a/web-client/test/runtime/settingsService.test.ts
+++ b/web-client/test/runtime/settingsService.test.ts
@@ -1,0 +1,27 @@
+jest.mock('@client/src/storage', () => ({
+    __esModule: true,
+    default: {
+        onChanged: {
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+        },
+    },
+    getItemSync: jest.fn(),
+    setItemSync: jest.fn(),
+}));
+
+import { defaultSettings } from '@client/src/defaultSettings';
+import { SettingsService } from '../../src/runtime/settingsService';
+
+describe('SettingsService', () => {
+    test('onChange notifies listener immediately with current snapshot', () => {
+        const initial = { ...defaultSettings, shortenExits: !defaultSettings.shortenExits };
+        const service = new SettingsService(initial);
+        const listener = jest.fn();
+
+        service.onChange(listener);
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(listener.mock.calls[0][0]).toEqual(initial);
+    });
+});

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     build: {
         minify: true,
         sourcemap: true,
+        target: 'esnext',
         rollupOptions: {
             input: {
                 plugin: resolve('src/plugin.ts'),


### PR DESCRIPTION
## Summary
- add runtime composition root with client, map, and settings providers plus reusable command dispatcher
- initialise the web client through initRuntime and expose the embedded map via the new providers while updating UI settings to consume them
- stub pako for tests and add runtime composition tests validating event hub wiring

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68f5797ac7ac832a8d70fa1ad354542f