### PR TITLE
Update Sucha Kepa carriage departure triggers

### DIFF
--- a/client/src/scripts/other/Podgrodzie Tretogoru - Gelibol.json
+++ b/client/src/scripts/other/Podgrodzie Tretogoru - Gelibol.json
@@ -1,0 +1,37 @@
+{
+    "enter": "Placisz kupcowi i wspinasz sie do wnetrza kupieckiego stojacego wozu z plandeka.",
+    "exit_command": "wyjscie",
+    "start": "Woznica oznajmia odjazd.",
+    "bind": "wyjrzyj przez okno",
+    "show_path": true,
+    "stops": [
+        {
+            "start": 3926,
+            "destination": 4092,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, srodek niewielkiej osady\\.$",
+            "set_pattern": "^Siedzacy na kozle wozu kupiec wola donosnym glosem: Za chwile ruszamy w kierunku miasta Gelibol!$",
+            "label": "Sucha Kepa"
+        },
+        {
+            "start": 4092,
+            "destination": 4163,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, glowny plac miasta\\.$",
+            "set_pattern": "^Siedzacy na kozle wozu kupiec wola donosnym glosem: Za chwile ruszamy w kierunku miasta stolecznego Tretogoru!$",
+            "label": "Gelibol"
+        },
+        {
+            "start": 4163,
+            "destination": 4092,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, srodek niewielkiej osady\\.$",
+            "set_pattern": "^Siedzacy na kozle wozu kupiec wola donosnym glosem: Za chwile ruszamy w kierunku miasta stolecznego Tretogoru!$",
+            "label": "Sucha Kepa"
+        },
+        {
+            "start": 4092,
+            "destination": 3926,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, podgrodzie Tretogoru\\.$",
+            "set_pattern": "^Siedzacy na kozle wozu kupiec wola donosnym glosem: Za chwile ruszamy w kierunku miasta Gelibol!$",
+            "label": "Podgrodzie Tretogoru"
+        }
+    ]
+}

--- a/client/src/scripts/transportStops.ts
+++ b/client/src/scripts/transportStops.ts
@@ -34,6 +34,7 @@ import Strag from "./ships/Strag.json";
 import Jouinard from "./other/Jouinard - Nuln.json";
 import KrainaZgromadzenia from "./other/Kraina Zgromadzenia - Nuln.json";
 import MariborGrabowa from "./other/Maribor - Grabowa Buchta.json";
+import PodgrodzieTretogoruGelibol from "./other/Podgrodzie Tretogoru - Gelibol.json";
 import Salignac from "./other/Salignac - Nuln.json";
 import Varieno from "./other/Varieno - Miragliano - Campogrotta.json";
 import WyzimaOxenfurt from "./other/Wyzima - Oxenfurt.json";
@@ -107,6 +108,7 @@ const RAW_DEFINITION_ENTRIES: Array<[string, RawTransportDefinition]> = [
     ["Jouinard - Nuln", Jouinard as RawTransportDefinition],
     ["Kraina Zgromadzenia - Nuln", KrainaZgromadzenia as RawTransportDefinition],
     ["Maribor - Grabowa Buchta", MariborGrabowa as RawTransportDefinition],
+    ["Podgrodzie Tretogoru - Gelibol", PodgrodzieTretogoruGelibol as RawTransportDefinition],
     ["Salignac - Nuln", Salignac as RawTransportDefinition],
     ["Varieno - Miragliano - Campogrotta", Varieno as RawTransportDefinition],
     ["Wyzima - Oxenfurt", WyzimaOxenfurt as RawTransportDefinition],


### PR DESCRIPTION
## Summary
- align the Podgrodzie Tretogoru – Gelibol route definition with the louder Sucha Kepa departure shouts heard from outside the wagon

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68f96e16ef94832a838bab0075c5221c