### PR TITLE
Use transport stats durations for timers

### DIFF
--- a/client/src/scripts/transportStops.ts
+++ b/client/src/scripts/transportStops.ts
@@ -1,7 +1,8 @@
 import Client from "../Client";
 import { isDirection } from "../utils/directions";
 import type { TransportTimerPayload } from "../types/transport";
-import { recordTransportSegment } from "../utils/transportStats";
+import { getAllTransportSegments, recordTransportSegment } from "../utils/transportStats";
+import type { StoredTransportSegmentRecord } from "../utils/transportStats";
 
 import Ancelmus from "./ships/Ancelmus.json";
 import Annibale from "./ships/Annibale.json";
@@ -259,18 +260,25 @@ function secondsBetween(start: number): number {
     return (Date.now() - start) / 1000;
 }
 
+function createSegmentKey(transport: string, fromId: number, toId: number): string {
+    return `${transport}::${fromId}->${toId}`;
+}
+
 class TransportTracker {
     private client: Client;
     private definitions: CompiledTransportDefinition[];
+    private definitionsByName: Map<string, CompiledTransportDefinition>;
     private currentJourney: JourneyState | null = null;
     private pendingCandidates = new Map<CompiledTransportDefinition, number[]>();
     private currentLocationId: number | null = null;
     private previousLocationId: number | null = null;
     private exitCommands: Set<string>;
+    private segmentDurationOverrides = new Map<string, number>();
 
     constructor(client: Client) {
         this.client = client;
         this.definitions = loadDefinitions();
+        this.definitionsByName = new Map(this.definitions.map(def => [def.name, def]));
         this.exitCommands = new Set(
             this.definitions
                 .map(def => def.exitCommand)
@@ -280,6 +288,78 @@ class TransportTracker {
         this.registerExitFailureTriggers();
         this.registerListeners();
         this.emitTimer(null);
+        void this.loadSegmentDurationOverrides();
+    }
+
+    private async loadSegmentDurationOverrides() {
+        try {
+            const records = await getAllTransportSegments();
+            this.applyStoredSegmentDurations(records);
+        } catch (error) {
+            console.warn("[Transport] Failed to load stored transport segment durations", error);
+        }
+    }
+
+    private applyStoredSegmentDurations(records: StoredTransportSegmentRecord[]) {
+        for (const record of records) {
+            const definition = this.definitionsByName.get(record.transport);
+            if (!definition) {
+                continue;
+            }
+            definition.stops.forEach((stop, index) => {
+                if (stop.start === record.fromId && stop.destination === record.toId) {
+                    this.applyDurationOverride(definition, index, record.shortestDuration.duration);
+                }
+            });
+        }
+    }
+
+    private applyDurationOverride(definition: CompiledTransportDefinition, index: number, duration: number) {
+        if (!Number.isFinite(duration) || duration <= 0) {
+            return;
+        }
+
+        const stop = definition.stops[index];
+        if (!stop) {
+            return;
+        }
+
+        const key = createSegmentKey(definition.name, stop.start, stop.destination);
+        const currentTime = typeof stop.time === "number" && !Number.isNaN(stop.time) ? stop.time : undefined;
+        if (duration < 1) {
+            if (this.segmentDurationOverrides.has(key)) {
+                const existing = this.segmentDurationOverrides.get(key);
+                if (existing !== undefined && existing <= duration) {
+                    return;
+                }
+            } else if (currentTime !== undefined) {
+                return;
+            }
+        }
+
+        const existingOverride = this.segmentDurationOverrides.get(key);
+        const bestDuration = existingOverride ?? currentTime;
+        const nextDuration = bestDuration !== undefined ? Math.min(bestDuration, duration) : duration;
+
+        if (existingOverride !== undefined && existingOverride <= nextDuration) {
+            return;
+        }
+
+        this.segmentDurationOverrides.set(key, nextDuration);
+        stop.time = nextDuration;
+
+        if (
+            this.currentJourney &&
+            this.currentJourney.definition === definition &&
+            this.currentJourney.activeIndex === index
+        ) {
+            const startedAt = this.currentJourney.startTimes.get(index);
+            if (typeof startedAt === "number") {
+                this.updateTimer(definition, stop, startedAt);
+            } else {
+                this.refreshTimer(this.currentJourney);
+            }
+        }
     }
 
     private registerListeners() {
@@ -619,6 +699,7 @@ class TransportTracker {
                 duration: elapsed,
                 expectedDuration: expected,
             });
+            this.applyDurationOverride(definition, index, elapsed);
         }
 
         this.stopCountdown();

--- a/client/test/transportStops.test.ts
+++ b/client/test/transportStops.test.ts
@@ -2,6 +2,7 @@ import initTransportStops from '../src/scripts/transportStops';
 import Triggers from '../src/Triggers';
 import type { TransportTimerPayload } from '../src/types/transport';
 import * as transportStats from '../src/utils/transportStats';
+import type { StoredTransportSegmentRecord } from '../src/utils/transportStats';
 
 class FakeClient {
   Triggers: Triggers;
@@ -30,7 +31,6 @@ describe('transport stop triggers', () => {
   beforeEach(async () => {
     await transportStats.clearTransportStats();
     client = new FakeClient();
-    initTransportStops(client as unknown as any);
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
     jest.clearAllMocks();
   });
@@ -40,12 +40,14 @@ describe('transport stop triggers', () => {
   });
 
   test('stop pattern does not register trigger', () => {
+    initTransportStops(client as unknown as any);
     const line = 'Bjorn krzyczy: Doplynelismy do przystani na wyspie Mekan! Mozna wysiadac!';
     parse(line);
     expect(client.Map.setMapRoomById).not.toHaveBeenCalled();
   });
 
   test('tracks Salignac - Nuln route from sample log', () => {
+    initTransportStops(client as unknown as any);
     jest.useFakeTimers();
     const events: (TransportTimerPayload | null)[] = [];
     client.sendEvent = jest.fn((type: string, payload: any) => {
@@ -109,6 +111,7 @@ describe('transport stop triggers', () => {
   });
 
   test('tracks Quenelles - Montlac - Merceaux-Descloux route from sample log', () => {
+    initTransportStops(client as unknown as any);
     jest.useFakeTimers();
     const events: (TransportTimerPayload | null)[] = [];
     client.sendEvent = jest.fn((type: string, payload: any) => {
@@ -174,6 +177,7 @@ describe('transport stop triggers', () => {
   });
 
   test('records transport segment stats when a stop completes', async () => {
+    initTransportStops(client as unknown as any);
     client.dispatchEvent('enterLocation', { id: 5200 });
 
     const parseLine = (line: string) => {
@@ -206,6 +210,7 @@ describe('transport stop triggers', () => {
   });
 
   test('tracks Wyzima - Oxenfurt route with shared stop pattern', () => {
+    initTransportStops(client as unknown as any);
     jest.useFakeTimers();
     const events: (TransportTimerPayload | null)[] = [];
     client.sendEvent = jest.fn((type: string, payload: any) => {
@@ -261,6 +266,7 @@ describe('transport stop triggers', () => {
   });
 
   test('outside set pattern selects pending slot with known location', () => {
+    initTransportStops(client as unknown as any);
     jest.useFakeTimers();
     const events: (TransportTimerPayload | null)[] = [];
     client.sendEvent = jest.fn((type: string, payload: any) => {
@@ -292,6 +298,7 @@ describe('transport stop triggers', () => {
   });
 
   test('exit failure keeps active journey running', () => {
+    initTransportStops(client as unknown as any);
     jest.useFakeTimers();
     const events: (TransportTimerPayload | null)[] = [];
     client.sendEvent = jest.fn((type: string, payload: any) => {
@@ -331,6 +338,7 @@ describe('transport stop triggers', () => {
   });
 
   test('set pattern outside chooses stop based on location', () => {
+    initTransportStops(client as unknown as any);
     jest.useFakeTimers();
     const events: (TransportTimerPayload | null)[] = [];
     client.sendEvent = jest.fn((type: string, payload: any) => {
@@ -362,6 +370,7 @@ describe('transport stop triggers', () => {
   });
 
   test('set pattern on board requires multiple candidates', () => {
+    initTransportStops(client as unknown as any);
     jest.useFakeTimers();
     const events: (TransportTimerPayload | null)[] = [];
     client.sendEvent = jest.fn((type: string, payload: any) => {
@@ -392,6 +401,57 @@ describe('transport stop triggers', () => {
     parseLine('Woznica wola: Nastepny postoj - Nuln!');
     expect(events.length).toBe(eventsAfterFirstSet);
     expect(events[events.length - 1]).toBe(targeted);
+
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('uses stored transport segment minimum duration when available', async () => {
+    const storedDuration = 40;
+    const record: StoredTransportSegmentRecord = {
+      segmentKey: 'Salignac - Nuln::5200->4985',
+      transport: 'Salignac - Nuln',
+      fromId: 5200,
+      toId: 4985,
+      fromLabel: 'Kreutzhofen',
+      toLabel: "'Pod piegowata elfka'",
+      shortestDuration: { duration: storedDuration, startedAt: 0, endedAt: storedDuration },
+      longestDuration: { duration: storedDuration + 5, startedAt: 0, endedAt: storedDuration + 5 },
+      expectedDuration: 53,
+      updatedAt: Date.now(),
+    };
+
+    jest.spyOn(transportStats, 'getAllTransportSegments').mockResolvedValue([record]);
+    initTransportStops(client as unknown as any);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    jest.useFakeTimers();
+    const events: (TransportTimerPayload | null)[] = [];
+    client.sendEvent = jest.fn((type: string, payload: any) => {
+      if (type === 'transportTimer') {
+        events.push(payload);
+      }
+    });
+
+    const parseLine = (line: string) => {
+      parse(line);
+    };
+
+    const emitCommand = (command: string) => {
+      client.dispatchEvent('command', command);
+    };
+
+    client.dispatchEvent('enterLocation', { id: 5200 });
+
+    parseLine("Woznica dylizansu glosno wola: Nastepny postoj - Karczma 'Pod piegowata elfka'!");
+    emitCommand('wsiadz do dylizansu');
+    parseLine('Oplacasz podroz u woznicy i wsiadasz do zielonego stojacego dylizansu.');
+
+    const payload = events[events.length - 1] as TransportTimerPayload;
+    expect(payload.label).toBe("Kreutzhofen → 'Pod piegowata elfka'");
+    expect(payload.total).toBe(storedDuration);
 
     jest.clearAllTimers();
     jest.useRealTimers();


### PR DESCRIPTION
## Summary
- load stored transport segment durations from IndexedDB and apply them to stop definitions
- track per-segment overrides so active countdowns update when better measurements are available
- adjust transport stop tests to initialize trackers on demand and verify stored durations override JSON defaults

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fa0e73970c832a9d796f154722bc17