### PR TITLE
Fix options saves to use latest state values

### DIFF
--- a/web-client/src/options/GuildsSettings.tsx
+++ b/web-client/src/options/GuildsSettings.tsx
@@ -3,6 +3,7 @@ import storage, { getCurrentCharacter } from "@client/src/storage";
 import { settingsStore, useSettingsSlice } from "@client/src/state/settingsStore";
 import GuildSection from "./GuildSection";
 import guilds from "./guilds";
+import useLatestRef from "./useLatestRef";
 
 function ensureGuildList(value: unknown): string[] {
     return Array.isArray(value) ? value.filter((guild): guild is string => typeof guild === "string") : [];
@@ -29,6 +30,9 @@ function GuildsSettings({ registerSave }: { registerSave: (cb: () => void) => vo
     const [selected, setSelected] = useState<string[]>(() => ensureGuildList(storeGuilds));
     const [enemySelected, setEnemySelected] = useState<string[]>(() => ensureGuildList(storeEnemyGuilds));
     const [colors, setColors] = useState<Record<string, string | undefined>>(() => ensureGuildColors(storeGuildColors));
+    const selectedRef = useLatestRef(selected);
+    const enemySelectedRef = useLatestRef(enemySelected);
+    const colorsRef = useLatestRef(colors);
     const [locked, setLocked] = useState(!getCurrentCharacter());
     const defaultColors = useMemo(() => {
         const map: Record<string, string> = {};
@@ -90,11 +94,11 @@ function GuildsSettings({ registerSave }: { registerSave: (cb: () => void) => vo
 
     useEffect(() => {
         registerSave(() => settingsStore.getState().updateSettings({
-            guilds: selected,
-            enemyGuilds: enemySelected,
-            guildColors: colors,
+            guilds: selectedRef.current,
+            enemyGuilds: enemySelectedRef.current,
+            guildColors: colorsRef.current,
         }));
-    }, [registerSave, selected, enemySelected, colors]);
+    }, [registerSave, selectedRef, enemySelectedRef, colorsRef]);
 
     return (
         <div className="p-2 h-100">

--- a/web-client/src/options/LuaGagsSettings.tsx
+++ b/web-client/src/options/LuaGagsSettings.tsx
@@ -9,6 +9,7 @@ import {
     LuaGagLineType,
     normalizeLuaGagsDeleteLines,
 } from "@client/src/luaGagsSettings";
+import useLatestRef from "./useLatestRef";
 
 type RegisterSave = (cb: () => void) => void;
 
@@ -32,6 +33,7 @@ function LuaGagsSettings({ registerSave }: { registerSave: RegisterSave }) {
     const [deleteLines, setDeleteLines] = useState<DeleteLineState>(() => ({
         ...DEFAULT_LUA_GAGS_DELETE_LINES,
     }));
+    const deleteLinesRef = useLatestRef(deleteLines);
 
     useEffect(() => {
         const update = () => setLocked(!getCurrentCharacter());
@@ -66,8 +68,8 @@ function LuaGagsSettings({ registerSave }: { registerSave: RegisterSave }) {
     }, [loadFromStorage]);
 
     useEffect(() => {
-        registerSave(() => storage.setItem(LUA_GAGS_STORAGE_KEY, deleteLines));
-    }, [registerSave, deleteLines]);
+        registerSave(() => storage.setItem(LUA_GAGS_STORAGE_KEY, deleteLinesRef.current));
+    }, [registerSave, deleteLinesRef]);
 
     const labels = useMemo(() => {
         const map: Record<LuaGagLineType, string> = {} as Record<LuaGagLineType, string>;

--- a/web-client/src/options/Settings.tsx
+++ b/web-client/src/options/Settings.tsx
@@ -5,6 +5,7 @@ import storage, { getCurrentCharacter } from "@client/src/storage";
 import { settingsStore, useSettingsSlice } from "@client/src/state/settingsStore";
 import { defaultSettings } from "./defaultSettings";
 import type { Settings as BaseSettings } from "./defaultSettings";
+import useLatestRef from "./useLatestRef";
 
 interface FormSettings extends BaseSettings {
 }
@@ -70,6 +71,7 @@ function normalizeSettings(source: BaseSettings): FormSettings {
 function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void }) {
     const storeSettings = useSettingsSlice(settings => settings);
     const [settings, setSettings] = useState<FormSettings>(() => normalizeSettings(storeSettings));
+    const settingsRef = useLatestRef(settings);
 
     const [locked, setLocked] = useState(!getCurrentCharacter());
 
@@ -100,8 +102,8 @@ function SettingsForm({ registerSave }: { registerSave: (cb: () => void) => void
         })
     }
     useEffect(() => {
-        registerSave(() => settingsStore.getState().updateSettings(settings));
-    }, [registerSave, settings]);
+        registerSave(() => settingsStore.getState().updateSettings(settingsRef.current));
+    }, [registerSave, settingsRef]);
 
     return (
         <div className="p-2 h-100">

--- a/web-client/src/options/useLatestRef.ts
+++ b/web-client/src/options/useLatestRef.ts
@@ -1,0 +1,9 @@
+import { MutableRefObject, useLayoutEffect, useRef } from 'react';
+
+export default function useLatestRef<T>(value: T): MutableRefObject<T> {
+    const ref = useRef(value);
+    useLayoutEffect(() => {
+        ref.current = value;
+    }, [value]);
+    return ref;
+}


### PR DESCRIPTION
## Summary
- add a reusable `useLatestRef` hook to expose the current value of controlled option forms
- update general, guild, and Lua gag settings saves to pull from refs so the latest toggles and selections persist

## Testing
- yarn --cwd web-client test
- yarn --cwd client test
- yarn --cwd web-client build *(fails: Rollup cannot resolve `zustand` from `client/src/state/settingsStore.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68fc6e55c344832a81ddda66bd679424