### PR TITLE
Fix client alias resolution and recorder test setup

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -12,5 +12,6 @@ module.exports = {
   },
   moduleNameMapper: {
     '\\.(?:wasm)\\?url$': '<rootDir>/test/__mocks__/wasmUrlMock.js',
+    '^@client/(.*)$': '<rootDir>/$1',
   },
 }

--- a/client/src/People.ts
+++ b/client/src/People.ts
@@ -3,6 +3,8 @@ import Client from "./Client";
 import {color, RESET, findClosestColor} from './Colors';
 import {stripAnsiCodes} from './Triggers';
 
+const ANSI_SEQUENCE = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]|{clickOpen:\d+(?::[^}]+)?}|{clickClose}/y;
+
 export default class People {
 
     tag = 'people'
@@ -71,7 +73,8 @@ export default class People {
             const descCallback = (rawLine: string, _line: string, matches: RegExpMatchArray) => {
                 const index = matches.index || 0
                 const token = matches[0]
-                const suffix = rawLine.substring(index + token.length)
+                const suffixStart = this.resolveRawIndex(rawLine, index + token.length)
+                const suffix = rawLine.substring(suffixStart)
                 const nextWord = stripAnsiCodes(suffix)
                     .toLowerCase()
                     .replace(/^\s+/, '')
@@ -110,16 +113,41 @@ export default class People {
         return { inGuild, isEnemy, guildColor }
     }
 
+    private resolveRawIndex(rawLine: string, plainIndex: number) {
+        if (plainIndex <= 0) {
+            return 0
+        }
+
+        let rawIndex = 0
+        let processed = 0
+        while (rawIndex < rawLine.length && processed < plainIndex) {
+            ANSI_SEQUENCE.lastIndex = rawIndex
+            const match = ANSI_SEQUENCE.exec(rawLine)
+            if (match && match.index === rawIndex) {
+                rawIndex = ANSI_SEQUENCE.lastIndex
+                continue
+            }
+            rawIndex += 1
+            processed += 1
+        }
+
+        return rawIndex
+    }
+
     private buildNameHighlight(rawLine: string, token: string, index: number, colorCode: number) {
-        const prefix = rawLine.substring(0, index)
-        const suffix = rawLine.substring(index + token.length)
+        const start = this.resolveRawIndex(rawLine, index)
+        const end = this.resolveRawIndex(rawLine, index + token.length)
+        const prefix = rawLine.substring(0, start)
+        const suffix = rawLine.substring(end)
         const highlighted = color(colorCode) + token + RESET
         return prefix + highlighted + suffix
     }
 
     private buildDescHighlight(rawLine: string, token: string, index: number, replacement: { name: string; guild: string }, state: { inGuild: boolean; isEnemy: boolean; guildColor?: number }, RED: number) {
-        const prefix = rawLine.substring(0, index)
-        const suffix = rawLine.substring(index + token.length)
+        const start = this.resolveRawIndex(rawLine, index)
+        const end = this.resolveRawIndex(rawLine, index + token.length)
+        const prefix = rawLine.substring(0, start)
+        const suffix = rawLine.substring(end)
         let highlighted = token
         if (state.isEnemy) {
             highlighted = color(RED) + token + RESET

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -5,6 +5,11 @@
     "outDir": "dist",
     "resolveJsonModule": true,
     "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@client/src/*": ["src/*"],
+    },
+    "allowImportingTsExtensions": true,
     /* Linting */
     "strict": false,
     "noUnusedLocals": true,

--- a/web-client/jest.setup.js
+++ b/web-client/jest.setup.js
@@ -34,3 +34,28 @@ if (typeof globalThis.fetch !== 'function') {
     });
   }
 }
+
+if (typeof globalThis.pako === 'undefined') {
+  class MockInflate {
+    constructor() {
+      this.result = new Uint8Array();
+    }
+
+    push(data) {
+      if (data instanceof Uint8Array) {
+        this.result = data;
+      } else if (typeof data === 'string') {
+        const encoder = new TextEncoder();
+        this.result = encoder.encode(data);
+      } else {
+        this.result = new Uint8Array();
+      }
+    }
+  }
+
+  globalThis.pako = {
+    inflate: (input) => input,
+    ungzip: (input) => input,
+    Inflate: MockInflate,
+  };
+}

--- a/web-client/src/Recorder.ts
+++ b/web-client/src/Recorder.ts
@@ -1,6 +1,5 @@
 import {saveRecording, getRecording, getRecordingNames, deleteRecording, RecordedEvent} from './recordingStorage';
 import {CommandOptions} from "@client/src/scripts/commandPreserveCaseMode.ts";
-import ArkadiaClient from "./ArkadiaClient.ts";
 
 export interface RecorderHooks {
     processIncomingData(data: string): void;
@@ -147,15 +146,15 @@ export default class Recorder {
         this.stopPlayback();
         this.isPlaying = true;
         this.hooks.emit('playback.start');
-        ArkadiaClient.emit("message", '== Playback start ==');
+        this.hooks.emit("message", '== Playback start ==');
         this.recordedMessages.forEach(ev => {
             if (ev.direction === 'in') {
                 this.hooks.processIncomingData(ev.message);
             } else {
-                ArkadiaClient.emit("message", '→ ' + ev.message);
+                this.hooks.emit("message", '→ ' + ev.message);
             }
         });
-        ArkadiaClient.emit("message", '== Playback end ==');
+        this.hooks.emit("message", '== Playback end ==');
         this.stopPlayback();
     }
 
@@ -166,7 +165,7 @@ export default class Recorder {
         this.paused = false;
         this.playbackIndex = 0;
         this.hooks.emit('playback.start', this.recordedMessages.length);
-        ArkadiaClient.emit("message", '== Playback start ==');
+        this.hooks.emit("message", '== Playback start ==');
         this.hooks.emit('playback.index', 0, this.recordedMessages.length);
         this.scheduleNext(0);
     }
@@ -175,7 +174,7 @@ export default class Recorder {
         if (ev.direction === 'in') {
             this.hooks.processIncomingData(ev.message);
         } else {
-            ArkadiaClient.emit("message", '→ ' + ev.message);
+            this.hooks.emit("message", '→ ' + ev.message);
             window.clientExtension.sendCommand(ev.message, false);
             this.hooks.sendCommand(ev.message, false);
         }
@@ -184,7 +183,7 @@ export default class Recorder {
     private executeCurrent() {
         const ev = this.recordedMessages[this.playbackIndex];
         if (!ev) {
-            ArkadiaClient.emit("message", '== Playback end ==');
+            this.hooks.emit("message", '== Playback end ==');
             this.stopPlayback();
             return;
         }
@@ -197,7 +196,7 @@ export default class Recorder {
         if (!this.isPlaying) return;
         const ev = this.recordedMessages[this.playbackIndex];
         if (!ev) {
-            ArkadiaClient.emit("message", '== Playback end ==');
+            this.hooks.emit("message", '== Playback end ==');
             this.stopPlayback();
             return;
         }


### PR DESCRIPTION
## Summary
- add proper path mapping for @client imports used in tests and adjust ansi handling in People highlights
- provide a Jest setup mock for the global pako dependency
- decouple the web client Recorder from ArkadiaClient to avoid constructor errors in tests

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68fa9ff51c90832aaf8406fa21b9cc4d