### PR TITLE
Add playback speed controls for recordings

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -60,6 +60,12 @@
         <div class="playback-controls-header" data-drag-handle>
             <span class="playback-controls-title">Sterowanie nagraniem</span>
         </div>
+        <div class="playback-speed-controls">
+            <button class="btn btn-secondary playback-speed-button" data-playback-speed="1">x1</button>
+            <button class="btn btn-secondary playback-speed-button" data-playback-speed="2">x2</button>
+            <button class="btn btn-secondary playback-speed-button" data-playback-speed="4">x4</button>
+            <button class="btn btn-secondary playback-speed-button" data-playback-speed="8">x8</button>
+        </div>
         <div class="playback-controls-actions">
             <button id="playback-pause" class="btn btn-secondary">Pauza</button>
             <button id="playback-stop" class="btn btn-secondary">Zatrzymaj</button>

--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -61,6 +61,12 @@
         <div class="playback-controls-header" data-drag-handle>
             <span class="playback-controls-title">Sterowanie nagraniem</span>
         </div>
+        <div class="playback-speed-controls">
+            <button class="btn btn-secondary playback-speed-button" data-playback-speed="1">x1</button>
+            <button class="btn btn-secondary playback-speed-button" data-playback-speed="2">x2</button>
+            <button class="btn btn-secondary playback-speed-button" data-playback-speed="4">x4</button>
+            <button class="btn btn-secondary playback-speed-button" data-playback-speed="8">x8</button>
+        </div>
         <div class="playback-controls-actions">
             <button id="playback-pause" class="btn btn-secondary">Pauza</button>
             <button id="playback-stop" class="btn btn-secondary">Zatrzymaj</button>

--- a/web-client/src/ArkadiaClient.ts
+++ b/web-client/src/ArkadiaClient.ts
@@ -466,6 +466,14 @@ class ArkadiaClient implements ClientAdapter {
         this.recorder.replayRecordedMessagesTimed();
     }
 
+    setPlaybackSpeed(speed: number) {
+        this.recorder.setPlaybackSpeed(speed);
+    }
+
+    getPlaybackSpeed() {
+        return this.recorder.getPlaybackSpeed();
+    }
+
     private maybeStartAutoRecording() {
         if (this.autoRecorder && this.autoRecorder.isRecordingActive()) return;
         const recorder = this.createRecorder(true);

--- a/web-client/src/Recorder.ts
+++ b/web-client/src/Recorder.ts
@@ -21,10 +21,12 @@ export default class Recorder {
     private playbackTimeout: number | null = null;
     private playbackIndex = 0;
     private playbackDelay = 0;
+    private playbackBaseDelay = 0;
     private playbackStart = 0;
     private pausedDelay = 0;
     private isPlaying = false;
     private paused = false;
+    private playbackSpeed = 1;
 
     constructor(private hooks: RecorderHooks) {
     }
@@ -88,6 +90,9 @@ export default class Recorder {
         this.isPlaying = false;
         this.paused = false;
         this.playbackIndex = 0;
+        this.playbackDelay = 0;
+        this.playbackBaseDelay = 0;
+        this.pausedDelay = 0;
         this.hooks.emit('playback.stop');
     }
 
@@ -96,7 +101,12 @@ export default class Recorder {
         if (this.playbackTimeout !== null) {
             clearTimeout(this.playbackTimeout);
             this.playbackTimeout = null;
-            this.pausedDelay = Math.max(0, this.playbackDelay - (Date.now() - this.playbackStart));
+            const elapsed = Date.now() - this.playbackStart;
+            const elapsedBase = elapsed * this.playbackSpeed;
+            const remainingBase = Math.max(0, this.playbackBaseDelay - elapsedBase);
+            this.pausedDelay = remainingBase;
+        } else {
+            this.pausedDelay = 0;
         }
         this.paused = true;
         this.hooks.emit('playback.pause');
@@ -105,7 +115,7 @@ export default class Recorder {
     resumePlayback() {
         if (!this.isPlaying || !this.paused) return;
         this.paused = false;
-        this.scheduleNext(this.pausedDelay);
+        this.scheduleNext(this.pausedDelay, true);
         this.hooks.emit('playback.resume');
     }
 
@@ -185,6 +195,35 @@ export default class Recorder {
         this.scheduleNext(0);
     }
 
+    setPlaybackSpeed(speed: number) {
+        const normalized = Number.isFinite(speed) && speed > 0 ? speed : 1;
+        const previousSpeed = this.playbackSpeed;
+        if (previousSpeed === normalized) {
+            this.hooks.emit('playback.speed', this.playbackSpeed);
+            return;
+        }
+        this.playbackSpeed = normalized;
+
+        if (this.isPlaying) {
+            if (this.paused) {
+                // pausedDelay already stores the base delay until the next event
+            } else if (this.playbackTimeout !== null) {
+                const elapsed = Date.now() - this.playbackStart;
+                const elapsedBase = elapsed * previousSpeed;
+                const remainingBase = Math.max(0, this.playbackBaseDelay - elapsedBase);
+                clearTimeout(this.playbackTimeout);
+                this.playbackTimeout = null;
+                this.scheduleNext(remainingBase, true);
+            }
+        }
+
+        this.hooks.emit('playback.speed', this.playbackSpeed);
+    }
+
+    getPlaybackSpeed() {
+        return this.playbackSpeed;
+    }
+
     private playEvent(ev: RecordedEvent) {
         const timestamp = typeof ev.timestamp === 'number' ? ev.timestamp : Date.now();
         if (ev.direction === 'in') {
@@ -251,7 +290,7 @@ export default class Recorder {
         this.hooks.emit('playback.index', this.playbackIndex, this.recordedMessages.length);
     }
 
-    private scheduleNext(initialDelay: number) {
+    private scheduleNext(initialDelay: number, overrideDelay = false) {
         if (!this.isPlaying) return;
         const ev = this.recordedMessages[this.playbackIndex];
         if (!ev) {
@@ -259,15 +298,27 @@ export default class Recorder {
             this.stopPlayback();
             return;
         }
-        const delay = this.playbackIndex === 0 ? initialDelay :
-            this.recordedMessages[this.playbackIndex].timestamp - this.recordedMessages[this.playbackIndex - 1].timestamp;
-        this.playbackDelay = delay;
+        let baseDelay: number;
+        if (this.playbackIndex === 0 || overrideDelay) {
+            baseDelay = initialDelay;
+        } else {
+            const currentTimestamp = typeof ev.timestamp === 'number' ? ev.timestamp : Date.now();
+            const previous = this.recordedMessages[this.playbackIndex - 1];
+            const previousTimestamp = typeof previous?.timestamp === 'number' ? previous.timestamp : currentTimestamp;
+            baseDelay = currentTimestamp - previousTimestamp;
+        }
+        if (!Number.isFinite(baseDelay) || baseDelay < 0) {
+            baseDelay = 0;
+        }
+        const adjustedDelay = baseDelay / this.playbackSpeed;
+        this.playbackBaseDelay = baseDelay;
+        this.playbackDelay = adjustedDelay;
         this.playbackStart = Date.now();
         this.playbackTimeout = window.setTimeout(() => {
             if (!this.isPlaying || this.paused) return;
             this.executeCurrent();
             this.scheduleNext(0);
-        }, delay);
+        }, Math.max(0, adjustedDelay));
     }
 }
 

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -481,6 +481,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const playbackReplay = document.getElementById('playback-replay') as HTMLButtonElement | null;
     const playbackStepBack = document.getElementById('playback-step-back') as HTMLButtonElement | null;
     const playbackStep = document.getElementById('playback-step') as HTMLButtonElement | null;
+    const playbackSpeedButtons = playbackControls
+        ? Array.from(playbackControls.querySelectorAll<HTMLButtonElement>('[data-playback-speed]'))
+        : [];
     wakeLockButton = document.getElementById('wake-lock-button') as HTMLButtonElement | null;
     updateWakeLockButton();
 
@@ -761,6 +764,27 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    const updatePlaybackSpeedButtons = (speed: number) => {
+        playbackSpeedButtons.forEach(button => {
+            const value = Number(button.dataset.playbackSpeed);
+            if (Number.isFinite(value) && value > 0 && Math.abs(value - speed) < 0.001) {
+                button.classList.add('is-active');
+            } else {
+                button.classList.remove('is-active');
+            }
+        });
+    };
+
+    playbackSpeedButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            const value = Number(button.dataset.playbackSpeed);
+            if (!Number.isFinite(value) || value <= 0) return;
+            arkadiaClient.setPlaybackSpeed(value);
+        });
+    });
+
+    updatePlaybackSpeedButtons(arkadiaClient.getPlaybackSpeed());
+
     if (playbackControls) {
         const dragTarget =
             (playbackControls.querySelector('[data-drag-handle]') as HTMLElement | null) ?? playbackControls;
@@ -844,6 +868,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (playbackControls) playbackControls.style.display = 'flex';
         if (playbackInfo) playbackInfo.textContent = `0 / ${total}`;
         if (playbackPause) playbackPause.textContent = 'Pause';
+        updatePlaybackSpeedButtons(arkadiaClient.getPlaybackSpeed());
         updateConnectButtons();
     });
 
