### PR TITLE
Add completed libraries section to knowledge report

### DIFF
--- a/client/src/scripts/knowledge.ts
+++ b/client/src/scripts/knowledge.ts
@@ -154,6 +154,10 @@ type KnowledgeReportPayload = {
   categories: KnowledgeReportCategory[];
 };
 
+type KnowledgeReportAction =
+  | { type: 'completeLibrary'; libraryId: string }
+  | { type: 'resetLibrary'; libraryId: string };
+
 function summarizeLibraryProgress(
   library: KnowledgeLibraryEntry,
   libraryProgress: Record<string, KnowledgeCategoryStatus>,
@@ -213,7 +217,7 @@ function buildKnowledgeReport(
     const libraryProgress = characterProgress[libraryId] ?? {};
     const summary = summarizeLibraryProgress(library, libraryProgress);
 
-    if (summary.total > 0 && summary.remaining > 0) {
+    if (summary.total > 0) {
       libraries.push({
         id: libraryId,
         name: library.name,
@@ -590,6 +594,133 @@ export default function initKnowledge(client: Client, aliases?: AliasEntry[]) {
       getUniqueLibraryCategories(context.library),
     );
   }
+
+  function dispatchKnowledgeReport() {
+    if (!currentSnapshot) {
+      client.sendEvent('knowledgeReport', null);
+      return;
+    }
+
+    const libraryEntries = Object.entries(currentSnapshot.data.libraries);
+    if (libraryEntries.length === 0) {
+      client.sendEvent('knowledgeReport', null);
+      return;
+    }
+
+    const characterKey = getCharacterProgressKey();
+    const characterProgress = currentSnapshot.data.progress[characterKey] ?? {};
+    const report = buildKnowledgeReport(libraryEntries, characterProgress);
+    client.sendEvent('knowledgeReport', report);
+  }
+
+  async function updateLibraryCategoriesStatus(
+    libraryId: string,
+    status: KnowledgeCategoryStatus,
+  ): Promise<boolean> {
+    if (!currentSnapshot) {
+      return false;
+    }
+
+    const library = currentSnapshot.data.libraries[libraryId];
+    if (!library) {
+      return false;
+    }
+
+    const categories = getUniqueLibraryCategories(library);
+    if (categories.length === 0) {
+      return false;
+    }
+
+    let updated = false;
+
+    try {
+      await store.applyLocalChange((snapshot) => {
+        if (!snapshot) {
+          return snapshot;
+        }
+
+        if (!snapshot.data.libraries[libraryId]) {
+          return snapshot;
+        }
+
+        const nextProgress = { ...snapshot.data.progress };
+        const characterKey = getCharacterProgressKey();
+        const characterProgress = { ...(nextProgress[characterKey] ?? {}) };
+        const libraryProgress = { ...(characterProgress[libraryId] ?? {}) };
+
+        if (status === 'not_started') {
+          let removedAny = false;
+          for (const category of categories) {
+            if (libraryProgress[category]) {
+              delete libraryProgress[category];
+              removedAny = true;
+            }
+          }
+
+          if (!removedAny) {
+            return snapshot;
+          }
+        } else {
+          let changedAny = false;
+          for (const category of categories) {
+            if (libraryProgress[category] === status) {
+              continue;
+            }
+            libraryProgress[category] = status;
+            changedAny = true;
+          }
+
+          if (!changedAny) {
+            return snapshot;
+          }
+        }
+
+        updated = true;
+
+        if (Object.keys(libraryProgress).length === 0) {
+          delete characterProgress[libraryId];
+        } else {
+          characterProgress[libraryId] = libraryProgress;
+        }
+
+        if (Object.keys(characterProgress).length === 0) {
+          delete nextProgress[characterKey];
+        } else {
+          nextProgress[characterKey] = characterProgress;
+        }
+
+        return {
+          ...snapshot,
+          data: {
+            ...snapshot.data,
+            progress: nextProgress,
+          },
+        };
+      });
+    } catch (error) {
+      console.error('Failed to update knowledge library status:', error);
+      return false;
+    }
+
+    if (updated) {
+      dispatchKnowledgeReport();
+    }
+
+    return updated;
+  }
+
+  window.addEventListener('knowledgeReportAction', (event) => {
+    const detail = (event as CustomEvent<KnowledgeReportAction | null | undefined>).detail;
+    if (!detail) {
+      return;
+    }
+
+    if (detail.type === 'completeLibrary') {
+      void updateLibraryCategoriesStatus(detail.libraryId, 'completed');
+    } else if (detail.type === 'resetLibrary') {
+      void updateLibraryCategoriesStatus(detail.libraryId, 'not_started');
+    }
+  });
 
   aliasList.push({ pattern: /\/zglebiaj$/, callback: showLibraryCategories });
   aliasList.push({ pattern: /\/biblioteki$/, callback: showLibrariesReport });

--- a/web-client/src/KnowledgeReport.tsx
+++ b/web-client/src/KnowledgeReport.tsx
@@ -42,6 +42,10 @@ type KnowledgeReportPayload = {
   categories: KnowledgeReportCategory[];
 };
 
+type KnowledgeReportAction =
+  | { type: 'completeLibrary'; libraryId: string }
+  | { type: 'resetLibrary'; libraryId: string };
+
 type PointerDragState = {
   pointerId: number;
   offsetX: number;
@@ -280,6 +284,24 @@ const KnowledgeReport: React.FC = () => {
     [],
   );
 
+  const sendKnowledgeReportAction = useCallback((action: KnowledgeReportAction) => {
+    window.dispatchEvent(new CustomEvent('knowledgeReportAction', { detail: action }));
+  }, []);
+
+  const handleCompleteLibrary = useCallback(
+    (libraryId: string) => {
+      sendKnowledgeReportAction({ type: 'completeLibrary', libraryId });
+    },
+    [sendKnowledgeReportAction],
+  );
+
+  const handleResetLibrary = useCallback(
+    (libraryId: string) => {
+      sendKnowledgeReportAction({ type: 'resetLibrary', libraryId });
+    },
+    [sendKnowledgeReportAction],
+  );
+
   const libraryContent = useMemo(() => {
     if (!data) {
       return null;
@@ -289,64 +311,117 @@ const KnowledgeReport: React.FC = () => {
         <div className="knowledge-empty">Brak wiedzy do zglebiania w znanych bibliotekach.</div>
       );
     }
-    return (
-      <div className="knowledge-libraries">
-        {data.libraries.map((library) => {
-          const grouped = groupLibraryCategories(library.categories);
-          const libraryExpanded = expandedStatuses[library.id] ?? {};
-          return (
-            <div key={library.id} className="knowledge-library">
-              <div className="knowledge-library-header">
-                <span className="knowledge-library-name">{library.name}</span>
-                <span className="knowledge-library-remaining">
-                  Pozostalo {library.remaining} z {library.total} kategorii
-                </span>
-              </div>
-              <div className="knowledge-library-statuses">
-                {LIBRARY_STATUS_CONFIG.map(({ key, label, chipClass }) => {
-                  const count = library[key];
-                  if (!count) {
-                    return null;
-                  }
-                  const isExpanded = Boolean(libraryExpanded[key]);
-                  return (
-                    <div
-                      key={key}
-                      className={`knowledge-library-status knowledge-library-status--${key}`}
-                    >
-                      <button
-                        type="button"
-                        className={`knowledge-chip knowledge-chip--${chipClass} ${
-                          isExpanded ? 'knowledge-chip--active' : ''
-                        }`}
-                        onClick={() => toggleLibraryStatus(library.id, key)}
-                      >
-                        {label}: {count}
-                      </button>
-                      {isExpanded && grouped[key].length > 0 && (
-                        <div className="knowledge-library-categories">
-                          {grouped[key].map((category) => (
-                            <button
-                              type="button"
-                              key={category.name}
-                              className={`knowledge-library-category knowledge-library-category--${category.status}`}
-                              onClick={() => handleStartCategory(category.dative)}
-                            >
-                              {category.name}
-                            </button>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
+
+    const activeLibraries = data.libraries.filter((library) => library.remaining > 0);
+    const completedLibraries = data.libraries.filter((library) => library.remaining === 0);
+
+    if (activeLibraries.length === 0 && completedLibraries.length === 0) {
+      return (
+        <div className="knowledge-empty">Brak wiedzy do zglebiania w znanych bibliotekach.</div>
+      );
+    }
+
+    const renderLibrary = (library: KnowledgeReportLibrary, mode: 'active' | 'completed') => {
+      const grouped = groupLibraryCategories(library.categories);
+      const libraryExpanded = expandedStatuses[library.id] ?? {};
+      return (
+        <div key={library.id} className="knowledge-library">
+          <div className="knowledge-library-header">
+            <div className="knowledge-library-info">
+              <span className="knowledge-library-name">{library.name}</span>
+              <span className="knowledge-library-remaining">
+                Pozostalo {library.remaining} z {library.total} kategorii
+              </span>
             </div>
-          );
-        })}
+            <div className="knowledge-library-actions">
+              {mode === 'active' ? (
+                <button
+                  type="button"
+                  className="knowledge-library-action"
+                  onClick={() => handleCompleteLibrary(library.id)}
+                  disabled={library.remaining === 0}
+                >
+                  Zakoncz biblioteke
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="knowledge-library-reset"
+                  onClick={() => handleResetLibrary(library.id)}
+                >
+                  Resetuj biblioteke
+                </button>
+              )}
+            </div>
+          </div>
+          <div className="knowledge-library-statuses">
+            {LIBRARY_STATUS_CONFIG.map(({ key, label, chipClass }) => {
+              const count = library[key];
+              if (!count) {
+                return null;
+              }
+              const isExpanded = Boolean(libraryExpanded[key]);
+              return (
+                <div key={key} className={`knowledge-library-status knowledge-library-status--${key}`}>
+                  <button
+                    type="button"
+                    className={`knowledge-chip knowledge-chip--${chipClass} ${
+                      isExpanded ? 'knowledge-chip--active' : ''
+                    }`}
+                    onClick={() => toggleLibraryStatus(library.id, key)}
+                  >
+                    {label}: {count}
+                  </button>
+                  {isExpanded && grouped[key].length > 0 && (
+                    <div className="knowledge-library-categories">
+                      {grouped[key].map((category) => (
+                        <button
+                          type="button"
+                          key={category.name}
+                          className={`knowledge-library-category knowledge-library-category--${category.status}`}
+                          onClick={() => handleStartCategory(category.dative)}
+                        >
+                          {category.name}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      );
+    };
+
+    return (
+      <div className="knowledge-library-groups">
+        {activeLibraries.length > 0 && (
+          <div className="knowledge-library-group">
+            <div className="knowledge-library-group-title">Do zglebienia</div>
+            <div className="knowledge-libraries">
+              {activeLibraries.map((library) => renderLibrary(library, 'active'))}
+            </div>
+          </div>
+        )}
+        {completedLibraries.length > 0 && (
+          <div className="knowledge-library-group">
+            <div className="knowledge-library-group-title">Ukonczone</div>
+            <div className="knowledge-libraries">
+              {completedLibraries.map((library) => renderLibrary(library, 'completed'))}
+            </div>
+          </div>
+        )}
       </div>
     );
-  }, [data, expandedStatuses, handleStartCategory, toggleLibraryStatus]);
+  }, [
+    data,
+    expandedStatuses,
+    handleCompleteLibrary,
+    handleResetLibrary,
+    handleStartCategory,
+    toggleLibraryStatus,
+  ]);
 
   const categoriesContent = useMemo(() => {
     if (!data) {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -865,8 +865,14 @@ h1 {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
+}
+
+.knowledge-library-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
 }
 
 .knowledge-library-name {
@@ -879,6 +885,53 @@ h1 {
   color: rgba(226, 232, 240, 0.8);
 }
 
+.knowledge-library-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-left: auto;
+}
+
+.knowledge-library-action,
+.knowledge-library-reset {
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease,
+    border-color 0.15s ease, color 0.15s ease;
+}
+
+.knowledge-library-action {
+  background-color: rgba(34, 197, 94, 0.18);
+  color: #4ade80;
+  border-color: rgba(34, 197, 94, 0.45);
+}
+
+.knowledge-library-action:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.45);
+}
+
+.knowledge-library-action:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.knowledge-library-reset {
+  background-color: rgba(248, 250, 252, 0.1);
+  color: #f8fafc;
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.knowledge-library-reset:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.4);
+}
+
 .knowledge-library-statuses {
   display: flex;
   flex-wrap: wrap;
@@ -889,6 +942,26 @@ h1 {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
+}
+
+.knowledge-library-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.knowledge-library-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.knowledge-library-group-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.75);
 }
 
 .knowledge-chip {


### PR DESCRIPTION
## Summary
- split the knowledge report into active and completed library groups and wire library-level completion/reset actions
- add styling for the new library actions and section headers
- allow the client knowledge script to mark entire libraries as completed or reset them and refresh the report data

## Testing
- yarn --cwd web-client test --watch=false
- yarn --cwd web-client build
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_68ff7cefbe78832aaaf2d8710985e66d