### PR TITLE
Ensure knowledge report popup is draggable

### DIFF
--- a/client/src/dataStores/knowledgeStore.ts
+++ b/client/src/dataStores/knowledgeStore.ts
@@ -1,0 +1,303 @@
+import { DataStore, createDataStoreSingleton } from '../dataStore/DataStore';
+import { LoaderContext, LoaderResult, LoaderStrategy, RefreshMetadata, StorageStrategy } from '../dataStore/types';
+import {
+  clearIndexedDB,
+  getFromIndexedDB,
+  IndexedDBConfig,
+  storeInIndexedDB,
+} from '../utils/dataCache';
+
+export interface KnowledgeBookEntry {
+  mianownik: string;
+  dopelniacz: string;
+  biernik: string;
+  categories: string[];
+}
+
+export interface KnowledgeLibraryEntry {
+  location_id: string;
+  categories: string[];
+  name: string;
+}
+
+export type KnowledgeCategoryStatus = 'not_started' | 'in_progress' | 'completed';
+
+export type KnowledgeLibraryProgress = Record<string, KnowledgeCategoryStatus>;
+
+export type KnowledgeProgress = Record<string, KnowledgeLibraryProgress>;
+
+export type KnowledgeProgressByCharacter = Record<string, KnowledgeProgress>;
+
+export const DEFAULT_KNOWLEDGE_CHARACTER_KEY = '__default__';
+
+export interface KnowledgeFile {
+  version?: number;
+  books: Record<string, KnowledgeBookEntry>;
+  libraries?: Record<string, KnowledgeLibraryEntry>;
+}
+
+export interface KnowledgeSnapshotData extends KnowledgeFile {
+  libraries: Record<string, KnowledgeLibraryEntry>;
+  progress: KnowledgeProgressByCharacter;
+}
+
+export interface KnowledgeSnapshot {
+  data: KnowledgeSnapshotData;
+  timestamp: number;
+}
+
+function sanitizeProgress(
+  previous: KnowledgeProgressByCharacter | undefined,
+  libraries: Record<string, KnowledgeLibraryEntry>,
+): KnowledgeProgressByCharacter {
+  const result: KnowledgeProgressByCharacter = {};
+
+  if (!previous || typeof previous !== 'object') {
+    return result;
+  }
+
+  for (const [character, progress] of Object.entries(previous)) {
+    if (!progress || typeof progress !== 'object') {
+      continue;
+    }
+
+    const sanitizedLibraries: KnowledgeProgress = {};
+
+    for (const [libraryId, libraryProgress] of Object.entries(progress)) {
+      const library = libraries[libraryId];
+      if (!library || !libraryProgress || typeof libraryProgress !== 'object') {
+        continue;
+      }
+
+      const categories = new Set(
+        library.categories.map((category) => category.toLowerCase()),
+      );
+      const sanitizedCategories: KnowledgeLibraryProgress = {};
+
+      for (const [category, status] of Object.entries(libraryProgress)) {
+        if (!categories.has(category.toLowerCase())) {
+          continue;
+        }
+
+        if (status === 'not_started' || status === 'in_progress' || status === 'completed') {
+          sanitizedCategories[category] = status;
+        }
+      }
+
+      if (Object.keys(sanitizedCategories).length > 0) {
+        sanitizedLibraries[libraryId] = sanitizedCategories;
+      }
+    }
+
+    if (Object.keys(sanitizedLibraries).length > 0) {
+      result[character] = sanitizedLibraries;
+    }
+  }
+
+  return result;
+}
+
+interface KnowledgeLoaderOptions {
+  url: string;
+  fetchImpl?: typeof fetch;
+}
+
+class KnowledgeLoader
+  implements LoaderStrategy<KnowledgeSnapshot, RefreshMetadata>
+{
+  private readonly url: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: KnowledgeLoaderOptions) {
+    this.url = options.url;
+    this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
+  }
+
+  async load(
+    context: LoaderContext<KnowledgeSnapshot, RefreshMetadata>,
+  ): Promise<LoaderResult<KnowledgeSnapshot, RefreshMetadata>> {
+    const response = await this.fetchImpl(this.url);
+    const data = (await response.json()) as KnowledgeFile;
+
+    const libraries = data.libraries ?? {};
+    const progress = sanitizeProgress(context.previousSnapshot?.data.progress, libraries);
+
+    return {
+      snapshot: {
+        data: {
+          version: data.version,
+          books: data.books ?? {},
+          libraries,
+          progress,
+        },
+        timestamp: Date.now(),
+      },
+    };
+  }
+}
+
+interface KnowledgeIndexedDbStrategyOptions {
+  books: IndexedDBConfig;
+  libraries: IndexedDBConfig;
+  metadata?: IndexedDBConfig;
+}
+
+type KnowledgeLibrariesPayload = {
+  libraries: Record<string, KnowledgeLibraryEntry>;
+  progress: KnowledgeProgressByCharacter;
+  version?: number;
+  timestamp?: number;
+};
+
+class KnowledgeIndexedDbStrategy<TMeta extends RefreshMetadata = RefreshMetadata>
+  implements StorageStrategy<KnowledgeSnapshot, TMeta>
+{
+  private readonly booksConfig: IndexedDBConfig;
+  private readonly librariesConfig: IndexedDBConfig;
+  private readonly metadataConfig: IndexedDBConfig;
+  private inMemorySnapshot: KnowledgeSnapshot | undefined;
+  private inMemoryMetadata: TMeta | undefined;
+
+  constructor(options: KnowledgeIndexedDbStrategyOptions) {
+    this.booksConfig = options.books;
+    this.librariesConfig = options.libraries;
+    this.metadataConfig =
+      options.metadata ?? {
+        ...options.libraries,
+        key: 'metadata',
+      };
+  }
+
+  async readSnapshot(): Promise<KnowledgeSnapshot | undefined> {
+    if (this.inMemorySnapshot) {
+      return this.inMemorySnapshot;
+    }
+
+    try {
+      const [books, librariesPayload] = await Promise.all([
+        getFromIndexedDB<Record<string, KnowledgeBookEntry>>(this.booksConfig),
+        getFromIndexedDB<KnowledgeLibrariesPayload>(this.librariesConfig),
+      ]);
+
+      if (books && librariesPayload) {
+        const libraries = librariesPayload.libraries ?? {};
+        this.inMemorySnapshot = {
+          data: {
+            version: librariesPayload.version,
+            books,
+            libraries,
+            progress: sanitizeProgress(librariesPayload.progress, libraries),
+          },
+          timestamp: librariesPayload.timestamp ?? Date.now(),
+        };
+      }
+    } catch (error) {
+      console.warn('Failed to read knowledge snapshot from IndexedDB:', error);
+    }
+
+    return this.inMemorySnapshot;
+  }
+
+  async writeSnapshot(snapshot: KnowledgeSnapshot | undefined): Promise<void> {
+    this.inMemorySnapshot = snapshot;
+
+    if (!snapshot) {
+      await Promise.all([
+        this.safeClear(this.booksConfig),
+        this.safeClear(this.librariesConfig),
+      ]);
+      return;
+    }
+
+    const payload: KnowledgeLibrariesPayload = {
+      libraries: snapshot.data.libraries,
+      progress: snapshot.data.progress,
+      version: snapshot.data.version,
+      timestamp: snapshot.timestamp,
+    };
+
+    await Promise.all([
+      this.safeStore(this.booksConfig, snapshot.data.books),
+      this.safeStore(this.librariesConfig, payload),
+    ]);
+  }
+
+  async readMetadata(): Promise<TMeta | undefined> {
+    if (this.inMemoryMetadata) {
+      return this.inMemoryMetadata;
+    }
+
+    try {
+      const value = await getFromIndexedDB<TMeta>(this.metadataConfig);
+      if (value != null) {
+        this.inMemoryMetadata = value;
+      }
+    } catch (error) {
+      console.warn('Failed to read knowledge metadata from IndexedDB:', error);
+    }
+
+    return this.inMemoryMetadata;
+  }
+
+  async writeMetadata(metadata: TMeta | undefined): Promise<void> {
+    this.inMemoryMetadata = metadata;
+
+    if (metadata === undefined) {
+      await this.safeClear(this.metadataConfig);
+      return;
+    }
+
+    await this.safeStore(this.metadataConfig, metadata);
+  }
+
+  async clear(): Promise<void> {
+    this.inMemorySnapshot = undefined;
+    this.inMemoryMetadata = undefined;
+
+    await Promise.all([
+      this.safeClear(this.booksConfig),
+      this.safeClear(this.librariesConfig),
+      this.safeClear(this.metadataConfig),
+    ]);
+  }
+
+  private async safeStore(config: IndexedDBConfig, data: unknown): Promise<void> {
+    try {
+      await storeInIndexedDB(config, data);
+    } catch (error) {
+      console.warn('Failed to store knowledge data in IndexedDB:', error);
+    }
+  }
+
+  private async safeClear(config: IndexedDBConfig): Promise<void> {
+    try {
+      await clearIndexedDB(config);
+    } catch (error) {
+      console.warn('Failed to clear knowledge data in IndexedDB:', error);
+    }
+  }
+}
+
+export const KNOWLEDGE_URL =
+  'https://raw.githubusercontent.com/tjurczyk/arkadia-data/refs/heads/master/knowledge_data.json';
+
+const TTL = 24 * 60 * 60 * 1000;
+
+export const getKnowledgeStore = createDataStoreSingleton(
+  () =>
+    new DataStore<KnowledgeSnapshot, RefreshMetadata>({
+      loader: new KnowledgeLoader({
+        url: KNOWLEDGE_URL,
+      }),
+      storage: new KnowledgeIndexedDbStrategy<RefreshMetadata>({
+        books: { dbName: 'ArkadiaKnowledgeDB', storeName: 'knowledge_books', key: 'books' },
+        libraries: {
+          dbName: 'ArkadiaKnowledgeDB',
+          storeName: 'knowledge_libraries',
+          key: 'libraries',
+        },
+      }),
+      ttlMs: TTL,
+    }),
+);
+

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -38,6 +38,7 @@ import initInvite from './scripts/invite'
 import initObjectAliases from './scripts/objectAliases'
 import initMagicKeys from './scripts/magicKeys'
 import initMagics from './scripts/magics'
