### PR TITLE
Add output performance measurement test

### DIFF
--- a/web-client/jest.setup.js
+++ b/web-client/jest.setup.js
@@ -34,3 +34,23 @@ if (typeof globalThis.fetch !== 'function') {
     });
   }
 }
+
+if (typeof globalThis.pako === 'undefined') {
+  class InflateMock {
+    constructor() {
+      this.result = [];
+      this.err = 0;
+      this.msg = '';
+      this.chunks = [];
+      this.ended = false;
+    }
+
+    push() {}
+  }
+
+  globalThis.pako = {
+    Inflate: InflateMock,
+    inflate: (input) => input,
+    ungzip: (input) => input,
+  };
+}

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -46,6 +46,7 @@ import {
 import "./triggerTester"
 import "./triggerFinder"
 import {getItemSync} from "@client/src/storage"
+import {setupOutputMessageHandler} from "./outputMessageHandler";
 
 initSessionLogger(arkadiaClient).catch(err => console.error('Logger init failed', err));
 
@@ -259,56 +260,13 @@ Promise.all([mapDataPromise, colorsPromise])
 
 
 // Set up message event listener for UI updates
-arkadiaClient.on('message', (message: string, type?: string) => {
-    if (message === "") {
-        return; //TODO investigate
-    }
-    const wrapper = document.createElement('div');
-    wrapper.classList.add('output_msg');
-
-    if (type) {
-        wrapper.classList.add(type);
-    }
-
-    const messageDiv = document.createElement('div');
-    messageDiv.innerHTML = message;
-    messageDiv.classList.add('output_msg_text');
-    messageDiv.style.whiteSpace = 'pre-wrap';
-
-    wrapper.appendChild(messageDiv);
-    outputWrapper.insertBefore(wrapper, splitBottom);
-
-    const maxElements = 1000;
-    while (outputWrapper.childElementCount - 1 > maxElements) {
-        const first = outputWrapper.firstElementChild;
-        if (first === splitBottom) {
-            const second = first.nextElementSibling;
-            if (second) {
-                outputWrapper.removeChild(second);
-            } else {
-                break;
-            }
-        } else if (first) {
-            outputWrapper.removeChild(first);
-        } else {
-            break;
-        }
-    }
-
-    if (isSplitView) {
-        stickyArea.appendChild(wrapper.cloneNode(true));
-        processSticky(1);
-        while (stickyArea.childElementCount > STICKY_LINES) {
-            const firstSticky = stickyArea.firstElementChild;
-            if (firstSticky) {
-                stickyArea.removeChild(firstSticky);
-            } else {
-                break;
-            }
-        }
-    } else {
-        outputWrapper.scrollTop = outputWrapper.scrollHeight;
-    }
+setupOutputMessageHandler(arkadiaClient, {
+    outputWrapper,
+    splitBottom,
+    stickyArea,
+    isSplitView: () => isSplitView,
+    processSticky,
+    stickyLines: STICKY_LINES,
 });
 
 // Track connection state

--- a/web-client/src/outputMessageHandler.ts
+++ b/web-client/src/outputMessageHandler.ts
@@ -1,0 +1,85 @@
+type MessageHandlerClient = {
+    on(event: string, listener: (message: string, type?: string) => void): void;
+    off(event: string, listener: (message: string, type?: string) => void): void;
+};
+
+type OutputHandlerOptions = {
+    outputWrapper: HTMLElement;
+    splitBottom: HTMLElement;
+    stickyArea: HTMLElement;
+    isSplitView: () => boolean;
+    processSticky: (count: number) => void;
+    stickyLines: number;
+    maxElements?: number;
+};
+
+export function setupOutputMessageHandler(
+    client: MessageHandlerClient,
+    {
+        outputWrapper,
+        splitBottom,
+        stickyArea,
+        isSplitView,
+        processSticky,
+        stickyLines,
+        maxElements = 1000,
+    }: OutputHandlerOptions,
+) {
+    const handleMessage = (message: string, type?: string) => {
+        if (message === "") {
+            return;
+        }
+
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('output_msg');
+
+        if (type) {
+            wrapper.classList.add(type);
+        }
+
+        const messageDiv = document.createElement('div');
+        messageDiv.innerHTML = message;
+        messageDiv.classList.add('output_msg_text');
+        messageDiv.style.whiteSpace = 'pre-wrap';
+
+        wrapper.appendChild(messageDiv);
+        outputWrapper.insertBefore(wrapper, splitBottom);
+
+        while (outputWrapper.childElementCount - 1 > maxElements) {
+            const first = outputWrapper.firstElementChild;
+            if (first === splitBottom) {
+                const second = first.nextElementSibling;
+                if (second) {
+                    outputWrapper.removeChild(second);
+                } else {
+                    break;
+                }
+            } else if (first) {
+                outputWrapper.removeChild(first);
+            } else {
+                break;
+            }
+        }
+
+        if (isSplitView()) {
+            stickyArea.appendChild(wrapper.cloneNode(true));
+            processSticky(1);
+            while (stickyArea.childElementCount > stickyLines) {
+                const firstSticky = stickyArea.firstElementChild;
+                if (firstSticky) {
+                    stickyArea.removeChild(firstSticky);
+                } else {
+                    break;
+                }
+            }
+        } else {
+            outputWrapper.scrollTop = outputWrapper.scrollHeight;
+        }
+    };
+
+    client.on('message', handleMessage);
+
+    return () => {
+        client.off('message', handleMessage);
+    };
+}

--- a/web-client/test/outputPerformance.test.ts
+++ b/web-client/test/outputPerformance.test.ts
@@ -1,0 +1,59 @@
+import arkadiaClient from '../src/ArkadiaClient';
+import {setupOutputMessageHandler} from '../src/outputMessageHandler';
+
+describe('output performance measurements', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="main_text_output_msg_wrapper">
+        <div id="split-bottom" class="split-hidden">
+          <div id="sticky-area"></div>
+        </div>
+      </div>
+    `;
+  });
+
+  test('logs timing for handling websocket output', () => {
+    const outputWrapper = document.getElementById('main_text_output_msg_wrapper') as HTMLElement;
+    const splitBottom = document.getElementById('split-bottom') as HTMLElement;
+    const stickyArea = document.getElementById('sticky-area') as HTMLElement;
+
+    const cleanup = setupOutputMessageHandler(arkadiaClient, {
+      outputWrapper,
+      splitBottom,
+      stickyArea,
+      isSplitView: () => false,
+      processSticky: () => {},
+      stickyLines: 15,
+    });
+
+    const clearMessages = () => {
+      let first = outputWrapper.firstElementChild;
+      while (first && first !== splitBottom) {
+        const next = first.nextElementSibling;
+        outputWrapper.removeChild(first);
+        first = next;
+      }
+    };
+
+    const measure = (count: number) => {
+      const start = performance.now();
+      for (let i = 0; i < count; i++) {
+        (arkadiaClient as any).processIncomingData(`Line ${i}`);
+      }
+      const end = performance.now();
+      return end - start;
+    };
+
+    try {
+      const singleLineDuration = measure(1);
+      console.log(`[performance] Time to handle 1 line: ${singleLineDuration.toFixed(3)} ms`);
+
+      clearMessages();
+
+      const burstDuration = measure(1000);
+      console.log(`[performance] Time to handle 1000 lines: ${burstDuration.toFixed(3)} ms`);
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- extract the output message listener into a reusable helper
- stub the browser `pako` global in the Jest environment
- add a Jest performance test that logs handling times for 1 and 1000 websocket lines

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68fac0e89f9c832aa79b739ec417ab92