### PR TITLE
Expose client extension to plugins

### DIFF
--- a/client/src/plugins/api.ts
+++ b/client/src/plugins/api.ts
@@ -3,6 +3,7 @@ import type { CommandOptions } from "../scripts/commandPreserveCaseMode";
 import storage from "../storage";
 
 export interface PluginClientAPI {
+    readonly extension: Client;
     sendCommand(command: string, echo?: boolean, options?: CommandOptions): void;
     send(command: string, echo?: boolean, options?: CommandOptions): void;
     addEventListener(event: string, listener: (ev: CustomEvent) => void, options?: AddEventListenerOptions | boolean): () => void;
@@ -96,8 +97,11 @@ export interface PluginDefinition {
 
 export type RegisterArkadiaPlugin = (definition: PluginDefinition) => void;
 
+export type { default as Client } from "../Client";
+
 export function createClientAPI(client: Client): PluginClientAPI {
     return {
+        extension: client,
         sendCommand: (command: string, echo?: boolean, options?: CommandOptions) => client.sendCommand(command, echo, options),
         send: (command: string, echo?: boolean, options?: CommandOptions) => client.send(command, echo, options),
         addEventListener: (event: string, listener: (ev: CustomEvent) => void, options?: AddEventListenerOptions | boolean) => client.addEventListener(event, listener, options),

--- a/client/test/plugins/PluginHost.test.ts
+++ b/client/test/plugins/PluginHost.test.ts
@@ -49,7 +49,8 @@ describe("PluginHost", () => {
         });
 
         let cleanupCount = 0;
-        const setup = jest.fn((_api: PluginAPI) => {
+        const setup = jest.fn((api: PluginAPI) => {
+            expect(api.client.extension).toBe(client);
             return () => {
                 cleanupCount++;
             };


### PR DESCRIPTION
## Summary
- expose the underlying client instance through the plugin API so plugins can access advanced features
- re-export the Client type for external plugin authors
- update PluginHost tests to cover the new API shape

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68facbb9af6c832a90d1de80d454d3c2