### PR TITLE
Assume IndexedDB support and simplify guards

### DIFF
--- a/client/src/peopleCache.ts
+++ b/client/src/peopleCache.ts
@@ -11,10 +11,6 @@ type MetadataRecord<TMeta> = {
   value: TMeta;
 };
 
-function isIndexedDBSupported(): boolean {
-  return typeof indexedDB !== 'undefined';
-}
-
 export interface IndexedDbCollectionStrategyOptions<TEntry> {
   dbName: string;
   entriesStore: string;
@@ -25,10 +21,6 @@ export interface IndexedDbCollectionStrategyOptions<TEntry> {
 }
 
 async function openDatabase(options: IndexedDbCollectionStrategyOptions<any>): Promise<IDBDatabase> {
-  if (!isIndexedDBSupported()) {
-    throw new Error('IndexedDB is not supported');
-  }
-
   return await new Promise<IDBDatabase>((resolve, reject) => {
     const request = indexedDB.open(options.dbName, options.version ?? 1);
 
@@ -73,10 +65,6 @@ export class IndexedDbCollectionStrategy<TEntry, TMeta extends RefreshMetadata>
       return this.inMemorySnapshot;
     }
 
-    if (!isIndexedDBSupported()) {
-      return this.inMemorySnapshot;
-    }
-
     try {
       const db = await openDatabase(this.options);
       try {
@@ -103,10 +91,6 @@ export class IndexedDbCollectionStrategy<TEntry, TMeta extends RefreshMetadata>
 
   async writeSnapshot(snapshot: TEntry[] | undefined): Promise<void> {
     this.inMemorySnapshot = snapshot;
-
-    if (!isIndexedDBSupported()) {
-      return;
-    }
 
     try {
       const db = await openDatabase(this.options);
@@ -142,10 +126,6 @@ export class IndexedDbCollectionStrategy<TEntry, TMeta extends RefreshMetadata>
       return this.inMemoryMetadata;
     }
 
-    if (!isIndexedDBSupported()) {
-      return this.inMemoryMetadata;
-    }
-
     try {
       const db = await openDatabase(this.options);
       try {
@@ -167,10 +147,6 @@ export class IndexedDbCollectionStrategy<TEntry, TMeta extends RefreshMetadata>
 
   async writeMetadata(metadata: TMeta | undefined): Promise<void> {
     this.inMemoryMetadata = metadata;
-
-    if (!isIndexedDBSupported()) {
-      return;
-    }
 
     try {
       const db = await openDatabase(this.options);
@@ -199,10 +175,6 @@ export class IndexedDbCollectionStrategy<TEntry, TMeta extends RefreshMetadata>
   async clear(): Promise<void> {
     this.inMemorySnapshot = undefined;
     this.inMemoryMetadata = undefined;
-
-    if (!isIndexedDBSupported()) {
-      return;
-    }
 
     try {
       const db = await openDatabase(this.options);

--- a/client/src/utils/dataCache.ts
+++ b/client/src/utils/dataCache.ts
@@ -4,20 +4,11 @@ export interface IndexedDBConfig {
     key: string;
 }
 
-function isIndexedDBSupported() {
-    return typeof indexedDB !== "undefined";
-}
-
 const dbCache: Record<string, Promise<IDBDatabase>> = {};
 
 async function getDatabase(config: IndexedDBConfig): Promise<IDBDatabase> {
     if (!dbCache[config.dbName]) {
         dbCache[config.dbName] = new Promise((resolve, reject) => {
-            if (!isIndexedDBSupported()) {
-                reject(new Error('IndexedDB is not supported'));
-                return;
-            }
-
             const request = indexedDB.open(config.dbName, 1);
             request.onupgradeneeded = () => {
                 const db = request.result;

--- a/client/src/utils/transportStats.ts
+++ b/client/src/utils/transportStats.ts
@@ -2,17 +2,9 @@ const DB_NAME = "ArkadiaTransportStatsDB";
 const STORE_NAME = "segments";
 const DB_VERSION = 2;
 
-function isIndexedDBSupported(): boolean {
-    return typeof indexedDB !== "undefined";
-}
-
 let dbPromise: Promise<IDBDatabase> | null = null;
 
 async function getDatabase(): Promise<IDBDatabase> {
-    if (!isIndexedDBSupported()) {
-        throw new Error("IndexedDB is not supported");
-    }
-
     if (!dbPromise) {
         dbPromise = new Promise((resolve, reject) => {
             const request = indexedDB.open(DB_NAME, DB_VERSION);
@@ -227,10 +219,6 @@ export async function recordTransportSegment(record: TransportSegmentRecord): Pr
 }
 
 export async function clearTransportStats(): Promise<void> {
-    if (!isIndexedDBSupported()) {
-        return;
-    }
-
     try {
         const db = await getDatabase();
         await new Promise<void>((resolve, reject) => {

--- a/web-client/src/options/ExportImport.tsx
+++ b/web-client/src/options/ExportImport.tsx
@@ -244,9 +244,6 @@ async function exportRecordings(): Promise<ExportedRecording[]> {
 }
 
 async function openRecordingsDb(): Promise<IDBDatabase> {
-    if (typeof indexedDB === "undefined") {
-        throw new Error("IndexedDB is not supported");
-    }
     return new Promise((resolve, reject) => {
         const request = indexedDB.open("ArkadiaRecordingsDB", 1);
         request.onupgradeneeded = () => {
@@ -261,9 +258,6 @@ async function openRecordingsDb(): Promise<IDBDatabase> {
 }
 
 async function importRecordings(records: ExportedRecording[]): Promise<void> {
-    if (typeof indexedDB === "undefined") {
-        return;
-    }
     const list = Array.isArray(records) ? records : [];
     const db = await openRecordingsDb();
     await new Promise<void>((resolve, reject) => {
@@ -282,9 +276,6 @@ async function importRecordings(records: ExportedRecording[]): Promise<void> {
 }
 
 async function openVisitedDb(): Promise<IDBDatabase> {
-    if (typeof indexedDB === "undefined") {
-        throw new Error("IndexedDB is not supported");
-    }
     return new Promise((resolve, reject) => {
         const request = indexedDB.open("ArkadiaVisitedRoomsDB", 1);
         request.onupgradeneeded = () => {
@@ -299,9 +290,6 @@ async function openVisitedDb(): Promise<IDBDatabase> {
 }
 
 async function exportVisitedRooms(selectedCharacters: string[]): Promise<ExportedVisitedRoomsEntry[]> {
-    if (typeof indexedDB === "undefined") {
-        return [];
-    }
     try {
         const db = await openVisitedDb();
         return await new Promise<ExportedVisitedRoomsEntry[]>((resolve, reject) => {
@@ -340,9 +328,6 @@ async function exportVisitedRooms(selectedCharacters: string[]): Promise<Exporte
 async function importVisitedRooms(entries: ExportedVisitedRoomsEntry[]): Promise<void> {
     if (!Array.isArray(entries)) return;
     if (entries.length === 0) return;
-    if (typeof indexedDB === "undefined") {
-        return;
-    }
     const db = await openVisitedDb();
     await new Promise<void>((resolve, reject) => {
         const tx = db.transaction(["visitedRooms"], "readwrite");
@@ -665,9 +650,7 @@ function ExportImport() {
 
     const applyImportedData = useCallback(async (payload: ExportPayload) => {
         applyLocalStorageImport(payload.localStorage);
-        if (typeof indexedDB !== "undefined") {
-            await replaceMultibinds(payload.indexedDB.multibinds ?? []);
-        }
+        await replaceMultibinds(payload.indexedDB.multibinds ?? []);
         await importRecordings(payload.indexedDB.recordings ?? []);
         await importVisitedRooms(payload.indexedDB.visitedRooms ?? []);
     }, []);

--- a/web-client/src/options/recordingStorage.ts
+++ b/web-client/src/options/recordingStorage.ts
@@ -4,16 +4,8 @@ export interface RecordedEvent {
     direction: 'in' | 'out';
 }
 
-function isIndexedDBSupported() {
-    return 'indexedDB' in window;
-}
-
 function openDB(): Promise<IDBDatabase> {
     return new Promise((resolve, reject) => {
-        if (!isIndexedDBSupported()) {
-            reject(new Error('IndexedDB is not supported'));
-            return;
-        }
         const request = indexedDB.open('ArkadiaRecordingsDB', 1);
         request.onupgradeneeded = () => {
             const db = request.result;

--- a/web-client/src/recordingStorage.ts
+++ b/web-client/src/recordingStorage.ts
@@ -4,16 +4,8 @@ export interface RecordedEvent {
     direction: 'in' | 'out';
 }
 
-function isIndexedDBSupported() {
-    return 'indexedDB' in window;
-}
-
 function openDB(): Promise<IDBDatabase> {
     return new Promise((resolve, reject) => {
-        if (!isIndexedDBSupported()) {
-            reject(new Error('IndexedDB is not supported'));
-            return;
-        }
         const request = indexedDB.open('ArkadiaRecordingsDB', 1);
         request.onupgradeneeded = () => {
             const db = request.result;


### PR DESCRIPTION
## Summary
- remove IndexedDB support checks from client caches now that the feature is guaranteed
- simplify web client export/import and recording storage helpers to always use IndexedDB

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fbba6fb9a4832a9ea0c32df92e47d6