### PR TITLE
Adjust knowledge report tabs layout on narrow screens

### DIFF
--- a/web-client/src/KnowledgeReport.tsx
+++ b/web-client/src/KnowledgeReport.tsx
@@ -89,8 +89,6 @@ function clamp(value: number, min: number, max: number): number {
   return value;
 }
 
-const COMPACT_TABS_BREAKPOINT = 520;
-
 const KnowledgeReport: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [data, setData] = useState<KnowledgeReportPayload | null>(null);
@@ -99,18 +97,8 @@ const KnowledgeReport: React.FC = () => {
   const [expandedStatuses, setExpandedStatuses] = useState<
     Record<string, Partial<Record<KnowledgeCategoryStatus, boolean>>>
   >({});
-  const [useCompactTabs, setUseCompactTabs] = useState(() =>
-    typeof window !== 'undefined' ? window.innerWidth < COMPACT_TABS_BREAKPOINT : false,
-  );
   const panelRef = useRef<HTMLDivElement>(null);
   const dragState = useRef<PointerDragState | null>(null);
-
-  const updateCompactTabs = useCallback(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    setUseCompactTabs(window.innerWidth < COMPACT_TABS_BREAKPOINT);
-  }, []);
 
   const close = useCallback(() => {
     setIsOpen(false);
@@ -265,11 +253,10 @@ const KnowledgeReport: React.FC = () => {
     }
     const handleResize = () => {
       setPosition((prev) => ensureVisiblePosition(prev));
-      updateCompactTabs();
     };
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, [ensureVisiblePosition, isOpen, updateCompactTabs]);
+  }, [ensureVisiblePosition, isOpen]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -277,12 +264,7 @@ const KnowledgeReport: React.FC = () => {
     }
     setPosition((prev) => ensureVisiblePosition(prev));
     panelRef.current?.focus();