+import initKnowledge from './scripts/knowledge'
 import initOdlozMagie from './scripts/odlozMagie'
 import registerGagTriggers from './scripts/gags'
 import initLeaderAttackWarning from './scripts/leaderAttackWarning'
@@ -200,6 +201,7 @@ export function registerScripts(client: Client) {
     initObjectAliases(client, aliases)
     initMagicKeys(client)
     initMagics(client)
+    initKnowledge(client, aliases)
     initOdlozMagie(client, aliases)
     initPriceEvaluation(client)
     initStoneValue(client, aliases)

--- a/client/src/scripts/knowledge.ts
+++ b/client/src/scripts/knowledge.ts
@@ -1,0 +1,623 @@
+import Client from '../Client';
+import { colorString, findClosestColor } from '../Colors';
+import {
+  DEFAULT_KNOWLEDGE_CHARACTER_KEY,
+  getKnowledgeStore,
+  KnowledgeCategoryStatus,
+  KnowledgeLibraryEntry,
+  KnowledgeLibraryProgress,
+  KnowledgeSnapshot,
+} from '../dataStores/knowledgeStore';
+import { getCurrentCharacter } from '../storage';
+
+type AliasEntry = { pattern: RegExp; callback: Function };
+
+const STATUS_COLORS: Record<KnowledgeCategoryStatus, number> = {
+  not_started: findClosestColor('#ffffff'),
+  in_progress: findClosestColor('#ffff00'),
+  completed: findClosestColor('#00ff00'),
+};
+
+const HEADER_COLOR = findClosestColor('#7cfc00');
+
+const START_LIBRARY_PATTERN =
+  /^Zaczynasz zglebiac tutejsze zasoby, probujac dowiedziec sie czegos wiecej o (.*)\.$/;
+const COMPLETE_LIBRARY_PATTERN =
+  /^Masz wrazenie, ze tutaj nie dowiesz sie juz niczego wiecej o (.*)\.$/;
+const KNOWLEDGE_PROMPT_PATTERN =
+  /^Wiedze o czym chcesz zglebiac\? (.*)$/;
+
+const CATEGORY_DECLENSION_TO_BASE: Record<string, string> = {
+  'chaosie i jego tworach': 'chaos i jego twory',
+  goblinoidach: 'goblinoidy',
+  golemach: 'golemy',
+  'istotach demonicznych': 'istoty demoniczne',
+  jaszczuroludziach: 'jaszczuroludzie',
+  'magii i jej tworach': 'magia i jej twory',
+  nieumarlych: 'nieumarli',
+  'pajakach i pajakowatych': 'pajaki i pajakowate',
+  ryboludziach: 'ryboludzie',
+  'smokach i smokowatych': 'smoki i smokowate',
+  'starszych rasach': 'starsze rasy',
+  'stworach pokoniunkcyjnych': 'stwory pokoniunkcyjne',
+  szczuroludziach: 'szczuroludzie',
+  wampirach: 'wampiry',
+};
+
+const CATEGORY_BASE_TO_DATIVE: Record<string, string> = {
+  'chaos i jego twory': 'chaosie i jego tworach',
+  goblinoidy: 'goblinoidach',
+  golemy: 'golemach',
+  'istoty demoniczne': 'istotach demonicznych',
+  jaszczuroludzie: 'jaszczuroludziach',
+  'magia i jej twory': 'magii i jej tworach',
+  nieumarli: 'nieumarlych',
+  'pajaki i pajakowate': 'pajakach i pajakowatych',
+  ryboludzie: 'ryboludziach',
+  'smoki i smokowate': 'smokach i smokowatych',
+  'starsze rasy': 'starszych rasach',
+  'stwory pokoniunkcyjne': 'stworach pokoniunkcyjnych',
+  szczuroludzie: 'szczuroludziach',
+  wampiry: 'wampirach',
+};
+
+function normalizeCategory(category: string, library: KnowledgeLibraryEntry): string | null {
+  const trimmed = category.trim();
+  const lowerTrimmed = trimmed.toLowerCase();
+  const baseCandidate =
+    CATEGORY_DECLENSION_TO_BASE[lowerTrimmed] !== undefined
+      ? CATEGORY_DECLENSION_TO_BASE[lowerTrimmed]
+      : trimmed;
+
+  for (const entry of library.categories) {
+    if (entry.toLowerCase() === baseCandidate.toLowerCase()) {
+      return entry;
+    }
+  }
+
+  if (baseCandidate !== trimmed) {
+    for (const entry of library.categories) {
+      if (entry.toLowerCase() === trimmed.toLowerCase()) {
+        return entry;
+      }
+    }
+  }
+
+  return null;
+}
+
+function formatCategory(
+  client: Client,
+  category: string,
+  status: KnowledgeCategoryStatus,
+): string {
+  const dativeCategory =
+    CATEGORY_BASE_TO_DATIVE[category.toLowerCase()] ?? category;
+  const clickable = client.OutputHandler.makeStringClickable(category, () => {
+    client.sendCommand(`zglebiaj wiedze o ${dativeCategory}`);
+  });
+  return colorString(clickable, STATUS_COLORS[status]);
+}
+
+function getUniqueLibraryCategories(library: KnowledgeLibraryEntry): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+
+  for (const category of library.categories) {
+    const key = category.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    unique.push(category);
+  }
+
+  return unique;
+}
+
+type KnowledgeReportLibraryCategory = {
+  name: string;
+  dative: string;
+  status: KnowledgeCategoryStatus;
+};
+
+type LibraryProgressSummary = {
+  total: number;
+  completed: number;
+  in_progress: number;
+  not_started: number;
+  remaining: number;
+  categories: KnowledgeReportLibraryCategory[];
+};
+
+type KnowledgeReportLibrary = Omit<LibraryProgressSummary, 'categories'> & {
+  id: string;
+  name: string;
+  categories: KnowledgeReportLibraryCategory[];
+};
+
+type KnowledgeReportCategoryLibrary = {
+  id: string;
+  name: string;
+  status: KnowledgeCategoryStatus;
+};
+
+type KnowledgeReportCategory = {
+  name: string;
+  dative: string;
+  libraries: KnowledgeReportCategoryLibrary[];
+};
+
+type KnowledgeReportPayload = {
+  libraries: KnowledgeReportLibrary[];
+  categories: KnowledgeReportCategory[];
+};
+
+function summarizeLibraryProgress(
+  library: KnowledgeLibraryEntry,
+  libraryProgress: Record<string, KnowledgeCategoryStatus>,
+): LibraryProgressSummary {
+  const categories = getUniqueLibraryCategories(library);
+  const categoryDetails: KnowledgeReportLibraryCategory[] = [];
+  const summary: LibraryProgressSummary = {
+    total: categories.length,
+    completed: 0,
+    in_progress: 0,
+    not_started: 0,
+    remaining: 0,
+    categories: categoryDetails,
+  };
+
+  for (const category of categories) {
+    const status = libraryProgress[category] ?? 'not_started';
+    const key = category.toLowerCase();
+    const dative = CATEGORY_BASE_TO_DATIVE[key] ?? category;
+
+    categoryDetails.push({
+      name: category,
+      dative,
+      status,
+    });
+
+    if (status === 'completed') {
+      summary.completed += 1;
+    } else if (status === 'in_progress') {
+      summary.in_progress += 1;
+    } else {
+      summary.not_started += 1;
+    }
+  }
+
+  summary.remaining = summary.not_started + summary.in_progress;
+
+  return summary;
+}
+
+function buildKnowledgeReport(
+  libraryEntries: [string, KnowledgeLibraryEntry][],
+  characterProgress: Record<string, KnowledgeLibraryProgress>,
+): KnowledgeReportPayload | null {
+  const libraries: KnowledgeReportLibrary[] = [];
+  const categoriesMap = new Map<
+    string,
+    {
+      category: string;
+      dative: string;
+      libraries: KnowledgeReportCategoryLibrary[];
+      hasRemaining: boolean;
+    }
+  >();
+
+  for (const [libraryId, library] of libraryEntries) {
+    const libraryProgress = characterProgress[libraryId] ?? {};
+    const summary = summarizeLibraryProgress(library, libraryProgress);
+
+    if (summary.total > 0 && summary.remaining > 0) {
+      libraries.push({
+        id: libraryId,
+        name: library.name,
+        total: summary.total,
+        remaining: summary.remaining,
+        not_started: summary.not_started,
+        in_progress: summary.in_progress,
+        completed: summary.completed,
+        categories: summary.categories,
+      });
+    }
+
+    if (summary.categories.length === 0) {
+      continue;
+    }
+
+    for (const detail of summary.categories) {
+      const category = detail.name;
+      const { status, dative } = detail;
+      let categoryEntry = categoriesMap.get(category);
+      if (!categoryEntry) {
+        categoryEntry = {
+          category,
+          dative,
+          libraries: [],
+          hasRemaining: false,
+        };
+        categoriesMap.set(category, categoryEntry);
+      }
+
+      categoryEntry.libraries.push({
+        id: libraryId,
+        name: library.name,
+        status,
+      });
+
+      if (status !== 'completed') {
+        categoryEntry.hasRemaining = true;
+      }
+    }
+  }
+
+  libraries.sort((a, b) => a.name.localeCompare(b.name));
+
+  const categories = Array.from(categoriesMap.values())
+    .filter((entry) => entry.hasRemaining)
+    .map<KnowledgeReportCategory>((entry) => ({
+      name: entry.category,
+      dative: entry.dative,
+      libraries: entry.libraries.sort((a, b) => a.name.localeCompare(b.name)),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  if (libraries.length === 0 && categories.length === 0) {
+    return null;
+  }
+
+  return { libraries, categories };
+}
+
+export default function initKnowledge(client: Client, aliases?: AliasEntry[]) {
+  const aliasList = aliases ?? client.aliases;
+  const store = getKnowledgeStore();
+  let currentLibraryId: string | null = null;
+  let currentSnapshot: KnowledgeSnapshot | undefined;
+  let pendingPromptTrigger: {
+    trigger: ReturnType<typeof client.Triggers.registerOneTimeTrigger>;
+    timeoutId: number;
+  } | null = null;
+
+  function getCharacterProgressKey(): string {
+    const current = getCurrentCharacter();
+    if (!current) {
+      return DEFAULT_KNOWLEDGE_CHARACTER_KEY;
+    }
+    const trimmed = current.trim();
+    return trimmed.length > 0 ? trimmed : DEFAULT_KNOWLEDGE_CHARACTER_KEY;
+  }
+
+  void store.refresh().catch((error) => {
+    console.error('Failed to refresh knowledge data:', error);
+  });
+
+  store.subscribe((snapshot) => {
+    currentSnapshot = snapshot ?? undefined;
+    if (client.Map.currentRoom) {
+      updateCurrentLibrary(client.Map.currentRoom);
+    }
+  });
+
+  function clearPendingPrompt(removeTrigger: boolean) {
+    if (!pendingPromptTrigger) {
+      return;
+    }
+
+    window.clearTimeout(pendingPromptTrigger.timeoutId);
+    if (removeTrigger) {
+      client.Triggers.removeTrigger(pendingPromptTrigger.trigger);
+    }
+    pendingPromptTrigger = null;
+  }
+
+  function updateCurrentLibrary(room: any) {
+    const internalId: string | undefined = room?.userData?.internal_id;
+    if (!internalId || !currentSnapshot?.data.libraries[internalId]) {
+      currentLibraryId = null;
+      return;
+    }
+    currentLibraryId = internalId;
+  }
+
+  function setProgress(category: string, status: KnowledgeCategoryStatus) {
+    if (!currentSnapshot) {
+      return;
+    }
+    const libraryId = currentLibraryId;
+    if (!libraryId) {
+      return;
+    }
+    const library = currentSnapshot.data.libraries[libraryId];
+    if (!library) {
+      return;
+    }
+    const normalized = normalizeCategory(category, library);
+    if (!normalized) {
+      return;
+    }
+
+    void store
+      .applyLocalChange((snapshot) => {
+        if (!snapshot) {
+          return snapshot;
+        }
+
+        if (!snapshot.data.libraries[libraryId]) {
+          return snapshot;
+        }
+
+        const nextProgress = { ...snapshot.data.progress };
+        const characterKey = getCharacterProgressKey();
+        const characterProgress = { ...(nextProgress[characterKey] ?? {}) };
+        const libraryProgress = { ...(characterProgress[libraryId] ?? {}) };
+        const previousStatus = libraryProgress[normalized];
+
+        if (previousStatus === 'completed' && status !== 'completed') {
+          return snapshot;
+        }
+
+        if (previousStatus === status) {
+          return snapshot;
+        }
+
+        libraryProgress[normalized] = status;
+        characterProgress[libraryId] = libraryProgress;
+        nextProgress[characterKey] = characterProgress;
+
+        return {
+          ...snapshot,
+          data: {
+            ...snapshot.data,
+            progress: nextProgress,
+          },
+        };
+      })
+      .catch((error) => {
+        console.error('Failed to update knowledge progress:', error);
+      });
+  }
+
+  client.addEventListener('enterLocation', (event: CustomEvent<{ room: any }>) => {
+    updateCurrentLibrary(event.detail.room);
+  });
+
+  client.addEventListener('command', (event: CustomEvent<string>) => {
+    const command = (event.detail ?? '').trim();
+    if (command !== 'zglebiaj wiedze') {
+      return;
+    }
+
+    clearPendingPrompt(true);
+    const trigger = client.Triggers.registerOneTimeTrigger(
+      KNOWLEDGE_PROMPT_PATTERN,
+      (_raw, _line, matches) => {
+        clearPendingPrompt(false);
+        const categoriesText = matches[1];
+        if (categoriesText) {
+          handleKnowledgePrompt(categoriesText);
+        }
+      },
+      'knowledge-progress',
+    );
+
+    const timeoutId = window.setTimeout(() => {
+      clearPendingPrompt(true);
+    }, 5000);
+
+    pendingPromptTrigger = { trigger, timeoutId };
+  });
+
+  client.Triggers.registerTrigger(
+    START_LIBRARY_PATTERN,
+    (_raw, _line, matches) => {
+      const category = matches[1];
+      if (category) {
+        setProgress(category, 'in_progress');
+      }
+    },
+    'knowledge-progress',
+  );
+
+  client.Triggers.registerTrigger(
+    COMPLETE_LIBRARY_PATTERN,
+    (_raw, _line, matches) => {
+      const category = matches[1];
+      if (category) {
+        setProgress(category, 'completed');
+      }
+    },
+    'knowledge-progress',
+  );
+
+  function getActiveLibraryContext():
+    | {
+        libraryId: string;
+        library: KnowledgeLibraryEntry;
+        libraryProgress: Record<string, KnowledgeCategoryStatus>;
+      }
+    | null {
+    if (!currentSnapshot) {
+      return null;
+    }
+
+    const libraryId = currentLibraryId;
+    if (!libraryId) {
+      return null;
+    }
+
+    const library = currentSnapshot.data.libraries[libraryId];
+    if (!library) {
+      return null;
+    }
+
+    const characterKey = getCharacterProgressKey();
+    const characterProgress = currentSnapshot.data.progress[characterKey] ?? {};
+    const libraryProgress = characterProgress[libraryId] ?? {};
+
+    return { libraryId, library, libraryProgress };
+  }
+
+  function printLibraryCategories(
+    library: KnowledgeLibraryEntry,
+    libraryProgress: Record<string, KnowledgeCategoryStatus>,
+    categories: string[],
+  ) {
+    const header = colorString(library.name, HEADER_COLOR);
+    const lines = categories.map((category) => {
+      const status = libraryProgress[category] ?? 'not_started';
+      return ` - ${formatCategory(client, category, status)}`;
+    });
+
+    client.println([header, ...lines].join('\n'));
+  }
+
+  function handleKnowledgePrompt(categoriesText: string) {
+    if (!currentSnapshot) {
+      client.println('Dane wiedzy nie sa jeszcze dostepne.');
+      return;
+    }
+
+    const libraryId = currentLibraryId;
+    if (!libraryId) {
+      client.println('Nie jestes w bibliotece.');
+      return;
+    }
+
+    const library = currentSnapshot.data.libraries[libraryId];
+    if (!library) {
+      client.println('Brak danych o tej bibliotece.');
+      return;
+    }
+
+    const cleaned = categoriesText.trim().replace(/\?$/, '').replace(/\s+/g, ' ');
+    const normalizedPrompt = cleaned.replace(/\s+czy o\s+/gi, ', o ');
+    const rawCategories = normalizedPrompt
+      .split(/, o /i)
+      .map((entry) => entry.trim().replace(/^[Oo]\s+/, '').trim())
+      .filter((entry) => entry.length > 0);
+
+    const normalizedCategories: string[] = [];
+    const seenNormalized = new Set<string>();
+    const unrecognized: string[] = [];
+    for (const rawCategory of rawCategories) {
+      const normalized = normalizeCategory(rawCategory, library);
+      if (!normalized) {
+        unrecognized.push(rawCategory);
+        continue;
+      }
+      const key = normalized.toLowerCase();
+      if (seenNormalized.has(key)) {
+        continue;
+      }
+
+      seenNormalized.add(key);
+      normalizedCategories.push(normalized);
+    }
+
+    const uniqueLibraryCategories = getUniqueLibraryCategories(library);
+    const expectedSet = new Set(uniqueLibraryCategories);
+    const seenSet = new Set(normalizedCategories);
+    const missing = uniqueLibraryCategories.filter((category) => !seenSet.has(category));
+    const unexpected = normalizedCategories.filter((category) => !expectedSet.has(category));
+
+    if (
+      unrecognized.length > 0 ||
+      missing.length > 0 ||
+      unexpected.length > 0 ||
+      normalizedCategories.length !== uniqueLibraryCategories.length
+    ) {
+      const messages: string[] = [];
+      if (unrecognized.length > 0) {
+        messages.push(
+          `Nie rozpoznano kategorii: ${unrecognized.join(', ')}.`,
+        );
+      }
+      if (missing.length > 0) {
+        messages.push(`Brakuje kategorii: ${missing.join(', ')}.`);
+      }
+      if (unexpected.length > 0) {
+        messages.push(`Nieoczekiwane kategorie: ${unexpected.join(', ')}.`);
+      }
+      messages.push('Prosze zglosic to do developera.');
+      client.println(messages.join('\n'));
+      console.warn('Knowledge prompt mismatch', {
+        categoriesText,
+        rawCategories,
+        unrecognized,
+        missing,
+        unexpected,
+      });
+      return;
+    }
+
+    const characterKey = getCharacterProgressKey();
+    const characterProgress = currentSnapshot.data.progress[characterKey] ?? {};
+    const libraryProgress = characterProgress[libraryId] ?? {};
+
+    printLibraryCategories(
+      library,
+      libraryProgress,
+      getUniqueLibraryCategories(library),
+    );
+  }
+
+  function showLibraryCategories() {
+    if (!currentSnapshot) {
+      client.println('Dane wiedzy nie sa jeszcze dostepne.');
+      return;
+    }
+
+    const context = getActiveLibraryContext();
+    if (!context) {
+      if (!currentLibraryId) {
+        client.println('Nie jestes w bibliotece.');
+        return;
+      }
+
+      client.println('Brak danych o tej bibliotece.');
+      return;
+    }
+
+    printLibraryCategories(
+      context.library,
+      context.libraryProgress,
+      getUniqueLibraryCategories(context.library),
+    );
+  }
+
+  aliasList.push({ pattern: /\/zglebiaj$/, callback: showLibraryCategories });
+  aliasList.push({ pattern: /\/biblioteki$/, callback: showLibrariesReport });
+
+  function showLibrariesReport() {
+    if (!currentSnapshot) {
+      client.println('Dane wiedzy nie sa jeszcze dostepne.');
+      return;
+    }
+
+    const libraryEntries = Object.entries(currentSnapshot.data.libraries);
+    if (libraryEntries.length === 0) {
+      client.println('Brak danych o bibliotekach.');
+      client.sendEvent('knowledgeReport', null);
+      return;
+    }
+
+    const characterKey = getCharacterProgressKey();
+    const characterProgress = currentSnapshot.data.progress[characterKey] ?? {};
+    const report = buildKnowledgeReport(libraryEntries, characterProgress);
+
+    if (!report) {
+      client.println('Brak wiedzy do zglebiania w znanych bibliotekach.');
+      client.sendEvent('knowledgeReport', null);
+      return;
+    }
+
+    client.sendEvent('knowledgeReport', report);
+  }
+}
+

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -190,6 +190,7 @@
             </div>
         </div>
     </div>
+    <div id="knowledge-root"></div>
     <div id="input-area">
         <div id="history-buttons">
             <button id="history-up-button">▲</button>

--- a/web-client/src/KnowledgeReport.tsx
+++ b/web-client/src/KnowledgeReport.tsx
@@ -1,0 +1,447 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type Client from '@client/src/Client';
+import type { KnowledgeCategoryStatus } from '@client/src/dataStores/knowledgeStore';
+
+type KnowledgeReportLibraryCategory = {
+  name: string;
+  dative: string;
+  status: KnowledgeCategoryStatus;
+};
+
+type KnowledgeReportLibrary = {
+  id: string;
+  name: string;
+  total: number;
+  remaining: number;
+  not_started: number;
+  in_progress: number;
+  completed: number;
+  categories: KnowledgeReportLibraryCategory[];
+};
+
+type KnowledgeReportCategoryLibrary = {
+  id: string;
+  name: string;
+  status: KnowledgeCategoryStatus;
+};
+
+type KnowledgeReportCategory = {
+  name: string;
+  dative: string;
+  libraries: KnowledgeReportCategoryLibrary[];
+};
+
+type KnowledgeReportPayload = {
+  libraries: KnowledgeReportLibrary[];
+  categories: KnowledgeReportCategory[];
+};
+
+type PointerDragState = {
+  pointerId: number;
+  offsetX: number;
+  offsetY: number;
+};
+
+const LIBRARY_STATUS_CONFIG: {
+  key: KnowledgeCategoryStatus;
+  label: string;
+  chipClass: string;
+}[] = [
+  { key: 'not_started', label: 'Nierozpoczete', chipClass: 'not-started' },
+  { key: 'in_progress', label: 'W trakcie', chipClass: 'in-progress' },
+  { key: 'completed', label: 'Ukonczone', chipClass: 'completed' },
+];
+
+function groupLibraryCategories(
+  categories: KnowledgeReportLibraryCategory[],
+): Record<KnowledgeCategoryStatus, KnowledgeReportLibraryCategory[]> {
+  return categories.reduce(
+    (acc, category) => {
+      acc[category.status].push(category);
+      return acc;
+    },
+    {
+      not_started: [] as KnowledgeReportLibraryCategory[],
+      in_progress: [] as KnowledgeReportLibraryCategory[],
+      completed: [] as KnowledgeReportLibraryCategory[],
+    },
+  );
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+}
+
+const KnowledgeReport: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [data, setData] = useState<KnowledgeReportPayload | null>(null);
+  const [activeTab, setActiveTab] = useState<'libraries' | 'categories'>('libraries');
+  const [position, setPosition] = useState<{ left: number; top: number } | null>(null);
+  const [expandedStatuses, setExpandedStatuses] = useState<
+    Record<string, Partial<Record<KnowledgeCategoryStatus, boolean>>>
+  >({});
+  const panelRef = useRef<HTMLDivElement>(null);
+  const dragState = useRef<PointerDragState | null>(null);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const ensureVisiblePosition = useCallback((prev: { left: number; top: number } | null) => {
+    if (!prev || !panelRef.current) {
+      return prev;
+    }
+    const margin = 16;
+    const width = panelRef.current.offsetWidth;
+    const height = panelRef.current.offsetHeight;
+    const maxLeft = Math.max(margin, window.innerWidth - width - margin);
+    const maxTop = Math.max(margin, window.innerHeight - height - margin);
+    const nextLeft = clamp(prev.left, margin, maxLeft);
+    const nextTop = clamp(prev.top, margin, maxTop);
+    if (nextLeft === prev.left && nextTop === prev.top) {
+      return prev;
+    }
+    return { left: nextLeft, top: nextTop };
+  }, []);
+
+  const handlePointerMove = useCallback((event: PointerEvent) => {
+    const drag = dragState.current;
+    if (!drag || event.pointerId !== drag.pointerId || !panelRef.current) {
+      return;
+    }
+    const margin = 16;
+    const width = panelRef.current.offsetWidth;
+    const height = panelRef.current.offsetHeight;
+    const maxLeft = Math.max(margin, window.innerWidth - width - margin);
+    const maxTop = Math.max(margin, window.innerHeight - height - margin);
+    const nextLeft = clamp(event.clientX - drag.offsetX, margin, maxLeft);
+    const nextTop = clamp(event.clientY - drag.offsetY, margin, maxTop);
+    setPosition({ left: nextLeft, top: nextTop });
+  }, []);
+
+  const endPointerDrag = useCallback(
+    (event: PointerEvent) => {
+      const drag = dragState.current;
+      if (!drag || event.pointerId !== drag.pointerId) {
+        return;
+      }
+      dragState.current = null;
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', endPointerDrag);
+      window.removeEventListener('pointercancel', endPointerDrag);
+    },
+    [handlePointerMove],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0) {
+        return;
+      }
+      if (!panelRef.current) {
+        return;
+      }
+      const rect = panelRef.current.getBoundingClientRect();
+      dragState.current = {
+        pointerId: event.pointerId,
+        offsetX: event.clientX - rect.left,
+        offsetY: event.clientY - rect.top,
+      };
+      setPosition((prev) => prev ?? { left: rect.left, top: rect.top });
+      window.addEventListener('pointermove', handlePointerMove);
+      window.addEventListener('pointerup', endPointerDrag);
+      window.addEventListener('pointercancel', endPointerDrag);
+      event.preventDefault();
+    },
+    [endPointerDrag, handlePointerMove],
+  );
+
+  useEffect(() => {
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', endPointerDrag);
+      window.removeEventListener('pointercancel', endPointerDrag);
+    };
+  }, [endPointerDrag, handlePointerMove]);
+
+  useEffect(() => {
+    if (isOpen) {
+      return;
+    }
+    dragState.current = null;
+    window.removeEventListener('pointermove', handlePointerMove);
+    window.removeEventListener('pointerup', endPointerDrag);
+    window.removeEventListener('pointercancel', endPointerDrag);
+  }, [endPointerDrag, handlePointerMove, isOpen]);
+
+  const handleReport = useCallback((detail: KnowledgeReportPayload | null | undefined) => {
+    if (!detail || (!detail.libraries?.length && !detail.categories?.length)) {
+      setData(null);
+      setIsOpen(false);
+      return;
+    }
+
+    setData(detail);
+    setIsOpen(true);
+    setPosition(null);
+    setExpandedStatuses({});
+    if (detail.libraries.length > 0) {
+      setActiveTab('libraries');
+    } else {
+      setActiveTab('categories');
+    }
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const custom = event as CustomEvent<KnowledgeReportPayload | null | undefined>;
+      handleReport(custom.detail);
+    };
+    window.addEventListener('knowledgeReport', handler as EventListener);
+    return () => window.removeEventListener('knowledgeReport', handler as EventListener);
+  }, [handleReport]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [close, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handlePointerDownOutside = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (target && panelRef.current?.contains(target)) {
+        return;
+      }
+      close();
+    };
+    window.addEventListener('pointerdown', handlePointerDownOutside);
+    return () => window.removeEventListener('pointerdown', handlePointerDownOutside);
+  }, [close, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handleResize = () => {
+      setPosition((prev) => ensureVisiblePosition(prev));
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [ensureVisiblePosition, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setPosition((prev) => ensureVisiblePosition(prev));
+    panelRef.current?.focus();
+  }, [ensureVisiblePosition, isOpen]);
+
+  const handleStartCategory = useCallback((dative: string) => {
+    const client = (window as any).clientExtension as Client | undefined;
+    if (!client) {
+      return;
+    }
+    client.sendCommand(`zglebiaj wiedze o ${dative}`);
+  }, []);
+
+  const toggleLibraryStatus = useCallback(
+    (libraryId: string, status: KnowledgeCategoryStatus) => {
+      setExpandedStatuses((prev) => {
+        const nextLibraryState = { ...(prev[libraryId] ?? {}) };
+        nextLibraryState[status] = !nextLibraryState[status];
+        return { ...prev, [libraryId]: nextLibraryState };
+      });
+    },
+    [],
+  );
+
+  const libraryContent = useMemo(() => {
+    if (!data) {
+      return null;
+    }
+    if (data.libraries.length === 0) {
+      return (
+        <div className="knowledge-empty">Brak wiedzy do zglebiania w znanych bibliotekach.</div>
+      );
+    }
+    return (
+      <div className="knowledge-libraries">
+        {data.libraries.map((library) => {
+          const grouped = groupLibraryCategories(library.categories);
+          const libraryExpanded = expandedStatuses[library.id] ?? {};
+          return (
+            <div key={library.id} className="knowledge-library">
+              <div className="knowledge-library-header">
+                <span className="knowledge-library-name">{library.name}</span>
+                <span className="knowledge-library-remaining">
+                  Pozostalo {library.remaining} z {library.total} kategorii
+                </span>
+              </div>
+              <div className="knowledge-library-statuses">
+                {LIBRARY_STATUS_CONFIG.map(({ key, label, chipClass }) => {
+                  const count = library[key];
+                  if (!count) {
+                    return null;
+                  }
+                  const isExpanded = Boolean(libraryExpanded[key]);
+                  return (
+                    <div
+                      key={key}
+                      className={`knowledge-library-status knowledge-library-status--${key}`}
+                    >
+                      <button
+                        type="button"
+                        className={`knowledge-chip knowledge-chip--${chipClass} ${
+                          isExpanded ? 'knowledge-chip--active' : ''
+                        }`}
+                        onClick={() => toggleLibraryStatus(library.id, key)}
+                      >
+                        {label}: {count}
+                      </button>
+                      {isExpanded && grouped[key].length > 0 && (
+                        <div className="knowledge-library-categories">
+                          {grouped[key].map((category) => (
+                            <button
+                              type="button"
+                              key={category.name}
+                              className={`knowledge-library-category knowledge-library-category--${category.status}`}
+                              onClick={() => handleStartCategory(category.dative)}
+                            >
+                              {category.name}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }, [data, expandedStatuses, handleStartCategory, toggleLibraryStatus]);
+
+  const categoriesContent = useMemo(() => {
+    if (!data) {
+      return null;
+    }
+    if (data.categories.length === 0) {
+      return <div className="knowledge-empty">Brak kategorii wymagajacych zglebiania.</div>;
+    }
+    return (
+      <div className="knowledge-category-grid">
+        {data.categories.map((category) => (
+          <div key={category.name} className="knowledge-category-tile">
+            <div className="knowledge-category-header">
+              <span className="knowledge-category-name">{category.name}</span>
+              <button
+                type="button"
+                className="knowledge-category-command"
+                onClick={() => handleStartCategory(category.dative)}
+              >
+                Zglebiaj
+              </button>
+            </div>
+            <div className="knowledge-category-libraries">
+              {category.libraries.map((library) => (
+                <div key={library.id} className="knowledge-category-entry">
+                  <span
+                    className={`knowledge-status-dot knowledge-status-dot--${library.status}`}
+                    title={
+                      library.status === 'completed'
+                        ? 'Ukonczone'
+                        : library.status === 'in_progress'
+                        ? 'W trakcie'
+                        : 'Nierozpoczete'
+                    }
+                  />
+                  <span className="knowledge-category-entry-name">{library.name}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }, [data, handleStartCategory]);
+
+  if (!isOpen || !data) {
+    return null;
+  }
+
+  const hasLibraries = data.libraries.length > 0;
+
+  return (
+    <div className="knowledge-window-container">
+      <div
+        ref={panelRef}
+        className={`knowledge-window ${
+          position ? 'knowledge-window--floating' : 'knowledge-window--center'
+        }`}
+        style={position ? { left: `${position.left}px`, top: `${position.top}px` } : undefined}
+        tabIndex={-1}
+      >
+        <div className="knowledge-window-header" onPointerDown={handlePointerDown}>
+          <h5 className="knowledge-window-title">Raport wiedzy</h5>
+          <button type="button" className="btn-close" onClick={close} />
+        </div>
+        <div className="knowledge-window-body">
+          <div className="knowledge-tabs">
+            <button
+              type="button"
+              className={`knowledge-tab-button ${
+                activeTab === 'libraries' ? 'knowledge-tab-button--active' : ''
+              }`}
+              onClick={() => setActiveTab('libraries')}
+              disabled={!hasLibraries}
+            >
+              Biblioteki
+            </button>
+            <button
+              type="button"
+              className={`knowledge-tab-button ${
+                activeTab === 'categories' ? 'knowledge-tab-button--active' : ''
+              }`}
+              onClick={() => setActiveTab('categories')}
+            >
+              Kategorie
+            </button>
+          </div>
+          <div className="knowledge-content">
+            {activeTab === 'libraries' ? libraryContent : categoriesContent}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default KnowledgeReport;
+

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -18,6 +18,7 @@ import FightTitle from "./FightTitle";
 import HpTitle from "./HpTitle";
 import initSessionLogger from "./sessionLogger";
 import LetterComposer from "./LetterComposer";
+import KnowledgeReport from "./KnowledgeReport";
 
 import "@client/src/main.ts"
 import MockPort from "./MockPort.ts";
@@ -1178,6 +1179,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const herbRoot = document.getElementById('herb-ui-root');
     if (herbRoot) {
         createRoot(herbRoot).render(createElement(HerbManager));
+    }
+
+    const knowledgeRoot = document.getElementById('knowledge-root');
+    if (knowledgeRoot) {
+        createRoot(knowledgeRoot).render(createElement(KnowledgeReport));
     }
 });
 

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -737,6 +737,346 @@ h1 {
   background-color: var(--surface-elevated);
 }
 
+.knowledge-window {
+  position: fixed;
+  z-index: 1050;
+  width: min(960px, calc(100vw - 2rem));
+  height: min(75vh, calc(100vh - 2rem));
+  max-height: calc(100vh - 2rem);
+  border-radius: 0.5rem;
+  background-color: var(--surface-elevated);
+  border: 1px solid var(--surface-border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  color: #f8f9fa;
+  box-shadow: 0 1.5rem 3rem #00000080;
+}
+
+.knowledge-window:focus,
+.knowledge-window:focus-visible {
+  outline: none;
+  border-color: var(--surface-border);
+  box-shadow: 0 1.5rem 3rem #00000080;
+}
+
+.knowledge-window--center {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.knowledge-window--floating {
+  transform: none;
+}
+
+.knowledge-window-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  cursor: move;
+  user-select: none;
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.knowledge-window-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: rgba(241, 245, 249, 0.94);
+}
+
+.knowledge-window-body {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem 1.25rem 1.35rem;
+  overflow: hidden;
+  background-color: var(--surface-elevated);
+}
+
+.knowledge-tabs {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.knowledge-tab-button {
+  flex: 0 0 auto;
+  border: 1px solid transparent;
+  background-color: rgba(255, 255, 255, 0.05);
+  color: rgba(241, 245, 249, 0.85);
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: background-color 0.15s ease, color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.knowledge-tab-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.knowledge-tab-button--active {
+  background-color: rgba(124, 252, 0, 0.18);
+  border-color: rgba(124, 252, 0, 0.35);
+  color: #d1fae5;
+}
+
+.knowledge-content {
+  flex: 1 1 auto;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.knowledge-libraries {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.85rem;
+  align-content: start;
+}
+
+@media (min-width: 720px) {
+  .knowledge-libraries {
+    grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  }
+}
+
+.knowledge-library {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.5rem;
+  padding: 0.75rem 0.9rem;
+  background-color: rgba(255, 255, 255, 0.03);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.knowledge-library-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.knowledge-library-name {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.knowledge-library-remaining {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.knowledge-library-statuses {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.knowledge-library-status {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.knowledge-chip {
+  border-radius: 999px;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease,
+    border-color 0.15s ease, color 0.15s ease;
+}
+
+.knowledge-chip:hover {
+  transform: translateY(-1px);
+}
+
+.knowledge-chip:focus,
+.knowledge-chip:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(124, 252, 0, 0.35);
+}
+
+.knowledge-chip--active {
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.45);
+}
+
+.knowledge-chip--not-started {
+  background-color: rgba(248, 250, 252, 0.15);
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.knowledge-chip--in-progress {
+  background-color: rgba(250, 204, 21, 0.25);
+  color: #facc15;
+  border: 1px solid rgba(234, 179, 8, 0.5);
+}
+
+.knowledge-chip--completed {
+  background-color: rgba(34, 197, 94, 0.2);
+  color: #4ade80;
+  border: 1px solid rgba(34, 197, 94, 0.5);
+}
+
+.knowledge-library-categories {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding-left: 0.2rem;
+}
+
+.knowledge-library-category {
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: 1px solid transparent;
+  background-color: rgba(255, 255, 255, 0.08);
+  color: rgba(241, 245, 249, 0.92);
+  cursor: pointer;
+  transition: transform 0.15s ease, border-color 0.15s ease, background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.knowledge-library-category:hover {
+  transform: translateY(-1px);
+}
+
+.knowledge-library-category--not_started {
+  background-color: rgba(248, 250, 252, 0.12);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: #e2e8f0;
+}
+
+.knowledge-library-category--in_progress {
+  background-color: rgba(250, 204, 21, 0.18);
+  border-color: rgba(234, 179, 8, 0.45);
+  color: #facc15;
+}
+
+.knowledge-library-category--completed {
+  background-color: rgba(34, 197, 94, 0.18);
+  border-color: rgba(34, 197, 94, 0.45);
+  color: #4ade80;
+}
+
+.knowledge-category-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+.knowledge-category-tile {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.6rem;
+  padding: 0.85rem;
+  background-color: rgba(255, 255, 255, 0.03);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.knowledge-category-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.knowledge-category-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.knowledge-category-command {
+  border: 1px solid rgba(124, 252, 0, 0.4);
+  background-color: rgba(124, 252, 0, 0.15);
+  color: #d1fae5;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.knowledge-category-command:hover {
+  background-color: rgba(124, 252, 0, 0.22);
+  border-color: rgba(124, 252, 0, 0.55);
+}
+
+.knowledge-category-libraries {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.knowledge-category-entry {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.88rem;
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.knowledge-status-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  flex: 0 0 auto;
+}
+
+.knowledge-status-dot--not_started {
+  background-color: #f8fafc;
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
+.knowledge-status-dot--in_progress {
+  background-color: #facc15;
+  border-color: rgba(217, 119, 6, 0.5);
+}
+
+.knowledge-status-dot--completed {
+  background-color: #22c55e;
+  border-color: rgba(22, 163, 74, 0.6);
+}
+
+.knowledge-category-entry-name {
+  flex: 1 1 auto;
+}
+
+.knowledge-empty {
+  padding: 1rem;
+  text-align: center;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: 0.5rem;
+  color: rgba(203, 213, 225, 0.85);
+  background-color: rgba(148, 163, 184, 0.1);
+}
+
 .herb-manager {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- set the knowledge report popup to 75% of the viewport height for a consistent report layout
- allow pointer events on the popup so dragging works reliably

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68fe2ca46e08832ab274aa03ce41b60f