### PR TITLE
Add Quenelles transport route definition

### DIFF
--- a/client/src/scripts/other/Quenelles - Montlac - Merceaux-Descloux.json
+++ b/client/src/scripts/other/Quenelles - Montlac - Merceaux-Descloux.json
@@ -1,0 +1,51 @@
+{
+    "enter": "Oplacasz podroz u woznicy i wsiadasz do blekitnego stojacego dylizansu.",
+    "start": "Drzwiczki sie zamykaja, drzenie przebiega przez caly pojazd, ktory powoli rusza.",
+    "exit_command": "wyjscie",
+    "bind": "wyjrzyj przez okno",
+    "show_path": true,
+    "stops": [
+        {
+            "start": 4659,
+            "destination": 7786,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, centrum wioski Montlac\\.$",
+            "set_pattern": "^Woznica.* wola: Nastepny postoj - Merceaux-Descloux!$",
+            "label": "Montlac"
+        },
+        {
+            "start": 7786,
+            "destination": 7744,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, w wiosce Merceaux-Descloux\\.$",
+            "set_pattern": "^Woznica.* wola: Nastepny postoj - most pod Parravon!$",
+            "label": "Merceaux-Descloux"
+        },
+        {
+            "start": 7744,
+            "destination": 26659,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, plac przed zajazdem\\.$",
+            "set_pattern": "^Woznica.* wola: Nastepny postoj - Merceaux-Descloux!$",
+            "label": "Parravon"
+        },
+        {
+            "start": 26659,
+            "destination": 7744,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, w wiosce Merceaux-Descloux\\.$",
+            "set_pattern": "^Woznica.* wola: Nastepny postoj - Montlac!$",
+            "label": "Merceaux-Descloux"
+        },
+        {
+            "start": 7744,
+            "destination": 7786,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, centrum wioski Montlac\\.$",
+            "set_pattern": "^Woznica.* wola: Nastepny postoj - Quenelles!$",
+            "label": "Montlac"
+        },
+        {
+            "start": 7786,
+            "destination": 4659,
+            "stop_pattern": "^Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, plac Gillesa le Breton\\.$",
+            "set_pattern": "^Woznica.* wola: Nastepny postoj - Montlac!$",
+            "label": "Quenelles"
+        }
+    ]
+}

--- a/client/src/scripts/transportStops.ts
+++ b/client/src/scripts/transportStops.ts
@@ -41,6 +41,7 @@ import MariborObawa from "./other/Maribor - Obawa.json";
 import Salignac from "./other/Salignac - Nuln.json";
 import Varieno from "./other/Varieno - Miragliano - Campogrotta.json";
 import WyzimaOxenfurt from "./other/Wyzima - Oxenfurt.json";
