### PR TITLE
Fix NPC popup column layout

### DIFF
--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -124,17 +124,31 @@ function Npc() {
                     style={{width: '100%', maxWidth: '160px'}}
                 />
             </div>
-            <Table bordered size="sm" hover className="table-modern table-zebra">
+            <Table bordered size="sm" hover className="table-modern table-zebra npc-table">
+                <colgroup>
+                    <col />
+                    <col className="npc-table__location-col" />
+                    <col className="npc-table__actions-col" />
+                </colgroup>
                 <tbody className="align-middle">
                 {npcs
                     .filter(item => item.name.toLowerCase().includes(filter.toLowerCase()))
                     .sort((a, b) => a.name.localeCompare(b.name))
                     .map((item) => (
                         <tr key={item.name + '-' + item.loc}>
-                            <td>{item.name}</td>
-                            <td>{item.loc}</td>
-                            <td>
-                                <Button variant="danger" size="sm" onClick={() => deleteNpc(item)}><TiDelete/></Button>
+                            <td className="npc-name">{item.name}</td>
+                            <td className="npc-location">
+                                <span className="npc-location__value">{item.loc}</span>
+                            </td>
+                            <td className="npc-actions text-end">
+                                <Button
+                                    variant="danger"
+                                    size="sm"
+                                    onClick={() => deleteNpc(item)}
+                                    className="npc-delete-button"
+                                >
+                                    <TiDelete/>
+                                </Button>
                             </td>
                         </tr>
                     ))}

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -260,6 +260,40 @@ input::placeholder {
   color: var(--text-secondary);
 }
 
+.npc-table {
+  width: 100%;
+}
+
+.npc-table col.npc-table__location-col {
+  width: 5ch;
+}
+
+.npc-table col.npc-table__actions-col {
+  width: 3.25rem;
+}
+
+.npc-location {
+  text-align: center;
+}
+
+.npc-location__value {
+  display: inline-block;
+  width: 5ch;
+  font-variant-numeric: tabular-nums;
+}
+
+.npc-actions {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.npc-actions .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: auto;
+}
+
 .dropdown-menu {
   background-color: var(--surface-elevated);
   border: 1px solid var(--surface-border);


### PR DESCRIPTION
## Summary
- fix NPC popup table layout to keep action column at the far right
- constrain location column width for consistent alignment across filters

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68fa38c098e8832abeb477c9b4c5acd4