### PR TITLE
Allow default context menu for output links

### DIFF
--- a/client/src/OutputHandler.ts
+++ b/client/src/OutputHandler.ts
@@ -81,6 +81,7 @@ export default class OutputHandler {
     }
 
     private decorateClickable(span: HTMLElement, cbIndex: number, title?: string) {
+        span.dataset.outputClickable = "true"
         span.style.cursor = "pointer"
         span.style.textDecoration = " underline"
         span.style.textDecorationStyle = "dotted"

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -219,6 +219,13 @@ function checkSplitView() {
 outputWrapper.addEventListener('scroll', checkSplitView);
 
 outputWrapper.addEventListener('contextmenu', event => {
+    if (event.defaultPrevented) {
+        return;
+    }
+    const target = event.target as HTMLElement | null;
+    if (target && target.closest('a, [data-output-clickable]')) {
+        return;
+    }
     const handler: any = (window as any).clientExtension?.OutputHandler;
     if (!handler || typeof handler.showContextMenu !== 'function') {
         return;


### PR DESCRIPTION
## Summary
- mark clickable output spans with a data attribute for downstream checks
- skip the custom output context menu when right-clicking existing links or handlers so their clicks keep working

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68fd426ff30c832aaf7d86899bb44ee4