### PR TITLE
Ensure settings listeners receive initial state

### DIFF
--- a/web-client/src/runtime/compositionRoot.ts
+++ b/web-client/src/runtime/compositionRoot.ts
@@ -64,7 +64,6 @@ async function bootstrap(options: RuntimeOptions): Promise<RuntimeContext> {
     setSettingsService(settingsService);
 
     const eventHub = getEventHub();
-    client.sendEvent('settings.updated', settingsService.snapshot);
     settingsService.onChange(settings => {
         client.sendEvent('settings.updated', settings);
     });

--- a/web-client/src/runtime/settingsService.ts
+++ b/web-client/src/runtime/settingsService.ts
@@ -42,6 +42,7 @@ class SettingsService {
             listener((ev as CustomEvent<Settings>).detail);
         };
         this.target.addEventListener('change', handler);
+        listener(this.snapshot);
         return () => this.target.removeEventListener('change', handler);
     }
 

--- a/web-client/test/runtime/settingsService.test.ts
+++ b/web-client/test/runtime/settingsService.test.ts
@@ -1,0 +1,27 @@
+jest.mock('@client/src/storage', () => ({
+    __esModule: true,
+    default: {
+        onChanged: {
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+        },
+    },
+    getItemSync: jest.fn(),
+    setItemSync: jest.fn(),
+}));
+
+import { defaultSettings } from '@client/src/defaultSettings';
+import { SettingsService } from '../../src/runtime/settingsService';
+
+describe('SettingsService', () => {
+    test('onChange notifies listener immediately with current snapshot', () => {
+        const initial = { ...defaultSettings, shortenExits: !defaultSettings.shortenExits };
+        const service = new SettingsService(initial);
+        const listener = jest.fn();
+
+        service.onChange(listener);
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(listener.mock.calls[0][0]).toEqual(initial);
+    });
+});


### PR DESCRIPTION
## Summary
- emit the current settings snapshot when a SettingsService listener subscribes
- rely on the subscription for the initial settings.updated event during runtime bootstrap
- cover the immediate emission behaviour with a dedicated unit test

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68f5ead19790832aba2f8114049c2d5d