### PR TITLE
Fix destination map label area name

### DIFF
--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -222,8 +222,8 @@ export class EmbeddedMap {
                 const destId = this.destinations[0];
                 const path = this.getPath(roomId, destId);
                 const distance = path ? path.length - 1 : 0;
-                const room = this.reader.getRoom(roomId)
-                const destArea = this.reader.getArea(room.area);
+                const destRoom = this.reader.getRoom(destId);
+                const destArea = destRoom ? this.reader.getArea(destRoom.area) : null;
                 const destName = destArea ? destArea.getAreaName() : destId;
                 text += ` → #${destId} ${destName} (${distance})`;
                 if (path) {


### PR DESCRIPTION
## Summary
- ensure the map label uses the destination room area when showing navigation info

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68fe0737f34c832a9c8e3eedd360e14a