### PR TITLE
Expose plugin UI helpers for plugin menu actions

### DIFF
--- a/client/src/plugins/PluginHost.ts
+++ b/client/src/plugins/PluginHost.ts
@@ -5,14 +5,22 @@ import {
     PluginAPI,
     PluginDefinition,
     PluginHostOptions,
+    PluginUIHooks,
+    PluginUIManager,
     RegisterArkadiaPlugin,
 } from "./api";
+
+type PluginUIResolution = {
+    hooks?: PluginUIHooks;
+    dispose?: () => void;
+};
 
 interface PluginState {
     definition: PluginDefinition;
     api: PluginAPI;
     setupPromise: Promise<void>;
     cleanup?: () => void | Promise<void>;
+    uiDispose?: () => void;
 }
 
 export default class PluginHost {
@@ -38,7 +46,8 @@ export default class PluginHost {
             console.warn("Arkadia plugin registration ignored – missing script URL.");
             return;
         }
-        const api = this.createPluginAPI(scriptUrl);
+        const {hooks: uiHooks, dispose: uiDispose} = this.resolvePluginUI(scriptUrl);
+        const api = this.createPluginAPI(scriptUrl, uiHooks);
         const state: PluginState = {
             definition,
             api,
@@ -53,6 +62,7 @@ export default class PluginHost {
                 .then(() => {
                     // ensure promise resolves to void
                 }),
+            uiDispose,
         };
         state.setupPromise.catch(err => {
             console.error(`Plugin setup failed for ${scriptUrl}`, err);
@@ -82,6 +92,13 @@ export default class PluginHost {
                 console.error(`Plugin dispose hook failed for ${scriptUrl}`, err);
             });
         }
+        if (state.uiDispose) {
+            try {
+                state.uiDispose();
+            } catch (err) {
+                console.error(`Plugin UI cleanup failed for ${scriptUrl}`, err);
+            }
+        }
     }
 
     async disposeAll(): Promise<void> {
@@ -93,14 +110,28 @@ export default class PluginHost {
         return Array.from(this.plugins.keys());
     }
 
-    private createPluginAPI(scriptUrl: string): PluginAPI {
+    private createPluginAPI(scriptUrl: string, uiHooks?: PluginUIHooks): PluginAPI {
         return {
             scriptUrl,
             client: createClientAPI(this.client),
             storage: this.storageApi,
             arkadia: this.options.arkadia,
-            ui: this.options.ui,
+            ui: uiHooks,
         };
+    }
+
+    private resolvePluginUI(scriptUrl: string): PluginUIResolution {
+        const option = this.options.ui;
+        if (!option) {
+            return {};
+        }
+        if (typeof option === "object" && "create" in option && typeof option.create === "function") {
+            const manager = option as PluginUIManager;
+            const hooks = manager.create(scriptUrl);
+            const dispose = manager.dispose ? () => manager.dispose!(scriptUrl) : undefined;
+            return {hooks, dispose};
+        }
+        return {hooks: option as PluginUIHooks};
     }
 
     private resolveCurrentScriptUrl(): string | null {

--- a/client/src/plugins/api.ts
+++ b/client/src/plugins/api.ts
@@ -26,9 +26,45 @@ export interface PluginStorageAPI {
     onChanged(listener: (changes: StorageChangeMap) => void): () => void;
 }
 
+export interface PluginMenuButtonOptions {
+    id?: string;
+    label: string;
+    title?: string;
+    beforeId?: string;
+    className?: string;
+}
+
+export interface PluginModalOptions {
+    title: string;
+    body?: string | Node;
+    footer?: string | Node;
+    size?: "sm" | "lg" | "xl";
+    scrollable?: boolean;
+    show?: boolean;
+}
+
+export interface PluginModalHandle {
+    element: HTMLElement;
+    body: HTMLElement;
+    footer: HTMLElement | null;
+    setTitle(title: string): void;
+    setBody(content?: string | Node | null): void;
+    setFooter(content?: string | Node | null): void;
+    show(): void;
+    hide(): void;
+    dispose(): void;
+}
+
 export interface PluginUIHooks {
     registerOptionsPanel?(pluginUrl: string, panelId: string, render: () => void): void;
     unregisterOptionsPanel?(pluginUrl: string, panelId?: string): void;
+    registerMenuButton?(options: PluginMenuButtonOptions, handler: (event: MouseEvent) => void): () => void;
+    openModal?(options: PluginModalOptions): PluginModalHandle;
+}
+
+export interface PluginUIManager {
+    create(pluginUrl: string): PluginUIHooks | undefined;
+    dispose?(pluginUrl: string): void;
 }
 
 export interface ArkadiaAdapter {
@@ -41,7 +77,7 @@ export interface ArkadiaAdapter {
 
 export interface PluginHostOptions {
     arkadia?: ArkadiaAdapter;
-    ui?: PluginUIHooks;
+    ui?: PluginUIHooks | PluginUIManager;
 }
 
 export interface PluginAPI {

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -194,7 +194,7 @@
         <button id="send-button">➢</button>
         <div class="dropdown me-0 me-md-2">
             <button id="menu-button" class="dropdown-toggle h-100" data-bs-toggle="dropdown">⋮</button>
-            <ul class="dropdown-menu dropdown-menu-end mb-1 gap-2">
+            <ul id="menu-dropdown" class="dropdown-menu dropdown-menu-end mb-1 gap-2">
                 <li>
                     <button class="w-100 p-1" id="options-button">Ustawienia</button>
                 </li>
@@ -246,7 +246,23 @@
                 <li>
                     <button class="w-100 p-1" id="fullscreen-button" title="Pełny ekran">⛶</button>
                 </li>
+                <li id="plugin-menu-divider" class="dropdown-divider d-none"></li>
             </ul>
+            <div id="plugin-modal-container"></div>
+            <template id="plugin-modal-template">
+                <div class="modal fade" tabindex="-1" data-plugin-modal>
+                    <div class="modal-dialog modal-dialog-scrollable">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title"></h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                            </div>
+                            <div class="modal-body"></div>
+                            <div class="modal-footer d-none"></div>
+                        </div>
+                    </div>
+                </div>
+            </template>
         </div>
     </div>
 

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -39,6 +39,7 @@ import Shortcuts from "./options/Shortcuts.tsx"
 import MobileButtons from "./options/MobileButtons.tsx"
 import MobileRadialCommands from "./options/MobileRadialCommands.tsx"
 import HerbManager from "./herbs/HerbManager";
+import createPluginUIManager from "./plugins/ui";
 import {
     loadSettings as loadMobileButtonSettings,
     applySettings as applyMobileButtonSettings
@@ -51,9 +52,14 @@ initSessionLogger(arkadiaClient).catch(err => console.error('Logger init failed'
 
 const client = new Client(arkadiaClient, new MockPort())
 window.clientExtension = client;
+const pluginUi = createPluginUIManager();
 registerScripts(client, {
     arkadia: arkadiaClient,
+    ui: pluginUi,
 })
+if (import.meta.env.DEV) {
+    import("./plugins/devDummyPlugin").catch(err => console.error("Failed to load dev demo plugin", err))
+}
 client.connect(client.port, true)
 
 

--- a/web-client/src/plugins/devDummyPlugin.ts
+++ b/web-client/src/plugins/devDummyPlugin.ts
@@ -1,0 +1,40 @@
+import type {PluginDefinition, PluginModalHandle, RegisterArkadiaPlugin} from "@client/src/plugins/api";
+
+const definition: PluginDefinition = {
+    name: "Dev UI demo",
+    setup(api) {
+        if (!api.ui?.registerMenuButton || !api.ui.openModal) {
+            console.warn("Plugin UI helper is not available for the dev demo plugin.");
+            return;
+        }
+
+        let modalHandle: PluginModalHandle | null = null;
+        const disposeButton = api.ui.registerMenuButton({
+            id: "dev-ui-demo",
+            label: "Dev modal",
+            title: "Show dev modal",
+        }, () => {
+            if (modalHandle) {
+                modalHandle.show();
+                return;
+            }
+            modalHandle = api.ui?.openModal?.({
+                title: "Development modal",
+                body: "This modal is rendered from a development plugin.",
+            }) ?? null;
+        });
+
+        return () => {
+            disposeButton?.();
+            modalHandle?.dispose();
+            modalHandle = null;
+        };
+    },
+};
+
+const register = window.registerArkadiaPlugin as RegisterArkadiaPlugin | undefined;
+if (register) {
+    register(definition);
+} else {
+    console.warn("registerArkadiaPlugin was not available for the dev demo plugin.");
+}

--- a/web-client/src/plugins/ui.ts
+++ b/web-client/src/plugins/ui.ts
@@ -1,0 +1,336 @@
+import {Modal} from "bootstrap";
+import type {
+    PluginMenuButtonOptions,
+    PluginModalHandle,
+    PluginModalOptions,
+    PluginUIHooks,
+    PluginUIManager,
+} from "@client/src/plugins/api";
+
+interface PluginUIState {
+    disposers: Set<() => void>;
+    modals: Set<PluginModalController>;
+}
+
+interface ModalElements {
+    element: HTMLElement;
+    title: HTMLElement;
+    body: HTMLElement;
+    footer: HTMLElement | null;
+    dialog: HTMLElement;
+}
+
+class PluginModalController implements PluginModalHandle {
+    readonly element: HTMLElement;
+    readonly body: HTMLElement;
+    readonly footer: HTMLElement | null;
+    private disposed = false;
+
+    constructor(
+        private readonly modal: Modal,
+        elements: ModalElements,
+        private readonly onDispose: () => void,
+    ) {
+        this.element = elements.element;
+        this.body = elements.body;
+        this.footer = elements.footer;
+        this.titleEl = elements.title;
+    }
+
+    private readonly titleEl: HTMLElement;
+
+    setTitle(title: string): void {
+        this.titleEl.textContent = title;
+    }
+
+    setBody(content?: string | Node | null): void {
+        applyContent(this.body, content);
+    }
+
+    setFooter(content?: string | Node | null): void {
+        if (!this.footer) {
+            return;
+        }
+        applyContent(this.footer, content);
+        toggleFooterVisibility(this.footer, content);
+    }
+
+    show(): void {
+        this.modal.show();
+    }
+
+    hide(): void {
+        this.modal.hide();
+    }
+
+    dispose(): void {
+        if (this.disposed) {
+            return;
+        }
+        this.disposed = true;
+        try {
+            this.modal.hide();
+        } catch {}
+        this.modal.dispose();
+        this.element.remove();
+        this.onDispose();
+    }
+}
+
+function applyContent(target: HTMLElement, content?: string | Node | null) {
+    while (target.firstChild) {
+        target.removeChild(target.firstChild);
+    }
+    if (content == null) {
+        return;
+    }
+    if (typeof content === "string") {
+        target.textContent = content;
+    } else {
+        target.appendChild(content);
+    }
+}
+
+function toggleFooterVisibility(footer: HTMLElement, content?: string | Node | null) {
+    if (content == null || (typeof content === "string" && content.length === 0)) {
+        footer.classList.add("d-none");
+    } else {
+        footer.classList.remove("d-none");
+    }
+}
+
+function resolveMenuElements(doc: Document) {
+    const menu = doc.getElementById("menu-dropdown") as HTMLUListElement | null;
+    const divider = doc.getElementById("plugin-menu-divider") as HTMLLIElement | null;
+    if (!menu || !divider) {
+        throw new Error("Plugin menu elements are missing in the DOM.");
+    }
+    return {menu, divider};
+}
+
+function resolveModalElements(doc: Document) {
+    const template = doc.getElementById("plugin-modal-template") as HTMLTemplateElement | null;
+    const container = doc.getElementById("plugin-modal-container") as HTMLElement | null;
+    if (!template || !container) {
+        throw new Error("Plugin modal template or container is missing in the DOM.");
+    }
+    return {template, container};
+}
+
+export default function createPluginUIManager(doc: Document = document): PluginUIManager {
+    const pluginStates = new Map<string, PluginUIState>();
+    let menuRef: HTMLUListElement | null = null;
+    let dividerRef: HTMLLIElement | null = null;
+    let templateRef: HTMLTemplateElement | null = null;
+    let containerRef: HTMLElement | null = null;
+    let buttonCount = 0;
+
+    const getMenuElements = () => {
+        if (!menuRef || !menuRef.isConnected || !dividerRef || !dividerRef.isConnected) {
+            const resolved = resolveMenuElements(doc);
+            menuRef = resolved.menu;
+            dividerRef = resolved.divider;
+        }
+        return {menu: menuRef!, divider: dividerRef!};
+    };
+
+    const getModalElements = () => {
+        if (!templateRef || !containerRef || !containerRef.isConnected) {
+            const resolved = resolveModalElements(doc);
+            templateRef = resolved.template;
+            containerRef = resolved.container;
+        }
+        return {template: templateRef!, container: containerRef!};
+    };
+
+    const ensureState = (pluginUrl: string): PluginUIState => {
+        let state = pluginStates.get(pluginUrl);
+        if (!state) {
+            state = {
+                disposers: new Set(),
+                modals: new Set(),
+            };
+            pluginStates.set(pluginUrl, state);
+        }
+        return state;
+    };
+
+    const removeStateIfEmpty = (pluginUrl: string) => {
+        const state = pluginStates.get(pluginUrl);
+        if (!state) {
+            return;
+        }
+        if (state.disposers.size === 0 && state.modals.size === 0) {
+            pluginStates.delete(pluginUrl);
+        }
+    };
+
+    const updateDivider = () => {
+        if (buttonCount <= 0) {
+            const {divider} = getMenuElements();
+            divider.classList.add("d-none");
+            buttonCount = 0;
+        } else {
+            const {divider} = getMenuElements();
+            divider.classList.remove("d-none");
+        }
+    };
+
+    const uiHooksForPlugin = (pluginUrl: string): PluginUIHooks => {
+        const state = ensureState(pluginUrl);
+
+        const registerMenuButton = (options: PluginMenuButtonOptions, handler: (event: MouseEvent) => void): (() => void) => {
+            const {menu} = getMenuElements();
+            const li = doc.createElement("li");
+            if (options.id) {
+                li.dataset.pluginMenuId = options.id;
+            }
+            const button = doc.createElement("button");
+            button.type = "button";
+            button.className = options.className || "w-100 p-1";
+            button.textContent = options.label;
+            if (options.title) {
+                button.title = options.title;
+            }
+            const clickHandler = (event: MouseEvent) => {
+                handler(event);
+            };
+            button.addEventListener("click", clickHandler);
+            li.appendChild(button);
+
+            const target = resolveInsertTarget(menu, options.beforeId);
+            menu.insertBefore(li, target);
+            buttonCount += 1;
+            updateDivider();
+
+            let disposed = false;
+            const dispose = () => {
+                if (disposed) {
+                    return;
+                }
+                disposed = true;
+                button.removeEventListener("click", clickHandler);
+                if (li.parentElement) {
+                    li.parentElement.removeChild(li);
+                }
+                state.disposers.delete(dispose);
+                buttonCount -= 1;
+                updateDivider();
+                removeStateIfEmpty(pluginUrl);
+            };
+
+            state.disposers.add(dispose);
+            return dispose;
+        };
+
+        const openModal = (options: PluginModalOptions): PluginModalHandle => {
+            const {template, container} = getModalElements();
+            const instance = instantiateModal(template, container);
+            const modal = new Modal(instance.element);
+            const controller = new PluginModalController(modal, instance, () => {
+                state.modals.delete(controller);
+                removeStateIfEmpty(pluginUrl);
+            });
+            state.modals.add(controller);
+
+            controller.setTitle(options.title);
+            controller.setBody(options.body);
+            if (options.footer !== undefined) {
+                controller.setFooter(options.footer);
+            }
+            if (options.size) {
+                applySize(instance.dialog, options.size);
+            }
+            if (options.scrollable === false) {
+                instance.dialog.classList.remove("modal-dialog-scrollable");
+            } else {
+                instance.dialog.classList.add("modal-dialog-scrollable");
+            }
+            if (options.show !== false) {
+                controller.show();
+            }
+            return controller;
+        };
+
+        return {
+            registerMenuButton,
+            openModal,
+        };
+    };
+
+    return {
+        create(pluginUrl: string) {
+            return uiHooksForPlugin(pluginUrl);
+        },
+        dispose(pluginUrl: string) {
+            const state = pluginStates.get(pluginUrl);
+            if (!state) {
+                return;
+            }
+            Array.from(state.disposers).forEach(dispose => {
+                try {
+                    dispose();
+                } catch (err) {
+                    console.error("Failed to dispose plugin menu button", err);
+                }
+            });
+            Array.from(state.modals).forEach(modal => {
+                try {
+                    modal.dispose();
+                } catch (err) {
+                    console.error("Failed to dispose plugin modal", err);
+                }
+            });
+            pluginStates.delete(pluginUrl);
+            updateDivider();
+        },
+    };
+}
+
+function resolveInsertTarget(menu: HTMLUListElement, beforeId?: string): ChildNode | null {
+    if (!beforeId) {
+        return null;
+    }
+    const selector = `[data-plugin-menu-id="${CSS.escape(beforeId)}"]`;
+    const candidate = menu.querySelector(selector);
+    if (candidate) {
+        return candidate as ChildNode;
+    }
+    return null;
+}
+
+function instantiateModal(
+    template: HTMLTemplateElement,
+    container: HTMLElement,
+): ModalElements {
+    const fragment = template.content.cloneNode(true) as DocumentFragment;
+    const element = fragment.querySelector<HTMLElement>("[data-plugin-modal]");
+    if (!element) {
+        throw new Error("Plugin modal template is invalid.");
+    }
+    const title = element.querySelector<HTMLElement>(".modal-title");
+    const body = element.querySelector<HTMLElement>(".modal-body");
+    const footer = element.querySelector<HTMLElement>(".modal-footer");
+    const dialog = element.querySelector<HTMLElement>(".modal-dialog");
+    if (!title || !body || !dialog) {
+        throw new Error("Plugin modal template is missing required elements.");
+    }
+    if (footer) {
+        toggleFooterVisibility(footer, undefined);
+    }
+    container.appendChild(element);
+    return {element, title, body, footer: footer ?? null, dialog};
+}
+
+function applySize(dialog: HTMLElement, size: "sm" | "lg" | "xl") {
+    dialog.classList.remove("modal-sm", "modal-lg", "modal-xl");
+    if (size === "sm") {
+        dialog.classList.add("modal-sm");
+    }
+    if (size === "lg") {
+        dialog.classList.add("modal-lg");
+    }
+    if (size === "xl") {
+        dialog.classList.add("modal-xl");
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable plugin modal template and container to the client shell
- implement a plugin UI manager that lets plugins register menu buttons and open Bootstrap modals while ensuring cleanup
- extend the plugin API and host to supply UI helpers per plugin and add a dev-only demo plugin for validation

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fac892cf58832aa4bb0245cd97e30d