### PR TITLE
Ensure /nn uses attack controller

### DIFF
--- a/client/src/scripts/attackQueue.ts
+++ b/client/src/scripts/attackQueue.ts
@@ -1,6 +1,5 @@
 import Client from "../Client";
-import { getItemSync } from "../storage";
-import { normalizeAttackCommand } from "../utils/attackCommand";
+import { createAttackController } from "../utils/attackController";
 
 type ResolvedEnemy = {
     id: string;
@@ -61,11 +60,7 @@ export default function initAttackQueue(
 ) {
     const list = aliases ?? client.aliases;
 
-    const storedSettings = getItemSync('settings')?.settings;
-    let attackCommand = normalizeAttackCommand(storedSettings?.attackCommand);
-    client.addEventListener('settings', (ev: CustomEvent) => {
-        attackCommand = normalizeAttackCommand(ev.detail?.attackCommand);
-    });
+    const attackController = createAttackController(client);
 
     const add = (matches: RegExpMatchArray) => {
         const resolved = resolveEnemy(client, matches[1] ?? matches[0]);
@@ -89,7 +84,7 @@ export default function initAttackQueue(
             client.println("Kolejka ataku jest pusta.");
             return;
         }
-        client.sendCommand(`${attackCommand} ob_${next}`);
+        attackController.attackById(next);
     };
 
     list.push({

--- a/client/src/scripts/objectAliases.ts
+++ b/client/src/scripts/objectAliases.ts
@@ -1,8 +1,7 @@
 import Client from "../Client";
 import {colorString, findClosestColor} from "../Colors";
 import {gmcp} from "../gmcp";
-import { getItemSync, setItemSync } from "../storage";
-import { normalizeAttackCommand } from "../utils/attackCommand";
+import { createAttackController } from "../utils/attackController";
 
 export default function initObjectAliases(
     client: Client,
@@ -67,21 +66,11 @@ export default function initObjectAliases(
         }
     }
 
-    const storedSettings = getItemSync('settings')?.settings;
-    let attackCommand = normalizeAttackCommand(storedSettings?.attackCommand);
-    client.addEventListener('settings', (ev: CustomEvent) => {
-        attackCommand = normalizeAttackCommand(ev.detail?.attackCommand);
-    });
+    const attackController = createAttackController(client);
 
-    function attackById(id: string, command: string = attackCommand) {
-        client.sendCommand(`${command} ob_${id}`);
-        if (attackMode !== 'A' && client.TeamManager.isLeader?.()) {
-            client.sendCommand(`wskaz ob_${id} jako cel ataku`, false);
-            if (attackMode === 'AWR') {
-                client.sendCommand(`rozkaz druzynie zaatakowac ob_${id}`, false);
-            }
-        }
-    }
+    const attackById = (id: string, command?: string) => {
+        attackController.attackById(id, command);
+    };
 
     function attack(short: string) {
         const obj = findByShortcut(short);
@@ -104,14 +93,6 @@ export default function initObjectAliases(
     client.addEventListener('releaseGuard', (event: CustomEvent<boolean>) => {
         releaseGuard = event.detail;
     });
-
-    let attackMode: 'A' | 'AW' | 'AWR' = getItemSync('attack_mode')?.attack_mode ?? 'A';
-    client.addEventListener('attackMode', (event: CustomEvent<'A' | 'AW' | 'AWR'>) => {
-        attackMode = event.detail;
-        setItemSync('attack_mode', attackMode);
-    });
-    client.sendEvent('attackMode', attackMode);
-
 
     if (aliases) {
         aliases.push({

--- a/client/src/utils/attackController.ts
+++ b/client/src/utils/attackController.ts
@@ -1,0 +1,35 @@
+import Client from "../Client";
+import { getItemSync, setItemSync } from "../storage";
+import { normalizeAttackCommand } from "./attackCommand";
+
+export type AttackMode = "A" | "AW" | "AWR";
+
+export function createAttackController(client: Client) {
+    const storedSettings = getItemSync("settings")?.settings;
+    let attackCommand = normalizeAttackCommand(storedSettings?.attackCommand);
+    client.addEventListener("settings", (ev: CustomEvent) => {
+        attackCommand = normalizeAttackCommand(ev.detail?.attackCommand);
+    });
+
+    let attackMode: AttackMode = getItemSync("attack_mode")?.attack_mode ?? "A";
+    client.addEventListener("attackMode", (event: CustomEvent<AttackMode>) => {
+        attackMode = event.detail;
+        setItemSync("attack_mode", attackMode);
+    });
+    client.sendEvent("attackMode", attackMode);
+
+    const attackById = (id: string, command: string = attackCommand) => {
+        client.sendCommand(`${command} ob_${id}`);
+        if (attackMode !== "A" && client.TeamManager.isLeader?.()) {
+            client.sendCommand(`wskaz ob_${id} jako cel ataku`, false);
+            if (attackMode === "AWR") {
+                client.sendCommand(`rozkaz druzynie zaatakowac ob_${id}`, false);
+            }
+        }
+    };
+
+    return {
+        attackById,
+        getAttackCommand: () => attackCommand,
+    };
+}

--- a/client/test/attackQueue.test.ts
+++ b/client/test/attackQueue.test.ts
@@ -2,12 +2,14 @@ import initAttackQueue from '../src/scripts/attackQueue';
 
 jest.mock('../src/storage', () => ({
   getItemSync: jest.fn(() => ({})),
+  setItemSync: jest.fn(),
 }));
 
 class FakeClient {
   TeamManager = {
     addEnemyToQueue: jest.fn(),
     shiftEnemyFromQueue: jest.fn(),
+    isLeader: jest.fn(() => true),
   };
   ObjectManager = {
     getObjectsOnLocation: jest.fn(),
@@ -28,6 +30,8 @@ describe('attack queue aliases', () => {
     initAttackQueue((client as unknown) as any, aliases);
     client.TeamManager.addEnemyToQueue.mockReset();
     client.TeamManager.shiftEnemyFromQueue.mockReset();
+    client.TeamManager.isLeader.mockClear();
+    client.TeamManager.isLeader.mockReturnValue(true);
     client.ObjectManager.getObjectsOnLocation.mockReset();
     client.println.mockClear();
     client.sendCommand.mockClear();
@@ -118,6 +122,37 @@ describe('attack queue aliases', () => {
 
     expect(client.TeamManager.shiftEnemyFromQueue).toHaveBeenCalled();
     expect(client.sendCommand).toHaveBeenCalledWith('zabij ob_77');
+  });
+
+  test('kills next enemy in AW mode marks target', () => {
+    const alias = aliases.find(a => a.pattern.test('/nn'))!;
+    const attackModeListenerCall = client.addEventListener.mock.calls.find(
+      call => call[0] === 'attackMode',
+    );
+    const attackModeListener = attackModeListenerCall && attackModeListenerCall[1];
+    client.TeamManager.shiftEnemyFromQueue.mockReturnValue('12');
+
+    attackModeListener?.({ detail: 'AW' } as any);
+    execAlias(alias, '/nn');
+
+    expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'zabij ob_12');
+    expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'wskaz ob_12 jako cel ataku', false);
+  });
+
+  test('kills next enemy in AWR mode orders team attack', () => {
+    const alias = aliases.find(a => a.pattern.test('/nn'))!;
+    const attackModeListenerCall = client.addEventListener.mock.calls.find(
+      call => call[0] === 'attackMode',
+    );
+    const attackModeListener = attackModeListenerCall && attackModeListenerCall[1];
+    client.TeamManager.shiftEnemyFromQueue.mockReturnValue('34');
+
+    attackModeListener?.({ detail: 'AWR' } as any);
+    execAlias(alias, '/nn');
+
+    expect(client.sendCommand).toHaveBeenNthCalledWith(1, 'zabij ob_34');
+    expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'wskaz ob_34 jako cel ataku', false);
+    expect(client.sendCommand).toHaveBeenNthCalledWith(3, 'rozkaz druzynie zaatakowac ob_34', false);
   });
 
   test('kills next enemy using attack command from settings', () => {

--- a/client/test/objectAliases.test.ts
+++ b/client/test/objectAliases.test.ts
@@ -266,25 +266,25 @@ describe('object aliases', () => {
   test('/ra alias orders attack on object', () => {
     client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 25, shortcut: '3' }]);
     orderAttack(['', '3'] as unknown as RegExpMatchArray);
-    expect(client.sendCommand).toHaveBeenCalledWith('rozkaz zaatakowac ob_25');
+    expect(client.sendCommand).toHaveBeenCalledWith('rozkaz druzynie zaatakowac ob_25');
   });
 
   test('/ra alias orders attack on attack target', () => {
     client.TeamManager.getAttackTargetId.mockReturnValue('40');
     orderAttackTarget();
-    expect(client.sendCommand).toHaveBeenCalledWith('rozkaz zaatakowac ob_40');
+    expect(client.sendCommand).toHaveBeenCalledWith('rozkaz druzynie zaatakowac ob_40');
   });
 
   test('/rz alias orders shield with object number', () => {
     client.ObjectManager.getObjectsOnLocation.mockReturnValue([{ num: 35, shortcut: 'A' }]);
     orderShield(['', 'A'] as unknown as RegExpMatchArray);
-    expect(client.sendCommand).toHaveBeenCalledWith('rozkaz zaslonic ob_35');
+    expect(client.sendCommand).toHaveBeenCalledWith('rozkaz druzynie zaslonic ob_35');
   });
 
   test('/rz alias orders shield of defense target', () => {
     client.TeamManager.getDefenseTargetId.mockReturnValue('44');
     orderShieldTarget();
-    expect(client.sendCommand).toHaveBeenCalledWith('rozkaz zaslonic ob_44');
+    expect(client.sendCommand).toHaveBeenCalledWith('rozkaz druzynie zaslonic ob_44');
   });
 
   test('/wa alias marks object as attack target', () => {


### PR DESCRIPTION
## Summary
- add a shared attack controller helper so attack queue and object aliases reuse attack logic
- update the /nn alias to trigger the same attack mode side effects as /z
- adjust tests to cover the new helper behaviour and existing order commands

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ff479f76a8832ab95b4f3c5eb48478