### PR TITLE
Fix plugin type build by stubbing client API

### DIFF
--- a/web-client/src/plugins/types/client.d.ts
+++ b/web-client/src/plugins/types/client.d.ts
@@ -1,0 +1,15 @@
+declare module "@client/src/Client" {
+    export interface CommandOptions {
+        preserveCase?: boolean;
+    }
+
+    export default interface Client {
+        sendCommand(command: string, echo?: boolean, options?: CommandOptions): void;
+        send(command: string, echo?: boolean, options?: CommandOptions): void;
+        addEventListener(event: string, listener: (ev: CustomEvent) => void, options?: AddEventListenerOptions | boolean): void;
+        removeEventListener(event: string, listener: EventListenerOrEventListenerObject | null): void;
+        sendEvent(type: string, payload?: any): void;
+        print(text: string): void;
+        println(text: string): void;
+    }
+}

--- a/web-client/tsconfig.plugins.json
+++ b/web-client/tsconfig.plugins.json
@@ -17,6 +17,9 @@
     ],
     "baseUrl": ".",
     "paths": {
+      "@client/src/Client": [
+        "./src/plugins/types/client"
+      ],
       "@client/*": [
         "../client/*"
       ]


### PR DESCRIPTION
## Summary
- add a local declaration for `@client/src/Client` so the plugin build no longer pulls in the entire client source tree
- update the plugin TypeScript paths to resolve the new declaration before falling back to the client sources

## Testing
- yarn --cwd web-client test --runInBand
- yarn --cwd web-client build
- yarn --cwd client test --runInBand --detectOpenHandles --forceExit

------
https://chatgpt.com/codex/tasks/task_e_68fad33ef384832ab75d66f78fff0a08