### PR TITLE
Refactor client scripts to use shared store

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -13,5 +13,8 @@ module.exports = {
   moduleNameMapper: {
     '\\.(?:wasm)\\?url$': '<rootDir>/test/__mocks__/wasmUrlMock.js',
     '^@client/(.*)$': '<rootDir>/$1',
+    '^zustand$': '<rootDir>/test/__mocks__/zustand.ts',
+    '^zustand/vanilla$': '<rootDir>/test/__mocks__/zustandVanilla.ts',
+    '^zustand/middleware$': '<rootDir>/test/__mocks__/zustandMiddleware.ts',
   },
 }

--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -27,6 +27,7 @@ import { DEFAULT_ATTACK_COMMAND, normalizeAttackCommand } from "./utils/attackCo
 import TriggerLine from "./triggers/TriggerLine";
 import {parseAnsiPatterns} from "front-client/src/ansiParser";
 import type { ClientStorageBridge } from "./state/storageBridge";
+import { createClientStore, ScriptStore } from "./state/scriptStore";
 
 const ANSI_SGR_REGEX = /\x1b\[[0-9;]*m/g;
 const ANSI_RESET = "\x1b[0m";
@@ -70,6 +71,7 @@ export interface ClientAdapter {
 export default class Client {
     clientAdapter: ClientAdapter;
     port: { postMessage: (message: any) => void };
+    store: ScriptStore;
     private storageBridge: ClientStorageBridge;
     eventTarget = eventBus;
     Colors = Colors;
@@ -135,6 +137,7 @@ export default class Client {
     constructor(clientAdapter: ClientAdapter, storageBridge: ClientStorageBridge) {
         this.clientAdapter = clientAdapter
         this.storageBridge = storageBridge
+        this.store = createClientStore(this)
         this.port = {
             postMessage: (message: any) => {
                 this.handleStorageMessage(message)

--- a/client/src/defaultSettings.ts
+++ b/client/src/defaultSettings.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_ATTACK_COMMAND } from "./utils/attackCommand";
 
-export interface Settings {
+export interface Settings extends Record<string, unknown> {
     packageHelper: boolean;
     inlineCompassRose: boolean;
     shortenExits: boolean;
@@ -18,6 +18,7 @@ export interface Settings {
     fullHpMessage: boolean;
     lowHpAlert: number;
     letterLineWidth: number;
+    autoWalkDelay?: number | string;
 }
 
 export const defaultSettings: Settings = {

--- a/client/src/scripts/bagManager.ts
+++ b/client/src/scripts/bagManager.ts
@@ -1,6 +1,7 @@
 import Client from "../Client";
 import {stripAnsiCodes} from "../Triggers";
 import {colorString, findClosestColor} from "../Colors";
+import { getClientStore } from "../state/scriptStore";
 
 const STORAGE_KEY = "containers";
 
@@ -70,7 +71,8 @@ function getBagForms(bag: string) {
 }
 
 function saveConfig(client: Client) {
-    client.port?.postMessage({ type: "SET_STORAGE", key: STORAGE_KEY, value: containerConfig });
+    const store = getClientStore(client);
+    void store.setStorageItem(STORAGE_KEY, structuredClone(containerConfig));
 }
 
 function setContainer(type: keyof ContainerConfig, bag: string, client: Client) {
@@ -198,12 +200,18 @@ export default function initBagManager(
     client: Client,
     aliases?: { pattern: RegExp; callback: Function }[]
 ) {
-    client.addEventListener("storage", (ev: CustomEvent) => {
-        if (ev.detail.key === STORAGE_KEY && ev.detail.value) {
-            Object.assign(containerConfig, ev.detail.value);
+    const store = getClientStore(client);
+    store.subscribeStorage<typeof containerConfig>(STORAGE_KEY, (value) => {
+        if (value) {
+            Object.assign(containerConfig, value);
         }
     });
-    client.port?.postMessage({ type: "GET_STORAGE", key: STORAGE_KEY });
+    void (async () => {
+        const stored = await store.getStorageItem<typeof containerConfig>(STORAGE_KEY);
+        if (stored) {
+            Object.assign(containerConfig, stored);
+        }
+    })();
     window.addEventListener("beforeunload", () => saveConfig(client));
 
     if (aliases) {

--- a/client/src/scripts/deposits.ts
+++ b/client/src/scripts/deposits.ts
@@ -2,6 +2,7 @@ import Client from "../Client";
 import { stripAnsiCodes } from "../Triggers";
 import { prettyPrintContainer, parseItems, ContainerItem } from "./prettyContainers";
 import { colorString, findClosestColor } from "../Colors";
+import { getClientStore } from "../state/scriptStore";
 
 interface DepositInfo {
     name: string;
@@ -21,19 +22,23 @@ function isBankRoom(room: any): boolean {
 }
 
 export default function initDeposits(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
-    client.addEventListener("storage", (event: CustomEvent) => {
-        if (event.detail.key === STORAGE_KEY) {
-            Object.keys(deposits).forEach(key => delete deposits[Number(key)]);
-            if (event.detail.value) {
-                Object.assign(deposits, event.detail.value);
-            }
+    const store = getClientStore(client);
+    store.subscribeStorage<typeof deposits>(STORAGE_KEY, (value) => {
+        Object.keys(deposits).forEach(key => delete deposits[Number(key)]);
+        if (value) {
+            Object.assign(deposits, value);
         }
     });
 
-    client.port?.postMessage({ type: "GET_STORAGE", key: STORAGE_KEY });
+    void (async () => {
+        const stored = await store.getStorageItem<typeof deposits>(STORAGE_KEY);
+        if (stored) {
+            Object.assign(deposits, stored);
+        }
+    })();
 
     const persist = () => {
-        client.port?.postMessage({ type: "SET_STORAGE", key: STORAGE_KEY, value: deposits });
+        void store.setStorageItem(STORAGE_KEY, structuredClone(deposits));
     };
 
     const clearDeposits = () => {

--- a/client/src/scripts/externalScripts.ts
+++ b/client/src/scripts/externalScripts.ts
@@ -1,8 +1,10 @@
 import Client from "../Client";
+import { getClientStore } from "../state/scriptStore";
 
 const STORAGE_KEY = "scripts";
 
 export default function initExternalScripts(client: Client) {
+    const store = getClientStore(client);
     const loaded: Record<string, HTMLScriptElement> = {};
     let known: string[] = [];
 
@@ -31,11 +33,7 @@ export default function initExternalScripts(client: Client) {
         handled = true;
         if (!known.includes(param)) {
             known.push(param);
-            client.port?.postMessage({
-                type: "SET_STORAGE",
-                key: STORAGE_KEY,
-                value: known,
-            });
+            void store.setStorageItem(STORAGE_KEY, structuredClone(known));
             apply(known);
         }
         const params = new URLSearchParams(window.location.search);
@@ -45,14 +43,17 @@ export default function initExternalScripts(client: Client) {
         window.location.replace(rest ? `${base}?${rest}` : base);
     };
 
-    client.addEventListener("storage", (ev: CustomEvent) => {
-        if (ev.detail.key === STORAGE_KEY) {
-            known = Array.isArray(ev.detail.value) ? ev.detail.value : [];
-            apply(known);
-        }
+    store.subscribeStorage<string[]>(STORAGE_KEY, (value) => {
+        known = Array.isArray(value) ? value : [];
+        apply(known);
     });
 
-    client.addEventListener("port-connected", () => {
+    void (async () => {
+        const stored = await store.getStorageItem<string[]>(STORAGE_KEY);
+        if (Array.isArray(stored)) {
+            known = stored;
+            apply(known);
+        }
         checkParam();
-    })
+    })();
 }

--- a/client/src/scripts/herbCounter.ts
+++ b/client/src/scripts/herbCounter.ts
@@ -7,6 +7,7 @@ import { openHerbContextMenu } from "../contextMenus";
 import type { HerbManagerApi, HerbMoveOptions, HerbBagsState, HerbBagState } from "../types/herbs";
 import { clampHerbBagCondition, normalizeHerbBagsState } from "../types/herbs";
 import { getWearValue } from "./wearUsed";
+import { getClientStore } from "../state/scriptStore";
 
 const headerColor = findClosestColor('#8470ff')
 const WHITE = findClosestColor('#ffffff');
@@ -104,6 +105,7 @@ function parseNumber(str: string): number {
 }
 
 export default async function initHerbCounter(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
+    const store = getClientStore(client);
     let herbs: HerbsData | null = null;
     let loading: Promise<void> | null = null;
     const herbMap: Record<string, string> = {};
@@ -129,31 +131,44 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
 
     const persistBags = () => {
         const snapshot = normalizeHerbBagsState(cloneBags());
-        client.port?.postMessage({ type: 'SET_STORAGE', key: STORAGE_KEY, value: snapshot });
-        client.sendEvent('herbCounts', structuredClone(snapshot));
         storedBags = snapshot;
+        void store.updateHerbCounts(snapshot);
     };
 
     const broadcastBags = () => {
         client.sendEvent('herbCounts', structuredClone(storedBags));
     };
 
+    const loadStoredBags = async () => {
+        const stored = await store.getStorageItem<HerbBagsState>(STORAGE_KEY);
+        if (!stored) {
+            return;
+        }
+        storedBags = normalizeHerbBagsState(structuredClone(stored));
+        await ensureData();
+        broadcastBags();
+    };
+
     const requestBagsIfNeeded = () => {
         if (Object.keys(storedBags).length > 0) {
             broadcastBags();
         } else {
-            client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
+            void loadStoredBags();
         }
     };
 
-    client.addEventListener('storage', async (ev: CustomEvent) => {
-        if (ev.detail.key === STORAGE_KEY) {
-            storedBags = normalizeHerbBagsState(ev.detail.value);
+    store.subscribeStorage<HerbBagsState>(STORAGE_KEY, (value) => {
+        void (async () => {
+            if (value) {
+                storedBags = normalizeHerbBagsState(structuredClone(value));
+            } else {
+                storedBags = {};
+            }
             await ensureData();
             broadcastBags();
-        }
+        })();
     });
-    client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
+    void loadStoredBags();
     window.addEventListener('request-herb-counts', requestBagsIfNeeded);
 
     let preUseCommands: string[] = [];
@@ -525,22 +540,16 @@ export default async function initHerbCounter(client: Client, aliases?: { patter
         aliases.push({pattern: /\/ziola_buduj$/, callback: start});
         aliases.push({pattern: /\/woreczki_buduj$/, callback: evaluateBagConditions});
         aliases.push({
-            pattern: /\/ziola_pokaz$/, callback: () => {
-                const listener = async (ev: CustomEvent) => {
-                    if (ev.detail.key === STORAGE_KEY) {
-                        const bags = normalizeHerbBagsState(ev.detail.value);
-                        await ensureData();
-                        const lines = buildSummary(bags, false, false);
-                        if (lines.length > 0) {
-                            client.println(lines.join('\n'));
-                        } else {
-                            client.println('Brak podsumowania.');
-                        }
-                        client.removeEventListener('storage', listener);
-                    }
-                };
-                client.addEventListener('storage', listener);
-                client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
+            pattern: /\/ziola_pokaz$/, callback: async () => {
+                const stored = await store.getStorageItem<HerbBagsState>(STORAGE_KEY);
+                const bags = normalizeHerbBagsState(structuredClone(stored ?? storedBags));
+                await ensureData();
+                const lines = buildSummary(bags, false, false);
+                if (lines.length > 0) {
+                    client.println(lines.join('\n'));
+                } else {
+                    client.println('Brak podsumowania.');
+                }
             }
         });
         aliases.push({

--- a/client/src/scripts/idz.ts
+++ b/client/src/scripts/idz.ts
@@ -1,9 +1,11 @@
 import Client from "../Client";
 import { longToShort } from "../MapHelper";
 import { getShortcut } from "./shortcuts";
+import { getClientStore } from "../state/scriptStore";
 
 
 export default function initIdz(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
+    const store = getClientStore(client);
     if (!aliases) return;
 
     let path: number[] = [];
@@ -91,7 +93,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
             delay = Math.max(0.5, d);
             lastDelay = delay;
             settings.autoWalkDelay = lastDelay;
-            client.port?.postMessage({ type: 'SET_STORAGE', key: 'settings', value: settings });
+            void store.updateSettings({ autoWalkDelay: lastDelay });
         } else {
             delay = Math.max(0.5, lastDelay);
         }
@@ -200,7 +202,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
             lastDelay = Math.max(0.5, parseFloat(m[1]));
             delay = lastDelay;
             settings.autoWalkDelay = lastDelay;
-            client.port?.postMessage({ type: 'SET_STORAGE', key: 'settings', value: settings });
+            void store.updateSettings({ autoWalkDelay: lastDelay });
             client.sendEvent('notify', { text: `[WALK] delay ${lastDelay.toFixed(2)}s` });
         }
     });
@@ -211,7 +213,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
             lastDelay = Math.max(0.5, lastDelay - 0.5);
             delay = Math.max(0.5, delay - 0.5);
             settings.autoWalkDelay = lastDelay;
-            client.port?.postMessage({ type: 'SET_STORAGE', key: 'settings', value: settings });
+            void store.updateSettings({ autoWalkDelay: lastDelay });
             client.sendEvent('notify', { text: `[WALK] delay ${lastDelay.toFixed(2)}s` });
         }
     });
@@ -222,7 +224,7 @@ export default function initIdz(client: Client, aliases?: { pattern: RegExp; cal
             lastDelay += 0.5;
             delay += 0.5;
             settings.autoWalkDelay = lastDelay;
-            client.port?.postMessage({ type: 'SET_STORAGE', key: 'settings', value: settings });
+            void store.updateSettings({ autoWalkDelay: lastDelay });
             client.sendEvent('notify', { text: `[WALK] delay ${lastDelay.toFixed(2)}s` });
         }
     });

--- a/client/src/scripts/improveCounter.ts
+++ b/client/src/scripts/improveCounter.ts
@@ -2,6 +2,7 @@ import Client from "../Client";
 import { colorString, findClosestColor, RESET } from "../Colors";
 import { stripAnsiCodes } from "../Triggers";
 import { getCurrentCharacter, getItemSync } from "../storage";
+import { getClientStore, ScriptStore } from "../state/scriptStore";
 
 const HEADER_COLOR = findClosestColor("#90ee90");
 const SECTION_COLOR = findClosestColor("#ffa500");
@@ -122,30 +123,30 @@ export default class ImproveCounter {
     private initialized = false;
     private static readonly STORAGE_KEY = "improve_counter";
     private static readonly LIFETIME_KEY = "improve_counter_lifetime";
+    private store: ScriptStore;
 
     constructor(client: Client, killCounter: any) {
         this.client = client;
         this.killCounter = killCounter;
+        this.store = getClientStore(client);
 
-        this.client.addEventListener("storage", (event: CustomEvent) => {
-            if (event.detail.key === ImproveCounter.STORAGE_KEY) {
-                this.load(event.detail.value ?? {});
-                this.loaded = true;
-                if (this.pendingLevel !== undefined) {
-                    const level = this.pendingLevel;
-                    this.pendingLevel = undefined;
-                    this.handleLevel(level);
-                }
+        this.store.subscribeStorage<any>(ImproveCounter.STORAGE_KEY, (value) => {
+            this.load(value ?? {});
+            this.loaded = true;
+            if (this.pendingLevel !== undefined) {
+                const level = this.pendingLevel;
+                this.pendingLevel = undefined;
+                this.handleLevel(level);
             }
-            if (event.detail.key === ImproveCounter.LIFETIME_KEY) {
-                this.loadLifetime(event.detail.value ?? {});
-                this.lifetimeLoaded = true;
-                if (this.pendingLifetime.length) {
-                    for (const p of this.pendingLifetime) {
-                        this.addToLifetime(p.count, p.time);
-                    }
-                    this.pendingLifetime = [];
+        });
+        this.store.subscribeStorage<any>(ImproveCounter.LIFETIME_KEY, (value) => {
+            this.loadLifetime(value ?? {});
+            this.lifetimeLoaded = true;
+            if (this.pendingLifetime.length) {
+                for (const p of this.pendingLifetime) {
+                    this.addToLifetime(p.count, p.time);
                 }
+                this.pendingLifetime = [];
             }
         });
 
@@ -153,14 +154,7 @@ export default class ImproveCounter {
 
         window.addEventListener("beforeunload", this.persist);
 
-        this.client.port?.postMessage({
-            type: "GET_STORAGE",
-            key: ImproveCounter.STORAGE_KEY,
-        });
-        this.client.port?.postMessage({
-            type: "GET_STORAGE",
-            key: ImproveCounter.LIFETIME_KEY,
-        });
+        void this.loadStoredData();
 
         this.client.addEventListener("gmcp.char.state", (ev: CustomEvent) => {
             const level = ev.detail?.improve;
@@ -168,6 +162,21 @@ export default class ImproveCounter {
                 this.handleLevel(level);
             }
         });
+    }
+
+    private async loadStoredData() {
+        const [snapshot, lifetime] = await Promise.all([
+            this.store.getStorageItem(ImproveCounter.STORAGE_KEY),
+            this.store.getStorageItem(ImproveCounter.LIFETIME_KEY),
+        ]);
+        if (snapshot) {
+            this.load(snapshot);
+            this.loaded = true;
+        }
+        if (lifetime) {
+            this.loadLifetime(lifetime);
+            this.lifetimeLoaded = true;
+        }
     }
 
     private getKills() {
@@ -341,24 +350,19 @@ export default class ImproveCounter {
     }
 
     private persist = () => {
-        this.client.port?.postMessage({
-            type: "SET_STORAGE",
-            key: ImproveCounter.STORAGE_KEY,
-            value: {
-                entries: this.entries,
-                lastTime: this.lastTime,
-                lastKills: this.lastKills,
-                level: this.level,
-                lastObjNum: this.lastObjNum,
-            },
+        void this.store.setStorageItem(ImproveCounter.STORAGE_KEY, {
+            entries: this.entries.map(entry => ({ ...entry })),
+            lastTime: this.lastTime,
+            lastKills: { ...this.lastKills },
+            level: this.level,
+            lastObjNum: this.lastObjNum,
         });
     };
-    
+
     private persistLifetime = () => {
-        this.client.port?.postMessage({
-            type: "SET_STORAGE",
-            key: ImproveCounter.LIFETIME_KEY,
-            value: { entries: this.lifetime, enabled: this.lifetimeEnabled },
+        void this.store.setStorageItem(ImproveCounter.LIFETIME_KEY, {
+            entries: this.lifetime.map(entry => ({ ...entry })),
+            enabled: this.lifetimeEnabled,
         });
     };
 

--- a/client/src/scripts/kill.ts
+++ b/client/src/scripts/kill.ts
@@ -1,6 +1,7 @@
 import Client from "../Client";
 import { colorString, findClosestColor } from "../Colors";
 import { stripAnsiCodes } from "../Triggers";
+import { getClientStore, ScriptStore } from "../state/scriptStore";
 
 type KillEntry = {
     mySession: number;
@@ -224,17 +225,17 @@ export { parseName, formatSessionTable, formatLifetimeTable };
 class KillCounter {
     private client: Client;
     private kills: KillCounts = {};
+    private store: ScriptStore;
 
     constructor(client: Client) {
         this.client = client;
+        this.store = getClientStore(client);
 
-        this.client.addEventListener("storage", (event: CustomEvent) => {
-            if (event.detail.key === STORAGE_KEY) {
-                this.loadTotals(event.detail.value ?? {});
-            }
-            if (event.detail.key === SESSION_STORAGE_KEY) {
-                this.loadSession(event.detail.value ?? {});
-            }
+        this.store.subscribeStorage<Record<string, number>>(STORAGE_KEY, (value) => {
+            this.loadTotals(value ?? {});
+        });
+        this.store.subscribeStorage<Record<string, { mySession: number; teamSession: number }>>(SESSION_STORAGE_KEY, (value) => {
+            this.loadSession(value ?? {});
         });
 
         this.client.addEventListener("reset", () => this.resetSession());
@@ -270,8 +271,20 @@ class KillCounter {
             }
         );
 
-        this.client.port?.postMessage({ type: "GET_STORAGE", key: STORAGE_KEY });
-        this.client.port?.postMessage({ type: "GET_STORAGE", key: SESSION_STORAGE_KEY });
+        void this.loadStoredData();
+    }
+
+    private async loadStoredData() {
+        const [totals, sessions] = await Promise.all([
+            this.store.getStorageItem<Record<string, number>>(STORAGE_KEY),
+            this.store.getStorageItem<Record<string, { mySession: number; teamSession: number }>>(SESSION_STORAGE_KEY),
+        ]);
+        if (totals) {
+            this.loadTotals(totals);
+        }
+        if (sessions) {
+            this.loadSession(sessions);
+        }
     }
 
     private loadTotals(totals: Record<string, number> = {}): void {
@@ -291,11 +304,7 @@ class KillCounter {
         Object.entries(this.kills).forEach(([name, entry]) => {
             totals[name] = entry.myTotal;
         });
-        this.client.port?.postMessage({
-            type: "SET_STORAGE",
-            key: STORAGE_KEY,
-            value: totals,
-        });
+        void this.store.setStorageItem(STORAGE_KEY, { ...totals });
     };
 
     private loadSession(session: Record<string, { mySession: number; teamSession: number }> = {}): void {
@@ -314,11 +323,7 @@ class KillCounter {
                 sessions[name] = { mySession: entry.mySession, teamSession: entry.teamSession };
             }
         });
-        this.client.port?.postMessage({
-            type: "SET_STORAGE",
-            key: SESSION_STORAGE_KEY,
-            value: sessions,
-        });
+        void this.store.setStorageItem(SESSION_STORAGE_KEY, structuredClone(sessions));
     };
 
     private ensureEntry(name: string): KillEntry {

--- a/client/src/scripts/language.ts
+++ b/client/src/scripts/language.ts
@@ -1,10 +1,12 @@
 import Client from "../Client";
+import { getClientStore } from "../state/scriptStore";
 
 function escapeRegExp(str: string) {
     return str.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
 export default function initLanguage(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
+    const store = getClientStore(client);
     if (!aliases) return;
 
     const STORAGE_KEY = 'lastLang';
@@ -13,17 +15,16 @@ export default function initLanguage(client: Client, aliases?: { pattern: RegExp
     let lastLang = '';
     let customAliases: { pattern: RegExp; callback: (m: RegExpMatchArray) => void }[] = [];
 
-    client.addEventListener('storage', (ev: CustomEvent) => {
-        if (ev.detail.key === STORAGE_KEY) {
-            lastLang = ev.detail.value || '';
+    store.subscribeStorage<string>(STORAGE_KEY, (value) => {
+        lastLang = typeof value === 'string' ? value : '';
+    });
+
+    void (async () => {
+        const stored = await store.getStorageItem<string>(STORAGE_KEY);
+        if (typeof stored === 'string') {
+            lastLang = stored;
         }
-    });
-
-    client.addEventListener('port-connected', () => {
-        client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
-    });
-
-    client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
+    })();
 
     function setLanguage(lang: string) {
         if (lang !== lastLang && lang !== 'potoczna') {
@@ -52,7 +53,7 @@ export default function initLanguage(client: Client, aliases?: { pattern: RegExp
         callback: (matches: RegExpMatchArray) => {
             client.send('justaw ' + matches[1], false);
             lastLang = matches[1];
-            client.port?.postMessage({ type: 'SET_STORAGE', key: STORAGE_KEY, value: lastLang });
+            void store.setStorageItem(STORAGE_KEY, lastLang);
         }
     })
 

--- a/client/src/scripts/luaGags.ts
+++ b/client/src/scripts/luaGags.ts
@@ -18,6 +18,7 @@ import {
     normalizeLuaGagsDeleteLines,
 } from "../luaGagsSettings";
 import {Table} from "lua-in-js";
+import { getClientStore } from "../state/scriptStore";
 
 const ERROR_COLOR = findClosestColor('#ff0000');
 
@@ -122,19 +123,19 @@ function getDeleteMode(type: string): LuaGagDeleteMode {
 }
 
 export default function registerLuaGagTriggers(client: Client) {
+    const store = getClientStore(client);
     applyDeleteLinesConfig(getItemSync(LUA_GAGS_STORAGE_KEY)?.[LUA_GAGS_STORAGE_KEY]);
 
-    client.addEventListener("storage", (event: CustomEvent) => {
-        if (event.detail?.key === LUA_GAGS_STORAGE_KEY) {
-            applyDeleteLinesConfig(event.detail.value);
+    store.subscribeStorage(LUA_GAGS_STORAGE_KEY, (value) => {
+        applyDeleteLinesConfig(value);
+    });
+
+    void (async () => {
+        const stored = await store.getStorageItem(LUA_GAGS_STORAGE_KEY);
+        if (stored !== undefined) {
+            applyDeleteLinesConfig(stored);
         }
-    });
-
-    client.addEventListener("port-connected", () => {
-        client.port?.postMessage({ type: "GET_STORAGE", key: LUA_GAGS_STORAGE_KEY });
-    });
-
-    client.port?.postMessage({ type: "GET_STORAGE", key: LUA_GAGS_STORAGE_KEY });
+    })();
 
     function toPattern(p: PatternObj) {
         if (p.type === 1) {

--- a/client/src/scripts/shortcuts.ts
+++ b/client/src/scripts/shortcuts.ts
@@ -1,5 +1,6 @@
 import Client from "../Client";
 import { colorString, findClosestColor } from "../Colors";
+import { getClientStore } from "../state/scriptStore";
 
 export interface ShortcutEntry {
     key: string;
@@ -16,6 +17,7 @@ export function getShortcut(id: string): number | undefined {
 }
 
 export default function initShortcuts(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
+    const store = getClientStore(client);
     const HEADER_COLOR = findClosestColor("#7cfc00");
     const NAME_COLOR = findClosestColor("#ffa500");
 
@@ -29,21 +31,20 @@ export default function initShortcuts(client: Client, aliases?: { pattern: RegEx
     }
 
     function persist() {
-        client.port?.postMessage({ type: "SET_STORAGE", key: STORAGE_KEY, value: Object.values(shortcuts) });
+        void store.setStorageItem(STORAGE_KEY, Object.values(shortcuts).map(sc => ({ ...sc })));
     }
 
-    client.addEventListener("storage", (ev: CustomEvent) => {
-        if (ev.detail.key === STORAGE_KEY) {
-            const value = Array.isArray(ev.detail.value) ? ev.detail.value : [];
-            apply(value);
+    store.subscribeStorage<ShortcutEntry[]>(STORAGE_KEY, (value) => {
+        const list = Array.isArray(value) ? value : [];
+        apply(list);
+    });
+
+    void (async () => {
+        const stored = await store.getStorageItem<ShortcutEntry[]>(STORAGE_KEY);
+        if (Array.isArray(stored)) {
+            apply(stored);
         }
-    });
-
-    client.addEventListener("port-connected", () => {
-        client.port?.postMessage({ type: "GET_STORAGE", key: STORAGE_KEY });
-    });
-
-    client.port?.postMessage({ type: "GET_STORAGE", key: STORAGE_KEY });
+    })();
 
     function printShortcuts() {
         const lines: string[] = [];

--- a/client/src/scripts/userAliases.ts
+++ b/client/src/scripts/userAliases.ts
@@ -1,4 +1,5 @@
 import Client from "../Client";
+import { getClientStore } from "../state/scriptStore";
 
 export interface UserAlias {
     pattern: string;
@@ -8,6 +9,7 @@ export interface UserAlias {
 const STORAGE_KEY = "aliases";
 
 export default function initUserAliases(client: Client, aliases?: { pattern: RegExp; callback: Function }[]) {
+    const store = getClientStore(client);
     const list = aliases || client.aliases;
     let mapped: { pattern: RegExp; callback: (matches: RegExpMatchArray) => void }[] = [];
 
@@ -35,16 +37,14 @@ export default function initUserAliases(client: Client, aliases?: { pattern: Reg
         mapped.forEach(a => list.push(a));
     };
 
-    client.addEventListener('storage', (ev: CustomEvent) => {
-        if (ev.detail.key === STORAGE_KEY) {
-            const value = Array.isArray(ev.detail.value) ? ev.detail.value : [];
-            apply(value);
+    store.subscribeStorage<UserAlias[]>(STORAGE_KEY, (value) => {
+        apply(Array.isArray(value) ? value : []);
+    });
+
+    void (async () => {
+        const stored = await store.getStorageItem<UserAlias[]>(STORAGE_KEY);
+        if (Array.isArray(stored)) {
+            apply(stored);
         }
-    });
-
-    client.addEventListener('port-connected', () => {
-        client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
-    });
-
-    client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
+    })();
 }

--- a/client/src/scripts/userTriggers.ts
+++ b/client/src/scripts/userTriggers.ts
@@ -1,5 +1,6 @@
 import Client from "../Client";
 import { colorString, findClosestColor } from "../Colors";
+import { getClientStore } from "../state/scriptStore";
 
 function toUpperSafe(text: string) {
     return text.split(/(\x1B\[[0-9;]*m)/g).map((seg, i) => i % 2 === 0 ? seg.toUpperCase() : seg).join('');
@@ -20,6 +21,7 @@ export interface UserTrigger {
 const STORAGE_KEY = 'triggers';
 
 export default function initUserTriggers(client: Client) {
+    const store = getClientStore(client);
     let registered: import("../Triggers").Trigger[] = [];
 
     const apply = (list: UserTrigger[] = []) => {
@@ -69,15 +71,14 @@ export default function initUserTriggers(client: Client) {
         });
     };
 
-    client.addEventListener('storage', (ev: CustomEvent) => {
-        if (ev.detail.key === STORAGE_KEY) {
-            apply(Array.isArray(ev.detail.value) ? ev.detail.value : []);
+    store.subscribeStorage<UserTrigger[]>(STORAGE_KEY, (value) => {
+        apply(Array.isArray(value) ? value : []);
+    });
+
+    void (async () => {
+        const stored = await store.getStorageItem<UserTrigger[]>(STORAGE_KEY);
+        if (Array.isArray(stored)) {
+            apply(stored);
         }
-    });
-
-    client.addEventListener('port-connected', () => {
-        client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
-    });
-
-    client.port?.postMessage({ type: 'GET_STORAGE', key: STORAGE_KEY });
+    })();
 }

--- a/client/src/state/scriptStore.ts
+++ b/client/src/state/scriptStore.ts
@@ -1,0 +1,97 @@
+import storage from '../storage';
+import type { Settings } from '../defaultSettings';
+import type { HerbBagsState } from '../types/herbs';
+import { settingsStore } from './settingsStore';
+import type { UiSettingsState } from './settingsStore';
+
+export interface ScriptStore {
+    getSettingsSnapshot(): Settings;
+    updateSettings(partial: Partial<Settings>): Promise<void>;
+    updateUiSettings(partial: Partial<UiSettingsState>): Promise<void>;
+    setStorageItem<T>(key: string, value: T): Promise<void>;
+    getStorageItem<T>(key: string): Promise<T | undefined>;
+    updateHerbCounts(value: HerbBagsState): Promise<void>;
+    subscribeStorage<T>(key: string, listener: (value: T | undefined) => void): () => void;
+}
+
+type ClientLike = {
+    sendEvent(type: string, detail?: unknown): void;
+};
+
+function extractValue<T>(key: string, response: any): T | undefined {
+    if (response && typeof response === 'object' && key in response) {
+        return response[key] as T;
+    }
+    return undefined;
+}
+
+const domainEvents: Record<string, (client: ClientLike, value: unknown) => void> = {
+    herb_counts: (client, value) => {
+        client.sendEvent('herbCounts', structuredClone(value));
+    },
+};
+
+export function createClientStore(client: ClientLike): ScriptStore {
+    const emitDomainEvent = (key: string, value: unknown) => {
+        const handler = domainEvents[key];
+        if (handler) {
+            handler(client, value);
+        }
+    };
+
+    const getSettingsSnapshot = () => settingsStore.getState().settings;
+
+    const updateSettings = async (partial: Partial<Settings>) => {
+        await settingsStore.getState().updateSettings(partial);
+    };
+
+    const updateUiSettings = async (partial: Partial<UiSettingsState>) => {
+        await settingsStore.getState().updateUiSettings(partial);
+    };
+
+    const setStorageItem = async <T>(key: string, value: T) => {
+        await storage.setItem(key, value);
+        emitDomainEvent(key, value);
+    };
+
+    const getStorageItem = async <T>(key: string) => {
+        const response = await storage.getItem(key);
+        return extractValue<T>(key, response);
+    };
+
+    const subscribeStorage = <T>(key: string, listener: (value: T | undefined) => void) => {
+        const handler = (changes: { [k: string]: { newValue: unknown } }) => {
+            if (key in changes) {
+                const next = changes[key]?.newValue as T | undefined;
+                Promise.resolve().then(() => listener(next));
+            }
+        };
+        storage.onChanged?.addListener(handler);
+        return () => {
+            storage.onChanged?.removeListener?.(handler);
+        };
+    };
+
+    const updateHerbCounts = async (value: HerbBagsState) => {
+        await setStorageItem('herb_counts', value);
+    };
+
+    return {
+        getSettingsSnapshot,
+        updateSettings,
+        updateUiSettings,
+        setStorageItem,
+        getStorageItem,
+        updateHerbCounts,
+        subscribeStorage,
+    };
+}
+
+export function getClientStore<T extends ClientLike & { store?: ScriptStore }>(client: T): ScriptStore {
+    if (client.store) {
+        return client.store;
+    }
+    const store = createClientStore(client);
+    (client as any).store = store;
+    return store;
+}

--- a/client/src/types/zustand.d.ts
+++ b/client/src/types/zustand.d.ts
@@ -1,0 +1,11 @@
+declare module 'zustand' {
+    export function useStore(...args: any[]): any;
+}
+
+declare module 'zustand/vanilla' {
+    export function createStore<T>(...args: any[]): any;
+}
+
+declare module 'zustand/middleware' {
+    export function subscribeWithSelector(...args: any[]): any;
+}

--- a/client/test/__mocks__/zustand.ts
+++ b/client/test/__mocks__/zustand.ts
@@ -1,0 +1,5 @@
+export const useStore = () => undefined;
+
+export default {
+  useStore,
+};

--- a/client/test/__mocks__/zustandMiddleware.ts
+++ b/client/test/__mocks__/zustandMiddleware.ts
@@ -1,0 +1,1 @@
+export const subscribeWithSelector = <T>(initializer: T) => initializer;

--- a/client/test/__mocks__/zustandVanilla.ts
+++ b/client/test/__mocks__/zustandVanilla.ts
@@ -1,0 +1,47 @@
+type Listener<T> = (state: T, previousState: T) => void;
+
+export function createStore<T>() {
+  return (
+    initializer: (
+      setState: (
+        partial: Partial<T> | ((state: T) => Partial<T>),
+        replace?: boolean,
+      ) => void,
+      getState: () => T,
+      api: {
+        setState: (
+          partial: Partial<T> | ((state: T) => Partial<T>),
+          replace?: boolean,
+        ) => void;
+        getState: () => T;
+        subscribe: (listener: Listener<T>) => () => void;
+      },
+    ) => T,
+  ) => {
+    let state: T;
+    const listeners = new Set<Listener<T>>();
+
+    const getState = () => state;
+
+    const setState = (
+      partial: Partial<T> | ((state: T) => Partial<T>),
+      replace = false,
+    ) => {
+      const next = typeof partial === 'function'
+        ? (partial as (state: T) => Partial<T>)(state)
+        : partial;
+      const previous = state;
+      state = replace ? (next as T) : { ...state, ...next };
+      listeners.forEach((listener) => listener(state, previous));
+    };
+
+    const subscribe = (listener: Listener<T>) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    };
+
+    const api = { setState, getState, subscribe };
+    state = initializer(setState, getState, api);
+    return api;
+  };
+}

--- a/client/test/deposit.test.ts
+++ b/client/test/deposit.test.ts
@@ -10,13 +10,44 @@ import { EventEmitter } from 'events';
 
 class FakeClient {
   private emitter = new EventEmitter();
+  private storageListeners: Record<string, Set<(value: any) => void>> = {};
   Triggers = new Triggers(({} as unknown) as any);
   Map = { currentRoom: { id: 1, name: 'Bank', userData: { bind: '/depozyt' } } } as any;
   println = jest.fn();
   print = jest.fn();
-  port = { postMessage: jest.fn() } as any;
+  storeData: Record<string, any> = {};
+  store = {
+    setStorageItem: jest.fn(async (key: string, value: any) => {
+      this.storeData[key] = value;
+      this.emitStorage(key, value);
+    }),
+    getStorageItem: jest.fn(async (key: string) => this.storeData[key]),
+    updateSettings: jest.fn().mockResolvedValue(undefined),
+    updateUiSettings: jest.fn().mockResolvedValue(undefined),
+    getSettingsSnapshot: jest.fn(() => ({} as any)),
+    updateHerbCounts: jest.fn().mockResolvedValue(undefined),
+    subscribeStorage: jest.fn((key: string, cb: (value: any) => void) => {
+      if (!this.storageListeners[key]) {
+        this.storageListeners[key] = new Set();
+      }
+      this.storageListeners[key].add(cb);
+      return () => {
+        this.storageListeners[key].delete(cb);
+      };
+    }),
+  } as any;
   sendCommand = jest.fn();
   contentWidth = 80;
+
+  emitStorage(key: string, value: any) {
+    this.storeData[key] = value;
+    const listeners = this.storageListeners[key];
+    if (listeners) {
+      listeners.forEach((cb) => {
+        Promise.resolve().then(() => cb(value));
+      });
+    }
+  }
 
   addEventListener(event: string, cb: any) {
     this.emitter.on(event, cb);
@@ -41,7 +72,7 @@ describe('deposits', () => {
     client = new FakeClient();
     const aliases: { pattern: RegExp; callback: () => void }[] = [];
     initDeposits((client as unknown) as any, aliases);
-    client.dispatch('storage', { key: 'deposits', value: {} });
+    client.emitStorage('deposits', {});
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
     refresh = aliases[0].callback;
     show = aliases[1].callback;
@@ -129,7 +160,7 @@ describe('deposits', () => {
     reset();
 
     expect(deposits[1]).toBeUndefined();
-    expect(client.port.postMessage).toHaveBeenLastCalledWith({ type: 'SET_STORAGE', key: 'deposits', value: {} });
+    expect(client.store.setStorageItem).toHaveBeenLastCalledWith('deposits', {});
     expect(client.println).toHaveBeenCalledWith('Zapisane depozyty zostaly usuniete.');
   });
 
@@ -139,18 +170,16 @@ describe('deposits', () => {
     expect(prettyPrintContainer).toHaveBeenCalledWith(expect.anything(), 3, 'DEPOZYT', 5, client.contentWidth);
   });
 
-  test('replaces stored deposits when storage updates', () => {
+  test('replaces stored deposits when storage updates', async () => {
     parse('Twoj depozyt zawiera miecz.');
     expect(deposits[1]?.items).toEqual([
       { count: 1, name: 'miecz' }
     ]);
 
-    client.dispatch('storage', {
-      key: 'deposits',
-      value: {
-        2: { name: 'Inny bank', items: [{ count: 3, name: 'klejnoty' }] }
-      }
+    client.emitStorage('deposits', {
+      2: { name: 'Inny bank', items: [{ count: 3, name: 'klejnoty' }] }
     });
+    await Promise.resolve();
 
     expect(deposits[1]).toBeUndefined();
     expect(deposits[2]).toEqual({

--- a/client/test/helpers/herbClient.ts
+++ b/client/test/helpers/herbClient.ts
@@ -4,11 +4,41 @@ import { normalizeHerbBagsState } from '../../src/types/herbs';
 
 export class FakeClient {
   private emitter = new EventEmitter();
+  private storageListeners: Record<string, Set<(value: any) => void>> = {};
   aliases: { pattern: RegExp; callback: Function }[] = [];
   Triggers = { registerTrigger: jest.fn() } as any;
   sendCommand = jest.fn();
   println = jest.fn();
-  port = { postMessage: jest.fn() } as any;
+  storeData: Record<string, any> = {};
+  emitStorage(key: string, value: any) {
+    this.storeData[key] = value;
+    const listeners = this.storageListeners[key];
+    if (listeners) {
+      listeners.forEach((cb) => {
+        Promise.resolve().then(() => cb(value));
+      });
+    }
+  }
+  store = {
+    updateHerbCounts: jest.fn().mockResolvedValue(undefined),
+    setStorageItem: jest.fn(async (key: string, value: any) => {
+      (this as any).storeData[key] = value;
+      (this as any).emitStorage(key, value);
+    }),
+    getStorageItem: jest.fn(async (key: string) => (this as any).storeData[key]),
+    updateSettings: jest.fn().mockResolvedValue(undefined),
+    updateUiSettings: jest.fn().mockResolvedValue(undefined),
+    getSettingsSnapshot: jest.fn(() => ({} as any)),
+    subscribeStorage: jest.fn((key: string, cb: (value: any) => void) => {
+      if (!this.storageListeners[key]) {
+        this.storageListeners[key] = new Set();
+      }
+      this.storageListeners[key].add(cb);
+      return () => {
+        this.storageListeners[key].delete(cb);
+      };
+    }),
+  } as any;
   herbManager: any;
   sendEvent(type: string, detail: any) {
     this.dispatch(type, detail);
@@ -40,15 +70,22 @@ export const defaultHerbData = {
 };
 
 export function initHerbClient(
-  client: { aliases: { pattern: RegExp; callback: Function }[]; dispatch(event: string, detail: any): void },
+  client: {
+    aliases: { pattern: RegExp; callback: Function }[];
+    dispatch(event: string, detail: any): void;
+    emitStorage(key: string, value: any): void;
+    storeData: Record<string, any>;
+  },
   herbCounts: Record<number, any> = {},
   herbData: any = defaultHerbData,
   aliases = client.aliases
 ) {
+  const normalized = normalizeHerbBagsState(herbCounts);
+  (client as any).storeData.herb_counts = normalized;
   (global as any).fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: () => Promise.resolve(herbData)
   });
   initHerbCounter((client as unknown) as any, aliases);
-  client.dispatch('storage', { key: 'herb_counts', value: normalizeHerbBagsState(herbCounts) });
+  client.emitStorage('herb_counts', normalized);
 }

--- a/client/test/herbCounter.test.ts
+++ b/client/test/herbCounter.test.ts
@@ -4,10 +4,40 @@ import { initHerbClient, defaultHerbData } from './helpers/herbClient';
 
 class FakeClient {
   private emitter = new EventEmitter();
+  private storageListeners: Record<string, Set<(value: any) => void>> = {};
   Triggers = new Triggers(({} as unknown) as any);
   sendCommand = jest.fn();
   println = jest.fn();
-  port = { postMessage: jest.fn() } as any;
+  storeData: Record<string, any> = {};
+  store = {
+    updateHerbCounts: jest.fn().mockResolvedValue(undefined),
+    setStorageItem: jest.fn(async (key: string, value: any) => {
+      this.storeData[key] = value;
+      this.emitStorage(key, value);
+    }),
+    getStorageItem: jest.fn(async (key: string) => this.storeData[key]),
+    updateSettings: jest.fn().mockResolvedValue(undefined),
+    updateUiSettings: jest.fn().mockResolvedValue(undefined),
+    getSettingsSnapshot: jest.fn(() => ({} as any)),
+    subscribeStorage: jest.fn((key: string, cb: (value: any) => void) => {
+      if (!this.storageListeners[key]) {
+        this.storageListeners[key] = new Set();
+      }
+      this.storageListeners[key].add(cb);
+      return () => {
+        this.storageListeners[key].delete(cb);
+      };
+    }),
+  } as any;
+  emitStorage(key: string, value: any) {
+    this.storeData[key] = value;
+    const listeners = this.storageListeners[key];
+    if (listeners) {
+      listeners.forEach((cb) => {
+        Promise.resolve().then(() => cb(value));
+      });
+    }
+  }
   sendEvent = jest.fn((type: string, detail: any) => {
     this.dispatch(type, detail);
   });
@@ -107,8 +137,9 @@ describe('herb counter', () => {
         resolve(line);
       });
     });
+    client.emitStorage('herb_counts', { 1: { deliona: 2 } });
+    await Promise.resolve();
     show();
-    client.dispatch('storage', { key: 'herb_counts', value: { 1: { deliona: 2 } } });
     const printed = await printedPromise;
     expect(printed).toMatch(/2/);
     expect(printed).toMatch(/deliona/);
@@ -122,23 +153,17 @@ describe('herb counter', () => {
       const wearEntry = aliases.find(({ pattern }) => pattern.test('/woreczki_buduj'));
       expect(wearEntry).toBeTruthy();
       client.sendCommand.mockClear();
-      client.port.postMessage.mockClear();
+      client.store.updateHerbCounts.mockClear();
       wearEntry?.callback();
       expect(client.sendCommand).toHaveBeenCalledWith('ocen wszystkie woreczki');
       parse('Ten element ekwipunku wyglada na troche zuzyty.');
       parse('Ten element ekwipunku wyglada na calkiem nowy.');
       jest.advanceTimersByTime(150);
       await Promise.resolve();
-      const setCalls = client.port.postMessage.mock.calls
-        .map(([arg]) => arg)
-        .filter(call => call?.type === 'SET_STORAGE');
+      const setCalls = client.store.updateHerbCounts.mock.calls.map(([arg]) => arg);
       expect(setCalls[setCalls.length - 1]).toEqual({
-        type: 'SET_STORAGE',
-        key: 'herb_counts',
-        value: {
-          1: { herbs: {}, condition: 3 },
-          2: { herbs: {}, condition: 5 }
-        }
+        1: { herbs: {}, condition: 3 },
+        2: { herbs: {}, condition: 5 }
       });
     } finally {
       jest.useRealTimers();
@@ -165,14 +190,8 @@ describe('herb counter', () => {
     expect(client.sendCommand).toHaveBeenNthCalledWith(4, 'otworz 2. swoj woreczek');
     expect(client.sendCommand).toHaveBeenNthCalledWith(5, 'wloz zolty jasny kwiat do 2. swojego woreczka');
     expect(client.sendCommand).toHaveBeenNthCalledWith(6, 'zamknij 2. swoj woreczek');
-    const setCalls = client.port.postMessage.mock.calls
-      .map(([arg]) => arg)
-      .filter(call => call?.type === 'SET_STORAGE');
-    expect(setCalls).toContainEqual({
-      type: 'SET_STORAGE',
-      key: 'herb_counts',
-      value: { 1: { herbs: {} }, 2: { herbs: { deliona: 1 } } }
-    });
+    const setCalls = client.store.updateHerbCounts.mock.calls.map(([arg]) => arg);
+    expect(setCalls).toContainEqual({ 1: { herbs: {} }, 2: { herbs: { deliona: 1 } } });
   });
 
   test('herb manager put adds herbs to bag', async () => {
@@ -182,13 +201,7 @@ describe('herb counter', () => {
     expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'otworz 1. swoj woreczek');
     expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'wloz 2 zolte jasne kwiaty do 1. swojego woreczka');
     expect(client.sendCommand).toHaveBeenNthCalledWith(3, 'zamknij 1. swoj woreczek');
-    const setCalls = client.port.postMessage.mock.calls
-      .map(([arg]) => arg)
-      .filter(call => call?.type === 'SET_STORAGE');
-    expect(setCalls).toContainEqual({
-      type: 'SET_STORAGE',
-      key: 'herb_counts',
-      value: { 1: { herbs: { deliona: 2 } } }
-    });
+    const setCalls = client.store.updateHerbCounts.mock.calls.map(([arg]) => arg);
+    expect(setCalls).toContainEqual({ 1: { herbs: { deliona: 2 } } });
   });
 });

--- a/client/test/improveCounter.test.ts
+++ b/client/test/improveCounter.test.ts
@@ -7,12 +7,34 @@ import { setItemSync } from '../src/storage';
 
 class FakeClient {
   private emitter = new EventEmitter();
+  private storageListeners: Record<string, Set<(value: any) => void>> = {};
   Triggers = new Triggers(({} as unknown) as any);
   TeamManager = { isInTeam: jest.fn() };
   prefix = (line: string, prefix: string) => prefix + line;
   print = jest.fn();
   println = jest.fn();
   port = { postMessage: jest.fn() } as any;
+  storeData: Record<string, any> = {};
+  store = {
+    setStorageItem: jest.fn(async (key: string, value: any) => {
+      this.storeData[key] = value;
+      this.emitStorage(key, value);
+    }),
+    getStorageItem: jest.fn(async (key: string) => this.storeData[key]),
+    updateSettings: jest.fn().mockResolvedValue(undefined),
+    updateUiSettings: jest.fn().mockResolvedValue(undefined),
+    getSettingsSnapshot: jest.fn(() => ({} as any)),
+    updateHerbCounts: jest.fn().mockResolvedValue(undefined),
+    subscribeStorage: jest.fn((key: string, cb: (value: any) => void) => {
+      if (!this.storageListeners[key]) {
+        this.storageListeners[key] = new Set();
+      }
+      this.storageListeners[key].add(cb);
+      return () => {
+        this.storageListeners[key].delete(cb);
+      };
+    }),
+  } as any;
 
   addEventListener(event: string, cb: any) {
     this.emitter.on(event, cb);
@@ -22,6 +44,15 @@ class FakeClient {
   }
   dispatch(event: string, detail: any) {
     this.emitter.emit(event, { detail });
+  }
+  emitStorage(key: string, value: any) {
+    this.storeData[key] = value;
+    const listeners = this.storageListeners[key];
+    if (listeners) {
+      listeners.forEach((cb) => {
+        Promise.resolve().then(() => cb(value));
+      });
+    }
   }
 }
 
@@ -39,12 +70,12 @@ describe('improve counter', () => {
     setItemSync('object_num', '1');
     client = new FakeClient();
     const killCounter = initKillCounter((client as unknown) as any, []);
-    client.dispatch('storage', { key: 'kill_counter', value: {} });
-    client.dispatch('storage', { key: 'kill_counter_session', value: {} });
+    client.emitStorage('kill_counter', {});
+    client.emitStorage('kill_counter_session', {});
     aliases = [];
     initImproveCounter((client as unknown) as any, killCounter, aliases);
-    client.dispatch('storage', { key: 'improve_counter', value: {} });
-    client.dispatch('storage', { key: 'improve_counter_lifetime', value: {} });
+    client.emitStorage('improve_counter', {});
+    client.emitStorage('improve_counter_lifetime', {});
     parse = (line: string) =>
       Triggers.prototype.parseLine.call(client.Triggers, line, '');
     show = aliases[0].callback;
@@ -164,7 +195,7 @@ describe('improve counter', () => {
   });
 
   test('adds initial improvement when not yet recorded', () => {
-    client.dispatch('storage', { key: 'improve_counter', value: { level: 0 } });
+    client.emitStorage('improve_counter', { level: 0 });
     client.dispatch('gmcp.char.state', { improve: 2 });
     showLifetime();
     const printed = stripAnsiCodes(client.print.mock.calls[0][0]);
@@ -178,21 +209,22 @@ describe('improve counter', () => {
     expect(printed2).toMatch(/WSZYSTKICH DO TEJ PORY: 2 postepow/);
   });
 
-  test('adds missed improvements on login before lifetime loads', () => {
+  test('adds missed improvements on login before lifetime loads', async () => {
     jest.useFakeTimers();
     const c = new FakeClient();
     const kill = initKillCounter((c as unknown) as any, []);
-    c.dispatch('storage', { key: 'kill_counter', value: {} });
-    c.dispatch('storage', { key: 'kill_counter_session', value: {} });
+    c.emitStorage('kill_counter', {});
+    c.emitStorage('kill_counter_session', {});
     const als: { pattern: RegExp; callback: any }[] = [];
     initImproveCounter((c as unknown) as any, kill, als);
-    c.dispatch('storage', {
-      key: 'improve_counter',
-      value: { level: 2, lastObjNum: 1 },
-    });
+    c.emitStorage('improve_counter', { level: 2, lastObjNum: 1 });
+    await Promise.resolve();
     c.dispatch('gmcp.char.state', { improve: 4 });
-    c.dispatch('storage', { key: 'improve_counter_lifetime', value: {} });
+    await Promise.resolve();
+    c.emitStorage('improve_counter_lifetime', {});
+    await Promise.resolve();
     const showLife = als.find((a) => a.pattern.source === '\\/postepy2$')!.callback;
+    await Promise.resolve();
     showLife();
     const printed = stripAnsiCodes(c.print.mock.calls[0][0]);
     expect(printed).toMatch(/- bardzo male/);
@@ -211,64 +243,53 @@ describe('improve counter', () => {
     expect(printed).toMatch(/WSZYSTKICH DO TEJ PORY: 1 postepow/);
   });
 
-  test('counts offline improvements and new gains after login', () => {
-    client.dispatch('storage', {
-      key: 'improve_counter',
-      value: { level: 2, lastObjNum: 1 },
-    });
-    client.dispatch('storage', {
-      key: 'improve_counter_lifetime',
-      value: { entries: [{ date: '1970/1/1', count: 2 }] },
-    });
+  test('counts offline improvements and new gains after login', async () => {
+    client.emitStorage('improve_counter', { level: 2, lastObjNum: 1 });
+    client.emitStorage('improve_counter_lifetime', { entries: [{ date: '1970/1/1', count: 2 }] });
+    await Promise.resolve();
     client.dispatch('gmcp.char.state', { improve: 4 });
+    await Promise.resolve();
     showLifetime();
     let printed = stripAnsiCodes(client.print.mock.calls[0][0]);
     expect(printed).toMatch(/WSZYSTKICH DO TEJ PORY: 4 postepow/);
     client.print.mockClear();
     client.dispatch('gmcp.char.state', { improve: 5 });
     client.dispatch('gmcp.char.state', { improve: 6 });
+    await Promise.resolve();
     showLifetime();
     printed = stripAnsiCodes(client.print.mock.calls[0][0]);
     expect(printed).toMatch(/WSZYSTKICH DO TEJ PORY: 6 postepow/);
   });
 
-  test('accumulates improvements across sessions with object numbers', () => {
-    client.dispatch('storage', {
-      key: 'improve_counter',
-      value: { level: 3, lastObjNum: 1 },
-    });
-    client.dispatch('storage', {
-      key: 'improve_counter_lifetime',
-      value: { entries: [{ date: '1970/1/1', count: 3 }] },
-    });
+  test('accumulates improvements across sessions with object numbers', async () => {
+    client.emitStorage('improve_counter', { level: 3, lastObjNum: 1 });
+    client.emitStorage('improve_counter_lifetime', { entries: [{ date: '1970/1/1', count: 3 }] });
+    await Promise.resolve();
     setItemSync('object_num', '2');
     client.dispatch('gmcp.char.state', { improve: 6 });
+    await Promise.resolve();
     showLifetime();
     const printed = stripAnsiCodes(client.print.mock.calls[0][0]);
     expect(printed).toMatch(/WSZYSTKICH DO TEJ PORY: 9 postepow/);
   });
 
-  test('does not re-add improvements when reconnecting with same object number', () => {
+  test('does not re-add improvements when reconnecting with same object number', async () => {
     // simulate existing data: level 2 already recorded for object 1
     const c = new FakeClient();
     const kill = initKillCounter((c as unknown) as any, []);
-    c.dispatch('storage', { key: 'kill_counter', value: {} });
-    c.dispatch('storage', { key: 'kill_counter_session', value: {} });
+    c.emitStorage('kill_counter', {});
+    c.emitStorage('kill_counter_session', {});
     const als: { pattern: RegExp; callback: any }[] = [];
     initImproveCounter((c as unknown) as any, kill, als);
-    c.dispatch('storage', {
-      key: 'improve_counter',
-      value: { level: 2, lastObjNum: 1 },
-    });
-    c.dispatch('storage', {
-      key: 'improve_counter_lifetime',
-      value: { entries: [{ date: '1970/1/1', count: 2 }] },
-    });
+    c.emitStorage('improve_counter', { level: 2, lastObjNum: 1 });
+    c.emitStorage('improve_counter_lifetime', { entries: [{ date: '1970/1/1', count: 2 }] });
+    await Promise.resolve();
     // same object number reports same level again
     setItemSync('object_num', '1');
     // server replays improvements from 1 to 2 on reconnect
     c.dispatch('gmcp.char.state', { improve: 1 });
     c.dispatch('gmcp.char.state', { improve: 2 });
+    await Promise.resolve();
     const showLife = als.find((a) => a.pattern.source === '\\/postepy2$')!.callback;
     showLife();
     const printed = stripAnsiCodes(c.print.mock.calls[0][0]);

--- a/client/test/kill.test.ts
+++ b/client/test/kill.test.ts
@@ -5,11 +5,45 @@ import { EventEmitter } from 'events';
 
 class FakeClient {
   private emitter = new EventEmitter();
+  private storageListeners: Record<string, Set<(value: any) => void>> = {};
   Triggers = new Triggers(({} as unknown) as any);
   TeamManager = { isInTeam: jest.fn() };
   prefix = (line: string, prefix: string) => prefix + line;
   print = jest.fn();
-  port = { postMessage: jest.fn() } as any;
+  storeData: Record<string, any> = {};
+  store = {
+    setStorageItem: jest.fn(async (key: string, value: any) => {
+      this.storeData[key] = value;
+      this.emitStorage(key, value);
+    }),
+    getStorageItem: jest.fn(async (key: string) => this.storeData[key]),
+    updateSettings: jest.fn().mockResolvedValue(undefined),
+    updateUiSettings: jest.fn().mockResolvedValue(undefined),
+    getSettingsSnapshot: jest.fn(() => ({} as any)),
+    updateHerbCounts: jest.fn().mockResolvedValue(undefined),
+    subscribeStorage: jest.fn((key: string, cb: (value: any) => void) => {
+      if (!this.storageListeners[key]) {
+        this.storageListeners[key] = new Set();
+      }
+      this.storageListeners[key].add(cb);
+      return () => {
+        this.storageListeners[key].delete(cb);
+      };
+    }),
+  } as any;
+  sendEvent = jest.fn((type: string, detail: any) => {
+    this.dispatch(type, detail);
+  });
+
+  emitStorage(key: string, value: any) {
+    this.storeData[key] = value;
+    const listeners = this.storageListeners[key];
+    if (listeners) {
+      listeners.forEach((cb) => {
+        Promise.resolve().then(() => cb(value));
+      });
+    }
+  }
 
   addEventListener(event: string, cb: any) {
     this.emitter.on(event, cb);
@@ -28,8 +62,8 @@ describe('kill counter team kills', () => {
   beforeEach(() => {
     client = new FakeClient();
     initKillCounter((client as unknown) as any, []);
-    client.dispatch('storage', { key: 'kill_counter', value: {} });
-    client.dispatch('storage', { key: 'kill_counter_session', value: {} });
+    client.emitStorage('kill_counter', {});
+    client.emitStorage('kill_counter_session', {});
   });
 
   const parse = (line: string) => {
@@ -61,7 +95,7 @@ describe('kill counter team kills', () => {
     let result = parse('> Eamon zabil smoka chaosu.');
     expect(stripAnsiCodes(result)).toContain('(0 / 1)');
 
-    client.dispatch('storage', { key: 'kill_counter', value: { 'smoka chaosu': 1 } });
+    client.emitStorage('kill_counter', { 'smoka chaosu': 1 });
 
     result = parse('> Eamon zabil smoka chaosu.');
     expect(stripAnsiCodes(result)).toContain('(0 / 2)');
@@ -78,8 +112,8 @@ describe('kill counter scenario', () => {
     aliases = [];
     client = new FakeClient();
     initKillCounter((client as unknown) as any, aliases);
-    client.dispatch('storage', { key: 'kill_counter', value: {} });
-    client.dispatch('storage', { key: 'kill_counter_session', value: {} });
+    client.emitStorage('kill_counter', {});
+    client.emitStorage('kill_counter_session', {});
     parse = (line: string) =>
       Triggers.prototype.parseLine.call(client.Triggers, line, '');
     // alias[0] corresponds to the /zabici command which prints

--- a/client/test/userTriggers.test.ts
+++ b/client/test/userTriggers.test.ts
@@ -4,20 +4,33 @@ import { findClosestColor } from '../src/Colors';
 
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
-  addEventListener = jest.fn();
-  removeEventListener = jest.fn();
-  port = { postMessage: jest.fn() } as any;
   playSound = jest.fn();
   sendCommand = jest.fn();
+  storageListeners: Record<string, (value: any) => void> = {};
+  store = {
+    getStorageItem: jest.fn().mockResolvedValue(undefined),
+    setStorageItem: jest.fn().mockResolvedValue(undefined),
+    updateSettings: jest.fn().mockResolvedValue(undefined),
+    updateUiSettings: jest.fn().mockResolvedValue(undefined),
+    getSettingsSnapshot: jest.fn(() => ({} as any)),
+    updateHerbCounts: jest.fn().mockResolvedValue(undefined),
+    subscribeStorage: jest.fn((key: string, cb: (value: any) => void) => {
+      this.storageListeners[key] = cb;
+      return jest.fn();
+    }),
+  } as any;
+  emitStorage(key: string, value: any) {
+    this.storageListeners[key]?.(value);
+  }
 }
 
 describe('userTriggers', () => {
   test('macros modify match only', () => {
     const client = new FakeClient();
     initUserTriggers((client as unknown) as any);
-    const apply = client.addEventListener.mock.calls.find(c => c[0] === 'storage')[1];
+    const apply = client.store.subscribeStorage.mock.calls[0][1];
     const list: UserTrigger[] = [{ pattern: 'foo', macros: [{ type: 'uppercase' }] }];
-    apply({ detail: { key: 'triggers', value: list } } as any);
+    apply(list);
     const result = client.Triggers.parseLine('bar foo baz', '');
     expect(result).toBe('bar FOO baz');
   });
@@ -25,9 +38,9 @@ describe('userTriggers', () => {
   test('uppercase does not break colors', () => {
     const client = new FakeClient();
     initUserTriggers((client as unknown) as any);
-    const apply = client.addEventListener.mock.calls.find(c => c[0] === 'storage')[1];
+    const apply = client.store.subscribeStorage.mock.calls[0][1];
     const list: UserTrigger[] = [{ pattern: 'foo', macros: [{ type: 'color', color: '#ff0000' }, { type: 'uppercase' }] }];
-    apply({ detail: { key: 'triggers', value: list } } as any);
+    apply(list);
     const code = findClosestColor('#ff0000');
     const result = client.Triggers.parseLine('bar foo baz', '');
     expect(result).toBe(`bar \x1B[22;38;5;${code}mFOO\x1B[0m baz`);
@@ -36,9 +49,9 @@ describe('userTriggers', () => {
   test('replace uses pattern match', () => {
     const client = new FakeClient();
     initUserTriggers((client as unknown) as any);
-    const apply = client.addEventListener.mock.calls.find(c => c[0] === 'storage')[1];
+    const apply = client.store.subscribeStorage.mock.calls[0][1];
     const list: UserTrigger[] = [{ pattern: 'foo', macros: [{ type: 'replace', to: 'bar' }] }];
-    apply({ detail: { key: 'triggers', value: list } } as any);
+    apply(list);
     const result = client.Triggers.parseLine('foo foo', '');
     expect(result).toBe('bar bar');
   });
@@ -46,9 +59,9 @@ describe('userTriggers', () => {
   test('beep plays sound', () => {
     const client = new FakeClient();
     initUserTriggers((client as unknown) as any);
-    const apply = client.addEventListener.mock.calls.find(c => c[0] === 'storage')[1];
+    const apply = client.store.subscribeStorage.mock.calls[0][1];
     const list: UserTrigger[] = [{ pattern: 'foo', macros: [{ type: 'beep' }] }];
-    apply({ detail: { key: 'triggers', value: list } } as any);
+    apply(list);
     const result = client.Triggers.parseLine('foo', '');
     expect(result).toBe('foo');
     expect(client.playSound).toHaveBeenCalledWith('beep');
@@ -57,9 +70,9 @@ describe('userTriggers', () => {
   test('command sends command', () => {
     const client = new FakeClient();
     initUserTriggers((client as unknown) as any);
-    const apply = client.addEventListener.mock.calls.find(c => c[0] === 'storage')[1];
+    const apply = client.store.subscribeStorage.mock.calls[0][1];
     const list: UserTrigger[] = [{ pattern: 'foo', macros: [{ type: 'command', command: 'bar' }] }];
-    apply({ detail: { key: 'triggers', value: list } } as any);
+    apply(list);
     const result = client.Triggers.parseLine('foo', '');
     expect(result).toBe('foo');
     expect(client.sendCommand).toHaveBeenCalledWith('bar');

--- a/client/test/wezz.test.ts
+++ b/client/test/wezz.test.ts
@@ -21,14 +21,11 @@ describe('wezz alias', () => {
     expect(client.sendCommand).toHaveBeenNthCalledWith(4, 'otworz 2. swoj woreczek');
     expect(client.sendCommand).toHaveBeenNthCalledWith(5, 'wez zolty jasny kwiat z 2. swojego woreczka');
     expect(client.sendCommand).toHaveBeenNthCalledWith(6, 'zamknij 2. swoj woreczek');
-    expect(client.port.postMessage).toHaveBeenCalledWith({ type: 'SET_STORAGE', key: 'herb_counts', value: { 1: { herbs: {} }, 2: { herbs: {} } } });
+    expect(client.store.updateHerbCounts).toHaveBeenCalledWith({ 1: { herbs: {} }, 2: { herbs: {} } });
   });
 
   test('takes multiple herbs from one bag in bulk', async () => {
-    client.dispatch('storage', {
-      key: 'herb_counts',
-      value: { 1: { deliona: 5 } }
-    });
+    client.emitStorage('herb_counts', { 1: { deliona: 5 } });
     const alias = client.aliases.find(a => a.pattern.test('/wezz deliona 3'))!;
     const m = '/wezz deliona 3'.match(alias.pattern) as RegExpMatchArray;
     await alias.callback(m);
@@ -38,11 +35,7 @@ describe('wezz alias', () => {
       'wez 3 zolte jasne kwiaty z 1. swojego woreczka'
     );
     expect(client.sendCommand).toHaveBeenNthCalledWith(3, 'zamknij 1. swoj woreczek');
-    expect(client.port.postMessage).toHaveBeenCalledWith({
-      type: 'SET_STORAGE',
-      key: 'herb_counts',
-      value: { 1: { herbs: { deliona: 2 } } }
-    });
+    expect(client.store.updateHerbCounts).toHaveBeenCalledWith({ 1: { herbs: { deliona: 2 } } });
   });
 
   test('defaults to one herb', async () => {
@@ -52,6 +45,6 @@ describe('wezz alias', () => {
     expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'otworz 1. swoj woreczek');
     expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'wez zolty jasny kwiat z 1. swojego woreczka');
     expect(client.sendCommand).toHaveBeenNthCalledWith(3, 'zamknij 1. swoj woreczek');
-    expect(client.port.postMessage).toHaveBeenCalledWith({ type: 'SET_STORAGE', key: 'herb_counts', value: { 1: { herbs: {} }, 2: { herbs: { deliona: 1 } } } });
+    expect(client.store.updateHerbCounts).toHaveBeenCalledWith({ 1: { herbs: {} }, 2: { herbs: { deliona: 1 } } });
   });
 });


### PR DESCRIPTION
## Summary
- introduce a shared script store abstraction that exposes update, storage, and subscription helpers for scripts
- refactor all client scripts that previously posted to the port to rely on the store actions and storage subscriptions
- update associated tests and Jest mocks to work with the new store interface and asynchronous storage notifications

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68fc198b16b4832a9463a55728080020