### PR TITLE
Aggregate transport segment durations and improve transport timer fallback

### DIFF
--- a/client/src/scripts/transportStops.ts
+++ b/client/src/scripts/transportStops.ts
@@ -814,7 +814,18 @@ class TransportTracker {
         }
         const index = this.determineActiveIndex(journey);
         if (index === undefined) {
-            this.emitTimer(null);
+            const fallbackIndex = this.selectUnknownDurationCandidate(journey);
+            if (fallbackIndex === undefined) {
+                this.emitTimer(null);
+                return;
+            }
+            const fallbackStop = journey.definition.stops[fallbackIndex];
+            const payload: TransportTimerPayload = {
+                label: formatLabel(journey.definition, fallbackStop),
+                remaining: null,
+                total: null,
+            };
+            this.emitTimer(payload);
             return;
         }
         const stop = journey.definition.stops[index];
@@ -829,6 +840,19 @@ class TransportTracker {
             total: typeof stop.time === "number" ? stop.time : null,
         };
         this.emitTimer(payload);
+    }
+
+    private selectUnknownDurationCandidate(journey: JourneyState): number | undefined {
+        for (const candidate of journey.candidateIndexes) {
+            const stop = journey.definition.stops[candidate];
+            if (!stop) {
+                continue;
+            }
+            if (typeof stop.time !== "number" || Number.isNaN(stop.time)) {
+                return candidate;
+            }
+        }
+        return undefined;
     }
 }
 

