### PR TITLE
Refactor trigger engine to expose TriggerLine helpers

### DIFF
--- a/client/src/People.ts
+++ b/client/src/People.ts
@@ -1,7 +1,7 @@
 import { loadPeople, type PersonEntry } from './peopleLoader';
 import Client from "./Client";
 import {color, RESET, findClosestColor} from './Colors';
-import {stripAnsiCodes} from './Triggers';
+import TriggerLine from "./triggers/TriggerLine";
 
 export default class People {
 
@@ -68,17 +68,18 @@ export default class People {
                 return
             }
 
-            const descCallback = (rawLine: string, _line: string, matches: RegExpMatchArray) => {
+            const descCallback = (rawLine: string, _line: string, matches: RegExpMatchArray, _type: string, triggerLine?: TriggerLine) => {
                 const index = matches.index || 0
                 const token = matches[0]
-                const suffix = rawLine.substring(index + token.length)
-                const nextWord = stripAnsiCodes(suffix)
+                const lineInstance = triggerLine ?? new TriggerLine(rawLine)
+                const plainSuffix = lineInstance.text.substring(index + token.length)
+                const nextWord = plainSuffix
                     .toLowerCase()
                     .replace(/^\s+/, '')
                 if (nextWord.startsWith('chaosu')) {
-                    return rawLine
+                    return triggerLine ? undefined : rawLine
                 }
-                return this.buildDescHighlight(rawLine, token, index, replacement, state, RED)
+                return this.buildDescHighlight(triggerLine, rawLine, token, index, replacement, state, RED)
             }
 
             this.client.Triggers.registerTokenTrigger(replacement.description, descCallback, this.tag, {caseInsensitive: true})
@@ -87,10 +88,10 @@ export default class People {
                 const key = `${replacement.name}|${replacement.guild}`
                 if (!addedNames.has(key) && replacement.name.length > 2) {
                     const chosenColor = state.isEnemy ? RED : state.guildColor!
-                    const nameCallback = (rawLine: string, _line: string, matches: RegExpMatchArray) => {
+                    const nameCallback = (rawLine: string, _line: string, matches: RegExpMatchArray, _type: string, triggerLine?: TriggerLine) => {
                         const index = matches.index || 0
                         const token = matches[0]
-                        return this.buildNameHighlight(rawLine, token, index, chosenColor)
+                        return this.buildNameHighlight(triggerLine, rawLine, token, index, chosenColor)
                     }
                     this.client.Triggers.registerTokenTrigger(replacement.name, nameCallback, this.tag, {caseInsensitive: true})
                     addedNames.add(key)
@@ -110,29 +111,39 @@ export default class People {
         return { inGuild, isEnemy, guildColor }
     }
 
-    private buildNameHighlight(rawLine: string, token: string, index: number, colorCode: number) {
-        const prefix = rawLine.substring(0, index)
-        const suffix = rawLine.substring(index + token.length)
-        const highlighted = color(colorCode) + token + RESET
-        return prefix + highlighted + suffix
+    private buildNameHighlight(triggerLine: TriggerLine | undefined, rawLine: string, token: string, index: number, colorCode: number) {
+        const line = triggerLine ?? new TriggerLine(rawLine)
+        const end = index + token.length
+        line.replace([index, end], color(colorCode) + token + RESET)
+        const esc = "\u001b"
+        const override = line.toAnsiString().replace(new RegExp(`${esc}\\[38;5;`, "g"), `${esc}[22;38;5;`)
+        line.setOverrideAnsi(override)
+        return triggerLine ? line : override
     }
 
-    private buildDescHighlight(rawLine: string, token: string, index: number, replacement: { name: string; guild: string }, state: { inGuild: boolean; isEnemy: boolean; guildColor?: number }, RED: number) {
-        const prefix = rawLine.substring(0, index)
-        const suffix = rawLine.substring(index + token.length)
-        let highlighted = token
-        if (state.isEnemy) {
-            highlighted = color(RED) + token + RESET
-        }
-
+    private buildDescHighlight(
+        triggerLine: TriggerLine | undefined,
+        rawLine: string,
+        token: string,
+        index: number,
+        replacement: { name: string; guild: string },
+        state: { inGuild: boolean; isEnemy: boolean; guildColor?: number },
+        RED: number
+    ) {
+        const line = triggerLine ?? new TriggerLine(rawLine)
+        const end = index + token.length
         let suffixText = ` \x1B[22;38;5;228m(${replacement.name} \x1B[22;38;5;210m${replacement.guild}\x1B[22;38;5;228m)`
         if (state.isEnemy) {
-            suffixText = ' ' + color(RED) + `(${replacement.name} ${replacement.guild})` + RESET
+            line.replace([index, end], color(RED) + token + RESET)
+            suffixText = RESET + ' ' + color(RED) + `(${replacement.name} ${replacement.guild})` + RESET
         } else if (state.inGuild && state.guildColor !== undefined) {
             suffixText = ' ' + color(state.guildColor) + `(${replacement.name} ${replacement.guild})` + RESET
         }
-
-        return prefix + highlighted + suffixText + suffix
+        line.insert(end, suffixText)
+        const esc = "\u001b"
+        const override = line.toAnsiString().replace(new RegExp(`${esc}\\[38;5;`, "g"), `${esc}[22;38;5;`)
+        line.setOverrideAnsi(override)
+        return triggerLine ? line : override
     }
 
 }

--- a/client/src/Triggers.ts
+++ b/client/src/Triggers.ts
@@ -1,19 +1,22 @@
 import Client from "./Client";
 import { stripAnsiCodes } from "./stripAnsiCodes";
+import TriggerLine from "./triggers/TriggerLine";
 export { stripAnsiCodes };
 
 type TriggerCallback = (
     rawLine: string,
     line: string,
     matches: RegExpMatchArray,
-    type: string
-) => string | undefined;
+    type: string,
+    triggerLine?: TriggerLine,
+) => string | TriggerLine | undefined;
 
 type TriggerMatchFunction = (
     rawLine: string,
     line: string,
     _matches: RegExpMatchArray | undefined,
-    type: string
+    type: string,
+    triggerLine?: TriggerLine,
 ) => RegExpMatchArray | undefined;
 
 type TriggerSubPattern = string | RegExp | TriggerMatchFunction;
@@ -27,7 +30,7 @@ export interface TriggerOptions {
 export function isType(type: string): TriggerMatchFunction {
     const matches = [] as unknown as RegExpMatchArray;
     matches.index = 0
-    return (_, __, ___, _type) => {
+    return (_raw, _line, _matches, _type) => {
         return _type === type ? matches : undefined;
     };
 }
@@ -65,9 +68,9 @@ export class Trigger {
     ) {
         const child = this.registerChild(
             pattern,
-            (rawLine, line, matches, type) => {
+            (rawLine, line, matches, type, triggerLine) => {
                 this.manager.removeTrigger(child);
-                return callback(rawLine, line, matches, type);
+                return callback(rawLine, line, matches, type, triggerLine);
             },
             tag,
             options
@@ -75,24 +78,28 @@ export class Trigger {
         return child;
     }
 
-    execute(rawLine: string, type: string) {
-        const line = stripAnsiCodes(rawLine).replace(/\s$/g, "");
+    execute(line: TriggerLine, type: string) {
+        const plainLine = line.text.replace(/\s$/g, "");
         this.openInstances = this.openInstances.map(v => v - 1).filter(v => v > 0);
         let matches: RegExpMatchArray | undefined;
         const patterns = Array.isArray(this.pattern) ? this.pattern : [this.pattern];
         for (const pattern of patterns) {
             if (pattern instanceof RegExp) {
-                matches = line.match(pattern);
+                matches = plainLine.match(pattern);
             } else if (typeof pattern === "string") {
                 const patternStr = pattern.toString();
-                const index = !this.options.caseInsensitive ? rawLine.indexOf(patternStr) : rawLine.toLowerCase().indexOf(patternStr.toLowerCase());
+                const haystack = !this.options.caseInsensitive ? plainLine : plainLine.toLowerCase();
+                const needle = !this.options.caseInsensitive ? patternStr : patternStr.toLowerCase();
+                const index = haystack.indexOf(needle);
                 if (index > -1) {
                     const end = index + patternStr.length;
-                    matches = [rawLine.substring(index, end)];
+                    const matchedText = plainLine.substring(index, end);
+                    matches = [matchedText] as RegExpMatchArray;
                     matches.index = index;
+                    matches.input = plainLine;
                 }
             } else if (typeof pattern === "function") {
-                matches = pattern(rawLine, line, undefined, type);
+                matches = pattern(line.toAnsiString(), plainLine, undefined, type, line);
             }
             if (matches) {
                 break;
@@ -107,15 +114,33 @@ export class Trigger {
         } else if (this.openInstances.length > 0) {
             matched = true;
         }
+        if (!matches) {
+            line.clearMatches();
+        }
         if (matched) {
             if (matches && this.callback) {
-                rawLine = this.callback(rawLine, line, matches, type) ?? rawLine;
+                line.setMatches({ matches, type, triggerId: this.id });
+                const result = this.callback(
+                    line.toAnsiString(),
+                    plainLine,
+                    matches,
+                    type,
+                    line,
+                );
+                if (this.manager.isTriggerEngineActive()) {
+                    if (result instanceof TriggerLine) {
+                        line = result;
+                    } else if (typeof result === "string") {
+                        line = new TriggerLine(result, line.matches, this.manager.isTriggerEngineActive());
+                        line.setOverrideAnsi(result);
+                    }
+                }
             }
             this.children.forEach(child => {
-                rawLine = child.execute(rawLine, type);
+                line = child.execute(line, type);
             });
         }
-        return rawLine;
+        return line;
     }
 }
 
@@ -125,9 +150,18 @@ export default class Triggers {
     triggers: Map<string, Trigger> = new Map();
     multilineTriggers: Map<string, Trigger> = new Map();
     private tokenTriggers: { words: string[]; trigger: Trigger }[] = [];
+    private triggerEngineActive = true;
 
     constructor(clientExtension: Client) {
         this.clientExtension = clientExtension;
+    }
+
+    isTriggerEngineActive(): boolean {
+        return this.triggerEngineActive;
+    }
+
+    setTriggerEngineActive(active: boolean) {
+        this.triggerEngineActive = active;
     }
 
     private removeByTagRecursive(tag: string, collection: Map<string, Trigger>) {
@@ -155,9 +189,9 @@ export default class Triggers {
     registerOneTimeTrigger(pattern: TriggerPattern, callback: TriggerCallback, tag?: string, options?: TriggerOptions) {
         const trigger = this.registerTrigger(
             pattern,
-            (rawLine, line, matches, type) => {
+            (rawLine, line, matches, type, triggerLine) => {
                 this.removeTrigger(trigger);
-                return callback(rawLine, line, matches, type);
+                return callback(rawLine, line, matches, type, triggerLine);
             },
             tag,
             options
@@ -178,9 +212,9 @@ export default class Triggers {
     registerOneTimeMultilineTrigger(pattern: TriggerPattern, callback: TriggerCallback, tag?: string, options?: TriggerOptions) {
         const trigger = this.registerMultilineTrigger(
             pattern,
-            (rawLine, line, matches, type) => {
+            (rawLine, line, matches, type, triggerLine) => {
                 this.removeTrigger(trigger);
-                return callback(rawLine, line, matches, type);
+                return callback(rawLine, line, matches, type, triggerLine);
             },
             tag,
             options
@@ -205,14 +239,15 @@ export default class Triggers {
     }
 
     parseLine(rawLine: string, type: string) {
-        const line = stripAnsiCodes(rawLine).replace(/\s$/g, "");
-        const tokens = line
+        let triggerLine = new TriggerLine(rawLine, { type }, this.triggerEngineActive);
+        const plain = stripAnsiCodes(triggerLine.text).replace(/\s$/g, "");
+        const tokens = plain
             .split(/[ \n\t.,!?*()\/\[\]]+/)
             .filter(t => t.length > 0)
             .map(t => t.toLowerCase());
 
         this.triggers.forEach(trigger => {
-            rawLine = trigger.execute(rawLine, type);
+            triggerLine = trigger.execute(triggerLine, type);
         });
 
         this.tokenTriggers.forEach(({ words, trigger }) => {
@@ -225,19 +260,20 @@ export default class Triggers {
                     }
                 }
                 if (found) {
-                    rawLine = trigger.execute(rawLine, type);
+                    triggerLine = trigger.execute(triggerLine, type);
                     break;
                 }
             }
         });
-        return rawLine;
+        return triggerLine.toAnsiString();
     }
 
     parseMultiline(rawLine: string, type: string) {
+        let triggerLine = new TriggerLine(rawLine, { type }, this.triggerEngineActive);
         this.multilineTriggers.forEach(trigger => {
-            rawLine = trigger.execute(rawLine, type);
+            triggerLine = trigger.execute(triggerLine, type);
         });
-        return rawLine;
+        return triggerLine.toAnsiString();
     }
 
 }

--- a/client/src/triggers/TriggerLine.ts
+++ b/client/src/triggers/TriggerLine.ts
@@ -20,17 +20,43 @@ export interface TriggerMatchMetadata {
     [key: string]: unknown;
 }
 
+function cloneMatches(matches: RegExpMatchArray): RegExpMatchArray {
+    const clone = [...matches] as RegExpMatchArray;
+    if (typeof matches.index === "number") {
+        clone.index = matches.index;
+    }
+    if (typeof matches.input === "string") {
+        clone.input = matches.input;
+    }
+    if (matches.groups) {
+        clone.groups = { ...matches.groups };
+    }
+    return clone;
+}
+
 export default class TriggerLine {
     private readonly buffer: AnsiAwareBuffer;
     private metadata: TriggerMatchMetadata;
+    private readonly mutable: boolean;
+    private overrideAnsi?: string;
 
-    constructor(textOrBuffer: string | AnsiAwareBuffer, metadata: TriggerMatchMetadata = {}) {
+    constructor(
+        textOrBuffer: string | AnsiAwareBuffer,
+        metadata: TriggerMatchMetadata = {},
+        mutable = true,
+    ) {
         if (typeof textOrBuffer === "string") {
             this.buffer = new AnsiAwareBuffer(textOrBuffer);
+            this.overrideAnsi = textOrBuffer;
         } else {
             this.buffer = textOrBuffer.clone();
+            this.overrideAnsi = undefined;
         }
-        this.metadata = { ...metadata };
+        this.metadata = {
+            ...metadata,
+            matches: metadata.matches ? cloneMatches(metadata.matches) : undefined,
+        };
+        this.mutable = mutable;
     }
 
     get text(): string {
@@ -42,11 +68,17 @@ export default class TriggerLine {
     }
 
     get matches(): Readonly<TriggerMatchMetadata> {
-        return { ...this.metadata };
+        return {
+            ...this.metadata,
+            matches: this.metadata.matches ? cloneMatches(this.metadata.matches) : undefined,
+        };
     }
 
     setMatches(metadata: TriggerMatchMetadata): void {
-        this.metadata = { ...metadata };
+        this.metadata = {
+            ...metadata,
+            matches: metadata.matches ? cloneMatches(metadata.matches) : undefined,
+        };
     }
 
     clearMatches(): void {
@@ -54,43 +86,66 @@ export default class TriggerLine {
     }
 
     replace(range: TextRange, text: string, style?: FormatStyle): this {
+        if (!this.mutable) return this;
+        this.overrideAnsi = undefined;
         this.buffer.replace(range, text, style);
         this.refreshMatchMetadata();
         return this;
     }
 
     insert(index: number, text: string, style?: FormatStyle): this {
+        if (!this.mutable) return this;
+        this.overrideAnsi = undefined;
         this.buffer.insert(index, text, style);
         this.refreshMatchMetadata();
         return this;
     }
 
     append(text: string, style?: FormatStyle): this {
+        if (!this.mutable) return this;
+        this.overrideAnsi = undefined;
         this.buffer.append(text, style);
         this.refreshMatchMetadata();
         return this;
     }
 
     prepend(text: string, style?: FormatStyle): this {
+        if (!this.mutable) return this;
+        this.overrideAnsi = undefined;
         this.buffer.prepend(text, style);
         this.refreshMatchMetadata();
         return this;
     }
 
     remove(range: TextRange): this {
+        if (!this.mutable) return this;
+        this.overrideAnsi = undefined;
         this.buffer.remove(range);
         this.refreshMatchMetadata();
         return this;
     }
 
+    isMutable(): boolean {
+        return this.mutable;
+    }
+
     /** @internal */
     toAnsiString(): string {
-        return this.buffer.toAnsiString();
+        return this.overrideAnsi ?? this.buffer.toAnsiString();
     }
 
     /** @internal */
     toHyperlinkSegments(): HyperlinkSegment[] {
         return this.buffer.toHyperlinkSegments();
+    }
+
+    /** @internal */
+    setOverrideAnsi(text?: string): void {
+        this.overrideAnsi = text;
+    }
+
+    toString(): string {
+        return this.toAnsiString();
     }
 
     /**
@@ -105,14 +160,9 @@ export default class TriggerLine {
             this.metadata = { ...this.metadata, matches: undefined };
             return;
         }
-        const clone = [...matches] as RegExpMatchArray;
+        const clone = cloneMatches(matches);
         clone.index = newIndex;
-        if (matches.input) {
-            clone.input = plainText;
-        }
-        if (matches.groups) {
-            clone.groups = { ...matches.groups };
-        }
+        clone.input = plainText;
         this.metadata = { ...this.metadata, matches: clone };
     }
 }


### PR DESCRIPTION
## Summary
- refactor Trigger execution to operate on TriggerLine instances and expose them to callbacks
- extend TriggerLine with cloning, mutability guards, and ANSI override support for safe scripting
- update People triggers to mutate TriggerLine directly while preserving colorized output

## Testing
- yarn --cwd client test -- people.test.ts --runInBand
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68fa9a09faa8832aa49e0db0196cc22a