### PR TITLE
Use literal triggers for attack and smith scripts

### DIFF
--- a/client/src/scripts/attackBeep.ts
+++ b/client/src/scripts/attackBeep.ts
@@ -93,5 +93,5 @@ export default function initAttackBeep(client: Client) {
         /^\w+(?: \w+){0,4} z pierwotna wsciekloscia (?<upper>rzuca sie na ciebie), rozpoczynajac walke!/
     ].forEach(p => client.Triggers.registerTrigger(p, beep, tag));
 
-    client.Triggers.registerTrigger(/atakuje cie!$/, (_r, line) => highlightPhrase(line), tag);
+    client.Triggers.registerTrigger('atakuje cie!', (_r, line) => highlightPhrase(line), tag);
 }

--- a/client/src/scripts/smith.ts
+++ b/client/src/scripts/smith.ts
@@ -37,10 +37,10 @@ export default function initSmith(client: Client, aliases?: { pattern: RegExp; c
         scheduleDefault();
     };
 
-    client.Triggers.registerTrigger(/konczy prace\.$/, endWork, tag);
+    client.Triggers.registerTrigger('konczy prace.', endWork, tag);
     client.Triggers.registerTrigger(/\bdaje ci/, endWork, tag);
     client.Triggers.registerTrigger(/do ciebie: .+ nie (?:nadaj|wymaga).* (?:ostrzenia|naprawy)/, nothingToRepair, tag);
-    client.Triggers.registerTrigger(/do ciebie: Zobacze co da sie zrobic\./, startWork, tag);
+    client.Triggers.registerTrigger('do ciebie: Zobacze co da sie zrobic.', startWork, tag);
 
     if (aliases) {
         aliases.push({


### PR DESCRIPTION
## Summary
- switch the attack beep trigger for "atakuje cie!" to use a string literal
- replace smith script polish triggers with simple string literals

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68fac84906d4832ab52885726644868d