@@ -863,6 +888,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     arkadiaClient.on('playback.index', (index: number, total: number) => {
         if (playbackInfo) playbackInfo.textContent = `${index} / ${total}`;
+    });
+
+    arkadiaClient.on('playback.speed', (speed: number) => {
+        updatePlaybackSpeedButtons(speed);
     });
 
     if (wakeLockButton) {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -1917,6 +1917,33 @@ h1 {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
+.playback-speed-controls {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.35rem;
+  padding: 0.35rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 0.85rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.playback-speed-controls .btn {
+  border-radius: 0.75rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.35rem 0.25rem;
+  opacity: 0.7;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.playback-speed-controls .btn.is-active {
+  opacity: 1;
+}
+
+.playback-speed-controls .btn:hover {
+  opacity: 1;
+}
+
 .playback-controls-actions .btn {
   border-radius: 0.75rem;
   font-size: 0.75rem;

--- a/web-client/test/Recorder.test.ts
+++ b/web-client/test/Recorder.test.ts
@@ -20,6 +20,19 @@ describe('Recorder playback', () => {
     expect(hooks.emit).toHaveBeenCalledWith('message', '→ look', undefined, 0);
   });
 
+  test('setPlaybackSpeed emits playback.speed event', () => {
+    const hooks = {
+      processIncomingData: jest.fn(),
+      sendCommand: jest.fn(),
+      emit: jest.fn(),
+      getCurrentMapLocation: jest.fn(),
+      setMapLocationSilently: jest.fn(),
+    };
+    const recorder = new Recorder(hooks as any);
+    recorder.setPlaybackSpeed(2);
+    expect(hooks.emit).toHaveBeenCalledWith('playback.speed', 2);
+  });
+
   test('stores start location and applies it once during playback', async () => {
     const getCurrentMapLocation = jest.fn()
       .mockReturnValueOnce(3525)


### PR DESCRIPTION
## Summary
- add 1x/2x/4x/8x playback speed buttons to the recording controls overlay (and sandbox) with styling
- extend the recorder and client to support adjustable playback speed and emit updates for the UI
- wire the options UI to the new controls and cover the speed setter with a Jest test

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build
- yarn --cwd web-client test Recorder.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ffd16489f8832a84501aa584b54de4