### PR TITLE
Include milliseconds in output timestamps

### DIFF
--- a/web-client/src/outputMessageHandler.ts
+++ b/web-client/src/outputMessageHandler.ts
@@ -24,7 +24,8 @@ function formatTimestamp(timestamp: number): string {
     const hours = date.getHours().toString().padStart(2, '0');
     const minutes = date.getMinutes().toString().padStart(2, '0');
     const seconds = date.getSeconds().toString().padStart(2, '0');
-    return `${hours}:${minutes}:${seconds}`;
+    const milliseconds = date.getMilliseconds().toString().padStart(3, '0');
+    return `${hours}:${minutes}:${seconds}.${milliseconds}`;
 }
 
 function applyTimestampVisibility() {


### PR DESCRIPTION
## Summary
- include milliseconds in formatted output timestamps so they match the log display

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68fde4bc5eb8832a88287222cb75a716