### PR TITLE
Show timestamps during recording playback

### DIFF
--- a/web-client/src/Recorder.ts
+++ b/web-client/src/Recorder.ts
@@ -20,6 +20,7 @@ export default class Recorder {
     private pausedDelay = 0;
     private isPlaying = false;
     private paused = false;
+    private playbackBaseTimestamp: number | null = null;
 
     constructor(private hooks: RecorderHooks) {
     }
@@ -89,6 +90,7 @@ export default class Recorder {
         this.isPlaying = false;
         this.paused = false;
         this.playbackIndex = 0;
+        this.playbackBaseTimestamp = null;
         this.hooks.emit('playback.stop');
     }
 
@@ -177,9 +179,11 @@ export default class Recorder {
         this.isPlaying = true;
         this.paused = false;
         this.playbackIndex = 0;
+        const firstTimestamp = this.recordedMessages[0]?.timestamp;
+        this.playbackBaseTimestamp = typeof firstTimestamp === 'number' ? firstTimestamp : null;
         this.hooks.emit('playback.start', this.recordedMessages.length);
         this.hooks.emit("message", '== Playback start ==');
-        this.hooks.emit('playback.index', 0, this.recordedMessages.length);
+        this.hooks.emit('playback.index', 0, this.recordedMessages.length, this.playbackBaseTimestamp, 0);
         this.scheduleNext(0);
     }
 
@@ -200,9 +204,13 @@ export default class Recorder {
             this.stopPlayback();
             return;
         }
+        const eventTimestamp = typeof ev.timestamp === 'number' ? ev.timestamp : null;
+        const offset = eventTimestamp !== null && this.playbackBaseTimestamp !== null
+            ? Math.max(0, eventTimestamp - this.playbackBaseTimestamp)
+            : null;
         this.playEvent(ev);
         this.playbackIndex++;
-        this.hooks.emit('playback.index', this.playbackIndex, this.recordedMessages.length);
+        this.hooks.emit('playback.index', this.playbackIndex, this.recordedMessages.length, eventTimestamp, offset);
     }
 
     private scheduleNext(initialDelay: number) {

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -452,6 +452,36 @@ document.addEventListener('DOMContentLoaded', () => {
     const playbackReplay = document.getElementById('playback-replay') as HTMLButtonElement | null;
     const playbackStepBack = document.getElementById('playback-step-back') as HTMLButtonElement | null;
     const playbackStep = document.getElementById('playback-step') as HTMLButtonElement | null;
+    const updatePlaybackInfoText = (() => {
+        const pad = (value: number) => value.toString().padStart(2, '0');
+        const formatAbsoluteTime = (timestamp: number) => {
+            const date = new Date(timestamp);
+            return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+        };
+        const formatDuration = (ms: number) => {
+            const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+            const hours = Math.floor(totalSeconds / 3600);
+            const minutes = Math.floor((totalSeconds % 3600) / 60);
+            const seconds = totalSeconds % 60;
+            if (hours > 0) {
+                return `${hours}:${pad(minutes)}:${pad(seconds)}`;
+            }
+            return `${pad(minutes)}:${pad(seconds)}`;
+        };
+        return (index: number, total: number, timestamp?: number | null, offset?: number | null) => {
+            if (!playbackInfo) return;
+            let extra = '';
+            if (typeof timestamp === 'number' && !Number.isNaN(timestamp)) {
+                extra = formatAbsoluteTime(timestamp);
+                if (typeof offset === 'number' && offset >= 0) {
+                    extra += ` | +${formatDuration(offset)}`;
+                }
+            } else if (typeof offset === 'number' && offset >= 0) {
+                extra = `+${formatDuration(offset)}`;
+            }
+            playbackInfo.textContent = extra ? `${index} / ${total} (${extra})` : `${index} / ${total}`;
+        };
+    })();
     wakeLockButton = document.getElementById('wake-lock-button') as HTMLButtonElement | null;
     updateWakeLockButton();
 
@@ -742,7 +772,7 @@ document.addEventListener('DOMContentLoaded', () => {
     arkadiaClient.on('playback.start', (total: number) => {
         playbackMode = true;
         if (playbackControls) playbackControls.style.display = 'flex';
-        if (playbackInfo) playbackInfo.textContent = `0 / ${total}`;
+        updatePlaybackInfoText(0, total);
         if (playbackPause) playbackPause.textContent = 'Pause';
         updateConnectButtons();
     });
@@ -761,8 +791,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (playbackPause) playbackPause.textContent = 'Pause';
     });
 
-    arkadiaClient.on('playback.index', (index: number, total: number) => {
-        if (playbackInfo) playbackInfo.textContent = `${index} / ${total}`;
+    arkadiaClient.on('playback.index', (index: number, total: number, timestamp?: number | null, offset?: number | null) => {
+        updatePlaybackInfoText(index, total, timestamp, offset);
     });
 
     if (wakeLockButton) {


### PR DESCRIPTION
## Summary
- emit recorded event timestamps during timed playback
- display absolute and relative times in the playback controls indicator

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fd30c3f0ac832abba46cf88c0a8a2f