### PR TITLE
Restore connect button after disconnect

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -365,7 +365,9 @@ arkadiaClient.on('client.connect', () => {
 arkadiaClient.on('client.disconnect', () => {
     isConnected = false;
     isConnecting = false;
+    authClosed = false;
     updateConnectButtons();
+    client.println('Rozłączono z serwerem Arkadii.');
     console.log('Client disconnected from Arkadia server.');
 });
 


### PR DESCRIPTION
## Summary
- reset the auth overlay closed flag when the client disconnects so the connect button is shown again
- print a disconnection notice to the client log when the session ends

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_69001106855c832aa0edd6b1d433ffaa