### PR TITLE
Preserve user NPC entries during downloads

### DIFF
--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -13,6 +13,8 @@ interface NpcProps {
     loc: number
 }
 
+const npcKey = (npc: NpcProps) => `${npc.name}-${npc.loc}`
+
 function Npc() {
 
     const [npcs, setNpcs] = useState<NpcProps[]>([])
@@ -37,13 +39,18 @@ function Npc() {
         }
     }, [])
 
-    function downloadNpcs() {
-        updateIndexedDB<NpcProps[]>(DB_CONFIG, NPC_URL)
-            .then(data => {
-                setNpcs(data)
-                ;(window as any).clientExtension?.sendEvent('npc', data)
-            })
-            .catch(e => console.error('Failed to update NPC data:', e));
+    async function downloadNpcs() {
+        try {
+            const downloaded = await updateIndexedDB<NpcProps[]>(DB_CONFIG, NPC_URL)
+            const downloadedKeys = new Set(downloaded.map(npcKey))
+            const preserved = npcs.filter(npc => !downloadedKeys.has(npcKey(npc)))
+            const merged = [...downloaded, ...preserved]
+            setNpcs(merged)
+            ;(window as any).clientExtension?.sendEvent('npc', merged)
+            void saveNpcs(merged)
+        } catch (e) {
+            console.error('Failed to update NPC data:', e)
+        }
     }
 
     function clearNpcs() {


### PR DESCRIPTION
## Summary
- ensure NPC downloads merge remote NPC data with existing user entries
- store the merged list in IndexedDB and notify extension listeners

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68fa1ad72970832a959d174e062fcfed