### PR TITLE
Refine client trigger processing pipeline

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -25,6 +25,7 @@ import { openMapContextMenu } from "./contextMenus";
 import type { HerbManagerApi } from "./types/herbs";
 import type { CommandOptions } from "./scripts/commandPreserveCaseMode";
 import { DEFAULT_ATTACK_COMMAND, normalizeAttackCommand } from "./utils/attackCommand";
+import TriggerLine from "./triggers/TriggerLine";
 
 export interface ClientAdapter {
     send(text: string, echo?: boolean, options?: CommandOptions): void;
@@ -434,12 +435,33 @@ export default class Client {
         this.eventTarget.dispatchEvent(new CustomEvent(LINE_START_EVENT))
         const ansiRegex = /\x1b\[[0-9;]*m/g
 
-        line = this.Triggers.parseMultiline(line, type)
-        let split = line.split('\n')
-        if (stripAnsiCodes(split[split.length - 1]) === '') {
+        const triggerEngineActive =
+            typeof this.Triggers.isTriggerEngineActive === 'function'
+                ? this.Triggers.isTriggerEngineActive()
+                : true
+        const multilineInput = new TriggerLine(line, { type }, triggerEngineActive)
+        const multilineResultRaw = this.Triggers.parseMultiline(multilineInput, type) as unknown
+        if (typeof multilineResultRaw === 'string' && multilineResultRaw === SKIP_LINE) {
+            this.inLineProcess = false
+            return ""
+        }
+        const multilineText = multilineResultRaw instanceof TriggerLine
+            ? multilineResultRaw.toAnsiString()
+            : String(multilineResultRaw ?? '')
+        let split = multilineText.split('\n')
+        if (split.length > 0 && stripAnsiCodes(split[split.length - 1]) === '') {
             split.pop()
         }
-        let result = split.map(partial => this.Triggers.parseLine(partial, type)).filter(line => line !== SKIP_LINE).join('\n')
+        const processedParts = split.map(partial => {
+            const lineInput = new TriggerLine(partial, { type }, triggerEngineActive)
+            const processedRaw = this.Triggers.parseLine(lineInput, type) as unknown
+            if (processedRaw instanceof TriggerLine) {
+                return processedRaw.toAnsiString()
+            }
+            return processedRaw as string
+        })
+        const serializedParts = processedParts.filter((part): part is string => part !== SKIP_LINE)
+        let result = serializedParts.join('\n')
         if (!result.startsWith("\x1b")) {
             result = color(255) + result
         }

--- a/client/src/Triggers.ts
+++ b/client/src/Triggers.ts
@@ -238,8 +238,11 @@ export default class Triggers {
         }
     }
 
-    parseLine(rawLine: string, type: string) {
-        let triggerLine = new TriggerLine(rawLine, { type }, this.triggerEngineActive);
+    parseLine(rawLine: string | TriggerLine, type: string): string {
+        let triggerLine =
+            rawLine instanceof TriggerLine
+                ? rawLine
+                : new TriggerLine(rawLine, { type }, this.triggerEngineActive);
         const plain = stripAnsiCodes(triggerLine.text).replace(/\s$/g, "");
         const tokens = plain
             .split(/[ \n\t.,!?*()\/\[\]]+/)
@@ -268,8 +271,11 @@ export default class Triggers {
         return triggerLine.toAnsiString();
     }
 
-    parseMultiline(rawLine: string, type: string) {
-        let triggerLine = new TriggerLine(rawLine, { type }, this.triggerEngineActive);
+    parseMultiline(rawLine: string | TriggerLine, type: string): string {
+        let triggerLine =
+            rawLine instanceof TriggerLine
+                ? rawLine
+                : new TriggerLine(rawLine, { type }, this.triggerEngineActive);
         this.multilineTriggers.forEach(trigger => {
             triggerLine = trigger.execute(triggerLine, type);
         });


### PR DESCRIPTION
## Summary
- build `TriggerLine` instances from raw telnet data before running multiline and line triggers
- preserve optional line skipping while reserialising trigger output via the buffer
- allow `Triggers.parseLine`/`parseMultiline` to accept prebuilt `TriggerLine` objects

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68faa25027ac832a835a66858a58d438