### PR TITLE
Fix IndexedDB people cache persistence

### DIFF
--- a/client/src/peopleCache.ts
+++ b/client/src/peopleCache.ts
@@ -1,11 +1,17 @@
-import type {CollectionRecord, RefreshMetadata, StorageStrategy} from './dataStore/types';
+import type { RefreshMetadata, StorageStrategy } from './dataStore/types';
 
 type MetadataRecord<TMeta> = {
   id: string;
   value: TMeta;
 };
 
-export interface IndexedDbCollectionStrategyOptions<TEntry extends CollectionRecord> {
+type CollectionEntryRecord<TEntry> = {
+  id: string;
+  order: number;
+  value: TEntry;
+};
+
+export interface IndexedDbCollectionStrategyOptions<TEntry> {
   dbName: string;
   entriesStore: string;
   metadataStore: string;
@@ -41,7 +47,7 @@ async function runRequest<T>(request: IDBRequest<T>): Promise<T> {
   });
 }
 
-export class IndexedDbCollectionStrategy<TEntry extends CollectionRecord, TMeta extends RefreshMetadata>
+export class IndexedDbCollectionStrategy<TEntry, TMeta extends RefreshMetadata>
   implements StorageStrategy<TEntry[], TMeta>
 {
   private readonly options: IndexedDbCollectionStrategyOptions<TEntry>;
@@ -64,12 +70,25 @@ export class IndexedDbCollectionStrategy<TEntry extends CollectionRecord, TMeta 
       try {
         const transaction = db.transaction([this.options.entriesStore], 'readonly');
         const store = transaction.objectStore(this.options.entriesStore);
-        const records = (await runRequest(store.getAll())) as TEntry[];
-        if (records.length === 0) {
+        const rawRecords = (await runRequest(store.getAll())) as Array<
+          CollectionEntryRecord<TEntry> | (TEntry & { id?: string })
+        >;
+        if (rawRecords.length === 0) {
           this.inMemorySnapshot = undefined;
           return this.inMemorySnapshot;
         }
-        this.inMemorySnapshot = records;
+        const normalized = rawRecords
+          .map((record, index) => {
+            if (record && typeof record === 'object' && 'value' in record) {
+              const typedRecord = record as CollectionEntryRecord<TEntry>;
+              return { order: typedRecord.order ?? index, entry: typedRecord.value };
+            }
+            const { id: _id, ...rest } = record as TEntry & { id?: string };
+            return { order: index, entry: rest as TEntry };
+          })
+          .sort((a, b) => a.order - b.order)
+          .map(({ entry }) => entry);
+        this.inMemorySnapshot = normalized;
         return this.inMemorySnapshot;
       } finally {
         db.close();
@@ -91,7 +110,12 @@ export class IndexedDbCollectionStrategy<TEntry extends CollectionRecord, TMeta 
         await runRequest(store.clear());
         if (snapshot) {
           snapshot.forEach((entry, index) => {
-            store.put(Object.assign({}, entry, { id: this.options.buildEntryId(entry, index) }));
+            const record: CollectionEntryRecord<TEntry> = {
+              id: this.options.buildEntryId(entry, index),
+              order: index,
+              value: entry,
+            };
+            store.put(record);
           });
         }
         await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Summary
- store collection snapshots in IndexedDB with explicit id, order, and value metadata while retaining backward compatibility with existing records
- normalize snapshot reads so tests receive plain entries in the correct order

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fc0806f81c832aad89afecc09a6aea