### PR TITLE
Fix PIP footer to show last two output lines

### DIFF
--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -639,7 +639,10 @@ html, body {
             if (child && child.classList && child.classList.contains("output_msg")) {
                 const textEl = child.querySelector<HTMLElement>(".output_msg_text");
                 if (textEl) {
-                    outputs.unshift(textEl.innerHTML);
+                    const lines = this.splitOutputHtmlIntoLines(textEl.innerHTML);
+                    for (let j = lines.length - 1; j >= 0 && outputs.length < 2; j--) {
+                        outputs.unshift(lines[j]);
+                    }
                 }
             }
         }
@@ -695,6 +698,47 @@ html, body {
             return "";
         }
         return `<div class="objects-list-pip-footer"><div class="objects-list-pip-footer-content">${this.pipLastOutputHtml}</div></div>`;
+    }
+
+    private splitOutputHtmlIntoLines(html: string): string[] {
+        const lines: string[] = [];
+        const stack: { open: string; close: string }[] = [];
+        let line = "";
+        const regex = /(<[^>]+>|\r?\n)/g;
+        let last = 0;
+        let match: RegExpExecArray | null;
+        const hasVisibleContent = (value: string) =>
+            value
+                .replace(/<[^>]+>/g, "")
+                .replace(/&nbsp;/gi, " ")
+                .trim().length > 0;
+        while ((match = regex.exec(html)) !== null) {
+            const token = match[0];
+            line += html.slice(last, match.index);
+            if (token === "\n" || token === "\r\n" || /^<br\b[^>]*>$/i.test(token)) {
+                const closedLine = line + stack.map(s => s.close).reverse().join("");
+                if (hasVisibleContent(closedLine)) {
+                    lines.push(closedLine);
+                }
+                line = stack.map(s => s.open).join("");
+            } else {
+                line += token;
+                if (token.startsWith("<") && !token.startsWith("</") && !token.endsWith("/>") && !token.startsWith("<!")) {
+                    const tag = token.match(/^<([a-zA-Z0-9:-]+)/);
+                    if (tag) {
+                        stack.push({ open: token, close: `</${tag[1]}>` });
+                    }
+                } else if (token.startsWith("</")) {
+                    stack.pop();
+                }
+            }
+            last = regex.lastIndex;
+        }
+        line += html.slice(last);
+        if (hasVisibleContent(line)) {
+            lines.push(line);
+        }
+        return lines;
     }
 
     private escapeHtml(text: string) {

--- a/web-client/test/ObjectList.test.ts
+++ b/web-client/test/ObjectList.test.ts
@@ -414,6 +414,56 @@ describe('ObjectList', () => {
     delete (window as any).documentPictureInPicture;
   });
 
+  test('picture-in-picture footer shows last two lines of multiline message', async () => {
+    document.body.innerHTML = `
+      <div id="location-text"></div>
+      <span id="cover-timer"></span>
+      <div id="main_text_output_msg_wrapper">
+        <div class="output_msg"><div class="output_msg_text">Initial</div></div>
+        <div id="split-bottom"></div>
+      </div>
+      <div id="objects-list"></div>
+    `;
+    const pipDoc = document.implementation.createHTMLDocument('pip');
+    const pipWindow = {
+      document: pipDoc,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      close: jest.fn(),
+    } as unknown as DocumentPictureInPictureWindow;
+    const requestWindow = jest.fn().mockResolvedValue(pipWindow);
+    (window as any).documentPictureInPicture = { requestWindow };
+
+    const client = new MockClient();
+    const objectList = new ObjectList(client as any);
+    (objectList as any).render();
+    (objectList as any).handleOutputUpdate();
+
+    const button = document.getElementById('objects-list-pip-button') as HTMLButtonElement;
+    button.click();
+    await Promise.resolve();
+
+    const wrapper = document.getElementById('main_text_output_msg_wrapper')!;
+    const msg = document.createElement('div');
+    msg.className = 'output_msg';
+    const msgText = document.createElement('div');
+    msgText.className = 'output_msg_text';
+    msgText.innerHTML = '<span class="ansi">First line</span><br><span class="ansi">Second line</span>\n<span class="ansi">Third line</span>';
+    msg.appendChild(msgText);
+    wrapper.insertBefore(msg, document.getElementById('split-bottom'));
+    (objectList as any).handleOutputUpdate();
+
+    const footerHtml = (
+      pipDoc.body.querySelector('.objects-list-pip-footer-content') as HTMLElement | null
+    )?.innerHTML || '';
+    expect(footerHtml).not.toContain('First line');
+    expect(footerHtml).toContain('Second line');
+    expect(footerHtml).toContain('Third line');
+    expect(footerHtml.split('<br>').length).toBe(2);
+
+    delete (window as any).documentPictureInPicture;
+  });
+
   test('picture-in-picture inherits objects list styling changes', async () => {
     document.body.innerHTML = '<div id="objects-list" style="font-size: 0.9rem; font-family: Courier, monospace;"></div>';
     const container = document.getElementById('objects-list') as HTMLElement;


### PR DESCRIPTION
## Summary
- split stored output HTML into individual lines when caching picture-in-picture content
- ensure the footer only displays the two most recent lines even for multi-line output
- add a regression test covering multi-line output rendering in the PIP footer

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68f5efbbbc20832ab8504a3974545daa