### PR TITLE
Handle missing prowadź destinations

### DIFF
--- a/client/src/scripts/mapAliases.ts
+++ b/client/src/scripts/mapAliases.ts
@@ -25,8 +25,20 @@ export default function initMapAliases(client: Client, aliases: { pattern: RegEx
         {
             pattern: /\/prowadz (.*)$/,
             callback: (matches: RegExpMatchArray) => {
-                const dest = getShortcut(matches[1]) ?? matches[1];
-                client.sendEvent('leadTo', dest);
+                const input = matches[1];
+                const shortcutId = getShortcut(input);
+                if (typeof shortcutId === 'number') {
+                    client.sendEvent('leadTo', shortcutId);
+                    return;
+                }
+
+                const numericId = Number(input);
+                if (!Number.isNaN(numericId)) {
+                    client.sendEvent('leadTo', numericId);
+                    return;
+                }
+
+                client.println(`Nie znaleziono celu prowadzenia dla '${input}'.`);
             }
         },
         {


### PR DESCRIPTION
## Summary
- prevent `/prowadz` alias from starting navigation without a valid destination
- fall back to shortcut id or numeric destination and inform the user when none is found

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_68ffc4636428832aa316455d10ac6224