### PR TITLE
Fix herb description coloring regression

### DIFF
--- a/client/src/scripts/herbDescriptions.ts
+++ b/client/src/scripts/herbDescriptions.ts
@@ -1,9 +1,6 @@
 import Client from "../Client";
 import loadHerbs from "./herbsLoader";
-import {color, RESET, findClosestColor} from "../Colors";
 import { openHerbContextMenu } from "../contextMenus";
-
-export const HERB_NAME_COLOR = findClosestColor("#ffffff");
 
 export default async function initHerbDescriptions(client: Client) {
     const tag = "herbDescriptions";
@@ -44,7 +41,7 @@ export default async function initHerbDescriptions(client: Client) {
                         return raw;
                     }
                     const clickable = client.OutputHandler.makeStringRightClickable(id, (ev) => showHerbActions(id, ev));
-                    const insertion = ` (${color(HERB_NAME_COLOR)}${clickable}${RESET})`;
+                    const insertion = ` (${clickable})`;
                     if (triggerLine) {
                         triggerLine.insert(index + token.length, insertion);
                         return triggerLine;

--- a/client/test/herbDescriptions.test.ts
+++ b/client/test/herbDescriptions.test.ts
@@ -1,6 +1,5 @@
 import initHerbDescriptions from '../src/scripts/herbDescriptions';
 import Triggers, { stripAnsiCodes } from '../src/Triggers';
-import { RESET } from '../src/Colors';
 import { EventEmitter } from 'events';
 
 class FakeClient {
@@ -49,7 +48,6 @@ describe('herb descriptions', () => {
     const result = client.Triggers.parseLine(line, '');
     expect(result.startsWith('Widzisz zolty jasny kwiat ')).toBe(true);
     expect(result).toContain('{clickOpen:0}deliona{clickClose}');
-    expect(result).toContain(RESET + ')');
     expect(stripAnsiCodes(result)).toBe('Widzisz zolty jasny kwiat (deliona)');
   });
 


### PR DESCRIPTION
## Summary
- remove ANSI color codes when injecting herb description links so the surrounding text keeps its original color
- update herb description test expectations to reflect the neutral formatting

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fbec942354832a9df71e34cb788e11