### PR TITLE
Stop mirroring NPC storage updates in MockPort

### DIFF
--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -1,3 +1,4 @@
+import { addLocalNpc } from "front-client/src/dataStores/npcStore";
 import {colorStringInLine, findClosestColor, RESET} from "./Colors";
 import Client from "./Client";
 import { Trigger } from "./Triggers";
@@ -328,11 +329,8 @@ export default class PackageHelper {
             if (matches[1] === 'Oddajesz') {
                 if (!this.npc[this.currentPackage.name]) {
                     this.client.println(`Nowy adresat: ${this.currentPackage.name} | ${this.client.Map.currentRoom.id}`)
-                    this.client.port.postMessage({
-                        type: 'NEW_NPC',
-                        name: this.currentPackage.name,
-                        loc: this.client.Map.currentRoom.id
-                    })
+                    void addLocalNpc({ name: this.currentPackage.name, loc: this.client.Map.currentRoom.id })
+                        .catch(err => console.error('Failed to add NPC:', err))
                 }
             }
             this.currentPackage = undefined;

--- a/client/test/PackageHelper.test.ts
+++ b/client/test/PackageHelper.test.ts
@@ -1,3 +1,7 @@
+jest.mock('front-client/src/dataStores/npcStore', () => ({
+  addLocalNpc: jest.fn().mockResolvedValue(undefined),
+}));
+
 import PackageHelper from '../src/PackageHelper';
 import { colorStringInLine, findClosestColor } from '../src/Colors';
 

--- a/web-client/src/MockPort.ts
+++ b/web-client/src/MockPort.ts
@@ -1,18 +1,7 @@
 import storage, { setItemSync, getItemSync } from "@client/src/storage";
-import {
-    getSnapshot as getMultibindsSnapshot,
-    replaceAll as replaceMultibinds,
-    subscribe as subscribeMultibinds,
-} from "./dataStores/multibindStore";
-import {
-    addLocalNpc,
-    setLocalNpcs,
-    subscribe as subscribeNpcStore,
-} from "./dataStores/npcStore";
 
 export default class MockPort {
     listeners: Array<(msg: any) => void> = [];
-    private currentNpc: { name: string; loc: number }[] = [];
 
     onMessage = {
         addListener: (cb: (msg: any) => void) => {
@@ -20,26 +9,14 @@ export default class MockPort {
         }
     };
 
-    private unsubscribeMultibinds: (() => void) | null = null;
-
     constructor() {
         storage.onChanged?.addListener(changes => {
             Object.entries(changes).forEach(([key, {newValue}]) => {
                 this.dispatch({storage: {key, value: newValue}});
-                if (key === 'settings' || key === 'npc' || key === 'uiSettings' || key === 'binds') {
+                if (key === 'settings' || key === 'uiSettings' || key === 'binds') {
                     this.dispatch({[key]: newValue});
                 }
             });
-        });
-
-        subscribeNpcStore(snapshot => {
-            this.currentNpc = snapshot?.all.data.map(({name, loc}) => ({name, loc})) ?? [];
-            this.dispatch({ npc: this.currentNpc });
-            this.dispatch({ storage: { key: 'npc', value: this.currentNpc } });
-        });
-
-        this.unsubscribeMultibinds = subscribeMultibinds(list => {
-            this.dispatch({ multibindsStorage: list });
         });
     }
 
@@ -48,35 +25,10 @@ export default class MockPort {
     }
 
     postMessage(message: any) {
-        if (message.type === 'NEW_NPC') {
-            addLocalNpc({ name: message.name, loc: message.loc }).catch(e => console.error('Failed to add NPC:', e));
-            return;
-        }
-        if (message.type === 'MULTIBINDS_LOAD') {
-            getMultibindsSnapshot()
-                .then(list => {
-                    this.dispatch({ multibindsStorage: list });
-                })
-                .catch(e => console.error('Failed to load multibinds:', e));
-            return;
-        }
-        if (message.type === 'MULTIBINDS_SAVE') {
-            const list = Array.isArray(message.value) ? message.value : [];
-            replaceMultibinds(list).catch(e => console.error('Failed to save multibinds:', e));
-            return;
-        }
         if (message.type === 'SET_STORAGE') {
-            if (message.key === 'npc') {
-                const list = Array.isArray(message.value) ? message.value : [];
-                setLocalNpcs(list).catch(e => console.error('Failed to replace NPC list:', e));
-                return;
-            }
             setItemSync(message.key, message.value);
             this.dispatch({storage: {key: message.key, value: message.value}});
             if (message.key === 'settings' || message.key === 'uiSettings' || message.key === 'binds') {
-                this.dispatch({[message.key]: message.value});
-            }
-            if (message.key === 'settings' || message.key === 'npc' || message.key === 'uiSettings' || message.key === 'binds') {
                 this.dispatch({[message.key]: message.value});
             }
             return;
@@ -88,12 +40,9 @@ export default class MockPort {
 
     private sendStorage(key: string) {
         const data = getItemSync(key);
-        let value = data ? data[key] : {};
-        if (key === 'npc') {
-            value = this.currentNpc;
-        }
+        const value = data ? data[key] : {};
         this.dispatch({ storage: { key, value } });
-        if (key === 'settings' || key === 'npc' || key === 'uiSettings' || key === 'binds') {
+        if (key === 'settings' || key === 'uiSettings' || key === 'binds') {
             this.dispatch({ [key]: value });
         }
     };


### PR DESCRIPTION
## Summary
- remove datastore subscriptions and message handlers from MockPort
- update PackageHelper to add new NPCs directly through the npc datastore
- mock the npc datastore in PackageHelper tests to keep unit tests isolated
- stop dispatching NPC storage updates from MockPort so the mock transport mirrors the real port

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fbc2f245ac832a934fbb31235830fd