### PR TITLE
Capture map location metadata in recordings

### DIFF
--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -304,6 +304,19 @@ export default class MapHelper {
         }
     }
 
+    renderRoomByIdSilently(id: number) {
+        if (typeof id !== 'number') {
+            return;
+        }
+        const previousSuppress = this.client.suppressMapMoveEvent;
+        this.client.suppressMapMoveEvent = true;
+        try {
+            this.renderRoomById(id, false);
+        } finally {
+            this.client.suppressMapMoveEvent = previousSuppress;
+        }
+    }
+
     renderRoomById(id: number, sendEvent = true) {
         if (!this.mapReader) {
             this.savedRoomId = id;

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -478,7 +478,26 @@ class ArkadiaClient implements ClientAdapter {
         const recorder = new Recorder({
             processIncomingData: (d) => this.processIncomingData(d),
             sendCommand: (cmd, echo, options) => this.send(cmd, echo, options),
-            emit: (ev, ...args) => this.emitRecorderEvent(auto, recorder, ev, ...args)
+            emit: (ev, ...args) => this.emitRecorderEvent(auto, recorder, ev, ...args),
+            getCurrentMapLocation: () => {
+                const ext: any = (window as any).clientExtension;
+                const id = ext?.Map?.currentRoom?.id;
+                return typeof id === 'number' ? id : null;
+            },
+            setMapLocationSilently: (locationId: number) => {
+                const ext: any = (window as any).clientExtension;
+                const map = ext?.Map;
+                if (!map || typeof locationId !== 'number') {
+                    return;
+                }
+                if (typeof map.renderRoomByIdSilently === 'function') {
+                    map.renderRoomByIdSilently(locationId);
+                    return;
+                }
+                if (typeof map.renderRoomById === 'function') {
+                    map.renderRoomById(locationId, false);
+                }
+            }
         });
         return recorder;
     }

--- a/web-client/src/Recorder.ts
+++ b/web-client/src/Recorder.ts
@@ -7,12 +7,17 @@ export interface RecorderHooks {
     sendCommand(command: string, echo?: boolean, options?: CommandOptions): void;
 
     emit(event: string, ...args: any[]): void;
+
+    getCurrentMapLocation?(): number | null;
+
+    setMapLocationSilently?(locationId: number): void;
 }
 
 export default class Recorder {
     private isRecording = false;
     private recordedMessages: RecordedEvent[] = [];
     private currentRecordingName: string | null = null;
+    private pendingInitialLocationId: number | null = null;
     private playbackTimeout: number | null = null;
     private playbackIndex = 0;
     private playbackDelay = 0;
@@ -26,21 +31,13 @@ export default class Recorder {
 
     handleIncoming(message: string) {
         if (this.isRecording) {
-            this.recordedMessages.push({
-                message,
-                timestamp: Date.now(),
-                direction: 'in'
-            });
+            this.recordEvent(message, 'in');
         }
     }
 
     handleOutgoing(message: string) {
         if (this.isRecording) {
-            this.recordedMessages.push({
-                message,
-                timestamp: Date.now(),
-                direction: 'out'
-            });
+            this.recordEvent(message, 'out');
         }
     }
 
@@ -48,11 +45,13 @@ export default class Recorder {
         this.recordedMessages = [];
         this.currentRecordingName = name;
         this.isRecording = true;
+        this.pendingInitialLocationId = this.readCurrentLocation();
         this.hooks.emit('recording.start', name);
     }
 
     async stopRecording(save?: boolean) {
         this.isRecording = false;
+        this.pendingInitialLocationId = null;
         if (save && this.currentRecordingName) {
             await saveRecording(this.currentRecordingName, this.recordedMessages);
         }
@@ -157,6 +156,7 @@ export default class Recorder {
     replayRecordedMessages() {
         if (this.recordedMessages.length === 0) return;
         this.stopPlayback();
+        this.applyInitialLocation();
         this.isPlaying = true;
         this.hooks.emit('playback.start');
         this.hooks.emit("message", '== Playback start ==');
@@ -174,6 +174,7 @@ export default class Recorder {
     replayRecordedMessagesTimed() {
         if (this.recordedMessages.length === 0) return;
         this.stopPlayback();
+        this.applyInitialLocation();
         this.isPlaying = true;
         this.paused = false;
         this.playbackIndex = 0;
@@ -191,6 +192,49 @@ export default class Recorder {
             window.clientExtension.sendCommand(ev.message, false);
             this.hooks.sendCommand(ev.message, false);
         }
+    }
+
+    private applyInitialLocation() {
+        if (typeof this.hooks.setMapLocationSilently !== 'function') {
+            return;
+        }
+        const initialEvent = this.recordedMessages.find(event => typeof event.initialLocationId === 'number');
+        const fallbackEvent = this.recordedMessages.find(event => typeof event.locationId === 'number');
+        const locationId = initialEvent?.initialLocationId ?? fallbackEvent?.locationId;
+        if (typeof locationId === 'number') {
+            this.hooks.setMapLocationSilently(locationId);
+        }
+    }
+
+    private recordEvent(message: string, direction: 'in' | 'out') {
+        const event: RecordedEvent = {
+            message,
+            timestamp: Date.now(),
+            direction
+        };
+        const currentLocation = this.readCurrentLocation();
+        if (typeof this.pendingInitialLocationId === 'number') {
+            event.initialLocationId = this.pendingInitialLocationId;
+            if (typeof currentLocation !== 'number') {
+                event.locationId = this.pendingInitialLocationId;
+            }
+            this.pendingInitialLocationId = null;
+        }
+        if (typeof currentLocation === 'number') {
+            event.locationId = currentLocation;
+        }
+        if (this.recordedMessages.length === 0 && typeof event.initialLocationId !== 'number' && typeof event.locationId === 'number') {
+            event.initialLocationId = event.locationId;
+        }
+        this.recordedMessages.push(event);
+    }
+
+    private readCurrentLocation(): number | null {
+        if (typeof this.hooks.getCurrentMapLocation !== 'function') {
+            return null;
+        }
+        const location = this.hooks.getCurrentMapLocation();
+        return typeof location === 'number' ? location : null;
     }
 
     private executeCurrent() {

--- a/web-client/src/options/recordingStorage.ts
+++ b/web-client/src/options/recordingStorage.ts
@@ -2,6 +2,8 @@ export interface RecordedEvent {
     message: string;
     timestamp: number;
     direction: 'in' | 'out';
+    locationId?: number;
+    initialLocationId?: number;
 }
 
 function openDB(): Promise<IDBDatabase> {

--- a/web-client/src/recordingStorage.ts
+++ b/web-client/src/recordingStorage.ts
@@ -2,6 +2,8 @@ export interface RecordedEvent {
     message: string;
     timestamp: number;
     direction: 'in' | 'out';
+    locationId?: number;
+    initialLocationId?: number;
 }
 
 function openDB(): Promise<IDBDatabase> {

--- a/web-client/test/Recorder.test.ts
+++ b/web-client/test/Recorder.test.ts
@@ -6,6 +6,8 @@ describe('Recorder playback', () => {
       processIncomingData: jest.fn(),
       sendCommand: jest.fn(),
       emit: jest.fn(),
+      getCurrentMapLocation: jest.fn(),
+      setMapLocationSilently: jest.fn(),
     };
     const recorder = new Recorder(hooks as any);
     (window as any).clientExtension = { sendCommand: jest.fn() };
@@ -16,5 +18,31 @@ describe('Recorder playback', () => {
     recorder.replayRecordedMessagesTimed();
     jest.runAllTimers();
     expect(hooks.emit).toHaveBeenCalledWith('message', '→ look');
+  });
+
+  test('stores start location and applies it once during playback', async () => {
+    const getCurrentMapLocation = jest.fn()
+      .mockReturnValueOnce(3525)
+      .mockReturnValue(3527);
+    const hooks = {
+      processIncomingData: jest.fn(),
+      sendCommand: jest.fn(),
+      emit: jest.fn(),
+      getCurrentMapLocation,
+      setMapLocationSilently: jest.fn(),
+    };
+    const recorder = new Recorder(hooks as any);
+    recorder.startRecording('demo');
+    recorder.handleIncoming('Some line');
+    await recorder.stopRecording(false);
+
+    const events = recorder.getRecordedMessages();
+    expect(events[0].initialLocationId).toBe(3525);
+    expect(events[0].locationId).toBe(3527);
+
+    recorder.replayRecordedMessages();
+
+    expect(hooks.setMapLocationSilently).toHaveBeenCalledTimes(1);
+    expect(hooks.setMapLocationSilently).toHaveBeenCalledWith(3525);
   });
 });


### PR DESCRIPTION
## Summary
- extend recorded events with map location metadata and capture the starting room when manual or automatic recordings begin
- set the recorded start location on playback without emitting map events by exposing silent map positioning through the map helper and the client
- cover the behaviour with a dedicated recorder unit test

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fd332606a8832a89b5eb7d5a6200e4