### PR TITLE
Fix enemy guild postfix coloring

### DIFF
--- a/client/src/scripts/guildPostfix.ts
+++ b/client/src/scripts/guildPostfix.ts
@@ -2,16 +2,20 @@ import Client from "../Client";
 import { colorString, findClosestColor } from "../Colors";
 
 const SLATE_BLUE = findClosestColor("#6a5acd");
+const ENEMY_RED = findClosestColor("#ff0000");
 
 type GuildColorMap = Record<string, number | undefined>;
 
 export default function initGuildPostfix(client: Client) {
     const tag = "guildPostfix";
     let guildColors: GuildColorMap = {};
+    let enemyGuilds = new Set<string>();
 
     client.addEventListener('settings', (ev: CustomEvent) => {
         const colors: Record<string, string | undefined> = ev.detail.guildColors || {};
+        const enemies: string[] = ev.detail.enemyGuilds || [];
         guildColors = {};
+        enemyGuilds = new Set(enemies);
         Object.entries(colors).forEach(([g, hex]) => {
             if (hex) {
                 guildColors[g] = findClosestColor(hex);
@@ -21,7 +25,7 @@ export default function initGuildPostfix(client: Client) {
 
     function register(pattern: RegExp | string, guild: string) {
         client.Triggers.registerTrigger(pattern, (raw) => {
-            const color = guildColors[guild] ?? SLATE_BLUE;
+            const color = enemyGuilds.has(guild) ? ENEMY_RED : guildColors[guild] ?? SLATE_BLUE;
             return client.postfix(raw, colorString(` [${guild}]`, color));
         }, tag);
     }

--- a/client/test/guildPostfix.test.ts
+++ b/client/test/guildPostfix.test.ts
@@ -1,0 +1,47 @@
+import initGuildPostfix from "../src/scripts/guildPostfix";
+import Triggers from "../src/Triggers";
+import { color, findClosestColor, RESET } from "../src/Colors";
+
+describe("guildPostfix", () => {
+  class FakeClient {
+    Triggers = new Triggers(({} as unknown) as any);
+    addEventListener = jest.fn();
+    postfix = jest.fn((raw: string, postfix: string) => raw + postfix);
+  }
+
+  const enemyLine = "Noszony przez niego pierscien czlonkow Kupcow.";
+
+  let client: FakeClient;
+  let parse: (line: string) => string;
+  let settingsHandler: ((event: { detail: { enemyGuilds?: string[]; guildColors?: Record<string, string | undefined> } }) => void) | undefined;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    initGuildPostfix((client as unknown) as any);
+    parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, "");
+    settingsHandler = client.addEventListener.mock.calls[0]?.[1] as ((event: { detail: { enemyGuilds?: string[]; guildColors?: Record<string, string | undefined> } }) => void) | undefined;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function emitSettings(detail: { enemyGuilds?: string[]; guildColors?: Record<string, string | undefined> }) {
+    settingsHandler?.({ detail });
+  }
+
+  test("colors guild postfix with configured color", () => {
+    const greenHex = "#00ff00";
+    emitSettings({ guildColors: { CKN: greenHex }, enemyGuilds: [] });
+    const result = parse(enemyLine);
+    const green = findClosestColor(greenHex);
+    expect(result).toContain(color(green) + " [CKN]" + RESET);
+  });
+
+  test("colors enemy guild postfix red", () => {
+    emitSettings({ enemyGuilds: ["CKN"] });
+    const result = parse(enemyLine);
+    const red = findClosestColor("#ff0000");
+    expect(result).toContain(color(red) + " [CKN]" + RESET);
+  });
+});


### PR DESCRIPTION
## Summary
- highlight guild postfix text in red when the guild is marked as an enemy
- keep track of enemy selections in the guildPostfix script alongside custom colors
- add tests that cover ally and enemy guild postfix coloring

## Testing
- yarn --cwd client test --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68fd474cd640832a9f5cd18c2937e8c6