--- a/client/src/utils/transportStats.ts
+++ b/client/src/utils/transportStats.ts
@@ -1,6 +1,6 @@
 const DB_NAME = "ArkadiaTransportStatsDB";
 const STORE_NAME = "segments";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 function isIndexedDBSupported(): boolean {
     return typeof indexedDB !== "undefined";
@@ -16,10 +16,52 @@ async function getDatabase(): Promise<IDBDatabase> {
     if (!dbPromise) {
         dbPromise = new Promise((resolve, reject) => {
             const request = indexedDB.open(DB_NAME, DB_VERSION);
-            request.onupgradeneeded = () => {
+            request.onupgradeneeded = event => {
                 const db = request.result;
+                const transaction = request.transaction;
+                if (!transaction) {
+                    return;
+                }
+
+                const createStore = () => {
+                    if (db.objectStoreNames.contains(STORE_NAME)) {
+                        db.deleteObjectStore(STORE_NAME);
+                    }
+                    const store = db.createObjectStore(STORE_NAME, { keyPath: "segmentKey" });
+                    store.createIndex("bySegment", "segmentKey", { unique: true });
+                    return store;
+                };
+
                 if (!db.objectStoreNames.contains(STORE_NAME)) {
-                    db.createObjectStore(STORE_NAME, { keyPath: "id", autoIncrement: true });
+                    createStore();
+                    return;
+                }
+
+                if (event.oldVersion < 2) {
+                    const existingStore = transaction.objectStore(STORE_NAME);
+                    const migrateRequest = existingStore.getAll();
+                    migrateRequest.onsuccess = () => {
+                        const rawRecords = Array.isArray(migrateRequest.result) ? migrateRequest.result : [];
+                        const store = createStore();
+                        const migrated = rawRecords.reduce<StoredTransportSegmentRecord[]>((acc, entry) => {
+                            const migratedRecord = migrateLegacyRecord(entry as any);
+                            if (migratedRecord) {
+                                const existingIndex = acc.findIndex(item => item.segmentKey === migratedRecord.segmentKey);
+                                if (existingIndex >= 0) {
+                                    acc[existingIndex] = mergeStoredSegments(acc[existingIndex], migratedRecord);
+                                } else {
+                                    acc.push(migratedRecord);
+                                }
+                            }
+                            return acc;
+                        }, []);
+                        migrated.forEach(record => {
+                            store.add(record);
+                        });
+                    };
+                    migrateRequest.onerror = () => {
+                        createStore();
+                    };
                 }
             };
             request.onsuccess = () => resolve(request.result);
@@ -28,6 +70,12 @@ async function getDatabase(): Promise<IDBDatabase> {
     }
 
     return dbPromise;
+}
+
+interface TransportSegmentDurationEntry {
+    duration: number;
+    startedAt: number;
+    endedAt: number;
 }
 
 export interface TransportSegmentRecord {
@@ -42,15 +90,134 @@ export interface TransportSegmentRecord {
     expectedDuration?: number | null;
 }
 
+export interface StoredTransportSegmentRecord {
+    segmentKey: string;
+    transport: string;
+    fromId: number;
+    toId: number;
+    fromLabel: string;
+    toLabel: string;
+    shortestDuration: TransportSegmentDurationEntry;
+    longestDuration: TransportSegmentDurationEntry;
+    expectedDuration?: number | null;
+    updatedAt: number;
+}
+
+interface LegacyTransportSegmentRecord extends TransportSegmentRecord {
+    id?: number;
+    createdAt?: number;
+}
+
+function createSegmentKey(record: { transport: string; fromId: number; toId: number }): string {
+    return `${record.transport}::${record.fromId}->${record.toId}`;
+}
+
+function toDurationEntry(record: TransportSegmentRecord): TransportSegmentDurationEntry {
+    return {
+        duration: record.duration,
+        startedAt: record.startedAt,
+        endedAt: record.endedAt,
+    };
+}
+
+function mergeStoredSegments(
+    current: StoredTransportSegmentRecord,
+    incoming: StoredTransportSegmentRecord
+): StoredTransportSegmentRecord {
+    const shortest =
+        incoming.shortestDuration.duration < current.shortestDuration.duration
+            ? incoming.shortestDuration
+            : current.shortestDuration;
+    const longest =
+        incoming.longestDuration.duration > current.longestDuration.duration
+            ? incoming.longestDuration
+            : current.longestDuration;
+
+    return {
+        ...current,
+        fromLabel: incoming.fromLabel || current.fromLabel,
+        toLabel: incoming.toLabel || current.toLabel,
+        shortestDuration: shortest,
+        longestDuration: longest,
+        expectedDuration:
+            incoming.expectedDuration !== undefined ? incoming.expectedDuration : current.expectedDuration ?? null,
+        updatedAt: Math.max(current.updatedAt, incoming.updatedAt),
+    };
+}
+
+function migrateLegacyRecord(entry: LegacyTransportSegmentRecord): StoredTransportSegmentRecord | null {
+    if (!entry || typeof entry.transport !== "string") {
+        return null;
+    }
+    const segmentKey = createSegmentKey(entry);
+    const duration = toDurationEntry(entry);
+    return {
+        segmentKey,
+        transport: entry.transport,
+        fromId: entry.fromId,
+        toId: entry.toId,
+        fromLabel: entry.fromLabel,
+        toLabel: entry.toLabel,
+        shortestDuration: duration,
+        longestDuration: duration,
+        expectedDuration: entry.expectedDuration ?? null,
+        updatedAt: Date.now(),
+    };
+}
+
 export async function recordTransportSegment(record: TransportSegmentRecord): Promise<void> {
     try {
         const db = await getDatabase();
         await new Promise<void>((resolve, reject) => {
             const transaction = db.transaction([STORE_NAME], "readwrite");
             const store = transaction.objectStore(STORE_NAME);
-            const request = store.add({ ...record, createdAt: Date.now() });
-            request.onsuccess = () => resolve();
-            request.onerror = () => reject(request.error ?? new Error("Failed to store transport segment"));
+            const segmentKey = createSegmentKey(record);
+            const getRequest = store.get(segmentKey);
+            getRequest.onsuccess = () => {
+                const existing = getRequest.result as StoredTransportSegmentRecord | undefined;
+                const duration = toDurationEntry(record);
+                const expectedDuration =
+                    record.expectedDuration !== undefined
+                        ? record.expectedDuration
+                        : existing?.expectedDuration ?? null;
+                const baseRecord: StoredTransportSegmentRecord = existing
+                    ? {
+                          ...existing,
+                          fromLabel: record.fromLabel,
+                          toLabel: record.toLabel,
+                          expectedDuration,
+                          updatedAt: Date.now(),
+                      }
+                    : {
+                          segmentKey,
+                          transport: record.transport,
+                          fromId: record.fromId,
+                          toId: record.toId,
+                          fromLabel: record.fromLabel,
+                          toLabel: record.toLabel,
+                          shortestDuration: duration,
+                          longestDuration: duration,
+                          expectedDuration,
+                          updatedAt: Date.now(),
+                      };
+
+                const nextRecord: StoredTransportSegmentRecord = existing
+                    ? {
+                          ...baseRecord,
+                          shortestDuration:
+                              duration.duration < existing.shortestDuration.duration
+                                  ? duration
+                                  : existing.shortestDuration,
+                          longestDuration:
+                              duration.duration > existing.longestDuration.duration ? duration : existing.longestDuration,
+                      }
+                    : baseRecord;
+
+                const putRequest = store.put(nextRecord);
+                putRequest.onsuccess = () => resolve();
+                putRequest.onerror = () => reject(putRequest.error ?? new Error("Failed to store transport segment"));
+            };
+            getRequest.onerror = () => reject(getRequest.error ?? new Error("Failed to read transport segment"));
         });
     } catch (error) {
         if (typeof process === "undefined" || process.env.NODE_ENV !== "test") {
@@ -75,14 +242,14 @@ export async function clearTransportStats(): Promise<void> {
     });
 }
 
-export async function getAllTransportSegments(): Promise<any[]> {
+export async function getAllTransportSegments(): Promise<StoredTransportSegmentRecord[]> {
     try {
         const db = await getDatabase();
-        return await new Promise<any[]>((resolve, reject) => {
+        return await new Promise<StoredTransportSegmentRecord[]>((resolve, reject) => {
             const transaction = db.transaction([STORE_NAME], "readonly");
             const store = transaction.objectStore(STORE_NAME);
             const request = store.getAll();
-            request.onsuccess = () => resolve(request.result ?? []);
+            request.onsuccess = () => resolve((request.result as StoredTransportSegmentRecord[]) ?? []);
             request.onerror = () => reject(request.error ?? new Error("Failed to read transport stats"));
         });
     } catch {

--- a/client/test/transportStats.test.ts
+++ b/client/test/transportStats.test.ts
@@ -21,9 +21,57 @@ describe('transport stats storage', () => {
 
     const segments = await getAllTransportSegments();
     expect(segments.length).toBeGreaterThanOrEqual(1);
-    const latest = segments[segments.length - 1];
-    expect(latest.transport).toBe('Test Route');
-    expect(latest.duration).toBe(1);
-    expect(latest.expectedDuration).toBeNull();
+    const latest = segments.find(segment => segment.transport === 'Test Route');
+    expect(latest).toBeTruthy();
+    const record = latest!;
+    expect(record.transport).toBe('Test Route');
+    expect(record.shortestDuration.duration).toBe(1);
+    expect(record.longestDuration.duration).toBe(1);
+    expect(record.expectedDuration).toBeNull();
+  });
+
+  test('stores only shortest and longest duration per segment', async () => {
+    const startedAt = Date.now();
+    await recordTransportSegment({
+      transport: 'Test Route',
+      fromId: 1,
+      toId: 2,
+      fromLabel: 'Start',
+      toLabel: 'End',
+      startedAt,
+      endedAt: startedAt + 1000,
+      duration: 1,
+      expectedDuration: null,
+    });
+
+    await recordTransportSegment({
+      transport: 'Test Route',
+      fromId: 1,
+      toId: 2,
+      fromLabel: 'Start',
+      toLabel: 'End',
+      startedAt,
+      endedAt: startedAt + 4000,
+      duration: 4,
+      expectedDuration: null,
+    });
+
+    await recordTransportSegment({
+      transport: 'Test Route',
+      fromId: 1,
+      toId: 2,
+      fromLabel: 'Start',
+      toLabel: 'End',
+      startedAt,
+      endedAt: startedAt + 2000,
+      duration: 2,
+      expectedDuration: null,
+    });
+
+    const segments = await getAllTransportSegments();
+    expect(segments.length).toBe(1);
+    const [record] = segments;
+    expect(record.shortestDuration.duration).toBe(1);
+    expect(record.longestDuration.duration).toBe(4);
   });
 });

--- a/client/test/transportStops.test.ts
+++ b/client/test/transportStops.test.ts
@@ -128,14 +128,16 @@ describe('transport stop triggers', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
     const segments = await transportStats.getAllTransportSegments();
     expect(segments.length).toBeGreaterThan(0);
-    const latest = segments[segments.length - 1];
-    expect(latest.transport).toBe('Salignac - Nuln');
-    expect(typeof latest.fromId).toBe('number');
-    expect(typeof latest.toId).toBe('number');
-    expect(typeof latest.fromLabel).toBe('string');
-    expect(latest.toLabel).toContain("'Pod piegowata elfka'");
-    expect(typeof latest.expectedDuration).toBe('number');
-    expect(typeof latest.duration).toBe('number');
+    const matching = segments.find(segment => segment.toLabel.includes("'Pod piegowata elfka'"));
+    expect(matching).toBeTruthy();
+    const record = matching!;
+    expect(record.transport).toBe('Salignac - Nuln');
+    expect(typeof record.fromId).toBe('number');
+    expect(typeof record.toId).toBe('number');
+    expect(typeof record.fromLabel).toBe('string');
+    expect(typeof record.expectedDuration).toBe('number');
+    expect(typeof record.shortestDuration.duration).toBe('number');
+    expect(typeof record.longestDuration.duration).toBe('number');
   });
 
   test('tracks Wyzima - Oxenfurt route with shared stop pattern', () => {


### PR DESCRIPTION
## Summary
- aggregate transport segment stats in IndexedDB by keeping only the shortest and longest observed durations per route segment
- migrate legacy segment data to the new aggregated format and expose typed helpers for stored records
- ensure the transport timer immediately displays a label for routes that lack a known duration by falling back to unknown candidates
- update transport stats tests to cover the aggregation behaviour and adjust transport stop tests for the new record shape

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68f9f396aa4c832abf07c720b912dbfb