-    updateCompactTabs();
-  }, [ensureVisiblePosition, isOpen, updateCompactTabs]);
-
-  useEffect(() => {
-    updateCompactTabs();
-  }, [updateCompactTabs]);
+  }, [ensureVisiblePosition, isOpen]);
 
   const handleStartCategory = useCallback((dative: string) => {
     const client = (window as any).clientExtension as Client | undefined;
@@ -526,48 +508,45 @@ const KnowledgeReport: React.FC = () => {
         </div>
         <div className="knowledge-window-body">
           <div className="knowledge-tabs">
-            {useCompactTabs ? (
-              <div className="knowledge-tab-select">
-                <select
-                  className="knowledge-tab-select-input"
-                  value={activeTab}
-                  onChange={(event) => {
-                    const nextTab = event.target.value as 'libraries' | 'categories';
-                    if (nextTab === 'libraries' && !hasLibraries) {
-                      return;
-                    }
-                    setActiveTab(nextTab);
-                  }}
-                >
-                  <option value="libraries" disabled={!hasLibraries}>
-                    Biblioteki
-                  </option>
-                  <option value="categories">Kategorie</option>
-                </select>
-              </div>
-            ) : (
-              <>
-                <button
-                  type="button"
-                  className={`knowledge-tab-button ${
-                    activeTab === 'libraries' ? 'knowledge-tab-button--active' : ''
-                  }`}
-                  onClick={() => setActiveTab('libraries')}
-                  disabled={!hasLibraries}
-                >
+            <div className="knowledge-tab-select">
+              <select
+                className="knowledge-tab-select-input"
+                value={activeTab}
+                onChange={(event) => {
+                  const nextTab = event.target.value as 'libraries' | 'categories';
+                  if (nextTab === 'libraries' && !hasLibraries) {
+                    return;
+                  }
+                  setActiveTab(nextTab);
+                }}
+              >
+                <option value="libraries" disabled={!hasLibraries}>
                   Biblioteki
-                </button>
-                <button
-                  type="button"
-                  className={`knowledge-tab-button ${
-                    activeTab === 'categories' ? 'knowledge-tab-button--active' : ''
-                  }`}
-                  onClick={() => setActiveTab('categories')}
-                >
-                  Kategorie
-                </button>
-              </>
-            )}
+                </option>
+                <option value="categories">Kategorie</option>
+              </select>
+            </div>
+            <div className="knowledge-tab-buttons">
+              <button
+                type="button"
+                className={`knowledge-tab-button ${
+                  activeTab === 'libraries' ? 'knowledge-tab-button--active' : ''
+                }`}
+                onClick={() => setActiveTab('libraries')}
+                disabled={!hasLibraries}
+              >
+                Biblioteki
+              </button>
+              <button
+                type="button"
+                className={`knowledge-tab-button ${
+                  activeTab === 'categories' ? 'knowledge-tab-button--active' : ''
+                }`}
+                onClick={() => setActiveTab('categories')}
+              >
+                Kategorie
+              </button>
+            </div>
           </div>
           <div className="knowledge-content">
             {activeTab === 'libraries' ? libraryContent : categoriesContent}

--- a/web-client/src/KnowledgeReport.tsx
+++ b/web-client/src/KnowledgeReport.tsx
@@ -89,6 +89,8 @@ function clamp(value: number, min: number, max: number): number {
   return value;
 }
 
+const COMPACT_TABS_BREAKPOINT = 520;
+
 const KnowledgeReport: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [data, setData] = useState<KnowledgeReportPayload | null>(null);
@@ -97,8 +99,18 @@ const KnowledgeReport: React.FC = () => {
   const [expandedStatuses, setExpandedStatuses] = useState<
     Record<string, Partial<Record<KnowledgeCategoryStatus, boolean>>>
   >({});
+  const [useCompactTabs, setUseCompactTabs] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth < COMPACT_TABS_BREAKPOINT : false,
+  );
   const panelRef = useRef<HTMLDivElement>(null);
   const dragState = useRef<PointerDragState | null>(null);
+
+  const updateCompactTabs = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    setUseCompactTabs(window.innerWidth < COMPACT_TABS_BREAKPOINT);
+  }, []);
 
   const close = useCallback(() => {
     setIsOpen(false);
@@ -253,10 +265,11 @@ const KnowledgeReport: React.FC = () => {
     }
     const handleResize = () => {
       setPosition((prev) => ensureVisiblePosition(prev));
+      updateCompactTabs();
     };
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, [ensureVisiblePosition, isOpen]);
+  }, [ensureVisiblePosition, isOpen, updateCompactTabs]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -264,7 +277,12 @@ const KnowledgeReport: React.FC = () => {
     }
     setPosition((prev) => ensureVisiblePosition(prev));
     panelRef.current?.focus();
-  }, [ensureVisiblePosition, isOpen]);
+    updateCompactTabs();
+  }, [ensureVisiblePosition, isOpen, updateCompactTabs]);
+
+  useEffect(() => {
+    updateCompactTabs();
+  }, [updateCompactTabs]);
 
   const handleStartCategory = useCallback((dative: string) => {
     const client = (window as any).clientExtension as Client | undefined;
@@ -508,25 +526,48 @@ const KnowledgeReport: React.FC = () => {
         </div>
         <div className="knowledge-window-body">
           <div className="knowledge-tabs">
-            <button
-              type="button"
-              className={`knowledge-tab-button ${
-                activeTab === 'libraries' ? 'knowledge-tab-button--active' : ''
-              }`}
-              onClick={() => setActiveTab('libraries')}
-              disabled={!hasLibraries}
-            >
-              Biblioteki
-            </button>
-            <button
-              type="button"
-              className={`knowledge-tab-button ${
-                activeTab === 'categories' ? 'knowledge-tab-button--active' : ''
-              }`}
-              onClick={() => setActiveTab('categories')}
-            >
-              Kategorie
-            </button>
+            {useCompactTabs ? (
+              <div className="knowledge-tab-select">
+                <select
+                  className="knowledge-tab-select-input"
+                  value={activeTab}
+                  onChange={(event) => {
+                    const nextTab = event.target.value as 'libraries' | 'categories';
+                    if (nextTab === 'libraries' && !hasLibraries) {
+                      return;
+                    }
+                    setActiveTab(nextTab);
+                  }}
+                >
+                  <option value="libraries" disabled={!hasLibraries}>
+                    Biblioteki
+                  </option>
+                  <option value="categories">Kategorie</option>
+                </select>
+              </div>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className={`knowledge-tab-button ${
+                    activeTab === 'libraries' ? 'knowledge-tab-button--active' : ''
+                  }`}
+                  onClick={() => setActiveTab('libraries')}
+                  disabled={!hasLibraries}
+                >
+                  Biblioteki
+                </button>
+                <button
+                  type="button"
+                  className={`knowledge-tab-button ${
+                    activeTab === 'categories' ? 'knowledge-tab-button--active' : ''
+                  }`}
+                  onClick={() => setActiveTab('categories')}
+                >
+                  Kategorie
+                </button>
+              </>
+            )}
           </div>
           <div className="knowledge-content">
             {activeTab === 'libraries' ? libraryContent : categoriesContent}

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -805,6 +805,28 @@ h1 {
   gap: 0.5rem;
 }
 
+.knowledge-tab-select {
+  flex: 1 1 auto;
+}
+
+.knowledge-tab-select-input {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background-color: rgba(255, 255, 255, 0.05);
+  color: rgba(241, 245, 249, 0.94);
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.knowledge-tab-select-input:focus {
+  outline: none;
+  border-color: rgba(124, 252, 0, 0.45);
+  box-shadow: 0 0 0 2px rgba(124, 252, 0, 0.18);
+}
+
 .knowledge-tab-button {
   flex: 0 0 auto;
   border: 1px solid transparent;

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -800,13 +800,21 @@ h1 {
   background-color: var(--surface-elevated);
 }
 
+
 .knowledge-tabs {
   display: flex;
+  align-items: center;
   gap: 0.5rem;
 }
 
 .knowledge-tab-select {
   flex: 1 1 auto;
+  display: none;
+}
+
+.knowledge-tab-buttons {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .knowledge-tab-select-input {
@@ -850,6 +858,22 @@ h1 {
   background-color: rgba(124, 252, 0, 0.18);
   border-color: rgba(124, 252, 0, 0.35);
   color: #d1fae5;
+}
+
+@media (max-width: 520px) {
+  .knowledge-tabs {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .knowledge-tab-select {
+    display: block;
+  }
+
+  .knowledge-tab-buttons {
+    display: none;
+  }
 }
 
 .knowledge-content {


### PR DESCRIPTION
## Summary
- switch the knowledge report tab buttons to a compact select control when the viewport is narrow
- update styles to support the select control and preserve the existing tab styling

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ffc5d99dc8832a96209636cc0f3cb5