### PR TITLE
Add transport label visibility toggle to settings

### DIFF
--- a/client/src/defaultSettings.ts
+++ b/client/src/defaultSettings.ts
@@ -18,6 +18,7 @@ export interface Settings {
     fullHpMessage: boolean;
     lowHpAlert: number;
     letterLineWidth: number;
+    showTransportLabel: boolean;
 }
 
 export const defaultSettings: Settings = {
@@ -36,6 +37,7 @@ export const defaultSettings: Settings = {
     herbPostUseCommand: '',
     attackCommand: DEFAULT_ATTACK_COMMAND,
     fullHpMessage: false,
+    showTransportLabel: true,
     lowHpAlert: 2,
     letterLineWidth: 72,
 };

--- a/web-client/src/TransportTimer.ts
+++ b/web-client/src/TransportTimer.ts
@@ -1,16 +1,36 @@
 import ArkadiaClient from "./ArkadiaClient.ts";
+import { getItemSync } from "@client/src/storage";
+import type { Settings } from "@client/src/defaultSettings";
 import type { TransportTimerPayload } from "@client/src/types/transport";
 
 export default class TransportTimer {
   private container: HTMLElement | null;
+  private showTransportLabel: boolean;
+  private lastPayload: TransportTimerPayload | null = null;
 
   constructor(client: typeof ArkadiaClient) {
     this.container = document.getElementById("transport-timer");
+    this.showTransportLabel = this.getInitialShowTransportLabel();
+    client.on("settings", (settings: Partial<Settings> | undefined) => {
+      if (settings && typeof settings.showTransportLabel === "boolean") {
+        this.showTransportLabel = settings.showTransportLabel;
+        this.update(this.lastPayload);
+      }
+    });
     client.on("transportTimer", (payload: TransportTimerPayload | null) => this.update(payload));
     this.update(null);
   }
 
+  private getInitialShowTransportLabel(): boolean {
+    const stored = getItemSync("settings")?.settings as Partial<Settings> | undefined;
+    if (stored && typeof stored.showTransportLabel === "boolean") {
+      return stored.showTransportLabel;
+    }
+    return true;
+  }
+
   private update(payload: TransportTimerPayload | null) {
+    this.lastPayload = payload;
     if (!this.container) return;
     if (!payload) {
       this.container.textContent = "";
@@ -19,12 +39,22 @@ export default class TransportTimer {
       return;
     }
     const hasTimer = typeof payload.remaining === "number" && typeof payload.total === "number";
+    if (!this.showTransportLabel && !hasTimer) {
+      this.container.textContent = "";
+      this.container.className = "";
+      this.container.style.display = "none";
+      return;
+    }
+    const parts = ["Tr:"];
+    if (this.showTransportLabel) {
+      parts.push(payload.label);
+    }
     if (hasTimer) {
       const remaining = Math.max(0, payload.remaining);
       const minutes = Math.floor(remaining / 60);
       const seconds = Math.floor(remaining % 60);
       const secondsText = seconds.toString().padStart(2, "0");
-      this.container.textContent = `Tr: ${payload.label} ${minutes}:${secondsText}`;
+      parts.push(`${minutes}:${secondsText}`);
       if (remaining < 10) {
         this.container.className = "red";
       } else if (remaining < 30) {
@@ -33,9 +63,9 @@ export default class TransportTimer {
         this.container.className = "green";
       }
     } else {
-      this.container.textContent = `Tr: ${payload.label}`;
       this.container.className = "";
     }
+    this.container.textContent = parts.join(" ");
     this.container.style.display = "block";
   }
 }

--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -153,6 +153,14 @@ function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void
                                 onChange={e => onChangeSetting(s => s.fullHpMessage = e.target.checked)}
                                 className="me-2"
                             />
+                            <Form.Check
+                                type="checkbox"
+                                id="showTransportLabel"
+                                label="Pokaz etykiete transportu"
+                                checked={settings.showTransportLabel}
+                                onChange={e => onChangeSetting(s => s.showTransportLabel = e.target.checked)}
+                                className="me-2"
+                            />
                             <Form.Group className="d-flex align-items-center me-2">
                                 <Form.Label className="me-1 mb-0" htmlFor="letterLineWidth">Szerokosc linii listu:</Form.Label>
                                 <Form.Control

--- a/web-client/test/TransportTimer.test.ts
+++ b/web-client/test/TransportTimer.test.ts
@@ -1,12 +1,11 @@
 import TransportTimer from "../src/TransportTimer";
-import type { TransportTimerPayload } from "@client/src/types/transport";
 
 class MockClient {
   private events: Record<string, Function[]> = {};
   on(event: string, listener: Function) {
     (this.events[event] ||= []).push(listener);
   }
-  emit(event: string, payload: TransportTimerPayload | null) {
+  emit(event: string, payload: any) {
     (this.events[event] || []).forEach(fn => fn(payload));
   }
 }
@@ -16,6 +15,7 @@ describe("TransportTimer", () => {
   let client: MockClient;
 
   beforeEach(() => {
+    localStorage.clear();
     document.body.innerHTML = '<span id="transport-timer"></span>';
     container = document.getElementById("transport-timer")!;
     client = new MockClient();
@@ -52,5 +52,16 @@ describe("TransportTimer", () => {
     expect(container.textContent).toBe("Tr: Kreutzhofen → Tajemnicze miejsce");
     expect(container.className).toBe("");
     expect(container.style.display).toBe("block");
+  });
+
+  test("hides label when option disabled", () => {
+    client.emit("settings", { showTransportLabel: false });
+    client.emit("transportTimer", { label: "Kreutzhofen → Hagge", remaining: 125, total: 140 });
+    expect(container.textContent).toBe("Tr: 2:05");
+    expect(container.className).toBe("green");
+
+    client.emit("transportTimer", { label: "Kreutzhofen → Tajemnicze miejsce", remaining: null, total: null });
+    expect(container.style.display).toBe("none");
+    expect(container.textContent).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- add a showTransportLabel flag to character settings with a default enabled value
- expose the new transport label toggle in the settings interface
- update the transport timer to respect the toggle and extend its tests

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fa146528dc832abb9c5254bce1d88f