### PR TITLE
Reset mapper history on manual room set

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -271,9 +271,10 @@ export default class MapHelper {
 
     setMapRoomById(id: number) {
         if (this.currentRoom?.id === id) {
+            this.locationHistory = [id];
             return;
         }
-        this.renderRoomById(id)
+        this.setMapRoom(id)
     }
 
     setMapRoom(room: number) {

--- a/client/test/mapHelperSetMapRoomById.test.ts
+++ b/client/test/mapHelperSetMapRoomById.test.ts
@@ -1,0 +1,34 @@
+import MapHelper from '../src/MapHelper';
+
+jest.mock('mudlet-map-renderer', () => ({ MapReader: function () {} }));
+
+describe('MapHelper setMapRoomById', () => {
+  const createClient = () => ({
+    addEventListener: () => {},
+    sendEvent: jest.fn(),
+    suppressMapMoveEvent: false,
+  });
+
+  test('replaces history with the new room id', () => {
+    const client: any = createClient();
+    const map = new MapHelper(client);
+    map.locationHistory = [1, 2, 3];
+
+    map.setMapRoomById(10);
+
+    expect(map.locationHistory).toEqual([10]);
+  });
+
+  test('replaces history even when staying in the same room', () => {
+    const client: any = createClient();
+    const map = new MapHelper(client);
+    map.currentRoom = { id: 5 } as any;
+    map.locationHistory = [5, 6, 7];
+    const callsBefore = client.sendEvent.mock.calls.length;
+
+    map.setMapRoomById(5);
+
+    expect(map.locationHistory).toEqual([5]);
+    expect(client.sendEvent).toHaveBeenCalledTimes(callsBefore);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure manually setting the map room clears the mapper history
- add tests covering the manual room set history behavior

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68f9e6f6de58832ab6b97b4f7f530460