### PR TITLE
Add disconnect button to dropdown menu

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -257,6 +257,9 @@
                     <button class="w-100 p-1" id="share-location-button">Kod QR lokacji</button>
                 </li>
                 <li>
+                    <button class="w-100 p-1 menu-disconnect-button" id="disconnect-button">Rozłącz</button>
+                </li>
+                <li>
                     <button class="w-100 p-1" id="fullscreen-button" title="Pełny ekran">⛶</button>
                 </li>
             </ul>

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -313,6 +313,7 @@ function updateConnectButtons() {
     const loginForm = document.getElementById('login-form') as HTMLFormElement | null;
     const authOverlay = document.getElementById('auth-overlay') as HTMLElement | null;
     const spinner = document.getElementById('connecting-spinner') as HTMLElement | null;
+    const disconnectButton = document.getElementById('disconnect-button') as HTMLButtonElement | null;
 
     if (connectButton) {
         if (isConnected || isConnecting || authClosed) {
@@ -344,6 +345,10 @@ function updateConnectButtons() {
 
     if (authOverlay) {
         authOverlay.style.display = (!isConnected && !playbackMode && !authClosed) ? 'flex' : 'none';
+    }
+
+    if (disconnectButton) {
+        disconnectButton.disabled = !isConnected;
     }
 }
 
@@ -464,6 +469,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const optionsButton = document.getElementById('options-button') as HTMLButtonElement;
     const exportImportButton = document.getElementById('export-import-button') as HTMLButtonElement | null;
     const optionsSave = document.getElementById('options-save') as HTMLButtonElement | null;
+    const disconnectButton = document.getElementById('disconnect-button') as HTMLButtonElement | null;
     const bindsButton = document.getElementById('binds-button') as HTMLButtonElement | null;
     const npcButton = document.getElementById('npc-button') as HTMLButtonElement | null;
     const scriptsButton = document.getElementById('scripts-button') as HTMLButtonElement | null;
@@ -593,6 +599,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (menuButton) {
         new Dropdown(menuButton);
+    }
+
+    if (disconnectButton) {
+        disconnectButton.addEventListener('click', () => {
+            if (!isConnected) {
+                return;
+            }
+            isConnecting = false;
+            updateConnectButtons();
+            arkadiaClient.disconnect();
+        });
     }
 
     window.addEventListener('close-options', () => {

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -2173,6 +2173,26 @@ h1 {
   text-align: left;
 }
 
+#input-area .dropdown-menu .menu-disconnect-button {
+  background-color: #dc3545;
+  border: 1px solid #dc3545;
+  color: #fff;
+}
+
+#input-area .dropdown-menu .menu-disconnect-button:hover,
+#input-area .dropdown-menu .menu-disconnect-button:focus {
+  background-color: #bb2d3b;
+  border-color: #bb2d3b;
+  color: #fff;
+}
+
+#input-area .dropdown-menu .menu-disconnect-button:disabled {
+  background-color: #6c757d;
+  border-color: #6c757d;
+  color: #fff;
+  opacity: 0.75;
+}
+
 #input-area button:hover {
   border-color: #fff;
 }


### PR DESCRIPTION
## Summary
- add a disconnect option to the input area dropdown menu
- highlight the disconnect action with a dedicated danger color
- wire the menu action to disconnect the client when it is connected

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_69000ca70328832aab560fdcb6ff68f7