### PR TITLE
Refactor plugin loader to import modules dynamically

### DIFF
--- a/client/src/plugins/PluginHost.ts
+++ b/client/src/plugins/PluginHost.ts
@@ -7,7 +7,6 @@ import {
     PluginHostOptions,
     PluginUIHooks,
     PluginUIManager,
-    RegisterArkadiaPlugin,
 } from "./api";
 
 type PluginUIResolution = {
@@ -29,22 +28,15 @@ export default class PluginHost {
 
     constructor(private readonly client: Client, private readonly options: PluginHostOptions = {}) {}
 
-    attachToWindow(): void {
-        const register: RegisterArkadiaPlugin = (definition: PluginDefinition) => {
-            const url = this.resolveCurrentScriptUrl();
-            if (!url) {
-                console.warn("Arkadia plugin registration ignored – unable to determine script URL.");
-                return;
-            }
-            this.register(url, definition);
-        };
-        window.registerArkadiaPlugin = register;
+    async load(scriptUrl: string): Promise<void> {
+        const definition = await this.importPluginDefinition(scriptUrl);
+        await this.register(scriptUrl, definition);
     }
 
-    register(scriptUrl: string, definition: PluginDefinition): void {
+    register(scriptUrl: string, definition: PluginDefinition): Promise<void> {
         if (!scriptUrl) {
             console.warn("Arkadia plugin registration ignored – missing script URL.");
-            return;
+            return Promise.resolve();
         }
         const {hooks: uiHooks, dispose: uiDispose} = this.resolvePluginUI(scriptUrl);
         const api = this.createPluginAPI(scriptUrl, uiHooks);
@@ -69,6 +61,7 @@ export default class PluginHost {
             this.plugins.delete(scriptUrl);
         });
         this.plugins.set(scriptUrl, state);
+        return state.setupPromise;
     }
 
     async dispose(scriptUrl: string): Promise<void> {
@@ -134,18 +127,34 @@ export default class PluginHost {
         return {hooks: option as PluginUIHooks};
     }
 
-    private resolveCurrentScriptUrl(): string | null {
-        const current = document.currentScript as HTMLScriptElement | null;
-        if (!current) {
-            return null;
+    private async importPluginDefinition(scriptUrl: string): Promise<PluginDefinition> {
+        const response = await fetch(scriptUrl);
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
         }
-        const fromDataset = current.dataset?.arkadiaPluginUrl;
-        if (fromDataset) {
-            return fromDataset;
+        const code = await response.text();
+        const blobUrl = URL.createObjectURL(new Blob([code], {type: "text/javascript"}));
+        try {
+            const module = await import(/* @vite-ignore */ blobUrl);
+            return this.resolveModuleDefinition(module);
+        } finally {
+            URL.revokeObjectURL(blobUrl);
         }
-        if (current.src) {
-            return current.src;
+    }
+
+    private resolveModuleDefinition(module: any): PluginDefinition {
+        const candidates = [module?.default, module];
+        for (const candidate of candidates) {
+            if (!candidate) {
+                continue;
+            }
+            if (typeof candidate === "function") {
+                return {setup: candidate};
+            }
+            if (typeof candidate === "object" && typeof candidate.setup === "function") {
+                return candidate as PluginDefinition;
+            }
         }
-        return null;
+        throw new Error("Plugin missing setup(api)");
     }
 }

--- a/client/src/plugins/api.ts
+++ b/client/src/plugins/api.ts
@@ -95,8 +95,6 @@ export interface PluginDefinition {
     dispose?(api: PluginAPI): void | Promise<void>;
 }
 
-export type RegisterArkadiaPlugin = (definition: PluginDefinition) => void;
-
 export type { default as Client } from "../Client";
 
 export function createClientAPI(client: Client): PluginClientAPI {
@@ -143,10 +141,4 @@ export function createStorageAPI(): PluginStorageAPI {
             };
         },
     };
-}
-
-declare global {
-    interface Window {
-        registerArkadiaPlugin?: RegisterArkadiaPlugin;
-    }
 }

--- a/client/src/scripts/externalScripts.ts
+++ b/client/src/scripts/externalScripts.ts
@@ -6,32 +6,27 @@ const STORAGE_KEY = "scripts";
 
 export default function initExternalScripts(client: Client, options: PluginHostOptions = {}) {
     const host = new PluginHost(client, options);
-    host.attachToWindow();
 
-    const loaded: Record<string, HTMLScriptElement> = {};
+    const loaded = new Set<string>();
     let known: string[] = [];
 
     const apply = (list: string[] = []) => {
-        Object.keys(loaded).forEach(url => {
+        Array.from(loaded).forEach(url => {
             if (!list.includes(url)) {
                 host.dispose(url).catch(err => console.error(`Failed to dispose plugin for ${url}`, err));
-                loaded[url].remove();
-                delete loaded[url];
+                loaded.delete(url);
             }
         });
         list.forEach(url => {
-            if (!loaded[url]) {
-                const script = document.createElement("script");
-                script.src = url;
-                script.async = true;
-                script.dataset.arkadiaPluginUrl = url;
-                script.addEventListener("error", () => {
-                    host.dispose(url).catch(err => console.error(`Failed to dispose plugin for ${url}`, err));
-                    delete loaded[url];
-                });
-                document.head.appendChild(script);
-                loaded[url] = script;
+            if (loaded.has(url)) {
+                return;
             }
+            loaded.add(url);
+            host.load(url).catch(err => {
+                console.error(`Failed to load plugin for ${url}`, err);
+                host.dispose(url).catch(disposeErr => console.error(`Failed to dispose plugin for ${url}`, disposeErr));
+                loaded.delete(url);
+            });
         });
     };
 

--- a/client/test/plugins/PluginHost.test.ts
+++ b/client/test/plugins/PluginHost.test.ts
@@ -30,23 +30,10 @@ describe("PluginHost", () => {
         } as unknown as Client;
     }
 
-    async function flushPromises() {
-        await Promise.resolve();
-        await new Promise(resolve => setTimeout(resolve, 0));
-    }
-
     test("registers and disposes plugins by URL", async () => {
         const client = createClientStub();
         const host = new PluginHost(client);
-        host.attachToWindow();
-
         const scriptUrl = "https://example.com/plugin.js";
-        const script = document.createElement("script");
-        script.dataset.arkadiaPluginUrl = scriptUrl;
-        Object.defineProperty(document, "currentScript", {
-            configurable: true,
-            value: script,
-        });
 
         let cleanupCount = 0;
         const setup = jest.fn((api: PluginAPI) => {
@@ -57,24 +44,22 @@ describe("PluginHost", () => {
         });
         const dispose = jest.fn();
 
-        window.registerArkadiaPlugin?.({
+        await host.register(scriptUrl, {
             name: "sample",
             setup,
             dispose,
         });
-        await flushPromises();
 
         expect(setup).toHaveBeenCalledTimes(1);
         expect(host.getRegisteredUrls()).toEqual([scriptUrl]);
         expect(cleanupCount).toBe(0);
         expect(dispose).not.toHaveBeenCalled();
 
-        window.registerArkadiaPlugin?.({
+        await host.register(scriptUrl, {
             name: "sample",
             setup,
             dispose,
         });
-        await flushPromises();
 
         expect(setup).toHaveBeenCalledTimes(2);
         expect(cleanupCount).toBe(1);
@@ -82,7 +67,6 @@ describe("PluginHost", () => {
         expect(host.getRegisteredUrls()).toEqual([scriptUrl]);
 
         await host.dispose(scriptUrl);
-        await flushPromises();
 
         expect(cleanupCount).toBe(2);
         expect(dispose).toHaveBeenCalledTimes(2);

--- a/web-client/src/plugins/devDummyPlugin.ts
+++ b/web-client/src/plugins/devDummyPlugin.ts
@@ -1,4 +1,4 @@
-import type {PluginDefinition, PluginModalHandle, RegisterArkadiaPlugin} from "./index";
+import type {PluginDefinition, PluginModalHandle} from "./index";
 
 const definition: PluginDefinition = {
     name: "Dev UI demo",
@@ -32,9 +32,4 @@ const definition: PluginDefinition = {
     },
 };
 
-const register = window.registerArkadiaPlugin as RegisterArkadiaPlugin | undefined;
-if (register) {
-    register(definition);
-} else {
-    console.warn("registerArkadiaPlugin was not available for the dev demo plugin.");
-}
+export default definition;

--- a/web-client/src/plugins/index.ts
+++ b/web-client/src/plugins/index.ts
@@ -100,4 +100,3 @@ export interface PluginDefinition {
     dispose?(api: PluginAPI): void | Promise<void>;
 }
 
-export type RegisterArkadiaPlugin = (definition: PluginDefinition) => void;


### PR DESCRIPTION
## Summary
- fetch external plugin scripts and import them dynamically instead of relying on window globals
- update the plugin host API, tests, and type definitions to match the module-based loading flow
- convert the development dummy plugin to export its definition directly

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68fad294faec832a9c6bfa3cf56222cc