### PR TITLE
Refactor GMCP ping tracking

### DIFF
--- a/client/src/eventBus.ts
+++ b/client/src/eventBus.ts
@@ -25,6 +25,7 @@ export interface KnownEvents {
     'npc': any;
     'zaskTimer': { seconds: number; ok: boolean } | null;
     'moveModeChanged': number;
+    'ping': number | null;
 }
 
 export type ClientEvents = KnownEvents & {

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -445,6 +445,7 @@
                         <button type="button" class="btn btn-secondary btn-sm" id="trigger-tester-button">Tester triggerów</button>
                         <button type="button" class="btn btn-secondary btn-sm" id="trigger-finder-button">Trigger finder</button>
                         <button type="button" class="btn btn-secondary btn-sm" id="notification-schedule-button">Powiadomienie</button>
+                        <span id="debug-ping" class="badge text-bg-secondary">Ping: --</span>
                         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                     </div>
                 </div>

--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -427,6 +427,7 @@
                         <button type="button" class="btn btn-secondary btn-sm" id="trigger-tester-button">Tester triggerów</button>
                         <button type="button" class="btn btn-secondary btn-sm" id="trigger-finder-button">Trigger finder</button>
                         <button type="button" class="btn btn-secondary btn-sm" id="notification-schedule-button">Powiadomienie</button>
+                        <span id="debug-ping" class="badge text-bg-secondary">Ping: --</span>
                         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                     </div>
                 </div>

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -7,6 +7,7 @@ import TelnetOptionNegotiation from "./TelnetOptionNegotiation.ts";
 import {md5} from 'js-md5';
 import {uncompress} from "./compression.ts";
 import {CommandOptions, normalizeCommand} from "@client/src/scripts/commandPreserveCaseMode.ts";
+import PingTracker from "./PingTracker.ts";
 
 type Params<T> = T extends void ? [] : T extends any[] ? T : [T];
 type EventListener<K extends keyof ClientEvents> = (...args: Params<ClientEvents[K]>) => void;
@@ -28,7 +29,7 @@ class ArkadiaClient implements ClientAdapter {
     private userCommand: string | null = null;
     private passwordCommand: string | null = null;
     private lastConnectManual = true;
-    private pingTimer: number | null = null;
+    private pingTracker: PingTracker;
     private messageBuffer: { text: string, type: string }[] = []
     private recorder = new Recorder({
         processIncomingData: (d) => this.processIncomingData(d),
@@ -37,6 +38,7 @@ class ArkadiaClient implements ClientAdapter {
     });
 
     constructor() {
+        this.pingTracker = new PingTracker(() => this.sendGmcp('core.ping'));
         addEventListener("beforeunload", (event) => {
             if (this.socket && this.socket.readyState === WebSocket.OPEN) {
                 event.preventDefault();
@@ -92,7 +94,7 @@ class ArkadiaClient implements ClientAdapter {
             this.socket.onclose = (event: CloseEvent) => {
                 this.emit('close', event);
                 this.emit('client.disconnect');
-                this.stopPing();
+                this.pingTracker.stop();
 
                 // @ts-ignore
                 this.readInflator = new pako.Inflate()
@@ -102,7 +104,7 @@ class ArkadiaClient implements ClientAdapter {
                 this.emit('open', event);
                 this.emit('client.connect');
                 this.mccp = false;
-                this.startPing();
+                this.pingTracker.start();
                 if (!this.lastConnectManual && this.userCommand && this.passwordCommand) {
                     this.send(this.userCommand, false);
                     if (this.passwordCommand !== this.userCommand) {
@@ -149,7 +151,7 @@ class ArkadiaClient implements ClientAdapter {
             this.socket.close();
         }
         this.mccp = false;
-        this.stopPing();
+        this.pingTracker.stop();
     }
 
     /**
@@ -252,19 +254,6 @@ class ArkadiaClient implements ClientAdapter {
             filename: filename,
         }
         this.sendGmcp('client.conf.set', data)
-    }
-
-    private startPing() {
-        this.stopPing();
-        this.sendGmcp('core.ping');
-        this.pingTimer = window.setInterval(() => this.sendGmcp('core.ping'), 3000);
-    }
-
-    private stopPing() {
-        if (this.pingTimer !== null) {
-            clearInterval(this.pingTimer);
-            this.pingTimer = null;
-        }
     }
 
     output(text?: string, type?: string) {
@@ -383,6 +372,10 @@ class ArkadiaClient implements ClientAdapter {
 
     listRecordings() {
         return this.recorder.listRecordings();
+    }
+
+    getLastPingDuration(): number | null {
+        return this.pingTracker.getLastDuration();
     }
 
     deleteRecording(name: string) {

--- a/web-client/src/PingTracker.ts
+++ b/web-client/src/PingTracker.ts
@@ -1,0 +1,57 @@
+import eventBus from "@client/src/eventBus.ts";
+
+const PING_INTERVAL_MS = 3000;
+
+type SendPing = () => void;
+
+class PingTracker {
+    private timer: number | null = null;
+    private lastSentAt: number | null = null;
+    private lastDuration: number | null = null;
+
+    constructor(private readonly sendPingCommand: SendPing) {
+        eventBus.on("gmcp.core.ping", this.handlePingResponse);
+    }
+
+    start() {
+        this.stop();
+        this.sendPing();
+        this.timer = window.setInterval(() => this.sendPing(), PING_INTERVAL_MS);
+    }
+
+    stop() {
+        if (this.timer !== null) {
+            clearInterval(this.timer);
+            this.timer = null;
+        }
+
+        this.lastSentAt = null;
+
+        if (this.lastDuration !== null) {
+            this.lastDuration = null;
+            eventBus.emit("ping", null);
+        }
+    }
+
+    getLastDuration() {
+        return this.lastDuration;
+    }
+
+    private sendPing() {
+        this.lastSentAt = performance.now();
+        this.sendPingCommand();
+    }
+
+    private handlePingResponse = () => {
+        if (this.lastSentAt === null) {
+            return;
+        }
+
+        const duration = performance.now() - this.lastSentAt;
+        this.lastSentAt = null;
+        this.lastDuration = duration;
+        eventBus.emit("ping", duration);
+    };
+}
+
+export default PingTracker;

--- a/web-client/src/debug.ts
+++ b/web-client/src/debug.ts
@@ -1,4 +1,5 @@
 import Modal from "bootstrap/js/dist/modal";
+import arkadiaClient from "./ArkadiaClient.ts";
 
 function initDebug() {
   const debugButton = document.getElementById("debug-button") as HTMLButtonElement | null;
@@ -8,6 +9,22 @@ function initDebug() {
   const modal = new Modal(modalEl);
   const content = modalEl.querySelector("#debug-content") as HTMLElement;
   const scheduleButton = modalEl.querySelector("#notification-schedule-button") as HTMLButtonElement | null;
+  const pingIndicator = modalEl.querySelector("#debug-ping") as HTMLElement | null;
+
+  const updatePingIndicator = (value: number | null) => {
+    if (!pingIndicator) return;
+    pingIndicator.textContent =
+      typeof value === "number" && !Number.isNaN(value)
+        ? `Ping: ${Math.round(value)} ms`
+        : "Ping: --";
+  };
+
+  if (pingIndicator) {
+    updatePingIndicator(arkadiaClient.getLastPingDuration());
+    arkadiaClient.on("ping", (duration: number | null) => {
+      updatePingIndicator(duration);
+    });
+  }
 
   const methods: Array<keyof Console> = ["log", "error", "warn", "info"];
   methods.forEach((m) => {


### PR DESCRIPTION
## Summary
- extract GMCP ping scheduling and event handling into a dedicated `PingTracker`
- update the Arkadia client to use the tracker for start/stop, emitting ping events, and exposing the last latency

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68f6afc454bc832a88dfaf9f23a4debd