### PR TITLE
Add value mapper to IndexedDb collection strategy

### DIFF
--- a/client/src/peopleCache.ts
+++ b/client/src/peopleCache.ts
@@ -18,6 +18,7 @@ export interface IndexedDbCollectionStrategyOptions<TEntry> {
   metadataKey?: string;
   version?: number;
   buildEntryId: (entry: TEntry, index: number) => string;
+  valueMapper?: (record: CollectionRecord<unknown>) => TEntry;
 }
 
 async function openDatabase(options: IndexedDbCollectionStrategyOptions<any>): Promise<IDBDatabase> {
@@ -52,12 +53,14 @@ export class IndexedDbCollectionStrategy<TEntry, TMeta extends RefreshMetadata>
 {
   private readonly options: IndexedDbCollectionStrategyOptions<TEntry>;
   private readonly metadataKey: string;
+  private readonly mapRecordValue: (record: CollectionRecord<unknown>) => TEntry;
   private inMemorySnapshot: TEntry[] | undefined;
   private inMemoryMetadata: TMeta | undefined;
 
   constructor(options: IndexedDbCollectionStrategyOptions<TEntry>) {
     this.options = options;
     this.metadataKey = options.metadataKey ?? 'metadata';
+    this.mapRecordValue = options.valueMapper ?? ((record) => record.value as TEntry);
   }
 
   async readSnapshot(): Promise<TEntry[] | undefined> {
@@ -70,14 +73,14 @@ export class IndexedDbCollectionStrategy<TEntry, TMeta extends RefreshMetadata>
       try {
         const transaction = db.transaction([this.options.entriesStore], 'readonly');
         const store = transaction.objectStore(this.options.entriesStore);
-        const records = (await runRequest(store.getAll())) as CollectionRecord<TEntry>[];
+        const records = (await runRequest(store.getAll())) as CollectionRecord<unknown>[];
         if (records.length === 0) {
           this.inMemorySnapshot = undefined;
           return this.inMemorySnapshot;
         }
         const ordered = records
           .sort((a, b) => a.order - b.order)
-          .map((record) => record.value);
+          .map((record) => this.mapRecordValue(record));
         this.inMemorySnapshot = ordered;
         return this.inMemorySnapshot;
       } finally {

--- a/client/test/peopleCache.test.ts
+++ b/client/test/peopleCache.test.ts
@@ -77,6 +77,57 @@ describe('IndexedDbCollectionStrategy', () => {
     }
   });
 
+  test('uses value mapper when reading snapshot', async () => {
+    strategy = new IndexedDbCollectionStrategy<PersonEntry, TestMetadata>({
+      dbName: DB_NAME,
+      entriesStore: 'peopleEntries',
+      metadataStore: 'peopleMetadata',
+      metadataKey: 'metadata',
+      version: 2,
+      buildEntryId: (person, index) => `legacy-${index}-${person.name}`,
+      valueMapper: (record) => {
+        const stored = record.value as { data: PersonEntry };
+        return stored.data;
+      },
+    });
+
+    const openRequest = indexedDB.open(DB_NAME, 2);
+    openRequest.onupgradeneeded = () => {
+      const db = openRequest.result;
+      if (!db.objectStoreNames.contains('peopleEntries')) {
+        db.createObjectStore('peopleEntries', { keyPath: 'id' });
+      }
+      if (!db.objectStoreNames.contains('peopleMetadata')) {
+        db.createObjectStore('peopleMetadata', { keyPath: 'id' });
+      }
+    };
+
+    const db: IDBDatabase = await new Promise((resolve, reject) => {
+      openRequest.onsuccess = () => resolve(openRequest.result);
+      openRequest.onerror = () => reject(openRequest.error ?? new Error('Failed to prepare legacy database state'));
+    });
+
+    try {
+      const transaction = db.transaction(['peopleEntries'], 'readwrite');
+      const store = transaction.objectStore('peopleEntries');
+      samplePeople.forEach((person, index) => {
+        store.put({ id: `legacy-${index}`, order: index, value: { data: person } });
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error ?? new Error('Failed to store legacy entries'));
+        transaction.onabort = () => reject(transaction.error ?? new Error('Storing legacy entries was aborted'));
+      });
+    } finally {
+      db.close();
+    }
+
+    const cachedSnapshot = await strategy.readSnapshot();
+
+    expect(cachedSnapshot).toEqual(samplePeople);
+  });
+
   test('clear removes snapshot and metadata', async () => {
     const metadata: TestMetadata = { refreshedAt: Date.now(), count: samplePeople.length };
     await strategy.writeSnapshot(samplePeople);

--- a/web-client/src/dataStores/__tests__/multibindStore.test.ts
+++ b/web-client/src/dataStores/__tests__/multibindStore.test.ts
@@ -1,23 +1,37 @@
-import {
-  applyLocalChange,
-  clear,
-  getSnapshot,
-  replaceAll,
-  subscribe,
-  type StoredMultibindRecord,
-} from '../multibindStore';
+const DB_NAME = 'ArkadiaMultibindsDB';
+
+async function deleteDatabase() {
+  await new Promise<void>((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(DB_NAME);
+    request.onsuccess = () => resolve();
+    request.onblocked = () => resolve();
+    request.onerror = () => reject(request.error ?? new Error('Failed to reset multibinds database'));
+  });
+}
+
+type MultibindStoreModule = typeof import('../multibindStore');
+
+async function importStore(): Promise<MultibindStoreModule> {
+  jest.resetModules();
+  return await import('../multibindStore');
+}
+
+async function prepareStore(): Promise<MultibindStoreModule> {
+  await deleteDatabase();
+  const store = await importStore();
+  await store.clear();
+  return store;
+}
 
 describe('multibindStore', () => {
-  beforeEach(async () => {
-    await clear();
-  });
-
   it('normalizes and persists multibinds when replacing', async () => {
-    const result = await replaceAll([
+    const store = await prepareStore();
+
+    const result = await store.replaceAll([
       { roomId: 2, index: 1, action: 'go north' },
       { roomId: 2, index: 1, action: 'go east' },
-      { roomId: '3', index: '2', action: 42 },
-      { roomId: 'bad', index: 3, action: 'noop' },
+      { roomId: '3' as unknown as number, index: '2' as unknown as number, action: 42 as unknown as string },
+      { roomId: 'bad' as unknown as number, index: 3, action: 'noop' },
     ]);
 
     expect(result).toEqual([
@@ -25,19 +39,21 @@ describe('multibindStore', () => {
       { roomId: 3, index: 2, action: '42' },
     ]);
 
-    const snapshot = await getSnapshot();
+    const snapshot = await store.getSnapshot();
     expect(snapshot).toEqual(result);
   });
 
   it('emits the initial snapshot to subscribers', async () => {
-    await replaceAll([
+    const store = await prepareStore();
+
+    await store.replaceAll([
       { roomId: 7, index: 1, action: 'alpha' },
       { roomId: 7, index: 2, action: 'beta' },
     ]);
 
-    const emissions: StoredMultibindRecord[][] = [];
+    const emissions: Array<Array<{ roomId: number; index: number; action: string }>> = [];
     await new Promise<void>((resolve) => {
-      const unsubscribe = subscribe((snapshot) => {
+      const unsubscribe = store.subscribe((snapshot) => {
         emissions.push(snapshot);
         if (emissions.length >= 1) {
           unsubscribe();
@@ -55,17 +71,71 @@ describe('multibindStore', () => {
   });
 
   it('deduplicates and normalizes during applyLocalChange', async () => {
-    await applyLocalChange(() => [
+    const store = await prepareStore();
+
+    await store.applyLocalChange(() => [
       { roomId: 1, index: 1, action: 'first' },
       { roomId: 1, index: 1, action: 'second' },
       { roomId: 4, index: 2, action: null as unknown as string },
-      { roomId: 5, index: NaN as unknown as number, action: 'invalid' },
+      { roomId: 5, index: Number.NaN as unknown as number, action: 'invalid' },
     ]);
 
-    const snapshot = await getSnapshot();
+    const snapshot = await store.getSnapshot();
     expect(snapshot).toEqual([
       { roomId: 1, index: 1, action: 'second' },
       { roomId: 4, index: 2, action: '' },
     ]);
   });
+
+  it('reads legacy multibind records stored with nested values', async () => {
+    await deleteDatabase();
+
+    const openRequest = indexedDB.open(DB_NAME, 2);
+    openRequest.onupgradeneeded = () => {
+      const db = openRequest.result;
+      if (!db.objectStoreNames.contains('multibinds')) {
+        db.createObjectStore('multibinds', { keyPath: 'id' });
+      }
+      if (!db.objectStoreNames.contains('metadata')) {
+        db.createObjectStore('metadata', { keyPath: 'id' });
+      }
+    };
+
+    const db: IDBDatabase = await new Promise((resolve, reject) => {
+      openRequest.onsuccess = () => resolve(openRequest.result);
+      openRequest.onerror = () => reject(openRequest.error ?? new Error('Failed to seed legacy multibinds'));
+    });
+
+    try {
+      const transaction = db.transaction(['multibinds'], 'readwrite');
+      const store = transaction.objectStore('multibinds');
+      store.put({
+        id: '1:1',
+        order: 0,
+        value: { data: { roomId: 1, index: 1, action: 'alpha' } },
+      });
+      store.put({
+        id: '1:2',
+        order: 1,
+        value: { value: { roomId: 1, index: 2, action: 'beta' } },
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error ?? new Error('Failed to store legacy multibinds'));
+        transaction.onabort = () => reject(transaction.error ?? new Error('Storing legacy multibinds was aborted'));
+      });
+    } finally {
+      db.close();
+    }
+
+    const store = await importStore();
+    const snapshot = await store.getSnapshot();
+
+    expect(snapshot).toEqual([
+      { roomId: 1, index: 1, action: 'alpha' },
+      { roomId: 1, index: 2, action: 'beta' },
+    ]);
+  });
 });
+

--- a/web-client/src/dataStores/multibindStore.ts
+++ b/web-client/src/dataStores/multibindStore.ts
@@ -51,6 +51,20 @@ function normalizeSnapshot(list: unknown): StoredMultibindRecord[] {
   return Array.from(unique.values());
 }
 
+function extractStoredEntry(record: { value: unknown }): StoredMultibindRecord {
+  const value = record.value as Record<string, unknown> | StoredMultibindRecord | undefined;
+  if (value && typeof value === 'object') {
+    const container = value as Record<string, unknown>;
+    if (container.data && typeof container.data === 'object') {
+      return container.data as StoredMultibindRecord;
+    }
+    if (container.value && typeof container.value === 'object') {
+      return container.value as StoredMultibindRecord;
+    }
+  }
+  return (value ?? record.value) as StoredMultibindRecord;
+}
+
 const getMultibindStore = createDataStoreSingleton(() =>
   new DataStore<StoredMultibindRecord[], RefreshMetadata>({
     loader: {
@@ -68,6 +82,7 @@ const getMultibindStore = createDataStoreSingleton(() =>
       metadataStore: DB_CONFIG.metadataStore,
       version: 2,
       buildEntryId,
+      valueMapper: (record) => extractStoredEntry(record),
     }),
   }),
 );


### PR DESCRIPTION
## Summary
- allow specifying a value mapper for IndexedDbCollectionStrategy snapshots
- use the mapper when reading records to support legacy data structures
- apply the value mapper to the multibind store and cover legacy nested entries

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68fbefa2d1f0832aac311a2db3b8d782