### PR TITLE
Add TriggerLine formatting regression tests

### DIFF
--- a/client/test/Triggers.test.ts
+++ b/client/test/Triggers.test.ts
@@ -136,4 +136,67 @@ describe('Triggers', () => {
     const matches = cb.mock.calls[0][2];
     expect(matches[0]).toBe('bar');
   });
+
+  test('triggerLine replace preserves ANSI formatting without manual handling', () => {
+    const triggers = new Triggers({} as any);
+    triggers.registerTrigger(/Azure/, (_raw, _line, matches, _type, triggerLine) => {
+      expect(triggerLine).toBeDefined();
+      triggerLine!.replace([matches.index!, matches.index! + matches[0].length], 'Blue');
+      return undefined;
+    });
+
+    const result = triggers.parseLine('\u001b[34mAzure\u001b[0m sea', '');
+
+    expect(result).toBe('\u001b[34mBlue\u001b[0m sea');
+  });
+
+  test('triggerLine insert retains hyperlink metadata', () => {
+    const triggers = new Triggers({} as any);
+    triggers.registerTrigger(/Map/, (_raw, _line, matches, _type, triggerLine) => {
+      expect(triggerLine).toBeDefined();
+      triggerLine!.insert(matches.index! + matches[0].length, ' link');
+      return undefined;
+    });
+
+    const raw = '{clickOpen:9:map}Map{clickClose} ahead';
+    const result = triggers.parseLine(raw, '');
+
+    expect(result).toBe('{clickOpen:9:map}Map link{clickClose} ahead');
+  });
+
+  test('multiline triggers keep plain-text indices aligned with metadata', () => {
+    const triggers = new Triggers({} as any);
+    let observedIndex: number | undefined;
+    triggers.registerMultilineTrigger(/Second/, (_raw, _line, matches, _type, triggerLine) => {
+      expect(triggerLine).toBeDefined();
+      const metadata = triggerLine!.matches.matches;
+      expect(metadata?.index).toBe(matches.index);
+      expect(triggerLine!.text.slice(matches.index!, matches.index! + matches[0].length)).toBe('Second');
+      observedIndex = matches.index;
+      return undefined;
+    });
+
+    const raw = '\u001b[31mFirst\u001b[0m line\n{clickOpen:7}Second{clickClose} line';
+    triggers.parseMultiline(raw, '');
+
+    expect(observedIndex).toBe('First line'.length + 1);
+  });
+
+  test('token triggers expose plain-text indices despite formatting', () => {
+    const triggers = new Triggers({} as any);
+    let observedIndex: number | undefined;
+    triggers.registerTokenTrigger('Eamon', (_raw, _line, matches, _type, triggerLine) => {
+      expect(triggerLine).toBeDefined();
+      const metadata = triggerLine!.matches.matches;
+      expect(metadata?.index).toBe(matches.index);
+      expect(triggerLine!.text.slice(matches.index!, matches.index! + matches[0].length)).toBe('Eamon');
+      observedIndex = matches.index;
+      return undefined;
+    });
+
+    const raw = '\u001b[32mEamon\u001b[0m arrives in style';
+    triggers.parseLine(raw, '');
+
+    expect(observedIndex).toBe(0);
+  });
 });

--- a/client/test/triggers/TriggerLine.test.ts
+++ b/client/test/triggers/TriggerLine.test.ts
@@ -1,0 +1,37 @@
+import TriggerLine from '../../src/triggers/TriggerLine';
+
+describe('TriggerLine formatting helpers', () => {
+  it('infers formatting when replacing text inside coloured segments', () => {
+    const raw = '\u001b[31mHello\u001b[0m friend';
+    const line = new TriggerLine(raw);
+
+    line.replace([0, 5], 'Hi');
+
+    expect(line.text).toBe('Hi friend');
+    expect(line.toAnsiString()).toBe('\u001b[31mHi\u001b[0m friend');
+  });
+
+  it('carries formatting forward when inserting at segment boundaries', () => {
+    const raw = '\u001b[32mGreen\u001b[0m!';
+    const line = new TriggerLine(raw);
+
+    line.insert(5, 'ish');
+
+    expect(line.text).toBe('Greenish!');
+    expect(line.toAnsiString()).toBe('\u001b[32mGreenish\u001b[0m!');
+  });
+
+  it('retains hyperlink metadata during insertions', () => {
+    const raw = '{clickOpen:7:profile}Eamon{clickClose} walks in';
+    const line = new TriggerLine(raw);
+
+    line.insert(5, ' the Brave');
+
+    expect(line.text).toBe('Eamon the Brave walks in');
+    expect(line.toAnsiString()).toBe('{clickOpen:7:profile}Eamon the Brave{clickClose} walks in');
+    expect(line.toHyperlinkSegments()).toEqual([
+      { text: 'Eamon the Brave', hyperlink: { id: 7, title: 'profile' } },
+      { text: ' walks in', hyperlink: undefined },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add TriggerLine unit tests covering replace/insert helpers keeping ANSI colours and hyperlink metadata intact
- extend trigger integration coverage to exercise the TriggerLine API and assert metadata indices for multiline and token triggers

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68faa9ac5540832aaa01e5d1acc2c4e6