### PR TITLE
Fix enemy highlight colors when switching palettes

### DIFF
--- a/client/src/Colors.ts
+++ b/client/src/Colors.ts
@@ -74,7 +74,7 @@ export function findClosestColor(hex: string | number[]): number {
             distance = compDistance
         }
     })
-    return currentPick + 1
+    return currentPick
 }
 
 export function mudletColorLine(line: string) {

--- a/client/src/People.ts
+++ b/client/src/People.ts
@@ -33,6 +33,9 @@ export default class People {
             this.guildColors = event.detail.guildColors || {}
             this.ensurePeopleTriggers()
         })
+        this.client.addEventListener('uiSettings', () => {
+            this.ensurePeopleTriggers(true)
+        })
         this.ensurePeopleTriggers()
     }
 

--- a/client/src/scripts/guildPostfix.ts
+++ b/client/src/scripts/guildPostfix.ts
@@ -1,31 +1,43 @@
 import Client from "../Client";
 import { colorString, findClosestColor } from "../Colors";
 
-const SLATE_BLUE = findClosestColor("#6a5acd");
-const ENEMY_RED = findClosestColor("#ff0000");
-
 type GuildColorMap = Record<string, number | undefined>;
 
 export default function initGuildPostfix(client: Client) {
     const tag = "guildPostfix";
     let guildColors: GuildColorMap = {};
+    let guildColorHex: Record<string, string | undefined> = {};
     let enemyGuilds = new Set<string>();
+    let slateBlue = findClosestColor("#6a5acd");
+    let enemyRed = findClosestColor("#ff0000");
+
+    const recalculateColors = () => {
+        slateBlue = findClosestColor("#6a5acd");
+        enemyRed = findClosestColor("#ff0000");
+        const updated: GuildColorMap = {};
+        Object.entries(guildColorHex).forEach(([guild, hex]) => {
+            if (hex) {
+                updated[guild] = findClosestColor(hex);
+            }
+        });
+        guildColors = updated;
+    };
 
     client.addEventListener('settings', (ev: CustomEvent) => {
         const colors: Record<string, string | undefined> = ev.detail.guildColors || {};
         const enemies: string[] = ev.detail.enemyGuilds || [];
-        guildColors = {};
+        guildColorHex = { ...colors };
         enemyGuilds = new Set(enemies);
-        Object.entries(colors).forEach(([g, hex]) => {
-            if (hex) {
-                guildColors[g] = findClosestColor(hex);
-            }
-        });
+        recalculateColors();
+    });
+
+    client.addEventListener('uiSettings', () => {
+        recalculateColors();
     });
 
     function register(pattern: RegExp | string, guild: string) {
         client.Triggers.registerTrigger(pattern, (raw) => {
-            const color = enemyGuilds.has(guild) ? ENEMY_RED : guildColors[guild] ?? SLATE_BLUE;
+            const color = enemyGuilds.has(guild) ? enemyRed : guildColors[guild] ?? slateBlue;
             return client.postfix(raw, colorString(` [${guild}]`, color));
         }, tag);
     }

--- a/client/test/guildPostfix.test.ts
+++ b/client/test/guildPostfix.test.ts
@@ -1,6 +1,6 @@
 import initGuildPostfix from "../src/scripts/guildPostfix";
 import Triggers from "../src/Triggers";
-import { color, findClosestColor, RESET } from "../src/Colors";
+import { color, findClosestColor, RESET, setXtermPalette } from "../src/Colors";
 
 describe("guildPostfix", () => {
   class FakeClient {
@@ -14,16 +14,19 @@ describe("guildPostfix", () => {
   let client: FakeClient;
   let parse: (line: string) => string;
   let settingsHandler: ((event: { detail: { enemyGuilds?: string[]; guildColors?: Record<string, string | undefined> } }) => void) | undefined;
+  let uiSettingsHandler: ((event: CustomEvent) => void) | undefined;
 
   beforeEach(() => {
     client = new FakeClient();
     initGuildPostfix((client as unknown) as any);
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, "");
-    settingsHandler = client.addEventListener.mock.calls[0]?.[1] as ((event: { detail: { enemyGuilds?: string[]; guildColors?: Record<string, string | undefined> } }) => void) | undefined;
+    settingsHandler = client.addEventListener.mock.calls.find(([event]) => event === 'settings')?.[1] as ((event: { detail: { enemyGuilds?: string[]; guildColors?: Record<string, string | undefined> } }) => void) | undefined;
+    uiSettingsHandler = client.addEventListener.mock.calls.find(([event]) => event === 'uiSettings')?.[1];
   });
 
   afterEach(() => {
     jest.clearAllMocks();
+    setXtermPalette('arkadia');
   });
 
   function emitSettings(detail: { enemyGuilds?: string[]; guildColors?: Record<string, string | undefined> }) {
@@ -43,5 +46,19 @@ describe("guildPostfix", () => {
     const result = parse(enemyLine);
     const red = findClosestColor("#ff0000");
     expect(result).toContain(color(red) + " [CKN]" + RESET);
+  });
+
+  test('updates enemy color after palette change', () => {
+    emitSettings({ enemyGuilds: ["CKN"] });
+    const before = parse(enemyLine);
+    const initialRed = findClosestColor('#ff0000');
+    expect(before).toContain(color(initialRed) + " [CKN]" + RESET);
+
+    setXtermPalette('proper');
+    uiSettingsHandler?.({ detail: { xtermPalette: 'proper' } } as any);
+
+    const after = parse(enemyLine);
+    const updatedRed = findClosestColor('#ff0000');
+    expect(after).toContain(color(updatedRed) + " [CKN]" + RESET);
   });
 });

--- a/client/test/people.test.ts
+++ b/client/test/people.test.ts
@@ -1,6 +1,6 @@
 import People from '../src/People';
 import Triggers, { stripAnsiCodes } from '../src/Triggers';
-import { color, RESET, findClosestColor } from '../src/Colors';
+import { color, RESET, findClosestColor, setXtermPalette } from '../src/Colors';
 import { refresh, subscribe, forceRefresh } from '../src/peopleStore';
 
 jest.mock('../src/peopleStore', () => ({
@@ -29,6 +29,7 @@ class FakeClient {
 describe('people triggers enemy highlight', () => {
   let client: FakeClient;
   let parse: (line: string) => string;
+  let uiSettingsHandler: ((event: CustomEvent) => void) | undefined;
   const subscribers: Array<(snapshot: typeof MOCK_PEOPLE | undefined) => void> = [];
 
   beforeEach(async () => {
@@ -55,9 +56,10 @@ describe('people triggers enemy highlight', () => {
     new People((client as unknown) as any);
     await refreshMock.mock.results[0]?.value;
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
-    const handler = client.addEventListener.mock.calls[0]?.[1];
-    if (handler) {
-      handler({ detail: { guilds: [], enemyGuilds: ['CKN'] } } as any);
+    const settingsHandler = client.addEventListener.mock.calls.find(([event]) => event === 'settings')?.[1];
+    uiSettingsHandler = client.addEventListener.mock.calls.find(([event]) => event === 'uiSettings')?.[1];
+    if (settingsHandler) {
+      settingsHandler({ detail: { guilds: [], enemyGuilds: ['CKN'] } } as any);
     }
     const lastCall = refreshMock.mock.results[refreshMock.mock.results.length - 1];
     await lastCall?.value;
@@ -66,6 +68,7 @@ describe('people triggers enemy highlight', () => {
   afterEach(() => {
     jest.clearAllMocks();
     subscribers.length = 0;
+    setXtermPalette('arkadia');
   });
 
   test('colors enemy description red', () => {
@@ -90,6 +93,24 @@ describe('people triggers enemy highlight', () => {
     const highlight = color(red) + 'Eamon' + RESET;
     const parts = result.split(highlight);
     expect(parts.length - 1).toBe(1);
+  });
+
+  test('re-registers enemy highlight after palette change', async () => {
+    const before = parse('Eamon wita cie.');
+    const initialRed = findClosestColor('#ff0000');
+    expect(before).toContain(color(initialRed) + 'Eamon' + RESET);
+
+    setXtermPalette('proper');
+    uiSettingsHandler?.({ detail: { xtermPalette: 'proper' } } as any);
+    expect(forceRefreshMock).toHaveBeenCalled();
+    const refreshCall = forceRefreshMock.mock.results[forceRefreshMock.mock.results.length - 1];
+    await refreshCall?.value;
+    const after = parse('Eamon wita cie.');
+    const updatedRed = findClosestColor('#ff0000');
+    const fallbackCode = updatedRed <= 15 ? (updatedRed <= 7 ? 30 + updatedRed : 90 + (updatedRed - 8)) : null;
+    const expectedHighlight = color(updatedRed) + 'Eamon' + RESET;
+    const fallbackHighlight = fallbackCode ? `\u001b[${fallbackCode}mEamon${RESET}` : null;
+    expect(after.includes(expectedHighlight) || (fallbackHighlight ? after.includes(fallbackHighlight) : false)).toBe(true);
   });
 
   test('ignores very short enemy names to avoid false positives', () => {
@@ -133,7 +154,7 @@ describe('people triggers guild highlight', () => {
     new People((client as unknown) as any);
     await refreshMock.mock.results[0]?.value;
     parse = (line: string) => Triggers.prototype.parseLine.call(client.Triggers, line, '');
-    settingsHandler = client.addEventListener.mock.calls[0]?.[1] as ((event: SettingsEvent) => void);
+    settingsHandler = client.addEventListener.mock.calls.find(([event]) => event === 'settings')?.[1] as ((event: SettingsEvent) => void);
     const lastGuildCall = refreshMock.mock.results[refreshMock.mock.results.length - 1];
     await lastGuildCall?.value;
   });
@@ -141,6 +162,7 @@ describe('people triggers guild highlight', () => {
   afterEach(() => {
     jest.clearAllMocks();
     subscribers.length = 0;
+    setXtermPalette('arkadia');
   });
 
   const emitSettings = (detail: { guilds: string[]; enemyGuilds: string[]; guildColors?: Record<string, string> }) => {


### PR DESCRIPTION
## Summary
- return zero-based palette indices from `findClosestColor` so xterm palette lookups stay accurate
- refresh people enemy highlights and guild postfix color mappings whenever the UI palette changes
- cover palette switching in the associated test suites

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68fd50cc02e0832a8f5b36b6a8bc3c6c