### PR TITLE
Improve recordings modal mobile layout

### DIFF
--- a/web-client/src/options/Recordings.tsx
+++ b/web-client/src/options/Recordings.tsx
@@ -1,5 +1,5 @@
 import {ChangeEvent, useEffect, useRef, useState} from 'react';
-import {Button, Table, Form} from 'react-bootstrap';
+import {Button, Form} from 'react-bootstrap';
 import {getRecordingNames, deleteRecording, getRecording, saveRecording, RecordedEvent} from './recordingStorage';
 
 const AUTO_RECENT_WINDOW_MS = 3 * 60 * 1000;
@@ -201,8 +201,8 @@ function Recordings() {
     }
 
     return (
-        <div className="m-2 d-flex flex-column gap-3">
-            <Form.Group className="d-flex gap-2 align-items-center">
+        <div className="recordings-options">
+            <Form.Group className="recordings-controls">
                 <Form.Control
                     type="text"
                     size="sm"
@@ -210,46 +210,70 @@ function Recordings() {
                     value={recordingName}
                     onChange={e => setRecordingName(e.target.value)}
                     disabled={recording}
-                    style={{maxWidth: '10rem'}}
+                    className="recording-name-input"
                 />
                 {recording ? (
                     <>
-                        <Button size="sm" variant="secondary" onClick={() => stop(false)}>Zatrzymaj</Button>
-                        <Button size="sm" onClick={() => stop(true)}>Zatrzymaj i zapisz</Button>
-                        <Button size="sm" variant="outline-primary" onClick={() => downloadRecording(recordingName)}>
+                        <Button size="sm" variant="secondary" className="recordings-action" onClick={() => stop(false)}>
+                            Zatrzymaj
+                        </Button>
+                        <Button size="sm" className="recordings-action" onClick={() => stop(true)}>
+                            Zatrzymaj i zapisz
+                        </Button>
+                        <Button
+                            size="sm"
+                            variant="outline-primary"
+                            className="recordings-action"
+                            onClick={() => downloadRecording(recordingName)}
+                        >
                             Pobierz (bieżący)
                         </Button>
                     </>
                 ) : (
-                    <Button size="sm" onClick={start}>Rozpocznij</Button>
+                    <Button size="sm" className="recordings-action" onClick={start}>Rozpocznij</Button>
                 )}
             </Form.Group>
             {autoRecordingName && (
-                <div className="d-flex flex-wrap gap-2 align-items-center text-muted small">
+                <div className="recordings-auto-info text-muted small">
                     <span>Automatyczne nagrywanie aktywne:</span>
                     <strong className="text-body">{autoRecordingName}</strong>
-                    <Button size="sm" onClick={() => downloadRecording(autoRecordingName)}>Pobierz aktualny stan</Button>
-                    <Button size="sm" variant="outline-primary" onClick={downloadAutoRecentRecording}>Pobierz ostatnie 3 minuty</Button>
+                    <Button size="sm" className="recordings-action" onClick={() => downloadRecording(autoRecordingName)}>
+                        Pobierz aktualny stan
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="outline-primary"
+                        className="recordings-action"
+                        onClick={downloadAutoRecentRecording}
+                    >
+                        Pobierz ostatnie 3 minuty
+                    </Button>
                 </div>
             )}
-            <Table bordered size="sm" hover className="table-modern table-zebra">
-                <tbody>
+            <div className="recordings-list">
                 {names.map(n => (
-                    <tr key={n}>
-                        <td>{n}</td>
-                        <td className="d-flex gap-2">
-                            <Button size="sm" onClick={() => handlePlay(n)}>Odtwórz</Button>
-                            <Button size="sm" onClick={() => handlePlayTimed(n)}>Odtwórz w czasie</Button>
-                            <Button size="sm" onClick={() => downloadRecording(n)}>Pobierz</Button>
-                            <Button size="sm" variant="danger" onClick={() => handleDelete(n)}>Usuń</Button>
-                        </td>
-                    </tr>
+                    <div key={n} className="recordings-item">
+                        <div className="recordings-item-name">{n}</div>
+                        <div className="recordings-row-actions">
+                            <Button size="sm" className="recordings-action" onClick={() => handlePlay(n)}>
+                                Odtwórz
+                            </Button>
+                            <Button size="sm" className="recordings-action" onClick={() => handlePlayTimed(n)}>
+                                Odtwórz w czasie
+                            </Button>
+                            <Button size="sm" className="recordings-action" onClick={() => downloadRecording(n)}>
+                                Pobierz
+                            </Button>
+                            <Button size="sm" variant="danger" className="recordings-action" onClick={() => handleDelete(n)}>
+                                Usuń
+                            </Button>
+                        </div>
+                    </div>
                 ))}
-                </tbody>
-            </Table>
-            <div className="d-flex gap-2">
-                <Button size="sm" onClick={downloadRecordings}>Eksport</Button>
-                <Button size="sm" onClick={triggerFileInput}>Importuj</Button>
+            </div>
+            <div className="recordings-footer-actions">
+                <Button size="sm" className="recordings-action" onClick={downloadRecordings}>Eksport</Button>
+                <Button size="sm" className="recordings-action" onClick={triggerFileInput}>Importuj</Button>
                 <input
                     ref={fileInput}
                     type="file"
@@ -258,7 +282,7 @@ function Recordings() {
                     onChange={uploadRecordings}
                 />
             </div>
-            {message && <div>{message}</div>}
+            {message && <div className="recordings-message">{message}</div>}
         </div>
     );
 }

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -1124,6 +1124,117 @@ h1 {
   color: white;
 }
 
+.recordings-options {
+  margin: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.recordings-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+
+.recording-name-input {
+  flex: 1 1 12rem;
+  min-width: 0;
+}
+
+.recordings-action {
+  flex: 1 1 10rem;
+}
+
+.recordings-auto-info {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.recordings-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.recordings-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background-color: rgba(255, 255, 255, 0.03);
+}
+
+.recordings-item-name {
+  word-break: break-word;
+  font-weight: 500;
+}
+
+.recordings-row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.recordings-row-actions .btn {
+  flex: 1 1 10rem;
+}
+
+.recordings-footer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.recordings-footer-actions .btn,
+.recordings-auto-info .btn {
+  flex: 1 1 12rem;
+}
+
+.recordings-message {
+  font-size: 0.875rem;
+}
+
+@media (min-width: 576px) {
+  .recordings-options {
+    gap: 1.25rem;
+  }
+
+  .recordings-controls {
+    align-items: center;
+  }
+
+  .recording-name-input {
+    flex: 0 0 12rem;
+  }
+
+  .recordings-action,
+  .recordings-footer-actions .btn,
+  .recordings-auto-info .btn {
+    flex: 0 0 auto;
+  }
+}
+
+@media (min-width: 768px) {
+  .recordings-item {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .recordings-item-name {
+    flex: 1;
+  }
+
+  .recordings-row-actions .btn {
+    flex: 0 0 auto;
+  }
+}
+
 #app {
   max-width: 90vw;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- refactor the recordings options modal to use a responsive flex layout instead of a fixed-width table
- add mobile-friendly utility styles so recording controls and actions wrap cleanly on narrow viewports

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68fcbd2ecf60832abb97b089ae527c29