### PR TITLE
Refactor embedded map provider usage across client scripts

### DIFF
--- a/client/src/runtime/embeddedMapBridge.ts
+++ b/client/src/runtime/embeddedMapBridge.ts
@@ -1,0 +1,58 @@
+export type LabelRenderModeOption = 'image' | 'data';
+
+export interface EmbeddedMapApi {
+    setZoom(zoom: number): void;
+    refresh(): void;
+    setExplorationMode(on: boolean): void;
+    setTransparentLabels(on: boolean): void;
+    setLabelRenderMode(mode: LabelRenderModeOption): void;
+    setInstantMove(on: boolean): void;
+    setHighlightCurrentRoom(on: boolean): void;
+    getVisitedCount(): number;
+    getRoomCount(): number;
+    getDestinations(): readonly number[];
+    getPrimaryDestination(): number | null;
+}
+
+type EmbeddedMapSubscriber = (map: EmbeddedMapApi | null) => void;
+
+let embeddedMapInstance: EmbeddedMapApi | null = null;
+const subscribers = new Set<EmbeddedMapSubscriber>();
+
+function notifySubscribers() {
+    subscribers.forEach(listener => {
+        try {
+            listener(embeddedMapInstance);
+        } catch (err) {
+            console.error('embeddedMapBridge subscriber failed', err);
+        }
+    });
+}
+
+export function setEmbeddedMapBridge(map: EmbeddedMapApi | null) {
+    embeddedMapInstance = map;
+    notifySubscribers();
+}
+
+export function clearEmbeddedMapBridge() {
+    setEmbeddedMapBridge(null);
+}
+
+export function getEmbeddedMap(): EmbeddedMapApi {
+    if (!embeddedMapInstance) {
+        throw new Error('Embedded map has not been initialised.');
+    }
+    return embeddedMapInstance;
+}
+
+export function peekEmbeddedMap(): EmbeddedMapApi | null {
+    return embeddedMapInstance;
+}
+
+export function subscribeEmbeddedMap(listener: EmbeddedMapSubscriber): () => void {
+    subscribers.add(listener);
+    listener(embeddedMapInstance);
+    return () => {
+        subscribers.delete(listener);
+    };
+}

--- a/client/src/scripts/idz.ts
+++ b/client/src/scripts/idz.ts
@@ -1,6 +1,7 @@
 import Client from "../Client";
 import { longToShort } from "../MapHelper";
 import { getShortcut } from "./shortcuts";
