### PR TITLE
Remove aria attributes and update guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Always run tests!
 
 In Regexps don't add ever polish letters.
 Prefer creation of HTML elements in HTML files, when possible.
+Do not use `aria-*` attributes; they are not needed in this project.
 
 ## Data directory
 

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -578,7 +578,7 @@
 <div id="letter-composer" class="letter-composer" hidden>
     <div class="letter-composer-header">
         <span>Nowy list</span>
-        <button type="button" class="btn-close btn-close-white" aria-label="Zamknij" data-letter-close></button>
+        <button type="button" class="btn-close btn-close-white" data-letter-close></button>
     </div>
     <form class="letter-composer-form">
         <div class="letter-composer-field">

--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -334,10 +334,8 @@ export default class ObjectList {
         button.type = "button";
         button.id = "objects-list-pip-button";
         button.className = "objects-list-button";
-        button.setAttribute("aria-pressed", "false");
-        button.setAttribute("aria-label", "Otwórz listę obiektów w trybie Picture-in-Picture");
         button.title = "Picture-in-Picture";
-        button.innerHTML = `<span aria-hidden="true">⤢</span>`;
+        button.innerHTML = `<span>⤢</span>`;
         button.addEventListener("click", this.togglePictureInPicture);
         controls.appendChild(button);
         this.container.insertBefore(controls, content);
@@ -422,7 +420,6 @@ export default class ObjectList {
 
     private updatePictureInPictureButton(active: boolean) {
         if (!this.pipButton) return;
-        this.pipButton.setAttribute("aria-pressed", active ? "true" : "false");
         if (active) {
             this.pipButton.classList.add("objects-list-button-active");
         } else {

--- a/web-client/src/herbs/HerbManager.tsx
+++ b/web-client/src/herbs/HerbManager.tsx
@@ -597,15 +597,13 @@ const HerbManager = () => {
                 className={`herb-window${position ? " herb-window--floating" : " herb-window--center"}`}
                 style={containerStyle}
                 role="dialog"
-                aria-modal="true"
-                aria-label="Woreczki ziół"
                 tabIndex={-1}
                 onClick={event => event.stopPropagation()}
                 onPointerDownCapture={closeContextMenu}
             >
                 <div className="herb-window-header" onPointerDown={handlePointerDown}>
                     <h5 className="herb-window-title">Woreczki ziół</h5>
-                    <button type="button" className="btn-close" aria-label="Zamknij" onClick={handleClose} />
+                    <button type="button" className="btn-close" onClick={handleClose} />
                 </div>
                 <div className="herb-window-body">
                     <div className={`herb-manager${busy ? " herb-manager--busy" : ""}`}>

--- a/web-client/test/ObjectList.test.ts
+++ b/web-client/test/ObjectList.test.ts
@@ -266,7 +266,7 @@ describe('ObjectList', () => {
     await Promise.resolve();
     expect(requestWindow).toHaveBeenCalled();
     expect(pipDoc.body.querySelector('#objects-list-pip')?.innerHTML).toContain('object-num');
-    expect(button.getAttribute('aria-pressed')).toBe('true');
+    expect(button.classList.contains('objects-list-button-active')).toBe(true);
     expect(pipDoc.title).toBe('Arkadia');
 
     document.title = 'Arkadia - Battle';
@@ -275,7 +275,7 @@ describe('ObjectList', () => {
     expect(pipDoc.title).toBe('Arkadia - Battle');
 
     handlers.pagehide?.call(pipWindow, undefined);
-    expect(button.getAttribute('aria-pressed')).toBe('false');
+    expect(button.classList.contains('objects-list-button-active')).toBe(false);
 
     delete (window as any).documentPictureInPicture;
   });


### PR DESCRIPTION
## Summary
- remove aria attributes from the letter composer and herb manager components
- update ObjectList button markup and tests to rely on class toggling instead of aria attributes
- document in AGENTS.md that aria attributes should not be used in this project

## Testing
- yarn --cwd web-client test --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68f924eab724832aa58f17cf3263de22