### PR TITLE
Adjust UI settings modal scrolling behavior

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -269,13 +269,13 @@
     <button id="connect-button-float">🔌</button>
 
     <div id="ui-settings-modal" class="modal fade" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
+        <div class="modal-dialog modal-dialog-scrollable h-100">
+            <div class="modal-content h-100">
                 <div class="modal-header">
                     <h5 class="modal-title">Ustawienia UI</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
-                <div class="modal-body">
+                <div class="modal-body overflow-auto" style="min-height: 0;">
                     <div class="ui-settings-layout">
                         <section class="ui-settings-section">
                             <h6 class="ui-settings-section-title">Mapa</h6>

--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -251,13 +251,13 @@
     </div>
 
     <div id="ui-settings-modal" class="modal fade" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
+        <div class="modal-dialog modal-dialog-scrollable h-100">
+            <div class="modal-content h-100">
                 <div class="modal-header">
                     <h5 class="modal-title">Ustawienia UI</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
-                <div class="modal-body">
+                <div class="modal-body overflow-auto" style="min-height: 0;">
                     <div class="ui-settings-layout">
                         <section class="ui-settings-section">
                             <h6 class="ui-settings-section-title">Mapa</h6>


### PR DESCRIPTION
## Summary
- update the UI settings modal markup to use a scrollable dialog so the footer stays pinned
- mirror the same dialog structure in the sandbox for parity

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68f92449cd10832a89fab4836ce6fee4