### PR TITLE
Refactor dataset loaders to use data store strategies

### DIFF
--- a/client/src/dataStore/DataStore.ts
+++ b/client/src/dataStore/DataStore.ts
@@ -1,6 +1,7 @@
 import { SnapshotEventEmitter } from './events';
 import {
   LoaderStrategy,
+  ProgressListener,
   RefreshMetadata,
   SnapshotListener,
   StorageStrategy,
@@ -11,6 +12,7 @@ type Clock = () => number;
 
 type RefreshOptions = {
   force?: boolean;
+  onProgress?: ProgressListener;
 };
 
 export interface DataStoreOptions<TSnapshot, TMeta extends RefreshMetadata> {
@@ -31,6 +33,15 @@ export class DataStore<TSnapshot, TMeta extends RefreshMetadata = RefreshMetadat
   private currentMetadata: TMeta | undefined;
   private initializationPromise: Promise<void> | null = null;
   private activeRefresh: Promise<TSnapshot | undefined> | null = null;
+  private pendingProgressListeners: ProgressListener[] | null = null;
+  private readonly progressDispatcher: ProgressListener = (progress, loaded, total) => {
+    if (!this.pendingProgressListeners) {
+      return;
+    }
+    for (const listener of [...this.pendingProgressListeners]) {
+      listener(progress, loaded, total);
+    }
+  };
 
   constructor(options: DataStoreOptions<TSnapshot, TMeta>) {
     this.loader = options.loader;
@@ -53,18 +64,38 @@ export class DataStore<TSnapshot, TMeta extends RefreshMetadata = RefreshMetadat
     await this.ensureInitialized();
 
     if (!options.force && !this.shouldRefresh()) {
+      options.onProgress?.(100);
       return this.currentSnapshot;
     }
 
     if (!this.activeRefresh) {
+      this.pendingProgressListeners = [];
+      if (options.onProgress) {
+        this.pendingProgressListeners.push(options.onProgress);
+      }
       this.activeRefresh = this.performRefresh(options.force === true);
+    } else if (options.onProgress) {
+      if (!this.pendingProgressListeners) {
+        this.pendingProgressListeners = [];
+      }
+      this.pendingProgressListeners.push(options.onProgress);
     }
 
     try {
-      return await this.activeRefresh;
+      const result = await this.activeRefresh;
+      if (options.onProgress && (!this.pendingProgressListeners || this.pendingProgressListeners.length === 0)) {
+        options.onProgress(100);
+      }
+      return result;
     } finally {
       this.activeRefresh = null;
+      this.pendingProgressListeners = null;
     }
+  }
+
+  async getSnapshot(): Promise<TSnapshot | undefined> {
+    await this.ensureInitialized();
+    return this.currentSnapshot;
   }
 
   async applyLocalChange(mutator: (current: TSnapshot | undefined) => TSnapshot): Promise<TSnapshot> {
@@ -113,10 +144,13 @@ export class DataStore<TSnapshot, TMeta extends RefreshMetadata = RefreshMetadat
   }
 
   private async performRefresh(force: boolean): Promise<TSnapshot | undefined> {
+    const onProgress = this.pendingProgressListeners ? this.progressDispatcher : undefined;
+
     const result = await this.loader.load({
       previousSnapshot: this.currentSnapshot,
       metadata: this.currentMetadata,
       force,
+      onProgress,
     });
 
     this.currentSnapshot = result.snapshot;
@@ -131,6 +165,8 @@ export class DataStore<TSnapshot, TMeta extends RefreshMetadata = RefreshMetadat
       this.storage.writeSnapshot(this.currentSnapshot),
       this.storage.writeMetadata(this.currentMetadata),
     ]);
+
+    onProgress?.(100);
 
     this.emitter.emit(this.currentSnapshot);
     return this.currentSnapshot;

--- a/client/src/dataStore/strategies/FetchJsonLoader.ts
+++ b/client/src/dataStore/strategies/FetchJsonLoader.ts
@@ -1,0 +1,81 @@
+import { LoaderContext, LoaderResult, LoaderStrategy, RefreshMetadata } from '../types';
+
+export interface FetchJsonLoaderOptions {
+  url: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface JsonDatasetSnapshot<TData> {
+  data: TData;
+  timestamp: number;
+}
+
+export class FetchJsonLoader<TData, TMeta extends RefreshMetadata = RefreshMetadata>
+  implements LoaderStrategy<JsonDatasetSnapshot<TData>, TMeta>
+{
+  private readonly url: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: FetchJsonLoaderOptions) {
+    this.url = options.url;
+    this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
+  }
+
+  async load(
+    context: LoaderContext<JsonDatasetSnapshot<TData>, TMeta>,
+  ): Promise<LoaderResult<JsonDatasetSnapshot<TData>, TMeta>> {
+    const response = await this.fetchImpl(this.url);
+    const totalHeader = (response as any).headers?.get?.('Content-Length');
+    const total = Number.parseInt(totalHeader ?? '0', 10);
+
+    const data = await this.readJson(response, total, context);
+
+    return {
+      snapshot: {
+        data,
+        timestamp: Date.now(),
+      },
+    };
+  }
+
+  private async readJson(
+    response: Response,
+    total: number,
+    context: LoaderContext<JsonDatasetSnapshot<TData>, TMeta>,
+  ): Promise<TData> {
+    if (response.body && Number.isFinite(total) && total > 0) {
+      const reader = response.body.getReader();
+      const chunks: Uint8Array[] = [];
+      let received = 0;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+          chunks.push(value);
+          received += value.length;
+          context.onProgress?.(
+            Math.min(100, (received / total) * 100),
+            received,
+            total,
+          );
+        }
+      }
+
+      const all = new Uint8Array(received);
+      let offset = 0;
+      for (const chunk of chunks) {
+        all.set(chunk, offset);
+        offset += chunk.length;
+      }
+
+      context.onProgress?.(100, received, total);
+
+      return JSON.parse(new TextDecoder().decode(all));
+    }
+
+    const json = await response.json();
+    context.onProgress?.(100);
+    return json as TData;
+  }
+}

