### PR TITLE
Use settings store in options and widgets

### DIFF
--- a/web-client/jest.setup.js
+++ b/web-client/jest.setup.js
@@ -54,3 +54,97 @@ if (typeof globalThis.pako === 'undefined') {
     ungzip: (input) => input,
   };
 }
+
+const { defaultSettings } = require('@client/src/defaultSettings');
+
+const storeState = {
+  settings: { ...defaultSettings },
+  uiSettings: {},
+  binds: {},
+  status: 'ready',
+};
+
+const storeListeners = {
+  settings: new Set(),
+  uiSettings: new Set(),
+  binds: new Set(),
+};
+
+function notify(kind) {
+  const listeners = storeListeners[kind];
+  listeners.forEach((entry) => {
+    const next = entry.selector(storeState[kind]);
+    const isEqual = entry.equalityFn ? entry.equalityFn(next, entry.current) : Object.is(next, entry.current);
+    if (!isEqual) {
+      const prev = entry.current;
+      entry.current = next;
+      entry.listener(next, prev);
+    }
+  });
+}
+
+function subscribe(kind, selector, listener, options = {}) {
+  const entry = {
+    selector,
+    listener,
+    equalityFn: options.equalityFn,
+    current: selector(storeState[kind]),
+  };
+  storeListeners[kind].add(entry);
+  if (options.fireImmediately) {
+    listener(entry.current, entry.current);
+  }
+  return () => {
+    storeListeners[kind].delete(entry);
+  };
+}
+
+storeState.initializeFromStorage = async () => {};
+storeState.updateSettings = async (partial) => {
+  storeState.settings = { ...defaultSettings, ...storeState.settings, ...partial };
+  notify('settings');
+};
+storeState.updateUiSettings = async (partial) => {
+  storeState.uiSettings = { ...storeState.uiSettings, ...partial };
+  notify('uiSettings');
+};
+storeState.updateBinds = async (partial) => {
+  storeState.binds = { ...storeState.binds, ...partial };
+  notify('binds');
+};
+
+const settingsStoreMock = {
+  getState: () => storeState,
+  setState: (updater) => {
+    const nextState = typeof updater === 'function' ? updater(storeState) : updater;
+    if (!nextState) {
+      return;
+    }
+    if (nextState.settings) {
+      storeState.settings = nextState.settings;
+      notify('settings');
+    }
+    if (nextState.uiSettings) {
+      storeState.uiSettings = nextState.uiSettings;
+      notify('uiSettings');
+    }
+    if (nextState.binds) {
+      storeState.binds = nextState.binds;
+      notify('binds');
+    }
+    if (nextState.status) {
+      storeState.status = nextState.status;
+    }
+  },
+};
+
+jest.mock('@client/src/state/settingsStore', () => ({
+  settingsStore: settingsStoreMock,
+  subscribeToSettings: (selector, listener, options) => subscribe('settings', selector, listener, options),
+  subscribeToUiSettings: (selector, listener, options) => subscribe('uiSettings', selector, listener, options),
+  subscribeToBinds: (selector, listener, options) => subscribe('binds', selector, listener, options),
+  useSettingsSlice: (selector) => selector(storeState.settings),
+  useUiSettingsSlice: (selector) => selector(storeState.uiSettings),
+  useBindsSlice: (selector) => selector(storeState.binds),
+  useSettingsStore: (selector) => selector(storeState),
+}));

--- a/web-client/src/ObjectList.ts
+++ b/web-client/src/ObjectList.ts
@@ -2,6 +2,7 @@ import Client from "@client/src/Client";
 import { getItemSync, setItemSync } from "@client/src/storage";
 import { DEFAULT_ATTACK_COMMAND, normalizeAttackCommand } from "@client/src/utils/attackCommand";
 import { COLOR_OBJECT, getColorLevel } from "./colors.ts";
