### PR TITLE
Use raw trigger text for token parsing

### DIFF
--- a/client/src/Triggers.ts
+++ b/client/src/Triggers.ts
@@ -1,7 +1,6 @@
 import Client from "./Client";
-import { stripAnsiCodes } from "./stripAnsiCodes";
 import TriggerLine from "./triggers/TriggerLine";
-export { stripAnsiCodes };
+export { stripAnsiCodes } from "./stripAnsiCodes";
 
 type TriggerCallback = (
     rawLine: string,
@@ -243,7 +242,7 @@ export default class Triggers {
             rawLine instanceof TriggerLine
                 ? rawLine
                 : new TriggerLine(rawLine, { type }, this.triggerEngineActive);
-        const plain = stripAnsiCodes(triggerLine.text).replace(/\s$/g, "");
+        const plain = triggerLine.text.replace(/\s$/g, "");
         const tokens = plain
             .split(/[ \n\t.,!?*()\/\[\]]+/)
             .filter(t => t.length > 0)


### PR DESCRIPTION
## Summary
- stop stripping ANSI codes when preparing trigger text for token matching
- keep re-export of `stripAnsiCodes` without importing it into the module

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68fcd735addc832a896a5fad4f3a2d0c