### PR TITLE
Fix TypeScript build by using client declaration imports

### DIFF
--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -1,12 +1,12 @@
 import {parseAnsiPatterns} from './ansiParser';
 import {RecordedEvent} from './recordingStorage';
 import Recorder from './Recorder';
-import {ClientAdapter} from "@client/src/Client.ts";
-import eventBus, {ClientEvents} from "@client/src/eventBus.ts";
+import {ClientAdapter} from "@client/src/Client";
+import eventBus, {ClientEvents} from "@client/src/eventBus";
 import TelnetOptionNegotiation from "./TelnetOptionNegotiation.ts";
 import {md5} from 'js-md5';
 import {uncompress} from "./compression.ts";
-import {CommandOptions, normalizeCommand} from "@client/src/scripts/commandPreserveCaseMode.ts";
+import {CommandOptions, normalizeCommand} from "@client/src/scripts/commandPreserveCaseMode";
 import PingTracker from "./PingTracker.ts";
 
 type Params<T> = T extends void ? [] : T extends any[] ? T : [T];

--- a/web-client/src/AttackMode.ts
+++ b/web-client/src/AttackMode.ts
@@ -1,5 +1,5 @@
 import ArkadiaClient from "./ArkadiaClient.ts";
-import { getItemSync } from "@client/src/storage.ts";
+import { getItemSync } from "@client/src/storage";
 
 const MODES = ["A", "AW", "AWR"] as const;
 type Mode = typeof MODES[number];

--- a/web-client/src/PingTracker.ts
+++ b/web-client/src/PingTracker.ts
@@ -1,4 +1,4 @@
-import eventBus from "@client/src/eventBus.ts";
+import eventBus from "@client/src/eventBus";
 
 const PING_INTERVAL_MS = 3000;
 

--- a/web-client/src/Recorder.ts
+++ b/web-client/src/Recorder.ts
@@ -1,5 +1,5 @@
 import {saveRecording, getRecording, getRecordingNames, deleteRecording, RecordedEvent} from './recordingStorage';
-import {CommandOptions} from "@client/src/scripts/commandPreserveCaseMode.ts";
+import {CommandOptions} from "@client/src/scripts/commandPreserveCaseMode";
 
 export interface RecorderHooks {
     processIncomingData(data: string): void;

--- a/web-client/src/ansiParser.ts
+++ b/web-client/src/ansiParser.ts
@@ -1,5 +1,5 @@
 // ANSI color table for terminal color rendering
-import {colorCodes} from "@client/src/Colors.ts";
+import {colorCodes} from "@client/src/Colors";
 
 
 /**

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -19,7 +19,7 @@ import HpTitle from "./HpTitle";
 import initSessionLogger from "./sessionLogger";
 import LetterComposer from "./LetterComposer";
 
-import "@client/src/main.ts"
+import "@client/src/main"
 import MockPort from "./MockPort.ts";
 import NoSleep from 'nosleep.js';
 import {loadMapData, loadColors} from "./mapDataLoader.ts";
@@ -1148,5 +1148,5 @@ window.client = arkadiaClient
 import MobileDirectionButtons from "./scripts/mobileDirectionButtons"
 import MobileCommandRadial from "./scripts/mobileCommandRadial"
 import initUiSettings from "./uiSettings";
-import Client from "@client/src/Client.ts";
-import {registerScripts} from "@client/src/main.ts";
+import Client from "@client/src/Client";
+import {registerScripts} from "@client/src/main";

--- a/web-client/src/mapDataLoader.ts
+++ b/web-client/src/mapDataLoader.ts
@@ -1,5 +1,5 @@
 // This file provides a way to load map and colors data asynchronously.
-import { loadCachedJSON } from "@client/src/utils/dataCache.ts";
+import { loadCachedJSON } from "@client/src/utils/dataCache";
 
 const TTL = 24 * 60 * 60 * 1000; // 24h
 

--- a/web-client/src/npcDataLoader.ts
+++ b/web-client/src/npcDataLoader.ts
@@ -1,5 +1,5 @@
 // Loader for NPC data sharing cache logic with map loader.
-import { loadCachedJSON } from "@client/src/utils/dataCache.ts";
+import { loadCachedJSON } from "@client/src/utils/dataCache";
 
 const TTL = 24 * 60 * 60 * 1000; // 24h
 

--- a/web-client/src/options/Npc.tsx
+++ b/web-client/src/options/Npc.tsx
@@ -1,7 +1,7 @@
 import '../style.css'
 import {ChangeEvent, useEffect, useState} from "react";
 import {Button, Form, Table} from 'react-bootstrap';
-import {clearIndexedDB, updateIndexedDB} from "@client/src/utils/dataCache.ts";
+import {clearIndexedDB, updateIndexedDB} from "@client/src/utils/dataCache";
 import {TiDelete} from "react-icons/ti";
 import {loadNpcData} from "../npcDataLoader.ts";
 

--- a/web-client/src/plugins/index.ts
+++ b/web-client/src/plugins/index.ts
@@ -1,7 +1,7 @@
 // Keep the interfaces below in sync with the implementations in
 // ../client/src/plugins/api.ts.
 
-import type Client from "@client/src/Client.ts";
+import type Client from "@client/src/Client";
 
 export interface CommandOptions {
     preserveCase?: boolean;

--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -8,7 +8,7 @@ import {
     defaultBackground,
 } from "../mobileButtonSettings";
 import { getItemSync, setItemSync } from "@client/src/storage";
-import { getShortDir } from "@client/src/utils/directions.ts";
+import { getShortDir } from "@client/src/utils/directions";
 
 const ORIENTATIONS = ["portrait", "landscape"] as const;
 type Orientation = (typeof ORIENTATIONS)[number];

--- a/web-client/src/types/globals.d.ts
+++ b/web-client/src/types/globals.d.ts
@@ -1,4 +1,4 @@
-import Client from "@client/src/Client.ts";
+import Client from "@client/src/Client";
 
 interface ClientInput {
     send(command: string): void;


### PR DESCRIPTION
## Summary
- switch @client imports in the web client to omit explicit .ts extensions so the plugin declaration build resolves against bundled type definitions
- update data loaders, UI components, and plugin types to follow the same path convention

## Testing
- yarn --cwd web-client build
- yarn --cwd web-client test
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68fad085c548832abc0e611dfbf74e30