### PR TITLE
Stop follow movement from issuing commands

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -439,9 +439,6 @@ export default class Client {
 
     private sendMovement(command: string, echo: boolean, options?: CommandOptions) {
         const moveRes = this.Map.move(command)
-        if (moveRes.supress) {
-            return
-        }
         if (moveRes.moved) {
             this.Map.setBlockable(true)
         }

--- a/client/src/MapHelper.ts
+++ b/client/src/MapHelper.ts
@@ -168,7 +168,7 @@ export default class MapHelper {
         return command
     }
 
-    move(direction: string): {direction: string, moved: boolean, supress?: boolean} {
+    move(direction: string): {direction: string, moved: boolean, translated?: boolean} {
         if (!this.mapReader) {
             return {direction, moved: false}
         }
@@ -194,8 +194,7 @@ export default class MapHelper {
             }
 
             if (actualDirection !== direction) {
-                this.client.sendCommand(actualDirection)
-                return {direction: actualDirection, moved: false, supress: true}
+                return {direction: actualDirection, moved: false, translated: true}
             }
 
             const locationId = allExits[getLongDir(actualDirection)]


### PR DESCRIPTION
## Summary
- prevent map follow updates from triggering outbound movement commands
- delegate movement command dispatch to the client so only user-initiated moves send commands

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68fd3dc94bb4832aae4f9c4ec1c1ef17