### PR TITLE
Keep collapsed mobile toggle button position stable

### DIFF
--- a/web-client/src/scripts/mobileDirectionButtons.ts
+++ b/web-client/src/scripts/mobileDirectionButtons.ts
@@ -707,7 +707,10 @@ export default class MobileDirectionButtons {
     }
 
     private toggleVisibility() {
-        if (!this.container) return;
+        if (!this.container || !this.toggleButton) return;
+
+        const previousRect = this.toggleButton.getBoundingClientRect();
+
         this.collapsed = !this.collapsed;
         if (this.collapsed) {
             this.container.classList.add('collapsed');
@@ -715,6 +718,36 @@ export default class MobileDirectionButtons {
             this.container.classList.remove('collapsed');
         }
         this.updateToggleButton();
+
+        requestAnimationFrame(() => {
+            const currentRect = this.toggleButton?.getBoundingClientRect();
+            if (!currentRect) return;
+
+            const deltaX = previousRect.left - currentRect.left;
+            const deltaY = previousRect.top - currentRect.top;
+
+            if (Math.abs(deltaX) < 0.5 && Math.abs(deltaY) < 0.5) {
+                return;
+            }
+
+            const containerRect = this.container.getBoundingClientRect();
+            let currentLeft = parseFloat(this.container.style.left);
+            if (!Number.isFinite(currentLeft)) {
+                currentLeft = containerRect.left;
+            }
+            let currentTop = parseFloat(this.container.style.top);
+            if (!Number.isFinite(currentTop)) {
+                currentTop = containerRect.top;
+            }
+
+            this.container.style.left = `${currentLeft + deltaX}px`;
+            this.container.style.top = `${currentTop + deltaY}px`;
+
+            this.clampToView();
+            if (!this.collapsed) {
+                this.persistCurrentPosition();
+            }
+        });
     }
 
     private highlightExits(exits: string[]) {


### PR DESCRIPTION
## Summary
- adjust the mobile direction toggle logic so the collapse button stays in place when hiding other buttons
- reposition the container after toggling to keep the button anchored and persist the saved location when expanded

## Testing
- yarn --cwd web-client test --watch=false

------
https://chatgpt.com/codex/tasks/task_e_69002b427704832ab706220bcde880c0