### PR TITLE
Handle telnet control bytes before MCCP inflate

### DIFF
--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -82,9 +82,7 @@ class ArkadiaClient implements ClientAdapter {
             this.socket = new WebSocket(WEBSOCKET_URL, []);
             this.socket.onmessage = (event: MessageEvent<string>) => {
                 try {
-                    const decodedData = this.inflate(atob(event.data));
-                    this.processIncomingData(decodedData);
-                    this.recordIncoming(decodedData);
+                    this.handleSocketMessage(event.data);
                 } catch (error) {
                     console.error('Error processing incoming message:', error);
                 }
@@ -122,30 +120,140 @@ class ArkadiaClient implements ClientAdapter {
         }
     }
 
-    private inflate(decodedData: string) {
-        if (this.mccp) {
-            try {
-                const byteArray = decodedData.split("").map(function (char) {
-                    return char.charCodeAt(0);
-                });
-                this.readInflator.push(byteArray, 2);
-                if (this.readInflator.err) {
-                    console.error("MCCP decompression error: " + this.readInflator.msg);
-                    return decodedData;
-                }
-                const decompressed = new Uint16Array(this.readInflator.result);
-                const length = decompressed.length;
-                decodedData = "";
-                for (let i = 0; i < length; i++) {
-                    decodedData += String.fromCharCode(decompressed[i]);
-                }
-                this.readInflator.chunks = []
-                this.readInflator.ended = false;
-            } catch (error) {
-                console.log("MCCP decompression error: " + error.message);
-            }
+    private inflate(data: Uint8Array): string {
+        if (!this.mccp) {
+            return this.bytesToString(data);
         }
-        return decodedData;
+
+        try {
+            this.readInflator.push(data, 2);
+            if (this.readInflator.err) {
+                console.error("MCCP decompression error: " + this.readInflator.msg);
+                return this.bytesToString(data);
+            }
+
+            const result = this.readInflator.result as any;
+            let decodedData = "";
+
+            if (typeof result === "string") {
+                decodedData = result;
+            } else if (result) {
+                const view = result instanceof Uint8Array ? result : new Uint8Array(result);
+                decodedData = this.bytesToString(view);
+            }
+
+            this.readInflator.chunks = []
+            this.readInflator.ended = false;
+
+            return decodedData;
+        } catch (error: any) {
+            console.log("MCCP decompression error: " + error.message);
+            return this.bytesToString(data);
+        }
+    }
+
+    private handleSocketMessage(base64Data: string): void {
+        const frame = this.stringToUint8Array(atob(base64Data));
+        const payload = this.extractTelnetPayload(frame);
+
+        if (payload.length === 0) {
+            this.processIncomingData("");
+            return;
+        }
+
+        const decodedData = this.inflate(payload);
+        this.processIncomingData(decodedData);
+        this.recordIncoming(decodedData);
+    }
+
+    private extractTelnetPayload(frame: Uint8Array): Uint8Array {
+        const payload: number[] = [];
+
+        for (let i = 0; i < frame.length; i++) {
+            const byte = frame[i];
+
+            if (byte !== 0xFF) {
+                payload.push(byte);
+                continue;
+            }
+
+            if (i + 1 >= frame.length) {
+                break;
+            }
+
+            const command = frame[i + 1];
+
+            if (command === 0xFF) {
+                payload.push(0xFF);
+                i += 1;
+                continue;
+            }
+
+            if (command === 0xFA) {
+                const end = this.findSubnegotiationEnd(frame, i + 2);
+                const sequence = frame.slice(i, end);
+                this.parseTelnetOption(this.bytesToString(sequence));
+                i = end - 1;
+                continue;
+            }
+
+            const length = this.commandRequiresOption(command) ? 3 : 2;
+            const sequence = frame.slice(i, Math.min(i + length, frame.length));
+            this.parseTelnetOption(this.bytesToString(sequence));
+            i += length - 1;
+        }
+
+        return Uint8Array.from(payload);
+    }
+
+    private findSubnegotiationEnd(frame: Uint8Array, start: number): number {
+        let index = start;
+
+        while (index < frame.length) {
+            if (frame[index] === 0xFF) {
+                if (index + 1 >= frame.length) {
+                    return frame.length;
+                }
+
+                const next = frame[index + 1];
+
+                if (next === 0xF0) {
+                    return index + 2;
+                }
+
+                if (next === 0xFF) {
+                    index += 2;
+                    continue;
+                }
+
+                index += 2;
+                continue;
+            }
+
+            index += 1;
+        }
+
+        return frame.length;
+    }
+
+    private commandRequiresOption(command: number): boolean {
+        return command === 0xFB || command === 0xFC || command === 0xFD || command === 0xFE;
+    }
+
+    private stringToUint8Array(value: string): Uint8Array {
+        const bytes = new Uint8Array(value.length);
+        for (let i = 0; i < value.length; i++) {
+            bytes[i] = value.charCodeAt(i);
+        }
+        return bytes;
+    }
+
+    private bytesToString(bytes: ArrayLike<number>): string {
+        let result = "";
+        for (let i = 0; i < bytes.length; i++) {
+            result += String.fromCharCode(bytes[i]);
+        }
+        return result;
     }
 
     /**
@@ -288,11 +396,21 @@ class ArkadiaClient implements ClientAdapter {
      * Parse telnet option from incoming data
      */
     private parseTelnetOption(optionData: string): string {
+        if (optionData.length < 2) {
+            return "";
+        }
+
+        const command = optionData.charCodeAt(1);
+
+        if (command === 0xFA && optionData.length >= 5) {
+            this.parseTelnetSubnegotiation(optionData.substring(2, optionData.length - 2));
+            return "";
+        }
+
         if (optionData.length === 3) {
             //this.telnetNegotiator.parseOptionNegotiation(optionData)
-        } else {
-            this.parseTelnetSubnegotiation(optionData.substring(2, optionData.length - 2));
         }
+
         return "";
     }
 

--- a/web-client/test/mccpTelnetFlow.test.ts
+++ b/web-client/test/mccpTelnetFlow.test.ts
@@ -1,0 +1,63 @@
+import arkadiaClient from '../src/ArkadiaClient';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pako: any = require('../public/pako.min.js');
+
+const GMCP_COMMAND_CODE = 201;
+
+const toCharCodes = (value: string) => value.split('').map(char => char.charCodeAt(0));
+
+describe('ArkadiaClient MCCP handling', () => {
+  let client: any;
+  let originalMccp: boolean;
+  let originalInflator: any;
+
+  beforeEach(() => {
+    client = arkadiaClient as any;
+    originalMccp = client.mccp;
+    originalInflator = client.readInflator;
+    client.mccp = true;
+    client.readInflator = new (pako as any).Inflate();
+  });
+
+  afterEach(() => {
+    client.mccp = originalMccp;
+    client.readInflator = originalInflator;
+    jest.restoreAllMocks();
+  });
+
+  test('decompresses MCCP data followed by GMCP subnegotiation without error', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const processIncoming = jest.spyOn(client, 'processIncomingData').mockImplementation(() => {});
+    const recordIncoming = jest.spyOn(client, 'recordIncoming').mockImplementation(() => {});
+
+    const sampleText = 'Test MCCP output';
+    const compressed = pako.deflate(sampleText);
+
+    const gmcpPayload = 'core.hello {}';
+    const gmcpBytes = [
+      0xFF,
+      0xFA,
+      GMCP_COMMAND_CODE,
+      ...toCharCodes(gmcpPayload),
+      0xFF,
+      0xF0,
+    ];
+
+    const frameBytes = new Uint8Array(compressed.length + gmcpBytes.length);
+    frameBytes.set(compressed, 0);
+    frameBytes.set(gmcpBytes, compressed.length);
+
+    const base64Frame = btoa(String.fromCharCode(...Array.from(frameBytes)));
+
+    client.handleSocketMessage(base64Frame);
+
+    const loggedMccpError = consoleError.mock.calls.some(call =>
+      call.some((arg: unknown) => typeof arg === 'string' && arg.includes('MCCP decompression error')),
+    );
+
+    expect(loggedMccpError).toBe(false);
+    expect(processIncoming).toHaveBeenCalledWith(sampleText);
+    expect(recordIncoming).toHaveBeenCalledWith(sampleText);
+  });
+});

--- a/web-client/tsconfig.test.json
+++ b/web-client/tsconfig.test.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "types": ["jest"],
+    "types": ["jest", "node"],
     "resolveJsonModule": true,
     "esModuleInterop": true
   },


### PR DESCRIPTION
## Summary
- peel telnet control sequences from websocket frames before routing compressed data through the MCCP inflater
- add utilities for extracting telnet payload bytes and adjust MCCP inflation to skip telnet-only frames
- cover the regression with an MCCP+GMCP test and enable Node typings for the Jest configuration

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fe3ffaca48832a8dfa24169a2a33ae