### PR TITLE
Add combat cooldown timer with UI toggle

### DIFF
--- a/client/src/eventBus.ts
+++ b/client/src/eventBus.ts
@@ -28,6 +28,7 @@ export interface KnownEvents {
     'moveModeChanged': number;
     'ping': number | null;
     'transportTimer': TransportTimerPayload | null;
+    'combatTimer': number | null;
 }
 
 export type ClientEvents = KnownEvents & {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -11,6 +11,7 @@ import initAttackBeep from './scripts/attackBeep'
 import initAttackQueue from './scripts/attackQueue'
 import initLamp from './scripts/lamp'
 import initCoverTimer from './scripts/coverTimer'
+import initCombatTimer from './scripts/combatTimer'
 import initZaskTimer from './scripts/zaskTimer'
 import initBinds from './scripts/binds'
 import initTempBinds from './scripts/tempBinds'
@@ -167,6 +168,7 @@ export function registerScripts(client: Client) {
     initAttackQueue(client, aliases)
     initLamp(client)
     initCoverTimer(client)
+    initCombatTimer(client)
     initZaskTimer(client)
     initBinds(client, aliases)
     initTempBinds(client, aliases)

--- a/client/src/scripts/combatTimer.ts
+++ b/client/src/scripts/combatTimer.ts
@@ -1,0 +1,113 @@
+import Client from "../Client";
+
+const DISPLAY_DURATION_MS = 30_000;
+const INITIAL_SECONDS = Math.ceil(DISPLAY_DURATION_MS / 1000);
+
+export default function initCombatTimer(client: Client) {
+    let playerNum: string | undefined;
+    let lastCombatState: boolean | null = null;
+    let timer: number | null = null;
+    let timerStart = 0;
+    let lastEmitted: number | null = null;
+
+    function emit(seconds: number | null) {
+        client.sendEvent('combatTimer', seconds);
+    }
+
+    function stopTimer() {
+        if (timer !== null) {
+            clearInterval(timer);
+            timer = null;
+        }
+        timerStart = 0;
+        lastEmitted = null;
+        emit(null);
+    }
+
+    function updateTimer() {
+        if (timer === null) {
+            return;
+        }
+        const elapsed = Date.now() - timerStart;
+        const remaining = DISPLAY_DURATION_MS - elapsed;
+        if (remaining <= 0) {
+            stopTimer();
+            return;
+        }
+        const seconds = Math.ceil(remaining / 1000);
+        if (seconds !== lastEmitted) {
+            lastEmitted = seconds;
+            emit(seconds);
+        }
+    }
+
+    function startTimer() {
+        if (timer !== null) {
+            clearInterval(timer);
+        }
+        timerStart = Date.now();
+        lastEmitted = INITIAL_SECONDS;
+        emit(INITIAL_SECONDS);
+        timer = window.setInterval(updateTimer, 250);
+    }
+
+    function setCombatState(inCombat: boolean) {
+        if (lastCombatState === null) {
+            lastCombatState = inCombat;
+            if (inCombat) {
+                stopTimer();
+            }
+            return;
+        }
+        if (inCombat === lastCombatState) {
+            return;
+        }
+        lastCombatState = inCombat;
+        if (inCombat) {
+            stopTimer();
+        } else {
+            startTimer();
+        }
+    }
+
+    client.addEventListener('gmcp.char.info', (event: CustomEvent) => {
+        const info = event.detail || {};
+        const newPlayerNum = typeof info.object_num !== 'undefined'
+            ? String(info.object_num)
+            : undefined;
+        if (newPlayerNum !== playerNum) {
+            playerNum = newPlayerNum;
+            lastCombatState = null;
+            stopTimer();
+        }
+    });
+
+    client.addEventListener('gmcp.objects.data', (event: CustomEvent<Record<string, any>>) => {
+        if (!playerNum) {
+            return;
+        }
+        const detail = event.detail;
+        if (!detail || typeof detail !== 'object') {
+            return;
+        }
+        const playerData = detail[playerNum];
+        if (!playerData || typeof playerData !== 'object') {
+            return;
+        }
+        if (!Object.prototype.hasOwnProperty.call(playerData, 'attack_num')) {
+            return;
+        }
+        const attackNum = playerData.attack_num;
+        const inCombat = attackNum !== false && typeof attackNum !== 'undefined';
+        setCombatState(inCombat);
+    });
+
+    client.addEventListener('client.disconnect', () => {
+        playerNum = undefined;
+        lastCombatState = null;
+        stopTimer();
+    });
+
+    emit(null);
+}
+

--- a/client/test/combatTimer.test.ts
+++ b/client/test/combatTimer.test.ts
@@ -1,0 +1,90 @@
+import initCombatTimer from "../src/scripts/combatTimer";
+
+describe("combat timer", () => {
+  class FakeClient extends EventTarget {
+    sendEvent = jest.fn((type: string, detail?: any) => {
+      super.dispatchEvent(new CustomEvent(type, { detail }));
+    });
+
+    addEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: AddEventListenerOptions | boolean,
+    ) {
+      super.addEventListener(type, listener as EventListener, options);
+      return () => super.removeEventListener(type, listener as EventListener, options as any);
+    }
+
+    removeEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: EventListenerOptions,
+    ) {
+      if (listener) {
+        super.removeEventListener(type, listener as EventListener, options);
+      }
+    }
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("starts countdown when combat ends", () => {
+    const client = new FakeClient();
+    initCombatTimer((client as unknown) as any);
+    expect(client.sendEvent).toHaveBeenLastCalledWith("combatTimer", null);
+    client.sendEvent.mockClear();
+
+    client.dispatchEvent(new CustomEvent("gmcp.char.info", { detail: { object_num: 7 } }));
+    client.sendEvent.mockClear();
+    client.dispatchEvent(
+      new CustomEvent("gmcp.objects.data", { detail: { "7": { attack_num: 1 } } }),
+    );
+    client.sendEvent.mockClear();
+    expect(client.sendEvent).not.toHaveBeenCalled();
+
+    client.dispatchEvent(
+      new CustomEvent("gmcp.objects.data", { detail: { "7": { attack_num: false } } }),
+    );
+    expect(client.sendEvent).toHaveBeenCalledWith("combatTimer", 30);
+
+    jest.advanceTimersByTime(1_000);
+    expect(client.sendEvent).toHaveBeenLastCalledWith("combatTimer", 29);
+
+    jest.advanceTimersByTime(29_000);
+    expect(client.sendEvent).toHaveBeenLastCalledWith("combatTimer", null);
+
+    client.sendEvent.mockClear();
+    client.dispatchEvent(
+      new CustomEvent("gmcp.objects.data", { detail: { "7": { attack_num: 3 } } }),
+    );
+    expect(client.sendEvent).toHaveBeenLastCalledWith("combatTimer", null);
+  });
+
+  test("ignores non-combat updates before first combat", () => {
+    const client = new FakeClient();
+    initCombatTimer((client as unknown) as any);
+    client.sendEvent.mockClear();
+
+    client.dispatchEvent(new CustomEvent("gmcp.char.info", { detail: { object_num: 13 } }));
+    client.sendEvent.mockClear();
+    client.dispatchEvent(
+      new CustomEvent("gmcp.objects.data", { detail: { "13": { attack_num: false } } }),
+    );
+    expect(client.sendEvent).not.toHaveBeenCalled();
+
+    client.dispatchEvent(
+      new CustomEvent("gmcp.objects.data", { detail: { "13": { attack_num: 2 } } }),
+    );
+    client.dispatchEvent(
+      new CustomEvent("gmcp.objects.data", { detail: { "13": { attack_num: false } } }),
+    );
+    expect(client.sendEvent).toHaveBeenCalledWith("combatTimer", 30);
+  });
+});
+

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -53,6 +53,7 @@
         <span id="release-guard"></span>
         <span id="cover-timer"></span>
         <span id="zask-timer"></span>
+        <span id="combat-timer" data-enabled="1"></span>
     </div>
     <div id="objects-list" data-mobile-command-radial-ignore></div>
     <button id="recording-button" class="btn btn-danger btn-sm" style="position:absolute;top:0.5rem;right:0.5rem;z-index:1012;display:none;">Zatrzymaj i zapisz</button>
@@ -440,6 +441,10 @@
                                 <div class="form-check">
                                     <input id="ui-show-transport-label" type="checkbox" class="form-check-input" />
                                     <label class="form-check-label" for="ui-show-transport-label">Etykieta transportu</label>
+                                </div>
+                                <div class="form-check">
+                                    <input id="ui-show-combat-timer" type="checkbox" class="form-check-input" />
+                                    <label class="form-check-label" for="ui-show-combat-timer">Timer walki (30s)</label>
                                 </div>
                                 <button type="button" class="btn btn-warning align-self-start" id="ui-enable-notifications">Włącz powiadomienia</button>
                             </div>

--- a/web-client/sandbox.html
+++ b/web-client/sandbox.html
@@ -54,6 +54,7 @@
         <span id="release-guard"></span>
         <span id="cover-timer"></span>
         <span id="zask-timer"></span>
+        <span id="combat-timer" data-enabled="1"></span>
     </div>
     <div id="objects-list" data-mobile-command-radial-ignore></div>
     <button id="recording-button" class="btn btn-danger btn-sm" style="position:absolute;top:0.5rem;right:0.5rem;z-index:1012;display:none;">Zatrzymaj i zapisz</button>

--- a/web-client/src/CombatTimer.ts
+++ b/web-client/src/CombatTimer.ts
@@ -1,0 +1,65 @@
+import ArkadiaClient from "./ArkadiaClient.ts";
+import { getItemSync } from "@client/src/storage";
+import type { UiSettings } from "./uiSettings.ts";
+
+export default class CombatTimer {
+  private container: HTMLElement | null;
+  private enabled: boolean;
+  private lastSeconds: number | null = null;
+
+  constructor(client: typeof ArkadiaClient) {
+    this.container = document.getElementById("combat-timer");
+    this.enabled = this.getInitialEnabled();
+    this.subscribeToUiSettings();
+    client.on("combatTimer", (seconds: number | null) => this.update(seconds));
+    this.update(null);
+  }
+
+  private getInitialEnabled(): boolean {
+    const stored = getItemSync("uiSettings")?.uiSettings as Partial<UiSettings> | undefined;
+    if (stored && typeof stored.showCombatTimer === "boolean") {
+      return stored.showCombatTimer;
+    }
+    if (this.container?.dataset.enabled) {
+      return this.container.dataset.enabled !== "0";
+    }
+    return true;
+  }
+
+  private subscribeToUiSettings() {
+    const ext: any = (window as any).clientExtension;
+    const target: EventTarget | undefined = ext?.eventTarget;
+    if (!target) {
+      return;
+    }
+    const handler: EventListener = (event: Event) => {
+      const detail = (event as CustomEvent<Partial<UiSettings>>).detail;
+      if (detail && typeof detail.showCombatTimer === "boolean") {
+        this.enabled = detail.showCombatTimer;
+        this.update(this.lastSeconds);
+      }
+    };
+    target.addEventListener("uiSettings", handler);
+  }
+
+  private update(seconds: number | null) {
+    this.lastSeconds = seconds;
+    if (!this.container) return;
+    if (!this.enabled || seconds == null || seconds <= 0) {
+      this.container.textContent = "";
+      this.container.className = "";
+      this.container.style.display = "none";
+      return;
+    }
+    this.container.style.display = "block";
+    this.container.textContent = `Walka: ${seconds}`;
+    if (seconds > 20) {
+      this.container.className = "red";
+    } else if (seconds > 10) {
+      this.container.className = "yellow";
+    } else {
+      this.container.className = "green";
+    }
+  }
+}
+

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -8,6 +8,7 @@ import LampTimer from "./LampTimer";
 import TransportTimer from "./TransportTimer";
 import CoverTimer from "./CoverTimer";
 import ZaskTimer from "./ZaskTimer";
+import CombatTimer from "./CombatTimer";
 import BreakItemWarning from "./BreakItemWarning";
 import PackageStatus from "./PackageStatus";
 import CharStateInfo from "./CharStateInfo";
@@ -1137,6 +1138,7 @@ document.addEventListener('DOMContentLoaded', () => {
     new LampTimer(arkadiaClient);
     new CoverTimer(arkadiaClient);
     new ZaskTimer(arkadiaClient);
+    new CombatTimer(arkadiaClient);
     new BreakItemWarning(arkadiaClient);
     new ReleaseGuard(arkadiaClient);
     new AttackMode(arkadiaClient);

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -1780,6 +1780,22 @@ h1 {
   color: tomato;
 }
 
+#combat-timer {
+  display: none;
+}
+
+#combat-timer.green {
+  color: springgreen;
+}
+
+#combat-timer.yellow {
+  color: yellow;
+}
+
+#combat-timer.red {
+  color: tomato;
+}
+
 #state-info {
   display: none;
 }

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -36,6 +36,7 @@ export interface UiSettings {
     outputBackground: string;
     clearInputOnSend: boolean;
     showTransportLabel: boolean;
+    showCombatTimer: boolean;
     fontFamily: UiFontSelection;
     customFontUrl: string;
     customFontFamily: string;
@@ -62,6 +63,7 @@ const defaultSettings: UiSettings = {
     outputBackground: '#242424',
     clearInputOnSend: false,
     showTransportLabel: true,
+    showCombatTimer: true,
     fontFamily: 'default',
     customFontUrl: '',
     customFontFamily: '',
@@ -198,6 +200,15 @@ function apply(settings: UiSettings) {
         charState.style.fontSize = settings.contentFontSize + 'rem';
         charState.setAttribute('data-footer-mode', String(settings.footerMode));
     }
+    const combatTimer = document.getElementById('combat-timer');
+    if (combatTimer) {
+        combatTimer.dataset.enabled = settings.showCombatTimer ? '1' : '0';
+        if (!settings.showCombatTimer) {
+            combatTimer.style.display = 'none';
+            combatTimer.textContent = '';
+            combatTimer.className = '';
+        }
+    }
     const objects = document.getElementById('objects-list');
     if (objects) {
         if (resolvedFontFamily) {
@@ -275,6 +286,7 @@ function apply(settings: UiSettings) {
                     fightTitleIcon: settings.fightTitleIcon,
                     clearInputOnSend: settings.clearInputOnSend,
                     showTransportLabel: settings.showTransportLabel,
+                    showCombatTimer: settings.showCombatTimer,
                 },
             })
         );
@@ -340,6 +352,9 @@ async function load(): Promise<UiSettings> {
             const showTransportLabel = typeof parsed.showTransportLabel === 'boolean'
                 ? parsed.showTransportLabel
                 : defaultSettings.showTransportLabel;
+            const showCombatTimer = typeof parsed.showCombatTimer === 'boolean'
+                ? parsed.showCombatTimer
+                : defaultSettings.showCombatTimer;
             return {
                 ...defaultSettings,
                 ...parsed,
@@ -358,6 +373,7 @@ async function load(): Promise<UiSettings> {
                 outputBackground,
                 clearInputOnSend,
                 showTransportLabel,
+                showCombatTimer,
                 fontFamily,
                 customFontUrl: normalizedCustomFontUrl,
                 customFontFamily,
@@ -401,6 +417,7 @@ export default async function initUiSettings() {
     const outputBackgroundReset = modalEl.querySelector('#ui-output-background-reset') as HTMLButtonElement | null;
     const clearInputOnSendInput = modalEl.querySelector('#ui-clear-input') as HTMLInputElement;
     const showTransportLabelInput = modalEl.querySelector('#ui-show-transport-label') as HTMLInputElement;
+    const showCombatTimerInput = modalEl.querySelector('#ui-show-combat-timer') as HTMLInputElement;
     const fontFamilyInput = modalEl.querySelector('#ui-font-family') as HTMLSelectElement;
     const customFontSettings = modalEl.querySelector('#ui-custom-font-settings') as HTMLElement | null;
     const customFontUrlInput = modalEl.querySelector('#ui-custom-font-url') as HTMLInputElement;
@@ -428,6 +445,7 @@ export default async function initUiSettings() {
     outputBackgroundInput.value = current.outputBackground;
     clearInputOnSendInput.checked = current.clearInputOnSend;
     showTransportLabelInput.checked = current.showTransportLabel;
+    showCombatTimerInput.checked = current.showCombatTimer;
     fontFamilyInput.value = current.fontFamily;
     customFontUrlInput.value = current.customFontUrl;
     customFontFamilyInput.value = current.customFontFamily;
@@ -621,6 +639,7 @@ export default async function initUiSettings() {
             outputBackground: backgroundValue,
             clearInputOnSend: clearInputOnSendInput.checked,
             showTransportLabel: showTransportLabelInput.checked,
+            showCombatTimer: showCombatTimerInput.checked,
             fontFamily: isUiFontSelection(fontFamilyInput.value) ? fontFamilyInput.value : defaultSettings.fontFamily,
             customFontUrl: (() => {
                 const value = customFontUrlInput.value.trim();

--- a/web-client/test/CombatTimer.test.ts
+++ b/web-client/test/CombatTimer.test.ts
@@ -1,0 +1,65 @@
+import CombatTimer from "../src/CombatTimer";
+
+class MockClient {
+  private events: Record<string, Function[]> = {};
+  on(event: string, listener: Function) {
+    (this.events[event] ||= []).push(listener);
+  }
+  emit(event: string, payload: any) {
+    (this.events[event] || []).forEach(fn => fn(payload));
+  }
+}
+
+describe("CombatTimer", () => {
+  let container: HTMLElement;
+  let client: MockClient;
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = '<span id="combat-timer" data-enabled="1"></span>';
+    container = document.getElementById("combat-timer")!;
+    (window as any).clientExtension = { eventTarget: new EventTarget() };
+    client = new MockClient();
+    new CombatTimer(client as any);
+  });
+
+  afterEach(() => {
+    delete (window as any).clientExtension;
+  });
+
+  test("hides timer when payload is null", () => {
+    client.emit("combatTimer", null);
+    expect(container.style.display).toBe("none");
+    expect(container.textContent).toBe("");
+    expect(container.className).toBe("");
+  });
+
+  test("shows countdown with color thresholds", () => {
+    client.emit("combatTimer", 30);
+    expect(container.style.display).toBe("block");
+    expect(container.textContent).toBe("Walka: 30");
+    expect(container.className).toBe("red");
+
+    client.emit("combatTimer", 15);
+    expect(container.className).toBe("yellow");
+
+    client.emit("combatTimer", 5);
+    expect(container.className).toBe("green");
+  });
+
+  test("respects ui setting toggle", () => {
+    const target = (window as any).clientExtension.eventTarget as EventTarget;
+    client.emit("combatTimer", 12);
+    expect(container.style.display).toBe("block");
+
+    target.dispatchEvent(new CustomEvent("uiSettings", { detail: { showCombatTimer: false } }));
+    expect(container.style.display).toBe("none");
+    expect(container.textContent).toBe("");
+
+    target.dispatchEvent(new CustomEvent("uiSettings", { detail: { showCombatTimer: true } }));
+    client.emit("combatTimer", 8);
+    expect(container.style.display).toBe("block");
+    expect(container.textContent).toBe("Walka: 8");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a combat cooldown timer script that records the time when the player leaves combat and emits countdown updates
- surface the combat timer in the web client footer with configurable colours and persistence across settings updates
- expose a "Timer walki" option in the UI settings modal and persist the preference in stored UI settings

## Testing
- yarn --cwd client test
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_69001522cf4c832a884af641236dbf7e