### PR TITLE
Add interface font switcher with lazy loading

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -357,9 +357,10 @@
                                 <div>
                                     <label class="form-label" for="ui-font-family">Czcionka okna wyjścia i listy obiektów</label>
                                     <select id="ui-font-family" class="form-select">
-                                        <option value="default">Domyślna (Open Sans)</option>
+                                        <option value="default">Domyślna (systemowa monospace)</option>
                                         <option value="fira-code">Fira Code</option>
                                         <option value="jetbrains-mono">JetBrains Mono</option>
+                                        <option value="cascadia-mono">Cascadia Mono</option>
                                         <option value="custom">Własna (link)</option>
                                     </select>
                                 </div>

--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -339,9 +339,10 @@
                                 <div>
                                     <label class="form-label" for="ui-font-family">Czcionka okna wyjścia i listy obiektów</label>
                                     <select id="ui-font-family" class="form-select">
-                                        <option value="default">Domyślna (Open Sans)</option>
+                                        <option value="default">Domyślna (systemowa monospace)</option>
                                         <option value="fira-code">Fira Code</option>
                                         <option value="jetbrains-mono">JetBrains Mono</option>
+                                        <option value="cascadia-mono">Cascadia Mono</option>
                                         <option value="custom">Własna (link)</option>
                                     </select>
                                 </div>

--- a/web-client/src/fontLoader.ts
+++ b/web-client/src/fontLoader.ts
@@ -1,14 +1,19 @@
-export type UiFontSelection = 'default' | 'fira-code' | 'jetbrains-mono' | 'custom';
+export type UiFontSelection = 'default' | 'fira-code' | 'jetbrains-mono' | 'cascadia-mono' | 'custom';
 
-const fontStylesheets: Record<'fira-code' | 'jetbrains-mono', string> = {
+const fontStylesheets: Record<'fira-code' | 'jetbrains-mono' | 'cascadia-mono', string> = {
     'fira-code': 'https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap',
     'jetbrains-mono': 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap',
+    'cascadia-mono': 'https://fonts.googleapis.com/css2?family=Cascadia+Mono:wght@400;500;600;700&display=swap',
 };
 
 const loadedFonts = new Map<UiFontSelection, string>();
 
 export function isUiFontSelection(value: unknown): value is UiFontSelection {
-    return value === 'default' || value === 'fira-code' || value === 'jetbrains-mono' || value === 'custom';
+    return value === 'default'
+        || value === 'fira-code'
+        || value === 'jetbrains-mono'
+        || value === 'cascadia-mono'
+        || value === 'custom';
 }
 
 export function ensureFontLoaded(selection: UiFontSelection, customHref?: string) {

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -153,6 +153,8 @@ function resolveOutputFontFamily(selection: UiFontSelection, customFontFamily: s
         return '"Fira Code", monospace';
     case 'jetbrains-mono':
         return '"JetBrains Mono", monospace';
+    case 'cascadia-mono':
+        return '"Cascadia Mono", monospace';
     case 'custom': {
         const trimmed = customFontFamily.trim();
         if (!trimmed) {


### PR DESCRIPTION
## Summary
- add a font selector to the UI settings modal with Fira Code and JetBrains Mono options
- persist the chosen font and expose it to the interface via a body data attribute
- lazily load optional fonts so they are only fetched when selected

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ff65e498c0832abc84d2a8fa455cba