### PR TITLE
Add Maribor to Obawa carriage route support

### DIFF
--- a/client/src/scripts/localizers.ts
+++ b/client/src/scripts/localizers.ts
@@ -68,14 +68,14 @@ export default function initLocalizers(client: Client) {
         { pattern: 'Postoj - rozdroza niedaleko Piany', roomId: 764 },
         { pattern: 'Postoj - wies na podgrodziu Oxenfurtu', roomId: 790 },
         // maribor-grabowa
-        { pattern: 'Postoj, przystan powozowa', roomId: 180 },
+        { pattern: 'Postoj, przystan powozowa.', roomId: 180 },
         { pattern: 'Postoj, na dziedzincu zajazdu', roomId: 3343 },
         { pattern: 'Postoj, centralny plac wioski', roomId: 3457 },
         { pattern: 'Postoj, placyk w Grabowej Buchcie', roomId: 3525 },
         // maribor-verden
-        { pattern: 'Postoj, lesne rozdroze', roomId: 536 },
+        { pattern: 'Postoj, lesne rozdroze.', roomId: 536 },
         { pattern: 'Postoj, przed zajazdem.', roomId: 3043 },
-        { pattern: 'placyk w centrum wsi', roomId: 3221 },
+        { pattern: 'Postoj, placyk w centrum wsi.', roomId: 3221 },
         // gelibol-tretogor
         { pattern: 'Postoj, podgrodzie Tretogoru.', roomId: 3926 },
         { pattern: 'Postoj, glowny plac miasta.', roomId: 4163 },

--- a/client/src/scripts/other/Maribor - Obawa.json
+++ b/client/src/scripts/other/Maribor - Obawa.json
@@ -1,0 +1,50 @@
+{
+    "enter": "Placisz woznicy i wspinasz sie na otwarty stojacy powoz.",
+    "exit_command": "wyjscie",
+    "start": "Woznica oznajmia odjazd.",
+    "bind": "wyjrzyj na zewnatrz",
+    "show_path": true,
+    "stops": [
+        {
+            "start": 3221,
+            "destination": 3043,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, przed zajazdem\\.$",
+            "set_pattern": "^Siedzacy na kozle woznica krzyczy: Za kilka chwil ruszamy w kierunku Mariboru!$",
+            "label": "Brugge"
+        },
+        {
+            "start": 3043,
+            "destination": 536,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, lesne rozdroze\\.$",
+            "set_pattern": "^Siedzacy na kozle woznica krzyczy: Za kilka chwil ruszamy w kierunku Mariboru!$",
+            "label": "Bialy Kiel"
+        },
+        {
+            "start": 536,
+            "destination": 180,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, przystan powozowa\\.$",
+            "set_pattern": "^Siedzacy na kozle woznica krzyczy: Za kilka chwil ruszamy w kierunku Twierdzy Bodrog!$",
+            "label": "Maribor"
+        },
+        {
+            "start": 180,
+            "destination": 536,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, lesne rozdroze\\.$",
+            "label": "Bialy Kiel"
+        },
+        {
+            "start": 536,
+            "destination": 3043,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, przed zajazdem\\.$",
+            "set_pattern": "^Siedzacy na kozle woznica krzyczy: Za kilka chwil ruszamy w kierunku Twierdzy Bodrog!$",
+            "label": "Brugge"
+        },
+        {
+            "start": 3043,
+            "destination": 3221,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, placyk w centrum wsi\\.$",
+            "set_pattern": "^Siedzacy na kozle woznica krzyczy: Za kilka chwil ruszamy w kierunku Mariboru!$",
+            "label": "Obawa"
+        }
+    ]
+}

--- a/client/src/scripts/transportStops.ts
+++ b/client/src/scripts/transportStops.ts
@@ -35,6 +35,7 @@ import BialyMostHagge from "./other/Bialy Most - Hagge.json";
 import Jouinard from "./other/Jouinard - Nuln.json";
 import KrainaZgromadzenia from "./other/Kraina Zgromadzenia - Nuln.json";
 import MariborGrabowa from "./other/Maribor - Grabowa Buchta.json";
+import MariborObawa from "./other/Maribor - Obawa.json";
 import Salignac from "./other/Salignac - Nuln.json";
 import Varieno from "./other/Varieno - Miragliano - Campogrotta.json";
 import WyzimaOxenfurt from "./other/Wyzima - Oxenfurt.json";
@@ -109,6 +110,7 @@ const RAW_DEFINITION_ENTRIES: Array<[string, RawTransportDefinition]> = [
     ["Jouinard - Nuln", Jouinard as RawTransportDefinition],
     ["Kraina Zgromadzenia - Nuln", KrainaZgromadzenia as RawTransportDefinition],
     ["Maribor - Grabowa Buchta", MariborGrabowa as RawTransportDefinition],
+    ["Maribor - Obawa", MariborObawa as RawTransportDefinition],
     ["Salignac - Nuln", Salignac as RawTransportDefinition],
     ["Varieno - Miragliano - Campogrotta", Varieno as RawTransportDefinition],
     ["Wyzima - Oxenfurt", WyzimaOxenfurt as RawTransportDefinition],


### PR DESCRIPTION
## Summary
- add a Maribor – Obawa carriage route definition with stop metadata
- register the route and align localizer patterns for the new stops

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68f97f45d688832ab4f75d7fe7d9927b