### PR TITLE
Add Carreras–Rivia–Scala transport route definition

### DIFF
--- a/client/src/scripts/other/Carreras - Rivia - Scala.json
+++ b/client/src/scripts/other/Carreras - Rivia - Scala.json
@@ -1,0 +1,50 @@
+{
+    "start": "Woznica siedzacy na kozle chrapliwym glosem oznajmia odjazd.",
+    "exit_command": "wyjscie",
+    "bind": "wyjscie",
+    "show_path": true,
+    "stops": [
+        {
+            "start": 860,
+            "destination": 680,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, pod murem zajazdu\\.$",
+            "set_pattern": "^Woznica wola: Za chwile ruszamy w kierunku lyrijskiej twierdzy Sp[a-z]+!$",
+            "label": "Scala - zajazd"
+        },
+        {
+            "start": 680,
+            "destination": 860,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, na rogatkach\\.$",
+            "set_pattern": "^Woznica wola: Za chwile ruszamy w kierunku lyrijskiej twierdzy Scali!$",
+            "label": "Scala - rogatki"
+        },
+        {
+            "start": 860,
+            "destination": 994,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, gosciniec rivski\\.$",
+            "set_pattern": "^Woznica wola: Za chwile ruszamy w kierunku miasta Rivii, stolicy Rivii!$",
+            "label": "Gosciniec Rivski"
+        },
+        {
+            "start": 994,
+            "destination": 266,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, na przeleczy\\.$",
+            "set_pattern": "^Woznica wola: Za chwile ruszamy w kierunku temerskiego miasta Carreras!$",
+            "label": "Przelecz"
+        },
+        {
+            "start": 266,
+            "destination": 994,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, gosciniec rivski\\.$",
+            "set_pattern": "^Woznica wola: Za chwile ruszamy w kierunku miasta Rivii, stolicy Rivii!$",
+            "label": "Gosciniec Rivski"
+        },
+        {
+            "start": 994,
+            "destination": 860,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, na rogatkach\\.$",
+            "set_pattern": "^Woznica wola: Za chwile ruszamy w kierunku lyrijskiej twierdzy Scali!$",
+            "label": "Scala - rogatki"
+        }
+    ]
+}

--- a/client/src/scripts/transportStops.ts
+++ b/client/src/scripts/transportStops.ts
@@ -32,6 +32,7 @@ import Rygwit from "./ships/Rygwit.json";
 import Strag from "./ships/Strag.json";
 
 import BialyMostHagge from "./other/Bialy Most - Hagge.json";
+import CarrerasRiviaScala from "./other/Carreras - Rivia - Scala.json";
 import Jouinard from "./other/Jouinard - Nuln.json";
 import KrainaZgromadzenia from "./other/Kraina Zgromadzenia - Nuln.json";
 import MariborGrabowa from "./other/Maribor - Grabowa Buchta.json";
@@ -109,6 +110,7 @@ const RAW_DEFINITION_ENTRIES: Array<[string, RawTransportDefinition]> = [
     ["Rygwit", Rygwit as RawTransportDefinition],
     ["Strag", Strag as RawTransportDefinition],
     ["Bialy Most - Hagge", BialyMostHagge as RawTransportDefinition],
+    ["Carreras - Rivia - Scala", CarrerasRiviaScala as RawTransportDefinition],
     ["Jouinard - Nuln", Jouinard as RawTransportDefinition],
     ["Kraina Zgromadzenia - Nuln", KrainaZgromadzenia as RawTransportDefinition],
     ["Maribor - Grabowa Buchta", MariborGrabowa as RawTransportDefinition],


### PR DESCRIPTION
## Summary
- add a transport definition for the Carreras – Rivia – Scala carriage route based on new stop logs
- register the new route with the transport tracker so the client can recognise its stops

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68f9e5d7b674832aadf68cf4e4b5352d