### PR TITLE
Ensure GMCP position overrides stored map room

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -70,6 +70,7 @@ export default class MapHelper {
                     if (!isNaN(value)) {
                         this.savedRoomId = value;
                         this.setMapRoomById(this.savedRoomId);
+                        this.client.sendEvent('refreshPositionWhenAble');
                     }
                 }
             };


### PR DESCRIPTION
## Summary
- trigger a map position refresh when character-specific storage updates the saved room id
- allow upcoming GMCP room info messages to restore the live position instead of the stored value overriding it

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68fc6ceb5384832a968c7a5a519ca88f