--- a/client/src/dataStore/strategies/IndexedDbSingleRecordStrategy.ts
+++ b/client/src/dataStore/strategies/IndexedDbSingleRecordStrategy.ts
@@ -1,0 +1,97 @@
+import {
+  clearIndexedDB,
+  getFromIndexedDB,
+  IndexedDBConfig,
+  storeInIndexedDB,
+} from '../../utils/dataCache';
+import { RefreshMetadata, StorageStrategy } from '../types';
+
+export interface IndexedDbSingleRecordStrategyOptions {
+  snapshot: IndexedDBConfig;
+  metadata?: IndexedDBConfig;
+}
+
+export class IndexedDbSingleRecordStrategy<TSnapshot, TMeta extends RefreshMetadata = RefreshMetadata>
+  implements StorageStrategy<TSnapshot, TMeta>
+{
+  private readonly snapshotConfig: IndexedDBConfig;
+  private readonly metadataConfig: IndexedDBConfig;
+  private inMemorySnapshot: TSnapshot | undefined;
+  private inMemoryMetadata: TMeta | undefined;
+
+  constructor(options: IndexedDbSingleRecordStrategyOptions) {
+    this.snapshotConfig = options.snapshot;
+    this.metadataConfig =
+      options.metadata ?? {
+        ...options.snapshot,
+        key: `${options.snapshot.key}-metadata`,
+      };
+  }
+
+  async readSnapshot(): Promise<TSnapshot | undefined> {
+    try {
+      const value = await getFromIndexedDB<TSnapshot>(this.snapshotConfig);
+      if (value != null) {
+        this.inMemorySnapshot = value;
+      }
+    } catch (error) {
+      console.warn('Failed to read snapshot from IndexedDB:', error);
+    }
+    return this.inMemorySnapshot;
+  }
+
+  async writeSnapshot(snapshot: TSnapshot | undefined): Promise<void> {
+    this.inMemorySnapshot = snapshot;
+    if (snapshot === undefined) {
+      await this.safeClear(this.snapshotConfig);
+      return;
+    }
+    await this.safeStore(this.snapshotConfig, snapshot);
+  }
+
+  async readMetadata(): Promise<TMeta | undefined> {
+    try {
+      const value = await getFromIndexedDB<TMeta>(this.metadataConfig);
+      if (value != null) {
+        this.inMemoryMetadata = value;
+      }
+    } catch (error) {
+      console.warn('Failed to read metadata from IndexedDB:', error);
+    }
+    return this.inMemoryMetadata;
+  }
+
+  async writeMetadata(metadata: TMeta | undefined): Promise<void> {
+    this.inMemoryMetadata = metadata;
+    if (metadata === undefined) {
+      await this.safeClear(this.metadataConfig);
+      return;
+    }
+    await this.safeStore(this.metadataConfig, metadata);
+  }
+
+  async clear(): Promise<void> {
+    this.inMemorySnapshot = undefined;
+    this.inMemoryMetadata = undefined;
+    await Promise.all([
+      this.safeClear(this.snapshotConfig),
+      this.safeClear(this.metadataConfig),
+    ]);
+  }
+
+  private async safeStore(config: IndexedDBConfig, data: unknown): Promise<void> {
+    try {
+      await storeInIndexedDB(config, data);
+    } catch (error) {
+      console.warn('Failed to store data in IndexedDB:', error);
+    }
+  }
+
+  private async safeClear(config: IndexedDBConfig): Promise<void> {
+    try {
+      await clearIndexedDB(config);
+    } catch (error) {
+      console.warn('Failed to clear IndexedDB:', error);
+    }
+  }
+}

