### PR TITLE
Use string literals for fixed triggers

### DIFF
--- a/client/src/TeamManager.ts
+++ b/client/src/TeamManager.ts
@@ -202,7 +202,7 @@ export default class TeamManager {
             this.clearTeam();
         };
         triggers.registerTrigger(/^\[?([A-Z][a-z ]+?)\]? zmusza cie do opuszczenia druzyny\.$/, clear, tag);
-        triggers.registerTrigger(/Nie jestes w zadnej druzynie\./, clear, tag);
+        triggers.registerTrigger("Nie jestes w zadnej druzynie.", clear, tag);
         triggers.registerTrigger(/^\[?([A-Z][a-z ]+?)\]? rozwiazuje druzyne\.$/, clear, tag);
         triggers.registerTrigger(/^Porzucasz (?:swoja druzyne|druzyne, ktorej przewodzil[ea]s)\.$/, clear, tag);
         triggers.registerTrigger(/^Przewodzisz druzynie, w ktorej oprocz ciebie (?:jest|sa) jeszcze(?:\:|) (?<team>.*)\.$/, (_r, _l, m): undefined => {

--- a/client/src/scripts/mountain.ts
+++ b/client/src/scripts/mountain.ts
@@ -6,7 +6,7 @@ export default function initMountain(client: Client) {
     const tag = "mountain";
     const YELLOW = findClosestColor("#ffff00");
 
-    client.Triggers.registerTrigger(/Zaczynasz schodzic na dol\./, (_r, line) => {
+    client.Triggers.registerTrigger("Zaczynasz schodzic na dol.", (_r, line) => {
         mountainMovingDir = "down";
         return colorString(line, YELLOW);
     }, tag);
@@ -16,12 +16,12 @@ export default function initMountain(client: Client) {
         return colorString(line, YELLOW);
     }, tag);
 
-    client.Triggers.registerTrigger(/Docierasz na gore\./, (_r, line) => {
+    client.Triggers.registerTrigger("Docierasz na gore.", (_r, line) => {
         mountainMovingDir = undefined;
         return colorString(line, YELLOW);
     }, tag);
 
-    client.Triggers.registerTrigger(/Bezpiecznie schodzisz na dol\./, (_r, line) => {
+    client.Triggers.registerTrigger("Bezpiecznie schodzisz na dol.", (_r, line) => {
         mountainMovingDir = undefined;
         return colorString(line, YELLOW);
     }, tag);

--- a/client/src/scripts/shipLocalizers.ts
+++ b/client/src/scripts/shipLocalizers.ts
@@ -14,7 +14,7 @@ function createHandler(client: Client, roomId: number) {
 }
 
 export default function initShipLocalizers(client: Client) {
-    const parent = client.Triggers.registerTrigger(/krzyczy:/, () => undefined, 'ship-localizers');
+    const parent = client.Triggers.registerTrigger('krzyczy:', () => undefined, 'ship-localizers');
 
     const entries: Localizer[] = [
         { pattern: /(?:Mlody smutny mezczyzna|Strag) krzyczy: Doplynelismy do przystani promu w Oxenfurcie! Mozna wysiadac!$/, roomId: 2464 },


### PR DESCRIPTION
## Summary
- replace fixed-sentence mountain triggers with string literals
- update ship localizer parent trigger to use a string
- switch the team manager "Nie jestes w zadnej druzynie." trigger to a string literal

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68fac50e54cc832a920e218d630b0378