### PR TITLE
Add responsive select navigation to knowledge report

### DIFF
--- a/web-client/src/KnowledgeDetailsReport.tsx
+++ b/web-client/src/KnowledgeDetailsReport.tsx
@@ -83,6 +83,7 @@ const KnowledgeDetailsReport: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [data, setData] = useState<KnowledgeDetailsReportPayload | null>(null);
   const [hideCompleted, setHideCompleted] = useState(false);
+  const [selectedNav, setSelectedNav] = useState('');
   const [position, setPosition] = useState<{ left: number; top: number } | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -274,6 +275,10 @@ const KnowledgeDetailsReport: React.FC = () => {
           : category.name,
     }));
   }, [data]);
+
+  useEffect(() => {
+    setSelectedNav('');
+  }, [navItems]);
 
   const handleNavigate = useCallback((elementId: string) => {
     const container = scrollContainerRef.current;
@@ -483,6 +488,30 @@ const KnowledgeDetailsReport: React.FC = () => {
                       {item.label}
                     </button>
                   ))}
+                </div>
+              )}
+              {navItems.length > 0 && (
+                <div className="knowledge-details-nav-select">
+                  <span className="knowledge-details-nav-select-label">Przejdź do kategorii</span>
+                  <select
+                    className="knowledge-details-nav-select-input"
+                    value={selectedNav}
+                    onChange={(event) => {
+                      const { value } = event.target;
+                      if (!value) {
+                        return;
+                      }
+                      setSelectedNav('');
+                      handleNavigate(value);
+                    }}
+                  >
+                    <option value="">Przejdź do kategorii…</option>
+                    {navItems.map((item) => (
+                      <option key={`select-${item.id}`} value={item.id}>
+                        {item.label}
+                      </option>
+                    ))}
+                  </select>
                 </div>
               )}
             </div>

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -1257,6 +1257,34 @@ h1 {
   flex-wrap: wrap;
 }
 
+.knowledge-details-nav-select {
+  display: none;
+  margin-top: 0.6rem;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.knowledge-details-nav-select-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.knowledge-details-nav-select-input {
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background-color: rgba(148, 163, 184, 0.08);
+  color: var(--text-primary);
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.knowledge-details-nav-select-input:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.45);
+  outline-offset: 2px;
+}
+
 .knowledge-details-nav-button {
   border: 1px solid rgba(148, 163, 184, 0.28);
   background-color: rgba(148, 163, 184, 0.12);
@@ -1276,6 +1304,16 @@ h1 {
   border-color: rgba(148, 163, 184, 0.45);
   color: #f8fafc;
   outline: none;
+}
+
+@media (max-width: 680px) {
+  .knowledge-details-nav {
+    display: none;
+  }
+
+  .knowledge-details-nav-select {
+    display: flex;
+  }
 }
 
 .knowledge-details-categories {


### PR DESCRIPTION
## Summary
- add a responsive select-based navigation fallback for the knowledge report
- reset the selection state when report data changes
- style the select and hide the button navigation on narrow screens

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ffd64b7714832a8f0afee74cae39ae