### PR TITLE
Fix plugin API type exports

### DIFF
--- a/client/src/plugins/api.ts
+++ b/client/src/plugins/api.ts
@@ -96,6 +96,7 @@ export interface PluginDefinition {
 }
 
 export type { default as Client } from "../Client";
+export type PluginApiClient = PluginClientAPI;
 
 export function createClientAPI(client: Client): PluginClientAPI {
     return {

--- a/web-client/src/plugins/index.ts
+++ b/web-client/src/plugins/index.ts
@@ -100,3 +100,6 @@ export interface PluginDefinition {
     dispose?(api: PluginAPI): void | Promise<void>;
 }
 
+export type PluginApiClient = PluginClientAPI;
+export type { Client };
+

--- a/web-client/tsconfig.test.json
+++ b/web-client/tsconfig.test.json
@@ -9,5 +9,8 @@
   "include": [
     "src",
     "test"
+  ],
+  "exclude": [
+    "src/plugins/types"
   ]
 }


### PR DESCRIPTION
## Summary
- expose the plugin client type alias from both runtime and generated plugin API definitions
- export the extension Client type in the plugin API package so consumers receive typings
- adjust the web client test TypeScript config to ignore plugin-only module stubs during tests

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fad726e7c0832ab7aecfec57f7eef9