### PR TITLE
Fix timestamp toggle triggering split view

### DIFF
--- a/web-client/src/outputMessageHandler.ts
+++ b/web-client/src/outputMessageHandler.ts
@@ -18,6 +18,12 @@ const TIMESTAMP_CLASS = 'output-show-timestamps';
 let timestampsVisible = false;
 let currentOutputWrapper: HTMLElement | null = null;
 let currentStickyArea: HTMLElement | null = null;
+let currentSplitBottom: HTMLElement | null = null;
+let currentIsSplitView: (() => boolean) | null = null;
+
+function isScrolledToBottom(wrapper: HTMLElement, splitBottom: HTMLElement) {
+    return wrapper.scrollTop + wrapper.clientHeight + splitBottom.clientHeight >= wrapper.scrollHeight - 1;
+}
 
 function formatTimestamp(timestamp: number): string {
     const date = new Date(timestamp);
@@ -51,8 +57,23 @@ export function areOutputTimestampsVisible() {
 }
 
 export function setOutputTimestampVisibility(visible: boolean) {
+    const shouldMaintainScroll =
+        !!currentOutputWrapper &&
+        !!currentSplitBottom &&
+        (!currentIsSplitView || !currentIsSplitView()) &&
+        isScrolledToBottom(currentOutputWrapper, currentSplitBottom);
+
     timestampsVisible = visible;
     applyTimestampVisibility();
+
+    if (shouldMaintainScroll && currentOutputWrapper && currentSplitBottom) {
+        requestAnimationFrame(() => {
+            if (!currentOutputWrapper || !currentSplitBottom) {
+                return;
+            }
+            currentOutputWrapper.scrollTop = currentOutputWrapper.scrollHeight;
+        });
+    }
 }
 
 export function toggleOutputTimestampVisibility() {
@@ -73,6 +94,8 @@ export function setupOutputMessageHandler(
 ) {
     currentOutputWrapper = outputWrapper;
     currentStickyArea = stickyArea;
+    currentSplitBottom = splitBottom;
+    currentIsSplitView = isSplitView;
     applyTimestampVisibility();
 
     const handleMessage = (message?: string, type?: string, timestamp?: number) => {
@@ -145,6 +168,12 @@ export function setupOutputMessageHandler(
         }
         if (currentStickyArea === stickyArea) {
             currentStickyArea = null;
+        }
+        if (currentSplitBottom === splitBottom) {
+            currentSplitBottom = null;
+        }
+        if (currentIsSplitView === isSplitView) {
+            currentIsSplitView = null;
         }
     };
 }


### PR DESCRIPTION
## Summary
- preserve scroll position when toggling timestamps while at the bottom of the log
- cache split view references for the timestamp toggle helper so it can maintain scroll state

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_68ffea2ee480832abe15a7228efa2f96