### PR TITLE
Preserve herb trigger line metadata when inserting descriptions

### DIFF
--- a/client/src/scripts/herbDescriptions.ts
+++ b/client/src/scripts/herbDescriptions.ts
@@ -2,6 +2,7 @@ import Client from "../Client";
 import loadHerbs from "./herbsLoader";
 import {color, RESET, findClosestColor} from "../Colors";
 import { openHerbContextMenu } from "../contextMenus";
+import TriggerLine from "../triggers/TriggerLine";
 
 export const HERB_NAME_COLOR = findClosestColor("#ffffff");
 
@@ -41,15 +42,13 @@ export default async function initHerbDescriptions(client: Client) {
                     const suffix = line.substring(index + token.length);
                     const after = suffix.trimStart();
                     if (after.startsWith("(")) {
-                        return raw;
+                        return triggerLine ?? raw;
                     }
                     const clickable = client.OutputHandler.makeStringRightClickable(id, (ev) => showHerbActions(id, ev));
                     const insertion = ` (${color(HERB_NAME_COLOR)}${clickable}${RESET})`;
-                    if (triggerLine) {
-                        triggerLine.insert(index + token.length, insertion);
-                        return triggerLine;
-                    }
-                    return line.substring(0, index + token.length) + insertion + suffix;
+                    const lineObj = triggerLine ?? new TriggerLine(raw);
+                    lineObj.insert(index + token.length, insertion);
+                    return lineObj;
                 }, tag, {caseInsensitive: true});
             });
         });

--- a/client/test/herbDescriptions.test.ts
+++ b/client/test/herbDescriptions.test.ts
@@ -2,6 +2,7 @@ import initHerbDescriptions from '../src/scripts/herbDescriptions';
 import Triggers, { stripAnsiCodes } from '../src/Triggers';
 import { RESET } from '../src/Colors';
 import { EventEmitter } from 'events';
+import TriggerLine from '../src/triggers/TriggerLine';
 
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
@@ -59,5 +60,27 @@ describe('herb descriptions', () => {
     const line = 'Widzisz zolty jasny kwiat (deliona)';
     const result = client.Triggers.parseLine(line, '');
     expect(result).toBe(line);
+  });
+
+  test('inserts suffix on trigger line instances regardless of source', async () => {
+    const client = new FakeClient();
+    const registerSpy = jest.spyOn(client.Triggers, 'registerTokenTrigger');
+    await initHerbDescriptions((client as unknown) as any);
+    const [, callback] = registerSpy.mock.calls.find(([token]) => token === 'zolty jasny kwiat')!;
+    registerSpy.mockRestore();
+
+    const baseLine = 'Widzisz zolty jasny kwiat';
+    const matches = ['zolty jasny kwiat'] as RegExpMatchArray;
+    matches.index = baseLine.indexOf('zolty jasny kwiat');
+    matches.input = baseLine;
+
+    const fromRaw = callback(baseLine, baseLine, matches, '', undefined) as TriggerLine;
+    expect(fromRaw).toBeInstanceOf(TriggerLine);
+    expect(stripAnsiCodes(fromRaw.toAnsiString())).toBe('Widzisz zolty jasny kwiat (deliona)');
+
+    const existingLine = new TriggerLine(baseLine);
+    const fromTriggerLine = callback(baseLine, baseLine, matches, '', existingLine) as TriggerLine;
+    expect(fromTriggerLine).toBe(existingLine);
+    expect(stripAnsiCodes(fromTriggerLine.toAnsiString())).toBe('Widzisz zolty jasny kwiat (deliona)');
   });
 });


### PR DESCRIPTION
## Summary
- ensure herb description triggers create or reuse TriggerLine instances so suffix insertion preserves metadata
- add unit coverage exercising suffix insertion for both raw strings and TriggerLine inputs

## Testing
- yarn --cwd client test herbDescriptions

------
https://chatgpt.com/codex/tasks/task_e_68fdf5894c70832a9a94bbef0cfb59f1