### PR TITLE
feat: package plugin api declarations

### DIFF
--- a/web-client/src/plugins/devDummyPlugin.ts
+++ b/web-client/src/plugins/devDummyPlugin.ts
@@ -1,4 +1,4 @@
-import type {PluginDefinition, PluginModalHandle, RegisterArkadiaPlugin} from "@client/src/plugins/api";
+import type {PluginDefinition, PluginModalHandle, RegisterArkadiaPlugin} from "./index";
 
 const definition: PluginDefinition = {
     name: "Dev UI demo",

--- a/web-client/src/plugins/index.ts
+++ b/web-client/src/plugins/index.ts
@@ -1,0 +1,100 @@
+// Keep the interfaces below in sync with the implementations in
+// ../client/src/plugins/api.ts.
+
+export interface CommandOptions {
+    preserveCase?: boolean;
+}
+
+export interface PluginClientAPI {
+    sendCommand(command: string, echo?: boolean, options?: CommandOptions): void;
+    send(command: string, echo?: boolean, options?: CommandOptions): void;
+    addEventListener(event: string, listener: (ev: CustomEvent) => void, options?: AddEventListenerOptions | boolean): () => void;
+    removeEventListener(event: string, listener: EventListenerOrEventListenerObject | null): void;
+    sendEvent(type: string, payload?: any): void;
+    print(text: string): void;
+    println(text: string): void;
+}
+
+export interface StorageChangeMap {
+    [key: string]: {
+        oldValue: any;
+        newValue: any;
+    };
+}
+
+export interface PluginStorageAPI {
+    getItem<T = any>(key: string): Promise<T | undefined>;
+    setItem<T = any>(key: string, value: T): Promise<void>;
+    downloadItem<T = any>(url: string, ttl: number): Promise<T>;
+    onChanged(listener: (changes: StorageChangeMap) => void): () => void;
+}
+
+export interface PluginMenuButtonOptions {
+    id?: string;
+    label: string;
+    title?: string;
+    beforeId?: string;
+    className?: string;
+}
+
+export interface PluginModalOptions {
+    title: string;
+    body?: string | Node;
+    footer?: string | Node;
+    size?: "sm" | "lg" | "xl";
+    scrollable?: boolean;
+    show?: boolean;
+}
+
+export interface PluginModalHandle {
+    element: HTMLElement;
+    body: HTMLElement;
+    footer: HTMLElement | null;
+    setTitle(title: string): void;
+    setBody(content?: string | Node | null): void;
+    setFooter(content?: string | Node | null): void;
+    show(): void;
+    hide(): void;
+    dispose(): void;
+}
+
+export interface PluginUIHooks {
+    registerOptionsPanel?(pluginUrl: string, panelId: string, render: () => void): void;
+    unregisterOptionsPanel?(pluginUrl: string, panelId?: string): void;
+    registerMenuButton?(options: PluginMenuButtonOptions, handler: (event: MouseEvent) => void): () => void;
+    openModal?(options: PluginModalOptions): PluginModalHandle;
+}
+
+export interface PluginUIManager {
+    create(pluginUrl: string): PluginUIHooks | undefined;
+    dispose?(pluginUrl: string): void;
+}
+
+export interface ArkadiaAdapter {
+    on?(event: string, listener: (...args: any[]) => void): void;
+    off?(event: string, listener: (...args: any[]) => void): void;
+    emit?(event: string, ...args: any[]): void;
+    send?(command: string, echo?: boolean, options?: CommandOptions): void;
+    sendGmcp?(type: string, payload?: any): void;
+}
+
+export interface PluginHostOptions {
+    arkadia?: ArkadiaAdapter;
+    ui?: PluginUIHooks | PluginUIManager;
+}
+
+export interface PluginAPI {
+    scriptUrl: string;
+    client: PluginClientAPI;
+    storage: PluginStorageAPI;
+    arkadia?: ArkadiaAdapter;
+    ui?: PluginUIHooks;
+}
+
+export interface PluginDefinition {
+    name?: string;
+    setup(api: PluginAPI): void | (() => void) | Promise<void | (() => void)>;
+    dispose?(api: PluginAPI): void | Promise<void>;
+}
+
+export type RegisterArkadiaPlugin = (definition: PluginDefinition) => void;

--- a/web-client/src/plugins/ui.ts
+++ b/web-client/src/plugins/ui.ts
@@ -5,7 +5,7 @@ import type {
     PluginModalOptions,
     PluginUIHooks,
     PluginUIManager,
-} from "@client/src/plugins/api";
+} from "./index";
 
 interface PluginUIState {
     disposers: Set<() => void>;

--- a/web-client/tsconfig.plugins.json
+++ b/web-client/tsconfig.plugins.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": false,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist/plugins/package",
+    "rootDir": "./src/plugins",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@client/*": [
+        "../client/*"
+      ]
+    }
+  },
+  "include": [
+    "src/plugins/index.ts"
+  ]
+}

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -1,16 +1,81 @@
 import {defineConfig, type PluginOption} from 'vite'
 import react from '@vitejs/plugin-react'
-import {resolve} from "path";
+import {resolve, join} from "path";
 import tsconfigPaths from "vite-tsconfig-paths";
-import {execSync} from 'child_process';
+import {execFileSync, execSync} from 'child_process';
+import {fileURLToPath} from "url";
+import {createRequire} from "module";
+import {existsSync, mkdirSync, rmSync, writeFileSync, renameSync} from "fs";
 
 const commitSha = execSync('git rev-parse --short HEAD').toString().trim();
 const commitDate = execSync('git log -1 --format=%cd --date=short').toString().trim();
+const configDir = fileURLToPath(new URL('.', import.meta.url));
+const require = createRequire(import.meta.url);
+
+function buildPluginApiPackage(): PluginOption {
+    return {
+        name: "arkadia-build-plugin-api-package",
+        apply: "build",
+        async closeBundle() {
+            const distDir = join(configDir, "dist");
+            const pluginsDir = join(distDir, "plugins");
+            mkdirSync(distDir, {recursive: true});
+            rmSync(pluginsDir, {recursive: true, force: true});
+
+            const tscBin = require.resolve("typescript/bin/tsc");
+            execFileSync("node", [tscBin, "--project", "tsconfig.plugins.json"], {
+                cwd: configDir,
+                stdio: "inherit",
+            });
+
+            const packageDir = join(pluginsDir, "package");
+            mkdirSync(packageDir, {recursive: true});
+
+            const declarationPath = join(packageDir, "index.d.ts");
+            if (!existsSync(declarationPath)) {
+                throw new Error("Plugin API declaration file was not generated");
+            }
+
+            const packageJson = {
+                name: "arkadia-web-client-plugin-api",
+                version: `0.0.0-${commitSha}`,
+                description: "Type definitions for Arkadia web client plugins.",
+                type: "module",
+                types: "./index.d.ts",
+                files: [
+                    "index.d.ts"
+                ],
+                sideEffects: false,
+                license: "MIT"
+            };
+
+            writeFileSync(join(packageDir, "package.json"), JSON.stringify(packageJson, null, 2));
+
+            const packOutput = execFileSync("npm", [
+                "pack",
+                "--pack-destination",
+                pluginsDir,
+            ], {
+                cwd: packageDir,
+                stdio: "pipe",
+            }).toString().trim().split(/\r?\n/).at(-1);
+
+            if (!packOutput) {
+                throw new Error("Failed to create plugin API tarball");
+            }
+
+            const tarballPath = join(pluginsDir, packOutput);
+            const finalTarball = join(distDir, "arkadia-web-client-plugin-api.tgz");
+            renameSync(tarballPath, finalTarball);
+        }
+    };
+}
 
 export default defineConfig({
     plugins: [
         react(),
-        tsconfigPaths()
+        tsconfigPaths(),
+        buildPluginApiPackage()
     ] as PluginOption[],
     base: "./",
     define: {


### PR DESCRIPTION
## Summary
- expose the plugin API surface from `web-client/src/plugins/index.ts` so plugin builds can import shared types
- add `tsconfig.plugins.json` and a Vite build hook that emits TypeScript declarations, writes package metadata, and produces a reusable tarball in `dist`
- update internal plugin modules to consume the new entry point

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68facc6c2d04832aba88652c2560ae88