### PR TITLE
Add native context menu option for output area

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -185,6 +185,9 @@ const stickyArea = document.getElementById('sticky-area') as HTMLElement;
 let isSplitView = false;
 const STICKY_LINES = 15;
 
+let allowNextNativeContextMenu = false;
+let lastContextMenuEvent: MouseEvent | null = null;
+
 function processSticky(count: number) {
     const handler: any = (window as any).clientExtension?.OutputHandler;
     if (handler && typeof handler.processOutput === 'function') {
@@ -219,19 +222,60 @@ function checkSplitView() {
 outputWrapper.addEventListener('scroll', checkSplitView);
 
 outputWrapper.addEventListener('contextmenu', event => {
-    const handler: any = (window as any).clientExtension?.OutputHandler;
-    if (!handler || typeof handler.showContextMenu !== 'function') {
+    if (allowNextNativeContextMenu) {
+        allowNextNativeContextMenu = false;
+        lastContextMenuEvent = null;
         return;
     }
+
+    const handler: any = (window as any).clientExtension?.OutputHandler;
+    if (!handler || typeof handler.showContextMenu !== 'function') {
+        lastContextMenuEvent = null;
+        return;
+    }
+
     event.preventDefault();
+    lastContextMenuEvent = event;
+
     const isVisible = areOutputTimestampsVisible();
     const items = [
         {
             label: isVisible ? 'Ukryj znaczniki czasu' : 'Pokaż znaczniki czasu',
             action: () => setOutputTimestampVisibility(!isVisible),
         },
+        {
+            label: 'Pokaż oryginalne menu',
+            action: () => {
+                if (typeof handler.hideContextMenu === 'function') {
+                    handler.hideContextMenu();
+                }
+                const originalEvent = lastContextMenuEvent;
+                lastContextMenuEvent = null;
+                if (!originalEvent) {
+                    return;
+                }
+                const { clientX, clientY } = originalEvent;
+                const target = document.elementFromPoint(clientX, clientY) as HTMLElement | null
+                    ?? (originalEvent.target instanceof HTMLElement ? originalEvent.target : outputWrapper);
+                allowNextNativeContextMenu = true;
+                requestAnimationFrame(() => {
+                    const nativeEvent = new MouseEvent('contextmenu', {
+                        bubbles: true,
+                        cancelable: true,
+                        view: window,
+                        clientX,
+                        clientY,
+                    });
+                    (target ?? outputWrapper).dispatchEvent(nativeEvent);
+                });
+            },
+        },
     ];
-    handler.showContextMenu(items, event.clientX, event.clientY);
+
+    handler.showContextMenu(items, event.clientX, event.clientY, {
+        header: `Znaczniki czasu: ${isVisible ? 'włączone' : 'wyłączone'}`,
+        smallHeader: true,
+    });
 });
 
 function closeHistoryScrollback() {

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -186,7 +186,12 @@ let isSplitView = false;
 const STICKY_LINES = 15;
 
 let allowNextNativeContextMenu = false;
-let lastContextMenuEvent: MouseEvent | null = null;
+type StoredContextEvent = {
+    clientX: number;
+    clientY: number;
+    target: EventTarget | null;
+};
+let lastContextMenuEvent: StoredContextEvent | null = null;
 
 function processSticky(count: number) {
     const handler: any = (window as any).clientExtension?.OutputHandler;
@@ -223,8 +228,10 @@ outputWrapper.addEventListener('scroll', checkSplitView);
 
 outputWrapper.addEventListener('contextmenu', event => {
     if (allowNextNativeContextMenu) {
-        allowNextNativeContextMenu = false;
-        lastContextMenuEvent = null;
+        if (event.isTrusted) {
+            allowNextNativeContextMenu = false;
+            lastContextMenuEvent = null;
+        }
         return;
     }
 
@@ -235,7 +242,11 @@ outputWrapper.addEventListener('contextmenu', event => {
     }
 
     event.preventDefault();
-    lastContextMenuEvent = event;
+    lastContextMenuEvent = {
+        clientX: event.clientX,
+        clientY: event.clientY,
+        target: event.target,
+    };
 
     const isVisible = areOutputTimestampsVisible();
     const items = [
@@ -251,13 +262,17 @@ outputWrapper.addEventListener('contextmenu', event => {
                 }
                 const originalEvent = lastContextMenuEvent;
                 lastContextMenuEvent = null;
+                allowNextNativeContextMenu = true;
                 if (!originalEvent) {
                     return;
                 }
-                const { clientX, clientY } = originalEvent;
-                const target = document.elementFromPoint(clientX, clientY) as HTMLElement | null
-                    ?? (originalEvent.target instanceof HTMLElement ? originalEvent.target : outputWrapper);
-                allowNextNativeContextMenu = true;
+                const {clientX, clientY, target} = originalEvent;
+                const fallbackTarget =
+                    document.elementFromPoint(clientX, clientY) as HTMLElement | null
+                    ?? (target instanceof HTMLElement
+                        ? target
+                        : (target as Node | null)?.parentElement)
+                    ?? outputWrapper;
                 requestAnimationFrame(() => {
                     const nativeEvent = new MouseEvent('contextmenu', {
                         bubbles: true,
@@ -266,7 +281,7 @@ outputWrapper.addEventListener('contextmenu', event => {
                         clientX,
                         clientY,
                     });
-                    (target ?? outputWrapper).dispatchEvent(nativeEvent);
+                    fallbackTarget.dispatchEvent(nativeEvent);
                 });
             },
         },


### PR DESCRIPTION
## Summary
- show the current timestamp visibility state in the output context menu header
- add an option to temporarily restore the browser's original context menu

## Testing
- yarn --cwd web-client test --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68fd408619a0832aad42389335295f92