### PR TITLE
Prevent recursive direction bind expansion

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -384,13 +384,21 @@ export default class Client {
         this.sendCommand('przestan kryc sie za zaslona')
     }
 
-    async sendCommand(command: string, echo: boolean = true, options?: CommandOptions): Promise<void> {
+    async sendCommand(command: string, echo: boolean = true, options?: CommandOptions, skipMapParse: boolean = false): Promise<void> {
         if (command) {
             command = stripPolishCharacters(command)
         }
         this.eventTarget.dispatchEvent(new CustomEvent('command', {detail: command}))
 
-        command = this.Map.parseCommand(command)
+        let commandChanged = false
+        if (!skipMapParse) {
+            const parsedCommand = this.Map.parseCommand(command)
+            if (parsedCommand === null) {
+                return
+            }
+            commandChanged = parsedCommand !== command
+            command = parsedCommand
+        }
         command = this.expandObjectShortcuts(command)
         if (command.startsWith('echo ')) {
             this.print(mudletColorLine(command.substring(5)))
@@ -399,7 +407,7 @@ export default class Client {
         const split = command.split(/[#;]/)
         if (split.length > 1) {
             for (const part of split) {
-                await this.sendCommand(part, echo, options)
+                await this.sendCommand(part, echo, options, skipMapParse || commandChanged)
             }
             return
         }

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -160,11 +160,10 @@ test('createButton creates button attached to panel', () => {
 test('sendCommand dispatches event and splits commands', async () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   await client.sendCommand('foo#bar');
+  expect(parseCommand).toHaveBeenCalledTimes(1);
   expect(parseCommand).toHaveBeenCalledWith('foo#bar');
-  expect(parseCommand).toHaveBeenCalledWith('parsed:foo');
-  expect(parseCommand).toHaveBeenCalledWith('bar');
-  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(1, 'parsed:parsed:foo', true, undefined);
-  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'parsed:bar', true, undefined);
+  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(1, 'parsed:foo', true, undefined);
+  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'bar', true, undefined);
 });
 
 test('sendCommand leaves casing unchanged by default', async () => {
@@ -224,8 +223,8 @@ test('sendCommand splits commands returned by parseCommand', async () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
   await client.sendCommand('e');
   expect(parseCommand).toHaveBeenCalledWith('e');
-  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(1, 'parsed:foo', true, undefined);
-  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'parsed:bar', true, undefined);
+  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(1, 'foo', true, undefined);
+  expect((global as any).clientAdapterMock.send).toHaveBeenNthCalledWith(2, 'bar', true, undefined);
 });
 
 test('sendCommand prints echo commands locally', async () => {


### PR DESCRIPTION
## Summary
- avoid reapplying map direction binds on commands that originate from a bind expansion to prevent infinite recursion
- adjust client command handling tests to reflect the new bind expansion behaviour

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_6900103b8a60832aa0d5b831a9d5b2f4