### PR TITLE
Improve trigger regex handling with ANSI-aware operations

### DIFF
--- a/client/src/AnsiString.ts
+++ b/client/src/AnsiString.ts
@@ -1,0 +1,178 @@
+import { stripAnsiCodes } from "./stripAnsiCodes";
+
+const ANSI_PATTERN = /\x1B\[[0-9;?]*[ -/]*[@-~]|{clickOpen:\d+(?::[^}]+)?}|{clickClose}/g;
+
+type AnsiSegment =
+    | { type: "ansi"; value: string }
+    | { type: "text"; value: string };
+
+function splitAnsiString(input: string): AnsiSegment[] {
+    if (!input) {
+        return [];
+    }
+    const segments: AnsiSegment[] = [];
+    let lastIndex = 0;
+    for (let match; (match = ANSI_PATTERN.exec(input));) {
+        if (match.index > lastIndex) {
+            const textSlice = input.slice(lastIndex, match.index);
+            if (textSlice.length > 0) {
+                segments.push({ type: "text", value: textSlice });
+            }
+        }
+        segments.push({ type: "ansi", value: match[0] });
+        lastIndex = match.index + match[0].length;
+    }
+    if (lastIndex < input.length) {
+        segments.push({ type: "text", value: input.slice(lastIndex) });
+    }
+    return segments;
+}
+
+function mergeAdjacentTextSegments(segments: AnsiSegment[]) {
+    for (let i = 0; i < segments.length - 1;) {
+        const current = segments[i];
+        const next = segments[i + 1];
+        if (current.type === "text" && next.type === "text") {
+            current.value += next.value;
+            segments.splice(i + 1, 1);
+        } else {
+            i += 1;
+        }
+    }
+}
+
+interface PlainLocation {
+    segmentIndex: number;
+    offset: number;
+}
+
+export default class AnsiString {
+    private segments: AnsiSegment[] = [];
+    private plain = "";
+
+    constructor(raw: string) {
+        this.setRaw(raw);
+    }
+
+    setRaw(raw: string) {
+        this.segments = splitAnsiString(raw);
+        this.recomputePlain();
+    }
+
+    toString() {
+        return this.segments.map(segment => segment.value).join("");
+    }
+
+    getRaw() {
+        return this.toString();
+    }
+
+    getPlain() {
+        return this.plain;
+    }
+
+    getPlainIndexFromRaw(rawIndex: number) {
+        if (rawIndex <= 0) {
+            return 0;
+        }
+        let consumedRaw = 0;
+        let consumedPlain = 0;
+        for (const segment of this.segments) {
+            if (segment.type === "ansi") {
+                const nextRaw = consumedRaw + segment.value.length;
+                if (rawIndex <= nextRaw) {
+                    return consumedPlain;
+                }
+                consumedRaw = nextRaw;
+                continue;
+            }
+            const nextRaw = consumedRaw + segment.value.length;
+            if (rawIndex <= nextRaw) {
+                return consumedPlain + (rawIndex - consumedRaw);
+            }
+            consumedRaw = nextRaw;
+            consumedPlain += segment.value.length;
+        }
+        return consumedPlain;
+    }
+
+    indexOf(target: string, start = 0, caseInsensitive = false) {
+        const haystack = caseInsensitive ? this.plain.toLowerCase() : this.plain;
+        const needle = caseInsensitive ? target.toLowerCase() : target;
+        return haystack.indexOf(needle, start);
+    }
+
+    replacePlainRange(start: number, end: number, replacement: string) {
+        const safeStart = Math.max(0, Math.min(start, this.plain.length));
+        const safeEnd = Math.max(safeStart, Math.min(end, this.plain.length));
+        const startIndex = this.splitAtPlainIndex(safeStart);
+        const endIndex = this.splitAtPlainIndex(safeEnd);
+        const replacementSegments = splitAnsiString(replacement);
+        this.segments.splice(startIndex, endIndex - startIndex, ...replacementSegments);
+        mergeAdjacentTextSegments(this.segments);
+        this.recomputePlain();
+        return this;
+    }
+
+    insertPlain(index: number, value: string) {
+        return this.replacePlainRange(index, index, value);
+    }
+
+    wrapPlainRange(start: number, end: number, prefix: string, suffix: string) {
+        this.replacePlainRange(end, end, suffix);
+        this.replacePlainRange(start, start, prefix);
+        return this;
+    }
+
+    stripAnsi() {
+        return stripAnsiCodes(this.getRaw());
+    }
+
+    private recomputePlain() {
+        this.plain = this.segments
+            .filter((segment): segment is { type: "text"; value: string } => segment.type === "text")
+            .map(segment => segment.value)
+            .join("");
+    }
+
+    private locatePlainIndex(index: number): PlainLocation {
+        if (this.plain.length === 0) {
+            return { segmentIndex: this.segments.length, offset: 0 };
+        }
+        const bounded = Math.max(0, Math.min(index, this.plain.length));
+        let consumed = 0;
+        for (let segmentIndex = 0; segmentIndex < this.segments.length; segmentIndex++) {
+            const segment = this.segments[segmentIndex];
+            if (segment.type !== "text") {
+                continue;
+            }
+            const next = consumed + segment.value.length;
+            if (bounded <= next) {
+                return { segmentIndex, offset: bounded - consumed };
+            }
+            consumed = next;
+        }
+        return { segmentIndex: this.segments.length, offset: 0 };
+    }
+
+    private splitAtPlainIndex(index: number) {
+        const location = this.locatePlainIndex(index);
+        if (location.segmentIndex >= this.segments.length) {
+            return this.segments.length;
+        }
+        const segment = this.segments[location.segmentIndex];
+        if (segment.type !== "text") {
+            return location.segmentIndex;
+        }
+        if (location.offset <= 0) {
+            return location.segmentIndex;
+        }
+        if (location.offset >= segment.value.length) {
+            return location.segmentIndex + 1;
+        }
+        const before: AnsiSegment = { type: "text", value: segment.value.slice(0, location.offset) };
+        const after: AnsiSegment = { type: "text", value: segment.value.slice(location.offset) };
+        this.segments.splice(location.segmentIndex, 1, before, after);
+        return location.segmentIndex + 1;
+    }
+}

