### PR TITLE
Sanitize prompt marker during trigger matching

### DIFF
--- a/web-client/src/triggerUtils.ts
+++ b/web-client/src/triggerUtils.ts
@@ -1,19 +1,17 @@
 import type { Trigger } from "@client/src/Triggers";
 import { stripAnsiCodes } from "@client/src/stripAnsiCodes";
 
-function sanitizeLine(
-    rawLine: string
-): { sanitized: string; stripped: string; withPrompt: string } {
-    const promptMatch = rawLine.match(/^>\s?/);
-    const prompt = promptMatch ? promptMatch[0] : "";
-    const sanitized = prompt ? rawLine.slice(prompt.length) : rawLine;
-    const stripped = stripAnsiCodes(sanitized).replace(/\s$/g, "");
-    const withPrompt = prompt ? `${prompt}${sanitized}` : sanitized;
-    return { sanitized, stripped, withPrompt };
+function sanitizeLine(rawLine: string): { sanitized: string; stripped: string } {
+    const colorless = stripAnsiCodes(rawLine);
+    const promptMatch = colorless.match(/^>\s?/);
+    const promptLength = promptMatch ? promptMatch[0].length : 0;
+    const sanitized = colorless.slice(promptLength);
+    const stripped = sanitized.replace(/\s$/g, "");
+    return { sanitized, stripped };
 }
 
 export function matchTrigger(trigger: Trigger, rawLine: string, type: string): boolean {
-    const { sanitized, stripped, withPrompt } = sanitizeLine(rawLine);
+    const { sanitized, stripped } = sanitizeLine(rawLine);
     const patterns = Array.isArray(trigger.pattern) ? trigger.pattern : [trigger.pattern];
     for (const pattern of patterns) {
         if (pattern instanceof RegExp) {
@@ -22,7 +20,7 @@ export function matchTrigger(trigger: Trigger, rawLine: string, type: string): b
             const index = sanitized.toLowerCase().indexOf(pattern.toLowerCase());
             if (index > -1) return true;
         } else if (typeof pattern === "function") {
-            const res = pattern(withPrompt, stripped, undefined as any, type);
+            const res = pattern(rawLine, stripped, undefined as any, type);
             if (res) return true;
         }
     }
@@ -30,7 +28,7 @@ export function matchTrigger(trigger: Trigger, rawLine: string, type: string): b
 }
 
 export function getMatchingPatterns(trigger: Trigger, rawLine: string, type: string): string[] {
-    const { sanitized, stripped, withPrompt } = sanitizeLine(rawLine);
+    const { sanitized, stripped } = sanitizeLine(rawLine);
     const matches: string[] = [];
     const patterns = Array.isArray(trigger.pattern) ? trigger.pattern : [trigger.pattern];
 
@@ -53,7 +51,7 @@ export function getMatchingPatterns(trigger: Trigger, rawLine: string, type: str
             return;
         }
         if (typeof pattern === "function") {
-            const res = pattern(withPrompt, stripped, undefined as any, type);
+            const res = pattern(rawLine, stripped, undefined as any, type);
             if (res) {
                 matches.push(pattern.name ? `[fn ${pattern.name}]` : "[fn]");
             }

--- a/web-client/test/triggerUtils.test.ts
+++ b/web-client/test/triggerUtils.test.ts
@@ -7,6 +7,22 @@ describe('triggerUtils prompt handling', () => {
     expect(matchTrigger(trigger, '> test', 'regular')).toBe(true);
   });
 
+  test('matches string trigger for narrative line prefixed with prompt', () => {
+    const trigger = {
+      pattern: 'otwierasz na chwile skorzana krasnoludzka torbe',
+    } as unknown as Trigger;
+    const line =
+      '>Otwierasz na chwile skorzana krasnoludzka torbe, sprawdzajac zawartosc. W srodku dostrzegasz wiele zlotych monet, osiemnascie srebrnych monet, dziesiec miedzianych monet, garnczkowy helm z jelenim porozem, drewniana okuta tarcze, pasiasty fluoryt, zolty celestyn, dwa zlociste piryty, oliwkowozielony serpentyn, bezbarwny gorski krysztal i upiorny mglisty calun.';
+    expect(matchTrigger(trigger, line, 'regular')).toBe(true);
+  });
+
+  test('matches regex trigger when prompt marker contains ANSI codes', () => {
+    const trigger = { pattern: /^otwierasz na chwile/ } as unknown as Trigger;
+    const line =
+      '\u001b[1;33m>\u001b[0m otwierasz na chwile skorzana krasnoludzka torbe, sprawdzajac zawartosc.';
+    expect(matchTrigger(trigger, line, 'regular')).toBe(true);
+  });
+
   test('passes line with prompt back to function triggers', () => {
     const received: string[] = [];
     const trigger = {


### PR DESCRIPTION
## Summary
- remove an optional leading prompt marker from lines before evaluating triggers
- ensure regex, string, and function trigger patterns work with the sanitized line content

## Testing
- yarn --cwd web-client test --watch=false
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fa24990284832a857602440fa723f8