### PR TITLE
Make knowledge libraries start leading on click

### DIFF
--- a/client/src/scripts/knowledge.ts
+++ b/client/src/scripts/knowledge.ts
@@ -134,6 +134,7 @@ type LibraryProgressSummary = {
 type KnowledgeReportLibrary = Omit<LibraryProgressSummary, 'categories'> & {
   id: string;
   name: string;
+  locationId: string;
   categories: KnowledgeReportLibraryCategory[];
 };
 
@@ -221,6 +222,7 @@ function buildKnowledgeReport(
       libraries.push({
         id: libraryId,
         name: library.name,
+        locationId: library.location_id,
         total: summary.total,
         remaining: summary.remaining,
         not_started: summary.not_started,

--- a/web-client/src/KnowledgeReport.tsx
+++ b/web-client/src/KnowledgeReport.tsx
@@ -17,6 +17,7 @@ type KnowledgeReportLibraryCategory = {
 type KnowledgeReportLibrary = {
   id: string;
   name: string;
+  locationId: string;
   total: number;
   remaining: number;
   not_started: number;
@@ -273,6 +274,17 @@ const KnowledgeReport: React.FC = () => {
     client.sendCommand(`zglebiaj wiedze o ${dative}`);
   }, []);
 
+  const handleLeadToLibrary = useCallback((locationId: string) => {
+    if (!locationId) {
+      return;
+    }
+    const client = (window as any).clientExtension as Client | undefined;
+    if (!client) {
+      return;
+    }
+    client.sendCommand(`/prowadz ${locationId}`);
+  }, []);
+
   const toggleLibraryStatus = useCallback(
     (libraryId: string, status: KnowledgeCategoryStatus) => {
       setExpandedStatuses((prev) => {
@@ -328,7 +340,13 @@ const KnowledgeReport: React.FC = () => {
         <div key={library.id} className="knowledge-library">
           <div className="knowledge-library-header">
             <div className="knowledge-library-info">
-              <span className="knowledge-library-name">{library.name}</span>
+              <button
+                type="button"
+                className="knowledge-library-name"
+                onClick={() => handleLeadToLibrary(library.locationId)}
+              >
+                {library.name}
+              </button>
               <span className="knowledge-library-remaining">
                 Pozostalo {library.remaining} z {library.total} kategorii
               </span>
@@ -419,6 +437,7 @@ const KnowledgeReport: React.FC = () => {
     expandedStatuses,
     handleCompleteLibrary,
     handleResetLibrary,
+    handleLeadToLibrary,
     handleStartCategory,
     toggleLibraryStatus,
   ]);

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -878,6 +878,17 @@ h1 {
 .knowledge-library-name {
   font-weight: 600;
   font-size: 1rem;
+  font: inherit;
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.knowledge-library-name:hover {
+  text-decoration: underline;
 }
 
 .knowledge-library-remaining {


### PR DESCRIPTION
## Summary
- include location identifiers in knowledge report library payloads
- allow clicking a library name to start leading to its location
- style the library name button to resemble the previous label

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ff82ccfc58832a95f5aebda87b078e