+import { subscribeToSettings } from "@client/src/state/settingsStore";
 
 export default class ObjectList {
     private client: Client;
@@ -28,16 +29,23 @@ export default class ObjectList {
     private pipLastOutputHtml = "";
     private cachedPipHtml = "";
     private attackCommand = DEFAULT_ATTACK_COMMAND;
+    private detachAttackCommand?: () => void;
 
     constructor(client: Client) {
         this.client = client;
         this.container = document.getElementById("objects-list");
         this.content = this.setupContainer();
         this.isMobile = this.isMobileBrowser();
-        const storedSettings = getItemSync("settings")?.settings;
-        this.attackCommand = normalizeAttackCommand(storedSettings?.attackCommand);
-        this.client.addEventListener("settings", (ev: CustomEvent) => {
-            this.attackCommand = normalizeAttackCommand(ev.detail?.attackCommand);
+        this.detachAttackCommand = subscribeToSettings(
+            settings => settings.attackCommand,
+            (next) => {
+                this.attackCommand = normalizeAttackCommand(next);
+            },
+            { fireImmediately: true },
+        );
+        this.client.addEventListener("client.disconnect", () => {
+            this.detachAttackCommand?.();
+            this.detachAttackCommand = undefined;
         });
         this.setupDraggable();
         if (!this.isMobile) {

--- a/web-client/src/TransportTimer.ts
+++ b/web-client/src/TransportTimer.ts
@@ -1,43 +1,37 @@
 import ArkadiaClient from "./ArkadiaClient.ts";
-import { getItemSync } from "@client/src/storage";
-import type { UiSettings } from "./uiSettings.ts";
 import type { TransportTimerPayload } from "@client/src/types/transport";
+import { subscribeToUiSettings } from "@client/src/state/settingsStore";
 
 export default class TransportTimer {
   private container: HTMLElement | null;
   private showTransportLabel: boolean;
   private lastPayload: TransportTimerPayload | null = null;
+  private detachUiSettings?: () => void;
 
   constructor(client: typeof ArkadiaClient) {
     this.container = document.getElementById("transport-timer");
-    this.showTransportLabel = this.getInitialShowTransportLabel();
+    this.showTransportLabel = true;
     this.subscribeToUiSettings();
     client.on("transportTimer", (payload: TransportTimerPayload | null) => this.update(payload));
     this.update(null);
-  }
-
-  private getInitialShowTransportLabel(): boolean {
-    const stored = getItemSync("uiSettings")?.uiSettings as Partial<UiSettings> | undefined;
-    if (stored && typeof stored.showTransportLabel === "boolean") {
-      return stored.showTransportLabel;
-    }
-    return true;
+    window.addEventListener("beforeunload", () => {
+      this.detachUiSettings?.();
+      this.detachUiSettings = undefined;
+    }, { once: true });
   }
 
   private subscribeToUiSettings() {
-    const ext: any = (window as any).clientExtension;
-    const target: EventTarget | undefined = ext?.eventTarget;
-    if (!target) {
-      return;
-    }
-    const handler: EventListener = (event: Event) => {
-      const detail = (event as CustomEvent<Partial<UiSettings>>).detail;
-      if (detail && typeof detail.showTransportLabel === "boolean") {
-        this.showTransportLabel = detail.showTransportLabel;
-        this.update(this.lastPayload);
-      }
-    };
-    target.addEventListener("uiSettings", handler);
+    this.detachUiSettings = subscribeToUiSettings(
+      ui => ui.showTransportLabel,
+      (value) => {
+        const next = typeof value === "boolean" ? value : true;
+        if (this.showTransportLabel !== next) {
+          this.showTransportLabel = next;
+          this.update(this.lastPayload);
+        }
+      },
+      { fireImmediately: true },
+    );
   }
 
   private update(payload: TransportTimerPayload | null) {

--- a/web-client/src/options/GuildsSettings.tsx
+++ b/web-client/src/options/GuildsSettings.tsx
@@ -1,13 +1,34 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import storage, { getCurrentCharacter } from "@client/src/storage";
+import { settingsStore, useSettingsSlice } from "@client/src/state/settingsStore";
 import GuildSection from "./GuildSection";
 import guilds from "./guilds";
-import { defaultSettings } from "./defaultSettings";
+
+function ensureGuildList(value: unknown): string[] {
+    return Array.isArray(value) ? value.filter((guild): guild is string => typeof guild === "string") : [];
+}
+
+function ensureGuildColors(value: unknown): Record<string, string | undefined> {
+    if (!value || typeof value !== "object") {
+        return {};
+    }
+    const entries = Object.entries(value as Record<string, unknown>);
+    const result: Record<string, string | undefined> = {};
+    entries.forEach(([guild, color]) => {
+        if (typeof color === "string") {
+            result[guild] = color;
+        }
+    });
+    return result;
+}
 
 function GuildsSettings({ registerSave }: { registerSave: (cb: () => void) => void }) {
-    const [selected, setSelected] = useState<string[]>([]);
-    const [enemySelected, setEnemySelected] = useState<string[]>([]);
-    const [colors, setColors] = useState<Record<string, string | undefined>>({});
+    const storeGuilds = useSettingsSlice(settings => settings.guilds);
+    const storeEnemyGuilds = useSettingsSlice(settings => settings.enemyGuilds);
+    const storeGuildColors = useSettingsSlice(settings => settings.guildColors);
+    const [selected, setSelected] = useState<string[]>(() => ensureGuildList(storeGuilds));
+    const [enemySelected, setEnemySelected] = useState<string[]>(() => ensureGuildList(storeEnemyGuilds));
+    const [colors, setColors] = useState<Record<string, string | undefined>>(() => ensureGuildColors(storeGuildColors));
     const [locked, setLocked] = useState(!getCurrentCharacter());
     const defaultColors = useMemo(() => {
         const map: Record<string, string> = {};
@@ -28,36 +49,16 @@ function GuildsSettings({ registerSave }: { registerSave: (cb: () => void) => vo
     }, []);
 
     useEffect(() => {
-        const load = () => {
-            storage.getItem("settings").then(res => {
-                if (res && res.settings) {
-                    setSelected(res.settings.guilds || []);
-                    setEnemySelected(res.settings.enemyGuilds || []);
-                    setColors(res.settings.guildColors || {});
-                } else {
-                    setSelected([]);
-                    setEnemySelected([]);
-                    setColors({});
-                }
-            });
-        };
+        setSelected(ensureGuildList(storeGuilds));
+    }, [storeGuilds]);
 
-        load();
+    useEffect(() => {
+        setEnemySelected(ensureGuildList(storeEnemyGuilds));
+    }, [storeEnemyGuilds]);
 
-        const listener = (changes: { [key: string]: { oldValue: any; newValue: any } }) => {
-            if (changes.settings) {
-                const s = changes.settings.newValue || {};
-                setSelected(s.guilds || []);
-                setEnemySelected(s.enemyGuilds || []);
-                setColors(s.guildColors || {});
-            }
-        };
-
-        storage.onChanged?.addListener(listener);
-        return () => {
-            storage.onChanged?.removeListener?.(listener);
-        };
-    }, []);
+    useEffect(() => {
+        setColors(ensureGuildColors(storeGuildColors));
+    }, [storeGuildColors]);
 
     function onChange(guild: string, checked: boolean) {
         setSelected(prev => checked ? [...prev, guild] : prev.filter(g => g !== guild));
@@ -88,20 +89,11 @@ function GuildsSettings({ registerSave }: { registerSave: (cb: () => void) => vo
     }
 
     useEffect(() => {
-        registerSave(() =>
-            storage.getItem("settings").then(res => {
-                const base = res && res.settings
-                    ? { ...defaultSettings, ...res.settings }
-                    : { ...defaultSettings };
-                const settings = {
-                    ...base,
-                    guilds: selected,
-                    enemyGuilds: enemySelected,
-                    guildColors: colors,
-                };
-                return storage.setItem("settings", settings);
-            })
-        );
+        registerSave(() => settingsStore.getState().updateSettings({
+            guilds: selected,
+            enemyGuilds: enemySelected,
+            guildColors: colors,
+        }));
     }, [registerSave, selected, enemySelected, colors]);
 
     return (

--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -2,6 +2,7 @@ import "../style.css";
 import { useEffect, useState } from "react";
 import { Form, Button } from "react-bootstrap";
 import storage, { getCurrentCharacter } from "@client/src/storage";
+import { settingsStore, useSettingsSlice } from "@client/src/state/settingsStore";
 import { defaultSettings } from "./defaultSettings";
 import type { Settings as BaseSettings } from "./defaultSettings";
 
@@ -58,8 +59,17 @@ const lowHpAlertOptions = [
 const LETTER_LINE_WIDTH_MIN = 40;
 const LETTER_LINE_WIDTH_MAX = 120;
 
+function normalizeSettings(source: BaseSettings): FormSettings {
+    const merged = Object.assign({}, defaultSettings, source);
+    if (typeof merged.lowHpAlert !== "number") {
+        merged.lowHpAlert = merged.lowHpAlert ? 2 : 0;
+    }
+    return merged;
+}
+
 function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void }) {
-    const [settings, setSettings] = useState<FormSettings>({ ...defaultSettings });
+    const storeSettings = useSettingsSlice(settings => settings);
+    const [settings, setSettings] = useState<FormSettings>(() => normalizeSettings(storeSettings));
 
     const [locked, setLocked] = useState(!getCurrentCharacter());
 
@@ -78,6 +88,10 @@ function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void
     const [aliasAdjInput, setAliasAdjInput] = useState<string>('')
     const [aliasLangInput, setAliasLangInput] = useState<string>('potoczna')
 
+    useEffect(() => {
+        setSettings(normalizeSettings(storeSettings));
+    }, [storeSettings]);
+
     function onChangeSetting(modifier: (settings: FormSettings) => void) {
         setSettings(prev => {
             const updated = {...prev}
@@ -86,33 +100,8 @@ function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void
         })
     }
     useEffect(() => {
-        registerSave(() => storage.setItem("settings", settings));
+        registerSave(() => settingsStore.getState().updateSettings(settings));
     }, [registerSave, settings]);
-
-    useEffect(() => {
-        const load = () => {
-            storage.getItem("settings").then(res => {
-                const merged = Object.assign({}, defaultSettings, res?.settings);
-                if (typeof merged.lowHpAlert !== 'number') {
-                    merged.lowHpAlert = merged.lowHpAlert ? 2 : 0;
-                }
-                setSettings(merged);
-            });
-        };
-
-        load();
-
-        const listener = (changes: { [key: string]: { oldValue: any; newValue: any } }) => {
-            if (changes.settings) {
-                load();
-            }
-        };
-
-        storage.onChanged?.addListener(listener);
-        return () => {
-            storage.onChanged?.removeListener?.(listener);
-        };
-    }, []);
 
     return (
         <div className="p-2 h-100">

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -1,5 +1,6 @@
 import Modal from "bootstrap/js/dist/modal";
 import {Settings} from "mudlet-map-renderer";
+import { settingsStore, subscribeToUiSettings } from "@client/src/state/settingsStore";
 
 const mapPositions = [
     'top-overlay',
@@ -59,6 +60,15 @@ const defaultSettings: UiSettings = {
     clearInputOnSend: false,
     showTransportLabel: true,
 };
+
+function normalizeMapScaleValue(value: unknown): number {
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+        return value;
+    }
+    const parsed = Number.parseFloat(typeof value === 'string' ? value : String(value ?? ''));
+    const normalized = Math.abs(parsed);
+    return Number.isFinite(normalized) && normalized > 0 ? normalized : defaultSettings.mapScale;
+}
 
 function apply(settings: UiSettings) {
     const contentArea = document.getElementById('content-area');
@@ -160,81 +170,69 @@ function apply(settings: UiSettings) {
     }
 }
 
-import storage from "@client/src/storage";
+function normalizeUiSettings(raw: unknown): UiSettings {
+    const parsed: any = (raw && typeof raw === 'object') ? { ...(raw as Record<string, unknown>) } : {};
+    const mapScale = normalizeMapScaleValue(parsed.mapScale);
+    const mapPosition = mapPositions.includes(parsed.mapPosition as MapPosition)
+        ? (parsed.mapPosition as MapPosition)
+        : defaultSettings.mapPosition;
+    const transparentLabels = typeof parsed.transparentLabels === 'boolean'
+        ? parsed.transparentLabels
+        : defaultSettings.transparentLabels;
+    const labelRenderMode = parsed.labelRenderMode === 'image' || parsed.labelRenderMode === 'data'
+        ? parsed.labelRenderMode
+        : defaultSettings.labelRenderMode;
+    const effectiveLabelRenderMode = transparentLabels ? 'data' : labelRenderMode;
+    const xtermPalette = parsed.xtermPalette === 'proper' ? 'proper' : defaultSettings.xtermPalette;
+    const footerMode = typeof parsed.footerMode === 'number' ? parsed.footerMode : defaultSettings.footerMode;
+    const explorationMode = !!parsed.explorationMode;
+    const fightTitleIcon = typeof parsed.fightTitleIcon === 'boolean' ? parsed.fightTitleIcon : defaultSettings.fightTitleIcon;
+    const hapticFeedback = typeof parsed.hapticFeedback === 'boolean' ? parsed.hapticFeedback : defaultSettings.hapticFeedback;
+    const instantMove = typeof parsed.instantMove === 'boolean' ? parsed.instantMove : defaultSettings.instantMove;
+    const highlightCurrentRoom = typeof parsed.highlightCurrentRoom === 'boolean'
+        ? parsed.highlightCurrentRoom
+        : defaultSettings.highlightCurrentRoom;
+    const outputBackground = typeof parsed.outputBackground === 'string'
+        && /^#[0-9a-f]{6}$/i.test(parsed.outputBackground.trim())
+            ? parsed.outputBackground.trim()
+            : defaultSettings.outputBackground;
+    const clearInputOnSend = typeof parsed.clearInputOnSend === 'boolean'
+        ? parsed.clearInputOnSend
+        : defaultSettings.clearInputOnSend;
+    const showTransportLabel = typeof parsed.showTransportLabel === 'boolean'
+        ? parsed.showTransportLabel
+        : defaultSettings.showTransportLabel;
+    return {
+        ...defaultSettings,
+        ...parsed,
+        mapScale,
+        mapPosition,
+        emojiLabels: !!parsed.emojiLabels,
+        xtermPalette,
+        footerMode,
+        explorationMode,
+        fightTitleIcon,
+        hapticFeedback,
+        instantMove,
+        highlightCurrentRoom,
+        transparentLabels,
+        labelRenderMode: effectiveLabelRenderMode,
+        outputBackground,
+        clearInputOnSend,
+        showTransportLabel,
+    };
+}
 
-async function load(): Promise<UiSettings> {
-    try {
-        const uiData = await storage.getItem('uiSettings');
-        let raw = uiData?.uiSettings;
-        let parsed: any = {};
-        if (raw) {
-            parsed = raw as any;
-        }
-        if (raw || Object.keys(parsed).length > 0) {
-            const mapScale = (() => {
-                const value = Math.abs(parseFloat(parsed.mapScale));
-                return value > 0 ? value : defaultSettings.mapScale;
-            })();
-            const mapPosition = mapPositions.includes(parsed.mapPosition as MapPosition)
-                ? (parsed.mapPosition as MapPosition)
-                : defaultSettings.mapPosition;
-            const transparentLabels = typeof parsed.transparentLabels === 'boolean'
-                ? parsed.transparentLabels
-                : defaultSettings.transparentLabels;
-            const labelRenderMode = parsed.labelRenderMode === 'image' || parsed.labelRenderMode === 'data'
-                ? parsed.labelRenderMode
-                : defaultSettings.labelRenderMode;
-            const effectiveLabelRenderMode = transparentLabels ? 'data' : labelRenderMode;
-            const xtermPalette = parsed.xtermPalette === 'proper' ? 'proper' : defaultSettings.xtermPalette;
-            const footerMode = typeof parsed.footerMode === 'number' ? parsed.footerMode : defaultSettings.footerMode;
-            const explorationMode = !!parsed.explorationMode;
-            const fightTitleIcon = typeof parsed.fightTitleIcon === 'boolean' ? parsed.fightTitleIcon : defaultSettings.fightTitleIcon;
-            const hapticFeedback = typeof parsed.hapticFeedback === 'boolean' ? parsed.hapticFeedback : defaultSettings.hapticFeedback;
-            const instantMove = typeof parsed.instantMove === 'boolean' ? parsed.instantMove : defaultSettings.instantMove;
-            const highlightCurrentRoom = typeof parsed.highlightCurrentRoom === 'boolean'
-                ? parsed.highlightCurrentRoom
-                : defaultSettings.highlightCurrentRoom;
-            const outputBackground = typeof parsed.outputBackground === 'string'
-                && /^#[0-9a-f]{6}$/i.test(parsed.outputBackground.trim())
-                    ? parsed.outputBackground.trim()
-                    : defaultSettings.outputBackground;
-            const clearInputOnSend = typeof parsed.clearInputOnSend === 'boolean'
-                ? parsed.clearInputOnSend
-                : defaultSettings.clearInputOnSend;
-            const showTransportLabel = typeof parsed.showTransportLabel === 'boolean'
-                ? parsed.showTransportLabel
-                : defaultSettings.showTransportLabel;
-            return {
-                ...defaultSettings,
-                ...parsed,
-                mapScale,
-                mapPosition,
-                emojiLabels: !!parsed.emojiLabels,
-                xtermPalette,
-                footerMode,
-                explorationMode,
-                fightTitleIcon,
-                hapticFeedback,
-                instantMove,
-                highlightCurrentRoom,
-                transparentLabels,
-                labelRenderMode: effectiveLabelRenderMode,
-                outputBackground,
-                clearInputOnSend,
-                showTransportLabel,
-            };
-        }
-    } catch {
-        // ignore malformed data
-    }
-    return { ...defaultSettings };
+function load(): UiSettings {
+    const state = settingsStore.getState().uiSettings;
+    return normalizeUiSettings(state);
 }
 
 function save(settings: UiSettings) {
-    storage.setItem('uiSettings', settings);
+    settingsStore.getState().updateUiSettings(settings);
 }
 
-export default async function initUiSettings() {
+export default function initUiSettings() {
     const button = document.getElementById('ui-settings-button') as HTMLButtonElement | null;
     const modalEl = document.getElementById('ui-settings-modal');
     if (!button || !modalEl) return;
@@ -264,7 +262,7 @@ export default async function initUiSettings() {
     const showTransportLabelInput = modalEl.querySelector('#ui-show-transport-label') as HTMLInputElement;
     const saveBtn = modalEl.querySelector('#ui-settings-save') as HTMLButtonElement;
 
-    let current = await load();
+    let current = load();
     contentInput.value = String(current.contentFontSize);
     objectsInput.value = String(current.objectsFontSize);
     buttonInput.value = String(current.buttonSize);
@@ -306,22 +304,14 @@ export default async function initUiSettings() {
         current = { ...current, mapScale: scale };
     };
 
-    const handleStorageChange = (changes: { [key: string]: { oldValue: any; newValue: any } }) => {
-        const uiSettingsChange = changes.uiSettings;
-        if (!uiSettingsChange || !uiSettingsChange.newValue) {
-            return;
-        }
-        const newValue = uiSettingsChange.newValue;
-        const scaleValue = typeof newValue.mapScale === 'number'
-            ? newValue.mapScale
-            : parseFloat(newValue.mapScale);
-        const normalizedScale = Number.isFinite(scaleValue) && scaleValue > 0
-            ? scaleValue
-            : defaultSettings.mapScale;
-        updateMapScale(normalizedScale);
-    };
-
-    storage.onChanged?.addListener(handleStorageChange);
+    subscribeToUiSettings(
+        ui => ui.mapScale,
+        (value) => {
+            const normalizedScale = normalizeMapScaleValue(value);
+            updateMapScale(normalizedScale);
+        },
+        { fireImmediately: true },
+    );
 
     function refreshExplorationStats() {
         const map = (window as any).embedded;

--- a/web-client/test/TransportTimer.test.ts
+++ b/web-client/test/TransportTimer.test.ts
@@ -1,4 +1,5 @@
 import TransportTimer from "../src/TransportTimer";
+import { settingsStore } from "@client/src/state/settingsStore";
 
 class MockClient {
   private events: Record<string, Function[]> = {};
@@ -16,6 +17,7 @@ describe("TransportTimer", () => {
 
   beforeEach(() => {
     localStorage.clear();
+    settingsStore.setState({ uiSettings: {} });
     document.body.innerHTML = '<span id="transport-timer"></span>';
     container = document.getElementById("transport-timer")!;
     (window as any).clientExtension = { eventTarget: new EventTarget() };
@@ -59,9 +61,8 @@ describe("TransportTimer", () => {
     expect(container.style.display).toBe("block");
   });
 
-  test("hides label when option disabled", () => {
-    const target = (window as any).clientExtension.eventTarget as EventTarget;
-    target.dispatchEvent(new CustomEvent("uiSettings", { detail: { showTransportLabel: false } }));
+  test("hides label when option disabled", async () => {
+    await settingsStore.getState().updateUiSettings({ showTransportLabel: false });
     client.emit("transportTimer", { label: "Kreutzhofen → Hagge", remaining: 125, total: 140 });
     expect(container.style.display).toBe("none");
     expect(container.textContent).toBe("");


### PR DESCRIPTION
## Summary
- replace options forms to read settings through the shared store and persist with updateSettings
- refactor uiSettings to load and subscribe via the settings store and update Ui settings with updateUiSettings
- subscribe ObjectList and TransportTimer to store helpers and add a Jest mock to support tests

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68fc1681b6c0832a815714a284525b86