### PR TITLE
Refactor color helpers to return TriggerLine objects

### DIFF
--- a/client/src/Colors.ts
+++ b/client/src/Colors.ts
@@ -2,6 +2,7 @@ import xtermArkadia from "./xtermArkadia";
 import xtermProper from "./xtermProper";
 import mudletColors from "./colors.json";
 import { getItemSync } from "./storage";
+import TriggerLine from "./triggers/TriggerLine";
 
 function hexToRgb(hex: string): [number, number, number] {
     const value = parseInt(hex.replace(/^#/, ''), 16);
@@ -45,21 +46,36 @@ export function colorString(string: string, colorCode: number) {
     return color(colorCode) + string + RESET;
 }
 
-export function colorStringInLine(rawLine: string, string: string, colorCode: number, startIndex = 0) {
-    const matchIndex = rawLine.indexOf(string, startIndex)
+export function colorStringInLine(
+    rawLine: TriggerLine | string,
+    string: string,
+    colorCode: number,
+    startIndex = 0,
+): TriggerLine {
+    const triggerLine = rawLine instanceof TriggerLine ? rawLine : new TriggerLine(rawLine);
+    const text = triggerLine.text;
+    const matchIndex = text.indexOf(string, startIndex);
     if (matchIndex === -1) {
-        return rawLine
+        return triggerLine;
     }
-    return rawLine.substring(0, matchIndex) + color(colorCode) + string + RESET + rawLine.substring(matchIndex + string.length)
+    return triggerLine.color([matchIndex, matchIndex + string.length], colorCode);
 }
 
-export function colorTokenInLine(rawLine: string, string: string, colorCode: number, startIndex = 0) {
-    const matchIndex = rawLine.toLowerCase().indexOf(string, startIndex)
-    const endIndex = matchIndex + string.length
+export function colorTokenInLine(
+    rawLine: TriggerLine | string,
+    string: string,
+    colorCode: number,
+    startIndex = 0,
+): TriggerLine {
+    const triggerLine = rawLine instanceof TriggerLine ? rawLine : new TriggerLine(rawLine);
+    const haystack = triggerLine.text.toLowerCase();
+    const needle = string.toLowerCase();
+    const matchIndex = haystack.indexOf(needle, startIndex);
     if (matchIndex === -1) {
-        return rawLine
+        return triggerLine;
     }
-    return rawLine.substring(0, matchIndex) + color(colorCode) + rawLine.substring(matchIndex, endIndex) + RESET + rawLine.substring(endIndex)
+    const endIndex = matchIndex + string.length;
+    return triggerLine.color([matchIndex, endIndex], colorCode);
 }
 
 export function findClosestColor(hex: string | number[]): number {

--- a/client/src/PackageHelper.ts
+++ b/client/src/PackageHelper.ts
@@ -76,7 +76,7 @@ export default class PackageHelper {
 
     init() {
         this.enabled = true;
-        this.client.Triggers.registerTrigger(/^Wypisano na niej duzymi literami: ([a-zA-Z ']+).*$/, (rawLine, __, matches): string => {
+        this.client.Triggers.registerTrigger(/^Wypisano na niej duzymi literami: ([a-zA-Z ']+).*$/, (rawLine, __, matches, _type, triggerLine) => {
             const name = toTitleCase(matches[1])
             this.leadToPackage(name)
             if (!this.currentPackage || this.currentPackage.name !== name) {
@@ -87,7 +87,7 @@ export default class PackageHelper {
                 this.registerDeliveryTrigger()
             }
             const colorCode = this.npc[name] ? KNOWN_NPC_COLOR : findClosestColor('#ffff00')
-            return colorStringInLine(rawLine, matches[1], colorCode)
+            return colorStringInLine(triggerLine ?? rawLine, matches[1], colorCode)
         }, tag)
         this.client.Triggers.registerMultilineTrigger(packageTableRegex, this.packageTableCallback(), tag)
     }
@@ -133,7 +133,8 @@ export default class PackageHelper {
             const line = this.extendStandardDataLine(rawLine, info)
             const colorCode = this.npc[info.name] ? KNOWN_NPC_COLOR : UNKNOWN_NPC_COLOR;
             const command = `${pickCommand} ${info.index}`
-            return this.client.OutputHandler.makeClickable(colorStringInLine(line, info.name, colorCode), info.name, () => {
+            const coloredLine = colorStringInLine(line, info.name, colorCode).toAnsiString()
+            return this.client.OutputHandler.makeClickable(coloredLine, info.name, () => {
                 this.client.sendCommand(command)
             }, command)
         };
@@ -170,8 +171,9 @@ export default class PackageHelper {
                     const heavy = info.heavy ? '* ' : '  ';
                     const first = RESET  + `${heavy}${info.index}. ${info.name}${city}`;
                     const colorCode = this.npc[info.name] ? KNOWN_NPC_COLOR : UNKNOWN_NPC_COLOR;
+                    const coloredFirst = colorStringInLine(first, info.name, colorCode).toAnsiString();
                     const clickable = this.client.OutputHandler.makeClickable(
-                        colorStringInLine(first, info.name, colorCode),
+                        coloredFirst,
                         info.name,
                         () => {
                             this.client.sendCommand('wybierz paczke ' + info.index);

--- a/client/src/scripts/coinColors.ts
+++ b/client/src/scripts/coinColors.ts
@@ -11,8 +11,8 @@ export default function initCoinColors(client: Client) {
         { regex: /(\w+\s+)?miedzian(a|e|ych)(?=.*\bmonet)/i, color: COPPER_COLOR }
     ];
     patterns.forEach(({ regex, color }) => {
-        client.Triggers.registerTrigger(regex, (raw, _line, m) => {
-            return colorStringInLine(raw, m[0], color);
+        client.Triggers.registerTrigger(regex, (raw, _line, m, _type, triggerLine) => {
+            return colorStringInLine(triggerLine ?? raw, m[0], color);
         }, tag);
     });
 }

--- a/client/src/scripts/dajeCiHighlight.ts
+++ b/client/src/scripts/dajeCiHighlight.ts
@@ -4,11 +4,11 @@ import { colorStringInLine, findClosestColor } from "../Colors";
 export default function initDajeCiHighlight(client: Client) {
     const TURQUOISE = findClosestColor("#40e0d0");
     const pattern = /^(?:[ >]*[A-Za-z !()]+ daje ci )(.*)$/;
-    client.Triggers.registerTrigger(pattern, (raw, _line, matches) => {
+    client.Triggers.registerTrigger(pattern, (raw, _line, matches, _type, triggerLine) => {
         const group = matches[1];
         if (group !== "nowy zapal do walki.") {
             const start = matches.index ?? 0;
-            return colorStringInLine(raw, group, TURQUOISE, start);
+            return colorStringInLine(triggerLine ?? raw, group, TURQUOISE, start);
         }
     }, "daje-ci-highlight");
 }

--- a/client/src/scripts/gags.ts
+++ b/client/src/scripts/gags.ts
@@ -1,5 +1,6 @@
-import {colorStringInLine, colorString, findClosestColor} from "../Colors";
+import {colorStringInLine, findClosestColor} from "../Colors";
 import Client from "../Client";
+import TriggerLine from "../triggers/TriggerLine";
 
 const gagColors = {
     "moje_ciosy": "#f0f8ff",
@@ -42,15 +43,18 @@ class EmptyMatches extends Array<string> implements RegExpMatchArray {
         return combatTypes.indexOf(type) > -1 ? new EmptyMatches() : undefined;
     }
 
-    function gag(rawLine: string, power: string, totalPower: string, kind: string) {
+    function gag(rawLine: TriggerLine | string, power: string, totalPower: string, kind: string) {
         return gagPrefix(rawLine, `${power}/${totalPower}`, kind)
     }
 
-    function gagPrefix(rawLine: string, prefix: string, type: string) {
-        return client.prefix(rawLine, colorString(`[${prefix}] `, gagColorCodes[type]));
+    function gagPrefix(rawLine: TriggerLine | string, prefix: string, type: string) {
+        const line = rawLine instanceof TriggerLine ? rawLine : new TriggerLine(rawLine);
+        const prefixText = `[${prefix}] `;
+        line.prepend(prefixText);
+        return line.color([0, prefixText.length], gagColorCodes[type]);
     }
 
-    function gagOwnRegularHits(rawLine: string, matches: RegExpMatchArray | { index: number }, power: string) {
+    function gagOwnRegularHits(rawLine: string, matches: RegExpMatchArray | { index: number }, power: string, triggerLine?: TriggerLine) {
         let ignoreList = [
             "opalizujacego runicznego",
             "czarnoblekitnego pulsujacego morgensterna",
@@ -60,31 +64,29 @@ class EmptyMatches extends Array<string> implements RegExpMatchArray {
 
 
         if (ignoreList.filter(ignore => rawLine.match(ignore)).length > 0) {
-            return rawLine
+            return triggerLine ?? new TriggerLine(rawLine)
         }
 
-        rawLine = colorStringInLine(rawLine, matches[0], OWN_HIT_COLOR)
+        const line = colorStringInLine(triggerLine ?? rawLine, matches[0], OWN_HIT_COLOR)
 
 
-        return gag(rawLine, power, "6", "moje_ciosy")
+        return gag(line, power, "6", "moje_ciosy")
     }
 
-    function color_hit(rawLine: string, matches: RegExpMatchArray, value: string, type: string) {
-        let target
-        if (type == "combat.avatar") {
-            target = "innych_ciosy_we_mnie"
-        }
-
+    function color_hit(rawLine: string, matches: RegExpMatchArray, value: string, type: string, triggerLine?: TriggerLine) {
+        let target = type == "combat.avatar" ? "innych_ciosy_we_mnie" : "innych_ciosy"
+        let line: TriggerLine | string = triggerLine ?? rawLine
 
         if (matches.groups.target) {
-            rawLine = colorStringInLine(rawLine, matches.groups.damage + " cie", DAMAGE_COLOR)
+            line = colorStringInLine(line, matches.groups.damage + " cie", DAMAGE_COLOR)
         } else {
             target = "innych_ciosy"
+            line = colorStringInLine(line, matches.groups.damage, DAMAGE_COLOR)
         }
-        return gag(rawLine, value, "6", target)
+        return gag(line, value, "6", target)
     }
 
-    function gagOtherRegularHits(rawLine: string, matches: RegExpMatchArray, type: string) {
+    function gagOtherRegularHits(rawLine: string, matches: RegExpMatchArray, type: string, triggerLine?: TriggerLine) {
         let damage = matches.groups.damage
         let value = 0
         switch (damage) {
@@ -110,17 +112,17 @@ class EmptyMatches extends Array<string> implements RegExpMatchArray {
         }
 
 
-        return color_hit(rawLine, matches, value.toString(), type)
+        return color_hit(rawLine, matches, value.toString(), type, triggerLine)
     }
 
     const combatMessages = client.Triggers.registerTrigger(isCombatMsg)
-    combatMessages.registerChild(/^Ledwo muskasz/, (rawLine, _, matches) => gagOwnRegularHits(rawLine, matches, "1"))
-    combatMessages.registerChild(/^Lekko ranisz/, (rawLine, _, matches) => gagOwnRegularHits(rawLine, matches, "2"))
-    combatMessages.registerChild(/^Ranisz/, (rawLine, _, matches) => gagOwnRegularHits(rawLine, matches, "3"))
-    combatMessages.registerChild(/^Powaznie ranisz/, (rawLine, _, matches) => gagOwnRegularHits(rawLine, matches, "4"))
-    combatMessages.registerChild(/^Bardzo ciezko ranisz/, (rawLine, _, matches) => gagOwnRegularHits(rawLine, matches, "5"))
-    combatMessages.registerChild(/^Masakrujesz/, (rawLine, _, matches) => gagOwnRegularHits(rawLine, matches, "6"))
-    combatMessages.registerChild(/^(?<attacker>\w+(?: \w+){0,4}?) (?<damage>ledwo muska|lekko rani|bardzo ciezko rani|powaznie rani|rani|masakruje|smiertelnie rani) (?<target>cie) (?<weapon>.+?), trafiajac cie w (?<where>.*)\.$/, (rawLine, _, matches, type) => gagOtherRegularHits(rawLine, matches, type))
-    combatMessages.registerChild(/^(?<attacker>\w+(?: \w+){0,4}?) (?<damage>ledwo muska|lekko rani|bardzo ciezko rani|powaznie rani|rani|masakruje|smiertelnie rani) (?<target_weapon>.+?), trafiajac (?:go|ja|je) w (?<where>.*)\.$/, (rawLine, _, matches, type) => gagOtherRegularHits(rawLine, matches, type))
+    combatMessages.registerChild(/^Ledwo muskasz/, (rawLine, _, matches, __, triggerLine) => gagOwnRegularHits(rawLine, matches, "1", triggerLine))
+    combatMessages.registerChild(/^Lekko ranisz/, (rawLine, _, matches, __, triggerLine) => gagOwnRegularHits(rawLine, matches, "2", triggerLine))
+    combatMessages.registerChild(/^Ranisz/, (rawLine, _, matches, __, triggerLine) => gagOwnRegularHits(rawLine, matches, "3", triggerLine))
+    combatMessages.registerChild(/^Powaznie ranisz/, (rawLine, _, matches, __, triggerLine) => gagOwnRegularHits(rawLine, matches, "4", triggerLine))
+    combatMessages.registerChild(/^Bardzo ciezko ranisz/, (rawLine, _, matches, __, triggerLine) => gagOwnRegularHits(rawLine, matches, "5", triggerLine))
+    combatMessages.registerChild(/^Masakrujesz/, (rawLine, _, matches, __, triggerLine) => gagOwnRegularHits(rawLine, matches, "6", triggerLine))
+    combatMessages.registerChild(/^(?<attacker>\w+(?: \w+){0,4}?) (?<damage>ledwo muska|lekko rani|bardzo ciezko rani|powaznie rani|rani|masakruje|smiertelnie rani) (?<target>cie) (?<weapon>.+?), trafiajac cie w (?<where>.*)\.$/, (rawLine, _, matches, type, triggerLine) => gagOtherRegularHits(rawLine, matches, type, triggerLine))
+    combatMessages.registerChild(/^(?<attacker>\w+(?: \w+){0,4}?) (?<damage>ledwo muska|lekko rani|bardzo ciezko rani|powaznie rani|rani|masakruje|smiertelnie rani) (?<target_weapon>.+?), trafiajac (?:go|ja|je) w (?<where>.*)\.$/, (rawLine, _, matches, type, triggerLine) => gagOtherRegularHits(rawLine, matches, type, triggerLine))
 }
 

--- a/client/src/scripts/magicKeys.ts
+++ b/client/src/scripts/magicKeys.ts
@@ -8,8 +8,8 @@ export default async function initMagicKeys(client: Client) {
     try {
         const keys = await loadMagicKeys();
         keys.forEach((pattern: string) => {
-            client.Triggers.registerTokenTrigger(pattern, (raw) => {
-                return colorTokenInLine(raw, pattern, KEYS_COLOR);
+            client.Triggers.registerTokenTrigger(pattern, (raw, _line, _matches, _type, triggerLine) => {
+                return colorTokenInLine(triggerLine ?? raw, pattern, KEYS_COLOR);
             }, tag, { caseInsensitive: true });
         });
     } catch (e) {

--- a/client/src/scripts/magics.ts
+++ b/client/src/scripts/magics.ts
@@ -8,8 +8,8 @@ export default async function initMagics(client: Client) {
     try {
         const magics = await loadMagics();
         magics.forEach((pattern: string) => {
-            client.Triggers.registerTokenTrigger(pattern, (raw) => {
-                return colorTokenInLine(raw, pattern, MAGICS_COLOR);
+            client.Triggers.registerTokenTrigger(pattern, (raw, _line, _matches, _type, triggerLine) => {
+                return colorTokenInLine(triggerLine ?? raw, pattern, MAGICS_COLOR);
             }, tag, {caseInsensitive: true});
         });
     } catch (e) {

--- a/client/src/scripts/przybywajaHighlight.ts
+++ b/client/src/scripts/przybywajaHighlight.ts
@@ -4,8 +4,8 @@ import { colorStringInLine, findClosestColor } from "../Colors";
 export default function initPrzybywajaHighlight(client: Client) {
     const HIGHLIGHT = findClosestColor('#ccb3ff');
     const pattern = /\b(przybyw(?:a|aja))\b/i;
-    client.Triggers.registerTrigger(pattern, (raw, _line, matches) => {
+    client.Triggers.registerTrigger(pattern, (raw, _line, matches, _type, triggerLine) => {
         const start = matches.index ?? 0;
-        return colorStringInLine(raw, matches[1], HIGHLIGHT, start);
+        return colorStringInLine(triggerLine ?? raw, matches[1], HIGHLIGHT, start);
     }, 'przybywaja-highlight');
 }

--- a/client/src/scripts/weaponColors.ts
+++ b/client/src/scripts/weaponColors.ts
@@ -1,5 +1,6 @@
 import Client from "../Client";
 import { colorStringInLine, findClosestColor, color, RESET } from "../Colors";
+import TriggerLine from "../triggers/TriggerLine";
 import { MAGICS_COLOR } from "./magics";
 
 export const WEAPON_COLOR = findClosestColor("#ffff00");
@@ -13,29 +14,31 @@ export default function initWeaponColors(client: Client) {
     const tag = "weaponColors";
     client.Triggers.registerTrigger(
         /^Trzyma(?:sz)? oburacz (?<weapon1>[a-z ]+)\.$/,
-        (raw, _line, m) => {
+        (raw, _line, m, _type, triggerLine) => {
             const weapon = m.groups!.weapon1;
             if (isMagicColored(raw, weapon)) {
-                return raw;
+                return triggerLine ?? new TriggerLine(raw);
             }
-            return colorStringInLine(raw, weapon, WEAPON_COLOR);
+            return colorStringInLine(triggerLine ?? raw, weapon, WEAPON_COLOR);
         },
         tag
     );
     client.Triggers.registerTrigger(
         /^Trzyma(?:sz)? (?<weapon1>[a-z ]+?) w (?:lewej|prawej) rece(?: oraz (?<weapon2>[a-z ]+?) w (?:lewej|prawej) rece)?\.$/,
-        (raw, _line, m) => {
+        (raw, _line, m, _type, triggerLine) => {
             const { weapon1, weapon2 } = m.groups as { weapon1: string; weapon2?: string };
+            const baseLine = triggerLine ?? new TriggerLine(raw);
+            const text = baseLine.text;
             if (!weapon2) {
                 if (isMagicColored(raw, weapon1)) {
-                    return raw;
+                    return baseLine;
                 }
-                return colorStringInLine(raw, weapon1, WEAPON_COLOR);
+                return colorStringInLine(baseLine, weapon1, WEAPON_COLOR);
             }
 
-            const firstIndex = raw.indexOf(weapon1);
-            const secondIndex = raw.indexOf(weapon2, firstIndex + weapon1.length);
-            let line = raw;
+            const firstIndex = text.indexOf(weapon1);
+            const secondIndex = text.indexOf(weapon2, firstIndex + weapon1.length);
+            let line: TriggerLine = baseLine;
 
             if (!isMagicColored(raw, weapon2) && secondIndex > -1) {
                 line = colorStringInLine(line, weapon2, WEAPON_COLOR, secondIndex);
@@ -51,23 +54,23 @@ export default function initWeaponColors(client: Client) {
     );
     client.Triggers.registerTrigger(
         /^.*przypiet(?:y|a|e).*?(?:pochwe|pochwy|uprzaz|temblak|temblaki).*, zawierajac(?:a|e|y) (?<weapon>[a-z ]+)\.$/,
-        (raw, _line, m) => {
+        (raw, _line, m, _type, triggerLine) => {
             const { weapon } = m.groups as { weapon: string };
             if (isMagicColored(raw, weapon)) {
-                return raw;
+                return triggerLine ?? new TriggerLine(raw);
             }
-            return colorStringInLine(raw, weapon, WEAPON_COLOR);
+            return colorStringInLine(triggerLine ?? raw, weapon, WEAPON_COLOR);
         },
         tag
     );
     client.Triggers.registerTrigger(
         /^.*przypiet(?:y|a|e).*?(?:pochwe|pochwy|uprzaz|temblak|temblaki).* z tkwiac.* w (?:niej|nim|nich) (?<weapon>[a-z ]+)\.$/,
-        (raw, _line, m) => {
+        (raw, _line, m, _type, triggerLine) => {
             const { weapon } = m.groups as { weapon: string };
             if (isMagicColored(raw, weapon)) {
-                return raw;
+                return triggerLine ?? new TriggerLine(raw);
             }
-            return colorStringInLine(raw, weapon, WEAPON_COLOR);
+            return colorStringInLine(triggerLine ?? raw, weapon, WEAPON_COLOR);
         },
         tag
     );

--- a/client/test/PackageHelper.test.ts
+++ b/client/test/PackageHelper.test.ts
@@ -87,7 +87,7 @@ describe('PackageHelper', () => {
     expect(helper['packages']).toEqual([{ name: 'Bob', time: '5', distance: undefined }]);
     expect(client.OutputHandler.makeClickable).toHaveBeenCalledTimes(1);
     const call = client.OutputHandler.makeClickable.mock.calls[0];
-    const expectedColor = colorStringInLine(stripped, 'Bob', findClosestColor('#aaaaaa'));
+    const expectedColor = colorStringInLine(stripped, 'Bob', findClosestColor('#aaaaaa')).toAnsiString();
     expect(call[0]).toBe(expectedColor);
     expect(call[1]).toBe('Bob');
     expect(call[3]).toBe('wybierz paczke 1');
@@ -150,8 +150,8 @@ describe('PackageHelper', () => {
 
     expect(helper.currentPackage).toEqual({ name: 'Bob' });
     expect(client.sendEvent).toHaveBeenCalledWith('packageStatus', { recipient: 'Bob' });
-    const expectedColor = colorStringInLine(raw, 'Bob', findClosestColor('#ffff00'));
-    expect(result).toBe(expectedColor);
+    const expectedColor = colorStringInLine(raw, 'Bob', findClosestColor('#ffff00')).toAnsiString();
+    expect(result.toAnsiString()).toBe(expectedColor);
     expect(startSpy).not.toHaveBeenCalled();
     expect(registerSpy).toHaveBeenCalled();
   });

--- a/client/test/coinColors.test.ts
+++ b/client/test/coinColors.test.ts
@@ -20,9 +20,9 @@ describe('coin colors trigger', () => {
   test('colors coins in receive sentence', () => {
     const line = 'Otrzymujesz 11 zlotych, 15 srebrnych i 8 miedzianych monet.';
     const result = parse(line);
-    const gold = colorStringInLine('11 zlotych', '11 zlotych', GOLD_COLOR);
-    const silver = colorStringInLine('15 srebrnych', '15 srebrnych', SILVER_COLOR);
-    const copper = colorStringInLine('8 miedzianych', '8 miedzianych', COPPER_COLOR);
+    const gold = colorStringInLine('11 zlotych', '11 zlotych', GOLD_COLOR).toAnsiString();
+    const silver = colorStringInLine('15 srebrnych', '15 srebrnych', SILVER_COLOR).toAnsiString();
+    const copper = colorStringInLine('8 miedzianych', '8 miedzianych', COPPER_COLOR).toAnsiString();
     expect(result).toContain(gold);
     expect(result).toContain(silver);
     expect(result).toContain(copper);
@@ -32,8 +32,8 @@ describe('coin colors trigger', () => {
   test('does not color words without following monety', () => {
     const line = 'Masz 10 srebrnych monet i zlote.';
     const result = parse(line);
-    const silver = colorStringInLine('10 srebrnych', '10 srebrnych', SILVER_COLOR);
-    const gold = colorStringInLine('zlote', 'zlote', GOLD_COLOR);
+    const silver = colorStringInLine('10 srebrnych', '10 srebrnych', SILVER_COLOR).toAnsiString();
+    const gold = colorStringInLine('zlote', 'zlote', GOLD_COLOR).toAnsiString();
     expect(result).toContain(silver);
     expect(result).toContain(' i zlote.');
     expect(result).not.toContain(gold);

--- a/client/test/colorString.test.ts
+++ b/client/test/colorString.test.ts
@@ -1,8 +1,11 @@
 import { colorStringInLine } from '../src/Colors';
+import TriggerLine from '../src/triggers/TriggerLine';
 
 describe('colorString', () => {
   test('returns input when substring missing', () => {
-    const input = 'some text';
-    expect(colorStringInLine(input, 'missing', 1)).toBe(input);
+    const input = new TriggerLine('some text');
+    const result = colorStringInLine(input, 'missing', 1);
+    expect(result).toBe(input);
+    expect(result.toAnsiString()).toBe('some text');
   });
 });

--- a/client/test/magicKeys.test.ts
+++ b/client/test/magicKeys.test.ts
@@ -20,9 +20,9 @@ describe('magic keys', () => {
         const pattern = call[0];
         const callback = call[1];
         const sentence = 'to jest alpha w zdaniu';
-        expect(callback(sentence, sentence, {} as any)).toBe(colorTokenInLine(sentence, pattern, KEYS_COLOR));
+        expect(callback(sentence, sentence, {} as any).toAnsiString()).toBe(colorTokenInLine(sentence, pattern, KEYS_COLOR).toAnsiString());
 
         const titleCase = 'Alpha pojawila sie w zdaniu';
-        expect(callback(titleCase, titleCase, {} as any)).toBe(colorTokenInLine(titleCase, pattern, KEYS_COLOR));
+        expect(callback(titleCase, titleCase, {} as any).toAnsiString()).toBe(colorTokenInLine(titleCase, pattern, KEYS_COLOR).toAnsiString());
     });
 });

--- a/client/test/magics.test.ts
+++ b/client/test/magics.test.ts
@@ -20,9 +20,9 @@ describe('magics', () => {
         const pattern = call[0];
         const callback = call[1];
         const sentence = 'to jest alpha w zdaniu';
-        expect(callback(sentence, sentence, {} as any)).toBe(colorTokenInLine(sentence, pattern, MAGICS_COLOR));
+        expect(callback(sentence, sentence, {} as any).toAnsiString()).toBe(colorTokenInLine(sentence, pattern, MAGICS_COLOR).toAnsiString());
 
         const titleCase = 'Alpha pojawila sie w zdaniu';
-        expect(callback(titleCase, titleCase, {} as any)).toBe(colorTokenInLine(titleCase, pattern, MAGICS_COLOR));
+        expect(callback(titleCase, titleCase, {} as any).toAnsiString()).toBe(colorTokenInLine(titleCase, pattern, MAGICS_COLOR).toAnsiString());
     });
 });

--- a/client/test/weaponColors.test.ts
+++ b/client/test/weaponColors.test.ts
@@ -20,15 +20,16 @@ describe('weapon colors trigger', () => {
   test('colors single weapon', () => {
     const line = 'Trzymasz oburacz stalowy miecz.';
     const result = parse(line);
-    const expected = colorStringInLine(line, 'stalowy miecz', WEAPON_COLOR);
+    const expected = colorStringInLine(line, 'stalowy miecz', WEAPON_COLOR).toAnsiString();
     expect(stripAnsiCodes(result)).toBe(line);
     expect(result).toBe(expected);
   });
 
   test('colors two weapons', () => {
     const line = 'Trzymasz stalowy miecz w lewej rece oraz drewniana tarcze w prawej rece.';
-    let expected = colorStringInLine(line, 'stalowy miecz', WEAPON_COLOR);
-    expected = colorStringInLine(expected, 'drewniana tarcze', WEAPON_COLOR);
+    let expectedLine = colorStringInLine(line, 'stalowy miecz', WEAPON_COLOR);
+    expectedLine = colorStringInLine(expectedLine, 'drewniana tarcze', WEAPON_COLOR);
+    const expected = expectedLine.toAnsiString();
     const result = parse(line);
     expect(stripAnsiCodes(result)).toBe(stripAnsiCodes(expected));
     expect(result).toBe(expected);
@@ -39,8 +40,9 @@ describe('weapon colors trigger', () => {
     const weapon = 'zebaty szeroki noz bojowy';
     const firstIndex = line.indexOf(weapon);
     const secondIndex = line.indexOf(weapon, firstIndex + weapon.length);
-    let expected = colorStringInLine(line, weapon, WEAPON_COLOR, secondIndex);
-    expected = colorStringInLine(expected, weapon, WEAPON_COLOR, firstIndex);
+    let expectedLine = colorStringInLine(line, weapon, WEAPON_COLOR, secondIndex);
+    expectedLine = colorStringInLine(expectedLine, weapon, WEAPON_COLOR, firstIndex);
+    const expected = expectedLine.toAnsiString();
     const result = parse(line);
     expect(stripAnsiCodes(result)).toBe(stripAnsiCodes(expected));
     expect(result).toBe(expected);
@@ -58,8 +60,8 @@ describe('weapon colors trigger', () => {
     const line = 'Trzymasz stalowy miecz w lewej rece oraz drewniana tarcze w prawej rece.';
     const magicColoredWeapon = color(MAGICS_COLOR) + 'stalowy miecz' + RESET;
     const precolored = line.replace('stalowy miecz', magicColoredWeapon);
-    let expected = precolored;
-    expected = colorStringInLine(expected, 'drewniana tarcze', WEAPON_COLOR);
+    let expectedLine = colorStringInLine(precolored, 'drewniana tarcze', WEAPON_COLOR);
+    const expected = expectedLine.toAnsiString();
     const result = parse(precolored);
     expect(stripAnsiCodes(result)).toBe(stripAnsiCodes(expected));
     expect(result).toBe(expected);
@@ -68,7 +70,7 @@ describe('weapon colors trigger', () => {
   test('colors weapon in scabbard', () => {
     const line = 'Masz do pasa przypieta pochwe, zawierajaca stalowy miecz.';
     const result = parse(line);
-    const expected = colorStringInLine(line, 'stalowy miecz', WEAPON_COLOR);
+    const expected = colorStringInLine(line, 'stalowy miecz', WEAPON_COLOR).toAnsiString();
     expect(stripAnsiCodes(result)).toBe(line);
     expect(result).toBe(expected);
   });
@@ -76,7 +78,7 @@ describe('weapon colors trigger', () => {
   test('colors weapon stuck in scabbard', () => {
     const line = 'Masz do pasa przypieta pochwe z tkwiacym w niej stalowym mieczem.';
     const result = parse(line);
-    const expected = colorStringInLine(line, 'stalowym mieczem', WEAPON_COLOR);
+    const expected = colorStringInLine(line, 'stalowym mieczem', WEAPON_COLOR).toAnsiString();
     expect(stripAnsiCodes(result)).toBe(line);
     expect(result).toBe(expected);
   });


### PR DESCRIPTION
## Summary
- update colorStringInLine and colorTokenInLine to operate on TriggerLine buffers
- pass through triggerLine instances in highlight scripts and package helper utilities
- refresh unit tests to assert against TriggerLine ANSI output

## Testing
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68fdf57cc640832aae9e224258b8404a