### PR TITLE
Ensure aliases wait for async commands

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -384,13 +384,12 @@ export default class Client {
         this.sendCommand('przestan kryc sie za zaslona')
     }
 
-    sendCommand(command: string, echo: boolean = true, options?: CommandOptions) {
+    async sendCommand(command: string, echo: boolean = true, options?: CommandOptions): Promise<void> {
         if (command) {
             command = stripPolishCharacters(command)
         }
         this.eventTarget.dispatchEvent(new CustomEvent('command', {detail: command}))
 
-        let preparse = command
         command = this.Map.parseCommand(command)
         command = this.expandObjectShortcuts(command)
         if (command.startsWith('echo ')) {
@@ -399,31 +398,28 @@ export default class Client {
         }
         const split = command.split(/[#;]/)
         if (split.length > 1) {
-            split.forEach(part => {
-                if (part !== preparse) {
-                    this.sendCommand(part, echo, options)
-                } else {
-                    this.sendMovement(part, echo, options)
-                }
-            })
+            for (const part of split) {
+                await this.sendCommand(part, echo, options)
+            }
             return
         }
 
-        const isAlias = this.aliases.find(alias => {
+        for (const alias of this.aliases) {
             const matches = command.match(alias.pattern)
             if (matches) {
-                alias.callback(matches)
-                return true
-            }
-            return false
-        })
-        if (!isAlias) {
-            if (command.trim().startsWith('/')) {
-                this.print(mudletColorLine(`--- <tomato>Nieznany alias<reset>: ${command}`))
+                const result = alias.callback(matches)
+                if (result && typeof (result as Promise<unknown>).then === 'function') {
+                    await result
+                }
                 return
             }
-            this.sendMovement(command, echo, options)
         }
+
+        if (command.trim().startsWith('/')) {
+            this.print(mudletColorLine(`--- <tomato>Nieznany alias<reset>: ${command}`))
+            return
+        }
+        this.sendMovement(command, echo, options)
     }
 
     sendGMCP(type: string, payload?: any) {

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -157,9 +157,9 @@ test('createButton creates button attached to panel', () => {
   expect(panel?.contains(button)).toBe(true);
 });
 
-test('sendCommand dispatches event and splits commands', () => {
+test('sendCommand dispatches event and splits commands', async () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
-  client.sendCommand('foo#bar');
+  await client.sendCommand('foo#bar');
   expect(parseCommand).toHaveBeenCalledWith('foo#bar');
   expect(parseCommand).toHaveBeenCalledWith('parsed:foo');
   expect(parseCommand).toHaveBeenCalledWith('bar');
@@ -167,16 +167,16 @@ test('sendCommand dispatches event and splits commands', () => {
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'parsed:bar', true, undefined);
 });
 
-test('sendCommand leaves casing unchanged by default', () => {
+test('sendCommand leaves casing unchanged by default', async () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   parseCommand.mockClear();
-  client.sendCommand('LOOK AROUND');
+  await client.sendCommand('LOOK AROUND');
   expect(parseCommand).toHaveBeenCalledTimes(1);
   expect(parseCommand).toHaveBeenCalledWith('LOOK AROUND');
   expect((global as any).clientAdapterMock.send).toHaveBeenCalledWith('parsed:LOOK AROUND', true, undefined);
 });
 
-test('sendCommand keeps casing for speech commands', () => {
+test('sendCommand keeps casing for speech commands', async () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   const speechCommands = [
     "'SHOUT",
@@ -189,18 +189,18 @@ test('sendCommand keeps casing for speech commands', () => {
     'jszepnij HELLO',
   ];
 
-  speechCommands.forEach((command) => {
+  for (const command of speechCommands) {
     parseCommand.mockClear();
-    client.sendCommand(command);
+    await client.sendCommand(command);
     expect(parseCommand).toHaveBeenCalledTimes(1);
     expect(parseCommand).toHaveBeenCalledWith(command);
-  });
+  }
 });
 
-test('sendCommand preserves casing when requested', () => {
+test('sendCommand preserves casing when requested', async () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   parseCommand.mockClear();
-  client.sendCommand('UPPER CASE', true, { preserveCase: true });
+  await client.sendCommand('UPPER CASE', true, { preserveCase: true });
   expect(parseCommand).toHaveBeenCalledTimes(1);
   expect(parseCommand).toHaveBeenCalledWith('UPPER CASE');
   expect((global as any).clientAdapterMock.send).toHaveBeenCalledWith(
@@ -212,27 +212,27 @@ test('sendCommand preserves casing when requested', () => {
   );
 });
 
-test('sendCommand allows empty command', () => {
+test('sendCommand allows empty command', async () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
-  client.sendCommand('');
+  await client.sendCommand('');
   expect(parseCommand).toHaveBeenCalledWith('');
   expect((global as any).clientAdapterMock.send).toHaveBeenCalledWith('parsed:', true, undefined);
 });
 
-test('sendCommand splits commands returned by parseCommand', () => {
+test('sendCommand splits commands returned by parseCommand', async () => {
   parseCommand.mockImplementationOnce(() => 'foo;bar');
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
-  client.sendCommand('e');
+  await client.sendCommand('e');
   expect(parseCommand).toHaveBeenCalledWith('e');
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(1, 'parsed:foo', true, undefined);
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'parsed:bar', true, undefined);
 });
 
-test('sendCommand prints echo commands locally', () => {
+test('sendCommand prints echo commands locally', async () => {
   parseCommand.mockImplementationOnce((cmd: string) => cmd);
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   const printSpy = jest.spyOn(client, 'print').mockImplementation();
-  client.sendCommand('echo <red> text');
+  await client.sendCommand('echo <red> text');
   expect(printSpy).toHaveBeenCalledWith(mudletColorLine('<red> text'));
   expect((global as any).clientAdapterMock.send).not.toHaveBeenCalled();
 });
@@ -336,7 +336,7 @@ test('support sends commands to support leader', () => {
   expect(client.sendCommand).toHaveBeenNthCalledWith(2, 'wesprzyj ob_5');
 });
 
-test('sendCommand expands object shortcuts', () => {
+test('sendCommand expands object shortcuts', async () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   jest.spyOn(client.ObjectManager, 'getObjectsOnLocation').mockReturnValue([
     { num: 5, shortcut: '1' },
@@ -344,13 +344,13 @@ test('sendCommand expands object shortcuts', () => {
     { num: 42, shortcut: '@' },
   ] as any);
 
-  client.sendCommand('zabij @1');
+  await client.sendCommand('zabij @1');
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(1, 'parsed:zabij ob_5', true, undefined);
 
-  client.sendCommand('obejrzyj @A');
+  await client.sendCommand('obejrzyj @A');
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'parsed:obejrzyj ob_7', true, undefined);
 
-  client.sendCommand('help @@');
+  await client.sendCommand('help @@');
   expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(3, 'parsed:help ob_42', true, undefined);
 });
 

--- a/client/test/userAliases.test.ts
+++ b/client/test/userAliases.test.ts
@@ -1,0 +1,109 @@
+import initUserAliases from '../src/scripts/userAliases';
+import { FakeClient, initHerbClient, defaultHerbData } from './helpers/herbClient';
+
+class AliasClient extends FakeClient {
+  executed: string[] = [];
+  output: string[] = [];
+  private pending: Promise<void>[] = [];
+
+  constructor() {
+    super();
+    this.sendCommand = jest.fn((command: string) => {
+      const promise = this.process(command);
+      this.pending.push(promise);
+      return promise;
+    });
+  }
+
+  private async process(command: string): Promise<void> {
+    if (!command) {
+      return;
+    }
+
+    const parts = command.split(/[#;]/);
+    if (parts.length > 1) {
+      for (const part of parts) {
+        const trimmed = part.trim();
+        if (trimmed) {
+          await this.process(trimmed);
+        }
+      }
+      return;
+    }
+
+    const aliasEntry = this.aliases.find((entry) => entry.pattern.test(command));
+    if (aliasEntry) {
+      const match = command.match(aliasEntry.pattern);
+      if (match) {
+        const result = aliasEntry.callback(match as RegExpMatchArray);
+        if (result && typeof (result as Promise<unknown>).then === 'function') {
+          await result;
+        }
+      }
+      return;
+    }
+
+    this.executed.push(command);
+    this.output.push(command);
+  }
+
+  async flush(): Promise<void> {
+    const current = this.pending;
+    this.pending = [];
+    await Promise.all(current);
+  }
+}
+
+describe('user aliases', () => {
+  test('executes herb taking commands before final action', async () => {
+    const client = new AliasClient();
+    const herbData = {
+      ...defaultHerbData,
+      herb_id_to_odmiana: {
+        ...defaultHerbData.herb_id_to_odmiana,
+        naparstnica: {
+          mianownik: 'naparstnica',
+          dopelniacz: 'naparstnicy',
+          biernik: 'naparstnice',
+          mnoga_mianownik: 'naparstnice',
+          mnoga_dopelniacz: 'naparstnic',
+          mnoga_biernik: 'naparstnice',
+        },
+      },
+    };
+
+    initHerbClient(client, { 1: { naparstnica: 1, deliona: 1 } }, herbData);
+    initUserAliases((client as unknown) as any, client.aliases);
+
+    client.dispatch('storage', {
+      key: 'aliases',
+      value: [
+        {
+          pattern: '/zm1',
+          command: '/wezz naparstnica;/wezz deliona;ob delione;zjedz ziola',
+        },
+      ],
+    });
+
+    const alias = client.aliases.find((entry) => entry.pattern.test('/zm1'));
+    expect(alias).toBeTruthy();
+
+    const match = '/zm1'.match(alias!.pattern) as RegExpMatchArray;
+    await alias!.callback(match);
+    await client.flush();
+
+    const expectedSequence = [
+      'otworz 1. swoj woreczek',
+      'wez naparstnice z 1. swojego woreczka',
+      'zamknij 1. swoj woreczek',
+      'otworz 1. swoj woreczek',
+      'wez zolty jasny kwiat z 1. swojego woreczka',
+      'zamknij 1. swoj woreczek',
+      'ob delione',
+      'zjedz ziola',
+    ];
+
+    expect(client.executed).toEqual(expectedSequence);
+    expect(client.output).toEqual(expectedSequence);
+  });
+});


### PR DESCRIPTION
## Summary
- make `Client.sendCommand` async so sequential commands await alias callbacks and promise results
- update client command tests to await the async API
- extend the herb alias test to cover an additional command and verify the full execution order

## Testing
- yarn --cwd client test userAliases
- yarn --cwd client test Client

------
https://chatgpt.com/codex/tasks/task_e_68ffe5434848832aad840ea09027e729