--- a/client/src/Colors.ts
+++ b/client/src/Colors.ts
@@ -2,6 +2,7 @@ import xtermArkadia from "./xtermArkadia";
 import xtermProper from "./xtermProper";
 import mudletColors from "./colors.json";
 import { getItemSync } from "./storage";
+import AnsiString from "./AnsiString";
 
 function hexToRgb(hex: string): [number, number, number] {
     const value = parseInt(hex.replace(/^#/, ''), 16);
@@ -46,20 +47,26 @@ export function colorString(string: string, colorCode: number) {
 }
 
 export function colorStringInLine(rawLine: string, string: string, colorCode: number, startIndex = 0) {
-    const matchIndex = rawLine.indexOf(string, startIndex)
+    const ansi = new AnsiString(rawLine)
+    const plainStart = startIndex > 0 ? ansi.getPlainIndexFromRaw(startIndex) : 0
+    const matchIndex = ansi.indexOf(string, plainStart)
     if (matchIndex === -1) {
         return rawLine
     }
-    return rawLine.substring(0, matchIndex) + color(colorCode) + string + RESET + rawLine.substring(matchIndex + string.length)
+    ansi.replacePlainRange(matchIndex, matchIndex + string.length, color(colorCode) + string + RESET)
+    return ansi.getRaw()
 }
 
 export function colorTokenInLine(rawLine: string, string: string, colorCode: number, startIndex = 0) {
-    const matchIndex = rawLine.toLowerCase().indexOf(string, startIndex)
-    const endIndex = matchIndex + string.length
+    const ansi = new AnsiString(rawLine)
+    const plainStart = startIndex > 0 ? ansi.getPlainIndexFromRaw(startIndex) : 0
+    const matchIndex = ansi.indexOf(string, plainStart, true)
     if (matchIndex === -1) {
         return rawLine
     }
-    return rawLine.substring(0, matchIndex) + color(colorCode) + rawLine.substring(matchIndex, endIndex) + RESET + rawLine.substring(endIndex)
+    const original = ansi.getPlain().substring(matchIndex, matchIndex + string.length)
+    ansi.replacePlainRange(matchIndex, matchIndex + string.length, color(colorCode) + original + RESET)
+    return ansi.getRaw()
 }
 
 export function findClosestColor(hex: string | number[]): number {

--- a/client/src/People.ts
+++ b/client/src/People.ts
@@ -1,7 +1,7 @@
 import { loadPeople, type PersonEntry } from './peopleLoader';
 import Client from "./Client";
 import {color, RESET, findClosestColor} from './Colors';
-import {stripAnsiCodes} from './Triggers';
+import AnsiString from "./AnsiString";
 
 export default class People {
 
@@ -68,17 +68,18 @@ export default class People {
                 return
             }
 
-            const descCallback = (rawLine: string, _line: string, matches: RegExpMatchArray) => {
+            const descCallback = (rawLine: string, _line: string, matches: RegExpMatchArray, _type: string, context?: AnsiString) => {
                 const index = matches.index || 0
                 const token = matches[0]
-                const suffix = rawLine.substring(index + token.length)
-                const nextWord = stripAnsiCodes(suffix)
+                const ctx = context ?? new AnsiString(rawLine)
+                const plainSuffix = ctx.getPlain().substring(index + token.length)
+                const nextWord = plainSuffix
                     .toLowerCase()
                     .replace(/^\s+/, '')
                 if (nextWord.startsWith('chaosu')) {
-                    return rawLine
+                    return ctx.getRaw()
                 }
-                return this.buildDescHighlight(rawLine, token, index, replacement, state, RED)
+                return this.buildDescHighlight(ctx, token, index, replacement, state, RED)
             }
 
             this.client.Triggers.registerTokenTrigger(replacement.description, descCallback, this.tag, {caseInsensitive: true})
@@ -87,10 +88,11 @@ export default class People {
                 const key = `${replacement.name}|${replacement.guild}`
                 if (!addedNames.has(key) && replacement.name.length > 2) {
                     const chosenColor = state.isEnemy ? RED : state.guildColor!
-                    const nameCallback = (rawLine: string, _line: string, matches: RegExpMatchArray) => {
+                    const nameCallback = (rawLine: string, _line: string, matches: RegExpMatchArray, _type: string, context?: AnsiString) => {
                         const index = matches.index || 0
                         const token = matches[0]
-                        return this.buildNameHighlight(rawLine, token, index, chosenColor)
+                        const ctx = context ?? new AnsiString(rawLine)
+                        return this.buildNameHighlight(ctx, token, index, chosenColor)
                     }
                     this.client.Triggers.registerTokenTrigger(replacement.name, nameCallback, this.tag, {caseInsensitive: true})
                     addedNames.add(key)
@@ -110,16 +112,12 @@ export default class People {
         return { inGuild, isEnemy, guildColor }
     }
 
-    private buildNameHighlight(rawLine: string, token: string, index: number, colorCode: number) {
-        const prefix = rawLine.substring(0, index)
-        const suffix = rawLine.substring(index + token.length)
-        const highlighted = color(colorCode) + token + RESET
-        return prefix + highlighted + suffix
+    private buildNameHighlight(context: AnsiString, token: string, index: number, colorCode: number) {
+        context.replacePlainRange(index, index + token.length, color(colorCode) + token + RESET)
+        return context.getRaw()
     }
 
-    private buildDescHighlight(rawLine: string, token: string, index: number, replacement: { name: string; guild: string }, state: { inGuild: boolean; isEnemy: boolean; guildColor?: number }, RED: number) {
-        const prefix = rawLine.substring(0, index)
-        const suffix = rawLine.substring(index + token.length)
+    private buildDescHighlight(context: AnsiString, token: string, index: number, replacement: { name: string; guild: string }, state: { inGuild: boolean; isEnemy: boolean; guildColor?: number }, RED: number) {
         let highlighted = token
         if (state.isEnemy) {
             highlighted = color(RED) + token + RESET
@@ -132,7 +130,8 @@ export default class People {
             suffixText = ' ' + color(state.guildColor) + `(${replacement.name} ${replacement.guild})` + RESET
         }
 
-        return prefix + highlighted + suffixText + suffix
+        context.replacePlainRange(index, index + token.length, highlighted + suffixText)
+        return context.getRaw()
     }
 
 }

--- a/client/src/Triggers.ts
+++ b/client/src/Triggers.ts
@@ -1,19 +1,22 @@
 import Client from "./Client";
 import { stripAnsiCodes } from "./stripAnsiCodes";
+import AnsiString from "./AnsiString";
 export { stripAnsiCodes };
 
 type TriggerCallback = (
     rawLine: string,
     line: string,
     matches: RegExpMatchArray,
-    type: string
+    type: string,
+    context?: AnsiString
 ) => string | undefined;
 
 type TriggerMatchFunction = (
     rawLine: string,
     line: string,
     _matches: RegExpMatchArray | undefined,
-    type: string
+    type: string,
+    context?: AnsiString
 ) => RegExpMatchArray | undefined;
 
 type TriggerSubPattern = string | RegExp | TriggerMatchFunction;
@@ -75,8 +78,9 @@ export class Trigger {
         return child;
     }
 
-    execute(rawLine: string, type: string) {
-        const line = stripAnsiCodes(rawLine).replace(/\s$/g, "");
+    execute(context: AnsiString, type: string) {
+        const rawLine = context.getRaw();
+        const line = context.getPlain().replace(/\s$/g, "");
         this.openInstances = this.openInstances.map(v => v - 1).filter(v => v > 0);
         let matches: RegExpMatchArray | undefined;
         const patterns = Array.isArray(this.pattern) ? this.pattern : [this.pattern];
@@ -85,14 +89,16 @@ export class Trigger {
                 matches = line.match(pattern);
             } else if (typeof pattern === "string") {
                 const patternStr = pattern.toString();
-                const index = !this.options.caseInsensitive ? rawLine.indexOf(patternStr) : rawLine.toLowerCase().indexOf(patternStr.toLowerCase());
+                const index = !this.options.caseInsensitive
+                    ? line.indexOf(patternStr)
+                    : line.toLowerCase().indexOf(patternStr.toLowerCase());
                 if (index > -1) {
                     const end = index + patternStr.length;
-                    matches = [rawLine.substring(index, end)];
+                    matches = [line.substring(index, end)];
                     matches.index = index;
                 }
             } else if (typeof pattern === "function") {
-                matches = pattern(rawLine, line, undefined, type);
+                matches = pattern(rawLine, line, undefined, type, context);
             }
             if (matches) {
                 break;
@@ -109,13 +115,16 @@ export class Trigger {
         }
         if (matched) {
             if (matches && this.callback) {
-                rawLine = this.callback(rawLine, line, matches, type) ?? rawLine;
+                const updated = this.callback(rawLine, line, matches, type, context);
+                if (typeof updated === "string") {
+                    context.setRaw(updated);
+                }
             }
             this.children.forEach(child => {
-                rawLine = child.execute(rawLine, type);
+                child.execute(context, type);
             });
         }
-        return rawLine;
+        return context.getRaw();
     }
 }
 
@@ -205,14 +214,15 @@ export default class Triggers {
     }
 
     parseLine(rawLine: string, type: string) {
-        const line = stripAnsiCodes(rawLine).replace(/\s$/g, "");
-        const tokens = line
+        const context = new AnsiString(rawLine);
+        const baseLine = stripAnsiCodes(rawLine).replace(/\s$/g, "");
+        const tokens = baseLine
             .split(/[ \n\t.,!?*()\/\[\]]+/)
             .filter(t => t.length > 0)
             .map(t => t.toLowerCase());
 
         this.triggers.forEach(trigger => {
-            rawLine = trigger.execute(rawLine, type);
+            trigger.execute(context, type);
         });
 
         this.tokenTriggers.forEach(({ words, trigger }) => {
@@ -225,19 +235,20 @@ export default class Triggers {
                     }
                 }
                 if (found) {
-                    rawLine = trigger.execute(rawLine, type);
+                    trigger.execute(context, type);
                     break;
                 }
             }
         });
-        return rawLine;
+        return context.getRaw();
     }
 
     parseMultiline(rawLine: string, type: string) {
+        const context = new AnsiString(rawLine);
         this.multilineTriggers.forEach(trigger => {
-            rawLine = trigger.execute(rawLine, type);
+            trigger.execute(context, type);
         });
-        return rawLine;
+        return context.getRaw();
     }
 
 }

--- a/client/src/scripts/dajeCiHighlight.ts
+++ b/client/src/scripts/dajeCiHighlight.ts
@@ -1,14 +1,17 @@
 import Client from "../Client";
-import { colorStringInLine, findClosestColor } from "../Colors";
+import { color, RESET, findClosestColor } from "../Colors";
+import AnsiString from "../AnsiString";
 
 export default function initDajeCiHighlight(client: Client) {
     const TURQUOISE = findClosestColor("#40e0d0");
     const pattern = /^(?:[ >]*[A-Za-z !()]+ daje ci )(.*)$/;
-    client.Triggers.registerTrigger(pattern, (raw, _line, matches) => {
+    client.Triggers.registerTrigger(pattern, (raw, _line, matches, _type, context) => {
         const group = matches[1];
         if (group !== "nowy zapal do walki.") {
             const start = matches.index ?? 0;
-            return colorStringInLine(raw, group, TURQUOISE, start);
+            const ctx = context ?? new AnsiString(raw);
+            ctx.replacePlainRange(start, start + group.length, color(TURQUOISE) + group + RESET);
+            return ctx.getRaw();
         }
     }, "daje-ci-highlight");
 }

--- a/client/src/scripts/przybywajaHighlight.ts
+++ b/client/src/scripts/przybywajaHighlight.ts
@@ -1,11 +1,15 @@
 import Client from "../Client";
-import { colorStringInLine, findClosestColor } from "../Colors";
+import { color, RESET, findClosestColor } from "../Colors";
+import AnsiString from "../AnsiString";
 
 export default function initPrzybywajaHighlight(client: Client) {
     const HIGHLIGHT = findClosestColor('#ccb3ff');
     const pattern = /\b(przybyw(?:a|aja))\b/i;
-    client.Triggers.registerTrigger(pattern, (raw, _line, matches) => {
+    client.Triggers.registerTrigger(pattern, (raw, _line, matches, _type, context) => {
         const start = matches.index ?? 0;
-        return colorStringInLine(raw, matches[1], HIGHLIGHT, start);
+        const target = matches[1];
+        const ctx = context ?? new AnsiString(raw);
+        ctx.replacePlainRange(start, start + target.length, color(HIGHLIGHT) + target + RESET);
+        return ctx.getRaw();
     }, 'przybywaja-highlight');
 }

--- a/client/test/AnsiString.test.ts
+++ b/client/test/AnsiString.test.ts
@@ -1,0 +1,20 @@
+import AnsiString from '../src/AnsiString';
+
+describe('AnsiString', () => {
+  test('indexOf ignores ansi color codes', () => {
+    const ansi = new AnsiString('\x1b[31mHel\x1b[0mlo');
+    expect(ansi.indexOf('Hello')).toBe(0);
+  });
+
+  test('replacing text inside colored segment preserves color codes', () => {
+    const ansi = new AnsiString('\x1b[31mHello\x1b[0m');
+    ansi.replacePlainRange(2, 4, 'XX');
+    expect(ansi.getRaw()).toBe('\x1b[31mHeXXo\x1b[0m');
+  });
+
+  test('inserting text inside colored segment keeps surrounding color', () => {
+    const ansi = new AnsiString('\x1b[32mHello\x1b[0m');
+    ansi.insertPlain(3, 'X');
+    expect(ansi.getRaw()).toBe('\x1b[32mHelXlo\x1b[0m');
+  });
+});

--- a/client/test/Triggers.test.ts
+++ b/client/test/Triggers.test.ts
@@ -136,4 +136,18 @@ describe('Triggers', () => {
     const matches = cb.mock.calls[0][2];
     expect(matches[0]).toBe('bar');
   });
+
+  test('string pattern matches text separated by ansi codes', () => {
+    const triggers = new Triggers({} as any);
+    const cb = jest.fn((raw, _line, matches, _type, context) => {
+      context?.replacePlainRange(matches.index ?? 0, (matches.index ?? 0) + matches[0].length, `[${matches[0]}]`);
+      return context ? context.getRaw() : raw;
+    });
+    triggers.registerTrigger('Hello', cb);
+
+    const result = triggers.parseLine('\x1b[31mHello\x1b[0m', '');
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(result).toBe('\x1b[31m[Hello]\x1b[0m');
+  });
 });


### PR DESCRIPTION
## Summary
- add an AnsiString helper to work with text while keeping ANSI control sequences intact
- update trigger execution and color helpers to operate on plain text while preserving color in modifications
- adjust highlight utilities and tests to cover ANSI-aware replacements

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fa8cc70218832ab49157d126fc7eef