### PR TITLE
Streamline GMCP message flush pipeline

### DIFF
--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -336,26 +336,34 @@ class ArkadiaClient implements ClientAdapter {
     }
 
     flushMessageBuffer() {
-        let processed = [];
-        this.messageBuffer.forEach((message, i) => {
-            if (processed[processed.length - 1]?.type === message.type) {
-                processed[processed.length - 1].text += message.text
+        const aggregated: { text: string, type: string }[] = [];
+        this.messageBuffer.forEach((message) => {
+            const last = aggregated[aggregated.length - 1];
+            if (last?.type === message.type) {
+                last.text += message.text;
             } else {
-                processed.push(message)
+                aggregated.push({...message});
             }
         })
-        processed.forEach((message, i) => {
-            this.sendLine(message.text, message.type, i)
+
+        const gmcpOutputs: { text: string, type: string }[] = [];
+        aggregated.forEach((message) => {
+            const processedText = this.sendLine(message.text, message.type);
+            gmcpOutputs.push({text: processedText, type: message.type});
         })
-        this.emit('output-sent', processed.length)
+
+        this.emit('output-sent', aggregated.length)
+        gmcpOutputs.forEach(({text, type}) => {
+            this.emit(`gmcp_msg.${type}`, text);
+        })
         this.messageBuffer = []
     }
 
-    private sendLine(text: string, type: string, i: number) {
-        text = window.clientExtension.onLine(text, type)
-        eventBus.on('output-sent', () => this.emit(`gmcp_msg.${type}`, text), {once: true})
-        this.emit("message", parseAnsiPatterns(text), type);
+    private sendLine(text: string, type: string) {
+        const processedText = window.clientExtension.onLine(text, type)
+        this.emit("message", processedText, type);
         this.emit('line-sent')
+        return processedText
     }
 
     startRecording(name: string) {

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -361,7 +361,8 @@ class ArkadiaClient implements ClientAdapter {
 
     private sendLine(text: string, type: string) {
         const processedText = window.clientExtension.onLine(text, type)
-        this.emit("message", processedText, type);
+        const parsedText = parseAnsiPatterns(processedText)
+        this.emit("message", parsedText, type);
         this.emit('line-sent')
         return processedText
     }


### PR DESCRIPTION
## Summary
- restructure GMCP flush pipeline to emit gmcp_msg events directly during flush
- reuse processed line output from the client extension when broadcasting messages

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fac4fd55fc832aa1aa28bd1716e00d