### PR TITLE
Decode gmcp message payloads before emitting output

### DIFF
--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -344,8 +344,9 @@ class ArkadiaClient implements ClientAdapter {
                     this.maybeStartAutoRecording();
                 }
                 if (type === "gmcp_msgs") {
-                    let text = atob(gmcp.text)
-                    this.messageBuffer.push({text, type: gmcp.type})
+                    const text = this.decodeBase64Text(gmcp.text ?? "");
+                    const messageType = typeof gmcp.type === "string" && gmcp.type.length ? gmcp.type : "other";
+                    this.messageBuffer.push({ text, type: messageType });
                 } else if (type === "client.conf.get") {
                     const data = JSON.parse(uncompress(gmcp.data))
                     const filename = gmcp.filename
@@ -587,6 +588,40 @@ class ArkadiaClient implements ClientAdapter {
             console.error('Failed to read recording snapshot:', error);
             return null;
         }
+    }
+
+    private decodeBase64Text(data: string): string {
+        if (typeof data !== "string" || data.length === 0) {
+            return "";
+        }
+
+        try {
+            if (typeof globalThis.atob === "function") {
+                const binary = globalThis.atob(data);
+                if (typeof TextDecoder !== "undefined") {
+                    const bytes = new Uint8Array(binary.length);
+                    for (let i = 0; i < binary.length; i++) {
+                        bytes[i] = binary.charCodeAt(i);
+                    }
+                    return new TextDecoder().decode(bytes);
+                }
+
+                let result = "";
+                for (let i = 0; i < binary.length; i++) {
+                    result += String.fromCharCode(binary.charCodeAt(i));
+                }
+                return result;
+            }
+
+            const bufferCtor = (globalThis as any).Buffer as { from(data: string, encoding: string): { toString(encoding: string): string } } | undefined;
+            if (bufferCtor) {
+                return bufferCtor.from(data, "base64").toString("utf-8");
+            }
+        } catch (error) {
+            console.error("Error decoding base64 GMCP text:", error);
+        }
+
+        return data;
     }
 
     private findRecorderByName(name: string) {

--- a/web-client/test/GmcpMsgs.test.ts
+++ b/web-client/test/GmcpMsgs.test.ts
@@ -1,0 +1,46 @@
+import arkadiaClient from "../src/ArkadiaClient";
+
+describe("gmcp_msgs handling", () => {
+  let originalClientExtension: any;
+
+  beforeEach(() => {
+    originalClientExtension = (window as any).clientExtension;
+    (window as any).clientExtension = {
+      onLine: jest.fn((line: string) => line),
+    };
+  });
+
+  afterEach(() => {
+    if (originalClientExtension) {
+      (window as any).clientExtension = originalClientExtension;
+    } else {
+      delete (window as any).clientExtension;
+    }
+  });
+
+  test("decodes gmcp base64 payloads into plain text output", () => {
+    const gmcpPlainText = "Przykladowa wiadomosc gmcp.\n";
+    const gmcpPayload = JSON.stringify({ text: btoa(gmcpPlainText), type: "other" });
+    const gmcpMessage = String.fromCharCode(201) + "gmcp_msgs " + gmcpPayload;
+
+    const messageListener = jest.fn();
+    const gmcpListener = jest.fn();
+
+    arkadiaClient.on("message", messageListener as any);
+    arkadiaClient.on("gmcp_msg.other", gmcpListener);
+
+    (arkadiaClient as any).parseTelnetSubnegotiation(gmcpMessage);
+    (arkadiaClient as any).flushMessageBuffer();
+
+    expect((window as any).clientExtension.onLine).toHaveBeenCalledWith(gmcpPlainText, "other");
+    expect(gmcpListener).toHaveBeenCalledTimes(1);
+    expect(gmcpListener.mock.calls[0][0]).toContain("Przykladowa wiadomosc gmcp.");
+
+    expect(messageListener).toHaveBeenCalledTimes(1);
+    expect(messageListener.mock.calls[0][0]).toContain("Przykladowa wiadomosc gmcp.");
+    expect(messageListener.mock.calls[0][1]).toBe("other");
+
+    arkadiaClient.off("message", messageListener as any);
+    arkadiaClient.off("gmcp_msg.other", gmcpListener);
+  });
+});


### PR DESCRIPTION
## Summary
- decode gmcp message payloads using a UTF-8 safe helper and ensure a fallback message type
- add a regression test that verifies gmcp_msgs deliver decoded text to message and gmcp_msg listeners

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68feb5972a50832a8bb2336b0282717f