### PR TITLE
Add trop bind when team member points down

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -82,6 +82,7 @@ import initLetter from './scripts/letter'
 import initCommandPreserveCaseMode from './scripts/commandPreserveCaseMode'
 import initTeamBlockers from './scripts/teamBlockers'
 import initZaznaczaj from './scripts/zaznaczaj'
+import initTropBind from './scripts/trop'
 import Client from "./Client";
 import {initSpecialLocations} from "./scripts/specialLocations";
 
@@ -172,6 +173,7 @@ export function registerScripts(client: Client) {
     initLocalizers(client)
     initShipLocalizers(client)
     initFollowSpecialExits(client)
+    initTropBind(client)
     initMountain(client)
     initMultibinds(client, aliases)
 

--- a/client/src/scripts/trop.ts
+++ b/client/src/scripts/trop.ts
@@ -1,0 +1,20 @@
+import Client from "../Client";
+
+const POINTS_DOWN_PATTERN = /^\[?(.*)\]? wskazuje na dol\.$/;
+
+export default function initTropBind(client: Client) {
+    const tag = "tropBind";
+
+    client.Triggers.registerTrigger(POINTS_DOWN_PATTERN, (_raw, _line, matches) => {
+        const name = matches[1]?.trim();
+        if (!name) {
+            return undefined;
+        }
+
+        if (client.TeamManager.isInTeam(name)) {
+            client.FunctionalBind.set("trop");
+        }
+
+        return undefined;
+    }, tag);
+}


### PR DESCRIPTION
## Summary
- add a trigger-based script that binds the trop command when a teammate points downward
- load the new trop bind script during client initialization

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fa243761d0832a82e4f7b9d4b46d3b