+import { peekEmbeddedMap } from "../runtime/embeddedMapBridge";
 
 
 export default function initIdz(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
@@ -116,9 +117,9 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
     const resumeWalk = (d?: number) => {
         if (target === null) {
             const current: any = client.Map.currentRoom;
-            const dest = (window as any).embedded?.destinations?.[0];
-            if (!current || !dest) return;
-            const p = client.Map.findPath(current.id, parseInt(dest));
+            const dest = peekEmbeddedMap()?.getPrimaryDestination();
+            if (!current || typeof dest !== 'number') return;
+            const p = client.Map.findPath(current.id, dest);
             if (!p || p.length < 2) return;
             path = p.map((n) => parseInt(n as any, 10)).filter(n => !isNaN(n));
             if (path.length < 2) {
@@ -126,7 +127,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
                 return;
             }
             index = 0;
-            target = parseInt(dest);
+            target = dest;
         }
         startWalk(target, d, 'resume');
     };

--- a/client/src/scripts/mapAliases.ts
+++ b/client/src/scripts/mapAliases.ts
@@ -1,6 +1,7 @@
 import Client from "../Client";
 import {longToShort} from "../MapHelper";
 import {getShortcut} from "./shortcuts";
+import {peekEmbeddedMap} from "../runtime/embeddedMapBridge";
 
 export default function initMapAliases(client: Client, aliases: { pattern: RegExp; callback: Function }[]) {
     aliases.push(
@@ -38,10 +39,10 @@ export default function initMapAliases(client: Client, aliases: { pattern: RegEx
         {
             pattern: /\/go$/,
             callback: () => {
-                const embedded: any = (window as any).embedded;
+                const embedded = peekEmbeddedMap();
                 const room: any = client.Map.currentRoom;
-                if (!embedded?.destinations?.length || !room) return;
-                const target = parseInt(embedded.destinations[0]);
+                const target = embedded?.getDestinations()?.[0];
+                if (typeof target !== 'number' || !room) return;
                 const path = client.Map.findPath(room.id, target);
                 if (!path || path.length < 2) return;
                 const next = path[1];

--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -256,6 +256,14 @@ export class EmbeddedMap {
         return this.totalRooms;
     }
 
+    getDestinations(): readonly number[] {
+        return this.destinations;
+    }
+
+    getPrimaryDestination(): number | null {
+        return this.destinations.length > 0 ? this.destinations[0] : null;
+    }
+
     setExplorationMode(on: boolean) {
         this.explorationMode = on;
         if (this.explorationMode) {
@@ -311,7 +319,7 @@ export class EmbeddedMap {
         if (id) {
             this.destinations = [parseInt(id)];
         } else {
-            this.destinations = [];6
+            this.destinations = [];
         }
         this.refresh();
     }

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -22,7 +22,6 @@ import "@client/src/main.ts"
 import NoSleep from 'nosleep.js';
 import {loadMapData, loadColors} from "./mapDataLoader.ts";
 import {loadNpcData} from "./npcDataLoader.ts";
-import {EmbeddedMap} from "./embed.ts"
 import {createElement} from 'react'
 import {createRoot} from 'react-dom/client'
 import Binds from "./options/Binds.tsx"
@@ -48,7 +47,7 @@ import "./triggerTester"
 import "./triggerFinder"
 import {getItemSync} from "@client/src/storage"
 import {initRuntime} from "./runtime/compositionRoot";
-import {setEmbeddedMap} from "./runtime/mapProvider";
+import {initializeEmbeddedMap} from "./runtime/mapProvider";
 
 const {client} = await initRuntime();
 
@@ -241,7 +240,7 @@ Promise.all([mapDataPromise, colorsPromise])
         console.log('Map data and colors loaded successfully');
         progressContainer.style.display = 'none';
         const {startId, reader, pathFinder} = client.Map.initialize(mapData, colors);
-        setEmbeddedMap(new EmbeddedMap(reader, pathFinder, startId));
+        initializeEmbeddedMap({ reader, pathFinder, startId });
     })
     .catch(error => {
         progressContainer.style.display = 'none';

--- a/web-client/src/runtime/mapProvider.ts
+++ b/web-client/src/runtime/mapProvider.ts
@@ -1,14 +1,50 @@
-import type { EmbeddedMap } from '../embed';
+import type { MapReader, PathFinder } from 'mudlet-map-renderer';
+import { EmbeddedMap } from '../embed';
+import {
+    clearEmbeddedMapBridge,
+    setEmbeddedMapBridge,
+} from '@client/src/runtime/embeddedMapBridge';
 
 let embeddedMapInstance: EmbeddedMap | null = null;
+type EmbeddedMapSubscriber = (map: EmbeddedMap | null) => void;
+const subscribers = new Set<EmbeddedMapSubscriber>();
 
-export function setEmbeddedMap(map: EmbeddedMap | null) {
+function notifySubscribers() {
+    subscribers.forEach(listener => {
+        try {
+            listener(embeddedMapInstance);
+        } catch (err) {
+            console.error('mapProvider subscriber failed', err);
+        }
+    });
+}
+
+function assignEmbeddedMap(map: EmbeddedMap | null) {
     embeddedMapInstance = map;
     if (map) {
-        (globalThis as any).embedded = map;
-    } else if ((globalThis as any).embedded) {
-        delete (globalThis as any).embedded;
+        setEmbeddedMapBridge(map);
+    } else {
+        clearEmbeddedMapBridge();
     }
+    notifySubscribers();
+}
+
+export function initializeEmbeddedMap({
+    reader,
+    pathFinder,
+    startId,
+}: {
+    reader: MapReader;
+    pathFinder: PathFinder;
+    startId?: number;
+}): EmbeddedMap {
+    const map = new EmbeddedMap(reader, pathFinder, startId);
+    assignEmbeddedMap(map);
+    return map;
+}
+
+export function setEmbeddedMap(map: EmbeddedMap | null) {
+    assignEmbeddedMap(map);
 }
 
 export function getEmbeddedMap(): EmbeddedMap {
@@ -22,6 +58,14 @@ export function peekEmbeddedMap(): EmbeddedMap | null {
     return embeddedMapInstance;
 }
 
+export function subscribeEmbeddedMap(listener: EmbeddedMapSubscriber): () => void {
+    subscribers.add(listener);
+    listener(embeddedMapInstance);
+    return () => {
+        subscribers.delete(listener);
+    };
+}
+
 export function clearEmbeddedMap() {
-    setEmbeddedMap(null);
+    assignEmbeddedMap(null);
 }

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -1,7 +1,13 @@
 import Modal from "bootstrap/js/dist/modal";
 import {Settings} from "mudlet-map-renderer";
 import {peekClient} from "./runtime/clientProvider";
-import {peekEmbeddedMap} from "./runtime/mapProvider";
+import {subscribeEmbeddedMap} from "./runtime/mapProvider";
+import type { EmbeddedMap } from "./embed";
+
+let embeddedMapRef: EmbeddedMap | null = null;
+subscribeEmbeddedMap(map => {
+    embeddedMapRef = map;
+});
 
 const mapPositions = [
     'top-overlay',
@@ -125,8 +131,8 @@ function apply(settings: UiSettings) {
         const baseRow = 36; // default row height in px
         div.style.gridAutoRows = baseRow * settings.buttonSize + 'px';
     });
-    const embedded = peekEmbeddedMap();
-    if (embedded && (embedded as any).renderer) {
+    const embedded = embeddedMapRef;
+    if (embedded) {
         embedded.setZoom(settings.mapScale);
         embedded.setExplorationMode(settings.explorationMode);
         embedded.refresh();
@@ -321,7 +327,7 @@ export default async function initUiSettings() {
     storage.onChanged?.addListener(handleStorageChange);
 
     function refreshExplorationStats() {
-        const map = peekEmbeddedMap();
+        const map = embeddedMapRef;
         if (map?.getVisitedCount && map?.getRoomCount && explorationStats) {
             const visited = map.getVisitedCount();
             const total = map.getRoomCount();

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     build: {
         minify: true,
         sourcemap: true,
+        target: 'esnext',
         rollupOptions: {
             input: {
                 plugin: resolve('src/plugin.ts'),


### PR DESCRIPTION
## Summary
- move embedded map initialisation into the runtime provider and publish changes through a subscription API
- add a client bridge for the embedded map and refactor scripts/settings to use the typed helpers instead of `window`
- expose destination accessors on the embedded map implementation and set the Vite target to support the async bootstrap

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68f583e538e0832aab7dd6d5032e373a