+import QuenellesMontlacMerceauxDescloux from "./other/Quenelles - Montlac - Merceaux-Descloux.json";
 
 const BOARD_COMMANDS = new Set([
     "wsiadz na statek",
@@ -119,6 +120,10 @@ const RAW_DEFINITION_ENTRIES: Array<[string, RawTransportDefinition]> = [
     ["Salignac - Nuln", Salignac as RawTransportDefinition],
     ["Varieno - Miragliano - Campogrotta", Varieno as RawTransportDefinition],
     ["Wyzima - Oxenfurt", WyzimaOxenfurt as RawTransportDefinition],
+    [
+        "Quenelles - Montlac - Merceaux-Descloux",
+        QuenellesMontlacMerceauxDescloux as RawTransportDefinition,
+    ],
 ];
 
 type TimerHandle = ReturnType<typeof setInterval>;

--- a/client/test/transportStops.test.ts
+++ b/client/test/transportStops.test.ts
@@ -108,6 +108,71 @@ describe('transport stop triggers', () => {
     jest.useRealTimers();
   });
 
+  test('tracks Quenelles - Montlac - Merceaux-Descloux route from sample log', () => {
+    jest.useFakeTimers();
+    const events: (TransportTimerPayload | null)[] = [];
+    client.sendEvent = jest.fn((type: string, payload: any) => {
+      if (type === 'transportTimer') {
+        events.push(payload);
+      }
+    });
+
+    const parseLine = (line: string) => {
+      parse(line);
+    };
+
+    const emitCommand = (command: string) => {
+      client.dispatchEvent('command', command);
+    };
+
+    client.dispatchEvent('enterLocation', { id: 4659 });
+
+    parseLine('Woznica oznajmia gromkim glosem: Postoj, plac Gillesa le Breton.');
+    parseLine('Woznica dylizansu glosno wola: Nastepny postoj - Montlac!');
+    emitCommand('wsiadz do dylizansu');
+    parseLine('Oplacasz podroz u woznicy i wsiadasz do blekitnego stojacego dylizansu.');
+
+    const lastEvent = () => events[events.length - 1];
+
+    expect(lastEvent()).toMatchObject({ label: 'Quenelles → Montlac', remaining: null, total: null });
+
+    parseLine('Drzwiczki sie zamykaja, drzenie przebiega przez caly pojazd, ktory powoli rusza.');
+
+    parseLine('Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, centrum wioski Montlac.');
+    expect(lastEvent()).toMatchObject({ label: 'Montlac → Merceaux-Descloux', remaining: null, total: null });
+
+    parseLine('Woznica wola: Nastepny postoj - Merceaux-Descloux!');
+    parseLine('Drzwiczki sie zamykaja, drzenie przebiega przez caly pojazd, ktory powoli rusza.');
+    parseLine('Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, w wiosce Merceaux-Descloux.');
+    expect(lastEvent()).toMatchObject({ label: 'Merceaux-Descloux → Parravon', remaining: null, total: null });
+
+    parseLine('Woznica wola: Nastepny postoj - most pod Parravon!');
+    parseLine('Drzwiczki sie zamykaja, drzenie przebiega przez caly pojazd, ktory powoli rusza.');
+    parseLine('Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, plac przed zajazdem.');
+    expect(lastEvent()).toMatchObject({ label: 'Parravon → Merceaux-Descloux', remaining: null, total: null });
+
+    parseLine('Woznica wola: Nastepny postoj - Merceaux-Descloux!');
+    parseLine('Drzwiczki sie zamykaja, drzenie przebiega przez caly pojazd, ktory powoli rusza.');
+    parseLine('Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, w wiosce Merceaux-Descloux.');
+    expect(lastEvent()).toMatchObject({ label: 'Merceaux-Descloux → Montlac', remaining: null, total: null });
+
+    parseLine('Woznica wola: Nastepny postoj - Montlac!');
+    parseLine('Drzwiczki sie zamykaja, drzenie przebiega przez caly pojazd, ktory powoli rusza.');
+    parseLine('Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, centrum wioski Montlac.');
+    expect(lastEvent()).toMatchObject({ label: 'Montlac → Quenelles', remaining: null, total: null });
+
+    parseLine('Woznica wola: Nastepny postoj - Quenelles!');
+    parseLine('Drzwiczki sie zamykaja, drzenie przebiega przez caly pojazd, ktory powoli rusza.');
+    parseLine('Z zewnatrz dochodzi stlumiony glos woznicy: Postoj, plac Gillesa le Breton.');
+    expect(lastEvent()).toMatchObject({ label: 'Quenelles → Montlac', remaining: null, total: null });
+
+    emitCommand('wyjscie');
+    expect(lastEvent()).toBeNull();
+
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
   test('records transport segment stats when a stop completes', async () => {
     client.dispatchEvent('enterLocation', { id: 5200 });
 


### PR DESCRIPTION
## Summary
- add a transport definition for the Quenelles – Montlac – Merceaux-Descloux diligence loop
- cover the new route with a regression test based on the shared log
- broaden the diligence set-pattern regexes so they also match exterior announcements

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fa00cda9e4832aa4376935de7a4b1c