--- a/client/src/dataStore/types.ts
+++ b/client/src/dataStore/types.ts
@@ -3,10 +3,13 @@ export interface RefreshMetadata {
   hash?: string;
 }
 
+export type ProgressListener = (progress: number, loaded?: number, total?: number) => void;
+
 export interface LoaderContext<TSnapshot, TMeta extends RefreshMetadata> {
   previousSnapshot?: TSnapshot;
   metadata?: TMeta;
   force?: boolean;
+  onProgress?: ProgressListener;
 }
 
 export interface LoaderResult<TSnapshot, TMeta extends RefreshMetadata> {

--- a/client/src/dataStores/herbsStore.ts
+++ b/client/src/dataStores/herbsStore.ts
@@ -1,0 +1,44 @@
+import { DataStore, createDataStoreSingleton } from '../dataStore/DataStore';
+import { FetchJsonLoader, JsonDatasetSnapshot } from '../dataStore/strategies/FetchJsonLoader';
+import { IndexedDbSingleRecordStrategy } from '../dataStore/strategies/IndexedDbSingleRecordStrategy';
+import { RefreshMetadata } from '../dataStore/types';
+
+export interface HerbForms {
+  mianownik: string;
+  dopelniacz: string;
+  biernik: string;
+  mnoga_mianownik: string;
+  mnoga_dopelniacz: string;
+  mnoga_biernik: string;
+}
+
+export interface HerbUse {
+  action: string;
+  effect: string;
+  dont_bind?: boolean;
+}
+
+export interface HerbsData {
+  herb_id_to_odmiana: Record<string, HerbForms>;
+  version: number;
+  herb_id_to_use: Record<string, HerbUse[]>;
+}
+
+export const HERBS_URL =
+  'https://raw.githubusercontent.com/tjurczyk/arkadia-data/refs/heads/master/herbs_data.json';
+
+export type HerbsSnapshot = JsonDatasetSnapshot<HerbsData>;
+
+const TTL = 24 * 60 * 60 * 1000;
+
+export const getHerbsStore = createDataStoreSingleton(() =>
+  new DataStore<HerbsSnapshot, RefreshMetadata>({
+    loader: new FetchJsonLoader<HerbsData>({
+      url: HERBS_URL,
+    }),
+    storage: new IndexedDbSingleRecordStrategy<HerbsSnapshot>({
+      snapshot: { dbName: 'ArkadiaHerbsDB', storeName: 'herbs', key: 'herbs' },
+    }),
+    ttlMs: TTL,
+  }),
+);

--- a/client/src/dataStores/magicKeysStore.ts
+++ b/client/src/dataStores/magicKeysStore.ts
@@ -1,0 +1,27 @@
+import { DataStore, createDataStoreSingleton } from '../dataStore/DataStore';
+import { FetchJsonLoader, JsonDatasetSnapshot } from '../dataStore/strategies/FetchJsonLoader';
+import { IndexedDbSingleRecordStrategy } from '../dataStore/strategies/IndexedDbSingleRecordStrategy';
+import { RefreshMetadata } from '../dataStore/types';
+
+export interface MagicKeysData {
+  magic_keys: string[];
+}
+
+export type MagicKeysSnapshot = JsonDatasetSnapshot<MagicKeysData>;
+
+export const MAGIC_KEYS_URL =
+  'https://raw.githubusercontent.com/tjurczyk/arkadia-data/refs/heads/master/magic_keys.json';
+
+const TTL = 24 * 60 * 60 * 1000;
+
+export const getMagicKeysStore = createDataStoreSingleton(() =>
+  new DataStore<MagicKeysSnapshot, RefreshMetadata>({
+    loader: new FetchJsonLoader<MagicKeysData>({
+      url: MAGIC_KEYS_URL,
+    }),
+    storage: new IndexedDbSingleRecordStrategy<MagicKeysSnapshot>({
+      snapshot: { dbName: 'ArkadiaMagicKeysDB', storeName: 'magicKeys', key: 'keys' },
+    }),
+    ttlMs: TTL,
+  }),
+);

--- a/client/src/dataStores/magicsStore.ts
+++ b/client/src/dataStores/magicsStore.ts
@@ -1,0 +1,27 @@
+import { DataStore, createDataStoreSingleton } from '../dataStore/DataStore';
+import { FetchJsonLoader, JsonDatasetSnapshot } from '../dataStore/strategies/FetchJsonLoader';
+import { IndexedDbSingleRecordStrategy } from '../dataStore/strategies/IndexedDbSingleRecordStrategy';
+import { RefreshMetadata } from '../dataStore/types';
+
+export interface MagicsFile {
+  magics: Record<string, { regexps?: string[] }>;
+}
+
+export type MagicsSnapshot = JsonDatasetSnapshot<MagicsFile>;
+
+export const MAGICS_URL =
+  'https://raw.githubusercontent.com/tjurczyk/arkadia-data/refs/heads/master/magics_data.json';
+
+const TTL = 24 * 60 * 60 * 1000;
+
+export const getMagicsStore = createDataStoreSingleton(() =>
+  new DataStore<MagicsSnapshot, RefreshMetadata>({
+    loader: new FetchJsonLoader<MagicsFile>({
+      url: MAGICS_URL,
+    }),
+    storage: new IndexedDbSingleRecordStrategy<MagicsSnapshot>({
+      snapshot: { dbName: 'ArkadiaMagicsDB', storeName: 'magics', key: 'magics' },
+    }),
+    ttlMs: TTL,
+  }),
+);

--- a/client/src/scripts/herbsLoader.ts
+++ b/client/src/scripts/herbsLoader.ts
@@ -1,40 +1,31 @@
-import { loadCachedJSON } from "../utils/dataCache";
+import { SubscriptionOptions } from '../dataStore/types';
+import {
+  getHerbsStore,
+  HERBS_URL,
+  HerbsData,
+  HerbForms,
+  HerbUse,
+} from '../dataStores/herbsStore';
 
-export const HERBS_URL = "https://raw.githubusercontent.com/tjurczyk/arkadia-data/refs/heads/master/herbs_data.json";
-
-export interface HerbForms {
-    mianownik: string;
-    dopelniacz: string;
-    biernik: string;
-    mnoga_mianownik: string;
-    mnoga_dopelniacz: string;
-    mnoga_biernik: string;
-}
-
-export interface HerbUse {
-    action: string;
-    effect: string;
-    dont_bind?: boolean;
-}
-
-export interface HerbsData {
-    herb_id_to_odmiana: Record<string, HerbForms>;
-    version: number;
-    herb_id_to_use: Record<string, HerbUse[]>;
-}
-
-const TTL = 24 * 60 * 60 * 1000; // 24h
+export { HERBS_URL };
+export type { HerbForms, HerbUse, HerbsData };
 
 export default async function loadHerbs(): Promise<HerbsData | null> {
-    try {
-        return await loadCachedJSON<HerbsData>({
-            url: HERBS_URL,
-            localStorageKey: "herbs_data",
-            indexedDB: { dbName: "ArkadiaHerbsDB", storeName: "herbs", key: "herbs" },
-            ttl: TTL,
-        });
-    } catch (e) {
-        console.error("Failed to load herbs:", e);
-        return null;
-    }
+  const store = getHerbsStore();
+  try {
+    const snapshot = await store.refresh();
+    return snapshot?.data ?? null;
+  } catch (error) {
+    console.error('Failed to load herbs:', error);
+    const fallback = await store.getSnapshot();
+    return fallback?.data ?? null;
+  }
+}
+
+export function subscribeToHerbs(
+  listener: (data: HerbsData | undefined) => void,
+  options?: SubscriptionOptions,
+): () => void {
+  const store = getHerbsStore();
+  return store.subscribe((snapshot) => listener(snapshot?.data), options);
 }

--- a/client/src/scripts/magicKeyLoader.ts
+++ b/client/src/scripts/magicKeyLoader.ts
@@ -1,27 +1,50 @@
-import { loadCachedJSON } from "../utils/dataCache";
+import { SubscriptionOptions } from '../dataStore/types';
+import {
+  getMagicKeysStore,
+  MAGIC_KEYS_URL,
+  MagicKeysData,
+} from '../dataStores/magicKeysStore';
 
-export const MAGIC_KEYS_URL = "https://raw.githubusercontent.com/tjurczyk/arkadia-data/refs/heads/master/magic_keys.json";
-
-interface MagicKeysData {
-    magic_keys: string[];
-}
-
-const TTL = 24 * 60 * 60 * 1000; // 24h
+export { MAGIC_KEYS_URL };
+export type { MagicKeysData };
 
 export default async function loadMagicKeys(): Promise<string[]> {
-    try {
-        const data = await loadCachedJSON<MagicKeysData>({
-            url: MAGIC_KEYS_URL,
-            localStorageKey: "magic_keys",
-            indexedDB: { dbName: "ArkadiaMagicKeysDB", storeName: "magicKeys", key: "keys" },
-            ttl: TTL,
-        });
-        if (!Array.isArray(data.magic_keys)) {
-            throw new Error("Invalid data format");
-        }
-        return data.magic_keys;
-    } catch (e) {
-        console.error("Failed to load magic keys:", e);
-        return [];
+  const store = getMagicKeysStore();
+  try {
+    const snapshot = await store.refresh();
+    const data = snapshot?.data;
+    if (!data) {
+      return [];
     }
+    if (!Array.isArray(data.magic_keys)) {
+      throw new Error('Invalid data format');
+    }
+    return data.magic_keys;
+  } catch (error) {
+    console.error('Failed to load magic keys:', error);
+    const fallback = await store.getSnapshot();
+    const data = fallback?.data;
+    if (!data || !Array.isArray(data.magic_keys)) {
+      return [];
+    }
+    return data.magic_keys;
+  }
+}
+
+export function subscribeToMagicKeys(
+  listener: (keys: string[] | undefined) => void,
+  options?: SubscriptionOptions,
+): () => void {
+  const store = getMagicKeysStore();
+  return store.subscribe(
+    (snapshot) => {
+      const data = snapshot?.data;
+      if (!data || !Array.isArray(data.magic_keys)) {
+        listener(undefined);
+        return;
+      }
+      listener(data.magic_keys);
+    },
+    options,
+  );
 }

--- a/client/src/scripts/magicsLoader.ts
+++ b/client/src/scripts/magicsLoader.ts
@@ -1,30 +1,45 @@
-import { loadCachedJSON } from "../utils/dataCache";
+import { SubscriptionOptions } from '../dataStore/types';
+import {
+  getMagicsStore,
+  MAGICS_URL,
+  MagicsFile,
+} from '../dataStores/magicsStore';
 
-export const MAGICS_URL = "https://raw.githubusercontent.com/tjurczyk/arkadia-data/refs/heads/master/magics_data.json";
+export { MAGICS_URL };
+export type { MagicsFile };
 
-interface MagicsFile {
-    magics: Record<string, { regexps?: string[] }>;
+function extractMagics(data: MagicsFile | undefined): string[] {
+  if (!data) {
+    return [];
+  }
+  const magics: string[] = [];
+  for (const value of Object.values(data.magics)) {
+    if (value && Array.isArray(value.regexps)) {
+      magics.push(...value.regexps);
+    }
+  }
+  return magics;
 }
 
-const TTL = 24 * 60 * 60 * 1000; // 24h
-
 export default async function loadMagics(): Promise<string[]> {
-    try {
-        const data = await loadCachedJSON<MagicsFile>({
-            url: MAGICS_URL,
-            localStorageKey: "magics",
-            indexedDB: { dbName: "ArkadiaMagicsDB", storeName: "magics", key: "magics" },
-            ttl: TTL,
-        });
-        const magics: string[] = [];
-        for (const value of Object.values(data.magics)) {
-            if (value && Array.isArray(value.regexps)) {
-                magics.push(...value.regexps);
-            }
-        }
-        return magics;
-    } catch (e) {
-        console.error("Failed to load magics:", e);
-        return [];
-    }
+  const store = getMagicsStore();
+  try {
+    const snapshot = await store.refresh();
+    return extractMagics(snapshot?.data);
+  } catch (error) {
+    console.error('Failed to load magics:', error);
+    const fallback = await store.getSnapshot();
+    return extractMagics(fallback?.data);
+  }
+}
+
+export function subscribeToMagics(
+  listener: (magics: string[] | undefined) => void,
+  options?: SubscriptionOptions,
+): () => void {
+  const store = getMagicsStore();
+  return store.subscribe(
+    (snapshot) => listener(snapshot ? extractMagics(snapshot.data) : undefined),
+    options,
+  );
 }

--- a/web-client/src/dataStores/mapStore.ts
+++ b/web-client/src/dataStores/mapStore.ts
@@ -1,0 +1,39 @@
+import { DataStore, createDataStoreSingleton } from '@client/src/dataStore/DataStore';
+import {
+  FetchJsonLoader,
+  JsonDatasetSnapshot,
+} from '@client/src/dataStore/strategies/FetchJsonLoader';
+import { IndexedDbSingleRecordStrategy } from '@client/src/dataStore/strategies/IndexedDbSingleRecordStrategy';
+import { RefreshMetadata } from '@client/src/dataStore/types';
+
+export const MAP_DATA_URL = 'https://delwing.github.io/arkadia-mapa/data/mapExport.json';
+export const MAP_COLORS_URL = 'https://delwing.github.io/arkadia-mapa/data/colors.json';
+
+const TTL = 24 * 60 * 60 * 1000;
+
+export type MapDataSnapshot = JsonDatasetSnapshot<MapData.Map>;
+export type MapColorsSnapshot = JsonDatasetSnapshot<MapData.Env[]>;
+
+export const getMapDataStore = createDataStoreSingleton(() =>
+  new DataStore<MapDataSnapshot, RefreshMetadata>({
+    loader: new FetchJsonLoader<MapData.Map>({
+      url: MAP_DATA_URL,
+    }),
+    storage: new IndexedDbSingleRecordStrategy<MapDataSnapshot>({
+      snapshot: { dbName: 'ArkadiaMapDB', storeName: 'mapData', key: 'mapExport' },
+    }),
+    ttlMs: TTL,
+  }),
+);
+
+export const getMapColorsStore = createDataStoreSingleton(() =>
+  new DataStore<MapColorsSnapshot, RefreshMetadata>({
+    loader: new FetchJsonLoader<MapData.Env[]>({
+      url: MAP_COLORS_URL,
+    }),
+    storage: new IndexedDbSingleRecordStrategy<MapColorsSnapshot>({
+      snapshot: { dbName: 'ArkadiaMapDB', storeName: 'mapColors', key: 'colors' },
+    }),
+    ttlMs: TTL,
+  }),
+);

--- a/web-client/src/mapDataLoader.ts
+++ b/web-client/src/mapDataLoader.ts
@@ -1,22 +1,86 @@
 // This file provides a way to load map and colors data asynchronously.
-import { loadCachedJSON } from "@client/src/utils/dataCache.ts";
+import { ProgressListener, SubscriptionOptions } from '@client/src/dataStore/types';
+import {
+  getMapColorsStore,
+  getMapDataStore,
+} from './dataStores/mapStore';
 
-const TTL = 24 * 60 * 60 * 1000; // 24h
+const mapProgressListeners = new Set<ProgressListener>();
 
-export function loadMapData(onProgress?: (progress: number, loaded?: number, total?: number) => void): Promise<MapData.Map> {
-    return loadCachedJSON({
-        url: 'https://delwing.github.io/arkadia-mapa/data/mapExport.json',
-        localStorageKey: 'cachedMapData',
-        indexedDB: { dbName: 'ArkadiaMapDB', storeName: 'mapData', key: 'mapExport' },
-        ttl: TTL,
-        onProgress,
-    });
+function buildProgressHandler(onProgress?: ProgressListener): ProgressListener | undefined {
+  const listeners: ProgressListener[] = [];
+  if (onProgress) {
+    listeners.push(onProgress);
+  }
+  if (mapProgressListeners.size > 0) {
+    listeners.push(...mapProgressListeners);
+  }
+  if (listeners.length === 0) {
+    return undefined;
+  }
+  return (progress, loaded, total) => {
+    for (const listener of [...listeners]) {
+      listener(progress, loaded, total);
+    }
+  };
 }
 
-export function loadColors(): Promise<MapData.Env[]> {
-    return loadCachedJSON({
-        url: 'https://delwing.github.io/arkadia-mapa/data/colors.json',
-        localStorageKey: 'cachedColors',
-        ttl: TTL,
-    });
+export async function loadMapData(
+  onProgress?: ProgressListener,
+): Promise<MapData.Map> {
+  const store = getMapDataStore();
+  const combinedProgress = buildProgressHandler(onProgress);
+  try {
+    const snapshot = await store.refresh({ onProgress: combinedProgress });
+    if (!snapshot) {
+      throw new Error('Map data unavailable');
+    }
+    return snapshot.data;
+  } catch (error) {
+    const fallback = await store.getSnapshot();
+    if (fallback) {
+      return fallback.data;
+    }
+    throw error;
+  }
+}
+
+export async function loadColors(): Promise<MapData.Env[]> {
+  const store = getMapColorsStore();
+  try {
+    const snapshot = await store.refresh();
+    if (!snapshot) {
+      throw new Error('Map colors unavailable');
+    }
+    return snapshot.data;
+  } catch (error) {
+    const fallback = await store.getSnapshot();
+    if (fallback) {
+      return fallback.data;
+    }
+    throw error;
+  }
+}
+
+export function subscribeToMapData(
+  listener: (map: MapData.Map | undefined) => void,
+  options?: SubscriptionOptions,
+): () => void {
+  const store = getMapDataStore();
+  return store.subscribe((snapshot) => listener(snapshot?.data), options);
+}
+
+export function subscribeToMapColors(
+  listener: (colors: MapData.Env[] | undefined) => void,
+  options?: SubscriptionOptions,
+): () => void {
+  const store = getMapColorsStore();
+  return store.subscribe((snapshot) => listener(snapshot?.data), options);
+}
+
+export function subscribeToMapDataProgress(listener: ProgressListener): () => void {
+  mapProgressListeners.add(listener);
+  return () => {
+    mapProgressListeners.delete(listener);
+  };
 }

--- a/web-client/test/mapDataLoader.test.ts
+++ b/web-client/test/mapDataLoader.test.ts
@@ -1,33 +1,117 @@
-import { loadMapData, loadColors } from '../src/mapDataLoader';
-import { loadCachedJSON } from '@client/src/utils/dataCache.ts';
+import {
+  loadMapData,
+  loadColors,
+  subscribeToMapColors,
+  subscribeToMapData,
+  subscribeToMapDataProgress,
+} from '../src/mapDataLoader';
 
-jest.mock('@client/src/utils/dataCache.ts', () => ({
-  loadCachedJSON: jest.fn()
+const mockMapDataStore = {
+  refresh: jest.fn(),
+  getSnapshot: jest.fn(),
+  subscribe: jest.fn(),
+};
+
+const mockMapColorsStore = {
+  refresh: jest.fn(),
+  getSnapshot: jest.fn(),
+  subscribe: jest.fn(),
+};
+
+jest.mock('../src/dataStores/mapStore', () => ({
+  getMapDataStore: jest.fn(() => mockMapDataStore),
+  getMapColorsStore: jest.fn(() => mockMapColorsStore),
 }));
 
 describe('mapDataLoader', () => {
   beforeEach(() => {
-    (loadCachedJSON as jest.Mock).mockClear();
+    jest.clearAllMocks();
   });
 
-  test('loadMapData passes correct options', () => {
-    const onProgress = jest.fn();
-    loadMapData(onProgress);
-    expect(loadCachedJSON).toHaveBeenCalledWith({
-      url: 'https://delwing.github.io/arkadia-mapa/data/mapExport.json',
-      localStorageKey: 'cachedMapData',
-      indexedDB: { dbName: 'ArkadiaMapDB', storeName: 'mapData', key: 'mapExport' },
-      ttl: 86400000,
-      onProgress
-    });
+  test('loadMapData returns refreshed data', async () => {
+    const expected = { rooms: [] } as any;
+    mockMapDataStore.refresh.mockResolvedValue({ data: expected });
+
+    const result = await loadMapData();
+
+    expect(result).toBe(expected);
+    expect(mockMapDataStore.refresh).toHaveBeenCalledWith({ onProgress: undefined });
+    expect(mockMapDataStore.getSnapshot).not.toHaveBeenCalled();
   });
 
-  test('loadColors passes correct options', () => {
-    loadColors();
-    expect(loadCachedJSON).toHaveBeenCalledWith({
-      url: 'https://delwing.github.io/arkadia-mapa/data/colors.json',
-      localStorageKey: 'cachedColors',
-      ttl: 86400000
+  test('loadMapData falls back to cached data when refresh fails', async () => {
+    const fallback = { rooms: ['cached'] } as any;
+    const error = new Error('network');
+    mockMapDataStore.refresh.mockRejectedValue(error);
+    mockMapDataStore.getSnapshot.mockResolvedValue({ data: fallback });
+
+    await expect(loadMapData()).resolves.toBe(fallback);
+    expect(mockMapDataStore.getSnapshot).toHaveBeenCalled();
+  });
+
+  test('loadMapData forwards progress to listeners', async () => {
+    const map = { rooms: ['a'] } as any;
+    const provided = jest.fn();
+    const subscriber = jest.fn();
+    const unsubscribe = subscribeToMapDataProgress(subscriber);
+    mockMapDataStore.refresh.mockImplementation(async ({ onProgress }) => {
+      onProgress?.(25);
+      onProgress?.(100);
+      return { data: map };
     });
+
+    await loadMapData(provided);
+
+    expect(provided).toHaveBeenCalledWith(25, undefined, undefined);
+    expect(subscriber).toHaveBeenCalledWith(25, undefined, undefined);
+    unsubscribe();
+  });
+
+  test('loadColors returns refreshed data', async () => {
+    const colors = [{ id: 1 }] as any;
+    mockMapColorsStore.refresh.mockResolvedValue({ data: colors });
+
+    await expect(loadColors()).resolves.toBe(colors);
+  });
+
+  test('loadColors falls back to cached data when refresh fails', async () => {
+    const colors = [{ id: 2 }] as any;
+    mockMapColorsStore.refresh.mockRejectedValue(new Error('fail'));
+    mockMapColorsStore.getSnapshot.mockResolvedValue({ data: colors });
+
+    await expect(loadColors()).resolves.toBe(colors);
+  });
+
+  test('subscribeToMapData proxies subscriptions', () => {
+    const unsubscribe = jest.fn();
+    const listener = jest.fn();
+    const options = { emitInitial: false };
+    mockMapDataStore.subscribe.mockReturnValue(unsubscribe);
+
+    const result = subscribeToMapData(listener, options);
+
+    expect(mockMapDataStore.subscribe).toHaveBeenCalledWith(expect.any(Function), options);
+    const handler = mockMapDataStore.subscribe.mock.calls[0][0];
+    handler({ data: { rooms: [] } } as any);
+    expect(listener).toHaveBeenCalledWith({ rooms: [] });
+    handler(undefined);
+    expect(listener).toHaveBeenCalledWith(undefined);
+    expect(result).toBe(unsubscribe);
+  });
+
+  test('subscribeToMapColors proxies subscriptions', () => {
+    const unsubscribe = jest.fn();
+    const listener = jest.fn();
+    mockMapColorsStore.subscribe.mockReturnValue(unsubscribe);
+
+    const result = subscribeToMapColors(listener);
+
+    expect(mockMapColorsStore.subscribe).toHaveBeenCalledWith(expect.any(Function), undefined);
+    const handler = mockMapColorsStore.subscribe.mock.calls[0][0];
+    handler({ data: [{ id: 1 }] } as any);
+    expect(listener).toHaveBeenCalledWith([{ id: 1 }]);
+    handler(undefined);
+    expect(listener).toHaveBeenCalledWith(undefined);
+    expect(result).toBe(unsubscribe);
   });
 });


### PR DESCRIPTION
## Summary
- add FetchJsonLoader and IndexedDbSingleRecordStrategy implementations to support JSON snapshot caching with timestamps
- create dedicated data stores for herbs, magics, magic keys, and map datasets backed by the new strategies
- update loader modules and map loader tests to consume the stores and expose subscription helpers

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fbae1e8dbc832a99cc5eaf3ded7523