### PR TITLE
Add pin toggle to herb and knowledge popups

### DIFF
--- a/web-client/src/KnowledgeDetailsReport.tsx
+++ b/web-client/src/KnowledgeDetailsReport.tsx
@@ -83,6 +83,7 @@ const KnowledgeDetailsReport: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [data, setData] = useState<KnowledgeDetailsReportPayload | null>(null);
   const [hideCompleted, setHideCompleted] = useState(false);
+  const [isPinned, setIsPinned] = useState(false);
   const [position, setPosition] = useState<{ left: number; top: number } | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -90,6 +91,10 @@ const KnowledgeDetailsReport: React.FC = () => {
 
   const close = useCallback(() => {
     setIsOpen(false);
+  }, []);
+
+  const togglePinned = useCallback(() => {
+    setIsPinned((prev) => !prev);
   }, []);
 
   const ensureVisiblePosition = useCallback((prev: { left: number; top: number } | null) => {
@@ -212,7 +217,7 @@ const KnowledgeDetailsReport: React.FC = () => {
   }, [close, isOpen]);
 
   useEffect(() => {
-    if (!isOpen) {
+    if (!isOpen || isPinned) {
       return;
     }
     const handlePointerDownOutside = (event: PointerEvent) => {
@@ -224,7 +229,7 @@ const KnowledgeDetailsReport: React.FC = () => {
     };
     window.addEventListener('pointerdown', handlePointerDownOutside);
     return () => window.removeEventListener('pointerdown', handlePointerDownOutside);
-  }, [close, isOpen]);
+  }, [close, isOpen, isPinned]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -448,7 +453,18 @@ const KnowledgeDetailsReport: React.FC = () => {
       >
         <div className="knowledge-window-header" onPointerDown={handlePointerDown}>
           <h5 className="knowledge-window-title">Raport wiedzy</h5>
-          <button type="button" className="btn-close" onClick={close} />
+          <div
+            className="window-header-actions"
+            onPointerDownCapture={(event) => event.stopPropagation()}
+          >
+            <button
+              type="button"
+              className={`window-pin-button${isPinned ? ' window-pin-button--active' : ''}`}
+              onClick={togglePinned}
+              title={isPinned ? 'Odepnij okno' : 'Przypnij okno'}
+            />
+            <button type="button" className="btn-close" onClick={close} />
+          </div>
         </div>
         <div className="knowledge-window-body knowledge-details-body">
           <div className="knowledge-details-content" ref={scrollContainerRef}>

--- a/web-client/src/KnowledgeReport.tsx
+++ b/web-client/src/KnowledgeReport.tsx
@@ -93,6 +93,7 @@ const KnowledgeReport: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [data, setData] = useState<KnowledgeReportPayload | null>(null);
   const [activeTab, setActiveTab] = useState<'libraries' | 'categories'>('libraries');
+  const [isPinned, setIsPinned] = useState(false);
   const [position, setPosition] = useState<{ left: number; top: number } | null>(null);
   const [expandedStatuses, setExpandedStatuses] = useState<
     Record<string, Partial<Record<KnowledgeCategoryStatus, boolean>>>
@@ -102,6 +103,10 @@ const KnowledgeReport: React.FC = () => {
 
   const close = useCallback(() => {
     setIsOpen(false);
+  }, []);
+
+  const togglePinned = useCallback(() => {
+    setIsPinned((prev) => !prev);
   }, []);
 
   const ensureVisiblePosition = useCallback((prev: { left: number; top: number } | null) => {
@@ -233,7 +238,7 @@ const KnowledgeReport: React.FC = () => {
   }, [close, isOpen]);
 
   useEffect(() => {
-    if (!isOpen) {
+    if (!isOpen || isPinned) {
       return;
     }
     const handlePointerDownOutside = (event: PointerEvent) => {
@@ -245,7 +250,7 @@ const KnowledgeReport: React.FC = () => {
     };
     window.addEventListener('pointerdown', handlePointerDownOutside);
     return () => window.removeEventListener('pointerdown', handlePointerDownOutside);
-  }, [close, isOpen]);
+  }, [close, isOpen, isPinned]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -504,7 +509,18 @@ const KnowledgeReport: React.FC = () => {
       >
         <div className="knowledge-window-header" onPointerDown={handlePointerDown}>
           <h5 className="knowledge-window-title">Raport wiedzy</h5>
-          <button type="button" className="btn-close" onClick={close} />
+          <div
+            className="window-header-actions"
+            onPointerDownCapture={(event) => event.stopPropagation()}
+          >
+            <button
+              type="button"
+              className={`window-pin-button${isPinned ? ' window-pin-button--active' : ''}`}
+              onClick={togglePinned}
+              title={isPinned ? 'Odepnij okno' : 'Przypnij okno'}
+            />
+            <button type="button" className="btn-close" onClick={close} />
+          </div>
         </div>
         <div className="knowledge-window-body">
           <div className="knowledge-tabs">

--- a/web-client/src/herbs/HerbManager.tsx
+++ b/web-client/src/herbs/HerbManager.tsx
@@ -221,6 +221,7 @@ const HerbManager = () => {
     const [busy, setBusy] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [isOpen, setIsOpen] = useState(false);
+    const [isPinned, setIsPinned] = useState(false);
     const [position, setPosition] = useState<{ left: number; top: number } | null>(null);
     const panelRef = useRef<HTMLDivElement | null>(null);
     const dragState = useRef<{ pointerId: number; offsetX: number; offsetY: number } | null>(null);
@@ -257,6 +258,10 @@ const HerbManager = () => {
         closeContextMenu();
         setIsOpen(false);
     }, [closeContextMenu]);
+
+    const togglePinned = useCallback(() => {
+        setIsPinned(prev => !prev);
+    }, []);
 
     useEffect(() => {
         const client = (window as any).clientExtension as Client | undefined;
@@ -328,7 +333,7 @@ const HerbManager = () => {
     }, [handleClose, isOpen]);
 
     useEffect(() => {
-        if (!isOpen) {
+        if (!isOpen || isPinned) {
             return;
         }
         const handlePointerDownOutside = (event: PointerEvent) => {
@@ -341,7 +346,7 @@ const HerbManager = () => {
         };
         window.addEventListener("pointerdown", handlePointerDownOutside);
         return () => window.removeEventListener("pointerdown", handlePointerDownOutside);
-    }, [handleClose, isOpen]);
+    }, [handleClose, isOpen, isPinned]);
 
     const handleResize = useCallback(() => {
         setPosition(prev => {
@@ -578,6 +583,9 @@ const HerbManager = () => {
     const emptyState = useMemo(() => bags.length === 0 || bags.every(bag => bag.items.length === 0), [bags]);
 
     const handleBackdropClick = () => {
+        if (isPinned) {
+            return;
+        }
         handleClose();
     };
 
@@ -591,7 +599,11 @@ const HerbManager = () => {
 
     return (
         <>
-            <div className="herb-overlay" role="presentation" onClick={handleBackdropClick} />
+            <div
+                className={`herb-overlay${isPinned ? " herb-overlay--pinned" : ""}`}
+                role="presentation"
+                onClick={handleBackdropClick}
+            />
             <div
                 ref={panelRef}
                 className={`herb-window${position ? " herb-window--floating" : " herb-window--center"}`}
@@ -603,7 +615,18 @@ const HerbManager = () => {
             >
                 <div className="herb-window-header" onPointerDown={handlePointerDown}>
                     <h5 className="herb-window-title">Woreczki ziół</h5>
-                    <button type="button" className="btn-close" onClick={handleClose} />
+                    <div
+                        className="window-header-actions"
+                        onPointerDownCapture={event => event.stopPropagation()}
+                    >
+                        <button
+                            type="button"
+                            className={`window-pin-button${isPinned ? " window-pin-button--active" : ""}`}
+                            onClick={togglePinned}
+                            title={isPinned ? "Odepnij okno" : "Przypnij okno"}
+                        />
+                        <button type="button" className="btn-close" onClick={handleClose} />
+                    </div>
                 </div>
                 <div className="herb-window-body">
                     <div className={`herb-manager${busy ? " herb-manager--busy" : ""}`}>

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -22,6 +22,16 @@
   --floating-close-background: rgba(255, 255, 255, 0.08);
   --floating-close-hover-background: rgba(255, 255, 255, 0.2);
   --floating-close-hover-shadow: 0 0 0 1px rgba(255, 255, 255, 0.35);
+  --floating-pin-size: 1.75rem;
+  --floating-pin-icon-size: 0.95rem;
+  --floating-pin-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none'%3E%0A%20%20%3Cpath stroke='%23e2e8f0' stroke-width='1.25' stroke-linecap='round' stroke-linejoin='round' d='M5.5 3.25h5m-2.5 0v6.5m-2.5-3h5M7.5 9.75l-1.75 1.75V13.5h5.5v-2l-1.75-1.75'/%3E%0A%3C/svg%3E");
+  --floating-pin-active-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none'%3E%0A%20%20%3Cpath stroke='%230f172a' stroke-width='1.25' stroke-linecap='round' stroke-linejoin='round' d='M5.5 3.25h5m-2.5 0v6.5m-2.5-3h5'/%3E%0A%20%20%3Cpath fill='%23bfdbfe' d='M6.1 9.7 4.75 11.05V13.5h6.5v-2.45L9.9 9.7c-.2-.2-.52-.2-.72 0l-1.18 1.18L6.82 9.7a.51.51 0 0 0-.72 0Z'/%3E%0A%3C/svg%3E");
+  --floating-pin-background: rgba(255, 255, 255, 0.08);
+  --floating-pin-hover-background: rgba(148, 163, 184, 0.24);
+  --floating-pin-hover-shadow: 0 0 0 1px rgba(148, 197, 253, 0.4);
+  --floating-pin-active-background: rgba(96, 165, 250, 0.35);
+  --floating-pin-active-hover-background: rgba(96, 165, 250, 0.48);
+  --floating-pin-active-hover-shadow: 0 0 0 1px rgba(96, 165, 250, 0.55);
   --bs-body-bg: var(--surface-content);
   --bs-body-color: var(--text-primary);
   color: var(--text-primary);
@@ -123,6 +133,53 @@ body {
     --close-button-hover-shadow,
     var(--floating-close-hover-shadow)
   );
+}
+
+.window-header-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.window-pin-button {
+  width: var(--pin-button-size, var(--floating-pin-size));
+  height: var(--pin-button-size, var(--floating-pin-size));
+  border-radius: 999px;
+  border: none;
+  padding: 0;
+  background-color: var(
+    --pin-button-background,
+    var(--floating-pin-background)
+  );
+  background-image: var(--pin-button-icon, var(--floating-pin-icon));
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: var(--pin-button-icon-size, var(--floating-pin-icon-size));
+  cursor: pointer;
+  opacity: var(--pin-button-opacity, 0.92);
+  transition: opacity 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.window-pin-button:hover,
+.window-pin-button:focus-visible {
+  outline: none;
+  opacity: 1;
+  background-color: var(
+    --pin-button-hover-background,
+    var(--floating-pin-hover-background)
+  );
+  box-shadow: var(
+    --pin-button-hover-shadow,
+    var(--floating-pin-hover-shadow)
+  );
+}
+
+.window-pin-button--active {
+  --pin-button-background: var(--floating-pin-active-background);
+  --pin-button-icon: var(--floating-pin-active-icon);
+  --pin-button-hover-background: var(--floating-pin-active-hover-background);
+  --pin-button-hover-shadow: var(--floating-pin-active-hover-shadow);
 }
 
 .modal .form-text,
@@ -676,6 +733,10 @@ h1 {
   position: fixed;
   inset: 0;
   z-index: 1040;
+}
+
+.herb-overlay--pinned {
+  pointer-events: none;
 }
 
 .herb-window {


### PR DESCRIPTION
## Summary
- add pin toggle controls to the herb manager, knowledge report, and knowledge details windows
- keep pinned popups open when clicking outside and disable the herb overlay while pinned
- add shared styling for the new pin button used by floating panels

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build
- yarn --cwd client test

------
https://chatgpt.com/codex/tasks/task_e_69000d0ce724832aa0620409c20c81ce