### PR TITLE
Implement ANSI-aware trigger parsing

### DIFF
--- a/client/src/AnsiAwareBuffer.ts
+++ b/client/src/AnsiAwareBuffer.ts
@@ -1,0 +1,57 @@
+import { createAnsiClickPattern } from "./stripAnsiCodes";
+
+export class AnsiAwareBuffer {
+    private readonly raw: string;
+    private readonly plainChars: string[] = [];
+    private readonly plainToRaw: number[] = [];
+    private rawLength = 0;
+
+    constructor(rawLine: string) {
+        this.raw = rawLine;
+        this.parse();
+    }
+
+    private parse() {
+        const matcher = createAnsiClickPattern("g");
+        let cursor = 0;
+        let match: RegExpExecArray | null;
+        const appendChunk = (chunk: string) => {
+            for (let i = 0; i < chunk.length; i++) {
+                this.plainToRaw.push(this.rawLength);
+                this.plainChars.push(chunk[i]);
+                this.rawLength += 1;
+            }
+        };
+
+        while ((match = matcher.exec(this.raw)) !== null) {
+            const start = match.index;
+            const chunk = this.raw.slice(cursor, start);
+            appendChunk(chunk);
+            this.rawLength += match[0].length;
+            cursor = matcher.lastIndex;
+        }
+
+        const rest = this.raw.slice(cursor);
+        appendChunk(rest);
+    }
+
+    getPlainText(): string {
+        return this.plainChars.join("");
+    }
+
+    mapPlainIndexToRaw(index: number): number {
+        if (index <= 0) {
+            return 0;
+        }
+        if (index >= this.plainToRaw.length) {
+            return this.rawLength;
+        }
+        return this.plainToRaw[index];
+    }
+
+    getRawLength(): number {
+        return this.rawLength;
+    }
+}
+
+export default AnsiAwareBuffer;

--- a/client/src/Triggers.ts
+++ b/client/src/Triggers.ts
@@ -1,5 +1,6 @@
 import Client from "./Client";
 import { stripAnsiCodes } from "./stripAnsiCodes";
+import AnsiAwareBuffer from "./AnsiAwareBuffer";
 export { stripAnsiCodes };
 
 type TriggerCallback = (
@@ -76,13 +77,20 @@ export class Trigger {
     }
 
     execute(rawLine: string, type: string) {
-        const line = stripAnsiCodes(rawLine).replace(/\s$/g, "");
+        const buffer = new AnsiAwareBuffer(rawLine);
+        const line = buffer.getPlainText().replace(/\s$/g, "");
         this.openInstances = this.openInstances.map(v => v - 1).filter(v => v > 0);
         let matches: RegExpMatchArray | undefined;
         const patterns = Array.isArray(this.pattern) ? this.pattern : [this.pattern];
         for (const pattern of patterns) {
             if (pattern instanceof RegExp) {
                 matches = line.match(pattern);
+                if (matches && matches.length > 0) {
+                    const plainIndex = matches.index ?? line.indexOf(matches[0]);
+                    if (plainIndex !== undefined && plainIndex >= 0) {
+                        matches.index = buffer.mapPlainIndexToRaw(plainIndex);
+                    }
+                }
             } else if (typeof pattern === "string") {
                 const patternStr = pattern.toString();
                 const index = !this.options.caseInsensitive ? rawLine.indexOf(patternStr) : rawLine.toLowerCase().indexOf(patternStr.toLowerCase());
@@ -205,7 +213,8 @@ export default class Triggers {
     }
 
     parseLine(rawLine: string, type: string) {
-        const line = stripAnsiCodes(rawLine).replace(/\s$/g, "");
+        const buffer = new AnsiAwareBuffer(rawLine);
+        const line = buffer.getPlainText().replace(/\s$/g, "");
         const tokens = line
             .split(/[ \n\t.,!?*()\/\[\]]+/)
             .filter(t => t.length > 0)

--- a/client/src/stripAnsiCodes.ts
+++ b/client/src/stripAnsiCodes.ts
@@ -1,2 +1,13 @@
-export const stripAnsiCodes = (str: string): string =>
-    str.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]|{clickOpen:\d+(?::[^}]+)?}|{clickClose}/g, "");
+const ANSI_SEQUENCE_PATTERN = "[\\u001b\\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]";
+const CLICK_OPEN_PATTERN = "\\{clickOpen:\\d+(?::[^}]+)?\\}";
+const CLICK_CLOSE_PATTERN = "\\{clickClose\\}";
+
+const PATTERN_SOURCE = `${ANSI_SEQUENCE_PATTERN}|${CLICK_OPEN_PATTERN}|${CLICK_CLOSE_PATTERN}`;
+
+export const createAnsiClickPattern = (flags = "g"): RegExp => new RegExp(PATTERN_SOURCE, flags);
+
+const STRIP_PATTERN = createAnsiClickPattern();
+
+export const stripAnsiCodes = (str: string): string => str.replace(STRIP_PATTERN, "");
+
+export const ansiPatternSource = PATTERN_SOURCE;

--- a/client/test/Triggers.test.ts
+++ b/client/test/Triggers.test.ts
@@ -136,4 +136,32 @@ describe('Triggers', () => {
     const matches = cb.mock.calls[0][2];
     expect(matches[0]).toBe('bar');
   });
+
+  test('regex match index maps to raw position with ansi codes', () => {
+    const triggers = new Triggers({} as any);
+    const raw = '\x1B[22;38;5;42mfoo\x1B[0m bar baz';
+    let captured: number | undefined;
+    triggers.registerTrigger(/bar/, (lineWithAnsi, _plain, matches) => {
+      captured = matches.index;
+      return lineWithAnsi;
+    });
+
+    triggers.parseLine(raw, '');
+
+    expect(captured).toBe(raw.indexOf('bar'));
+  });
+
+  test('regex match index skips clickable sequences', () => {
+    const triggers = new Triggers({} as any);
+    const raw = '{clickOpen:1}foo{clickClose} bar';
+    let captured: number | undefined;
+    triggers.registerTrigger(/bar/, (lineWithTags, _plain, matches) => {
+      captured = matches.index;
+      return lineWithTags;
+    });
+
+    triggers.parseLine(raw, '');
+
+    expect(captured).toBe(raw.indexOf('bar'));
+  });
 });


### PR DESCRIPTION
## Summary
- add a reusable ANSI-aware buffer that maps plain text positions to raw indices
- update trigger execution to leverage the buffer so regex matches preserve color/link offsets
- expose the shared ANSI pattern helper and extend trigger tests to cover ANSI and clickable spans

## Testing
- yarn --cwd client test --runInBand
- yarn --cwd web-client test --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68fa9163eb08832aa136b52ddcb6d0ed