### PR TITLE
Fix enemy red coloring for Xterm palette

### DIFF
--- a/client/src/Colors.ts
+++ b/client/src/Colors.ts
@@ -74,7 +74,7 @@ export function findClosestColor(hex: string | number[]): number {
             distance = compDistance
         }
     })
-    return currentPick + 1
+    return currentPick
 }
 
 export function mudletColorLine(line: string) {


### PR DESCRIPTION
## Summary
- return the exact palette index from `findClosestColor` so xterm colors map correctly

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fd50cc02e0832a8f5b36b6a8bc3c6c