### PR TITLE
Refactor client sound handling into event-driven manager

### DIFF
--- a/client/src/Client.ts
+++ b/client/src/Client.ts
@@ -3,7 +3,6 @@ import PackageHelper from "./PackageHelper";
 import MapHelper from "./MapHelper";
 import InlineCompassRose from "./scripts/inlineCompassRose";
 import Pausers from "./Pausers";
-import {Howl} from "howler";
 import {mudletColorLine, setXtermPalette} from "./Colors";
 import {
     FunctionalBind,
@@ -13,7 +12,6 @@ import {
 import OutputHandler from "./OutputHandler";
 import TeamManager from "./TeamManager";
 import ObjectManager from "./ObjectManager";
-import {beepSound} from "./sounds";
 import {attachGmcpListener} from "./gmcp";
 import { setCurrentCharacter, getItemSync, setItemSync } from "./storage";
 import {color, Colors} from "./Colors";
@@ -26,6 +24,7 @@ import type { CommandOptions } from "./scripts/commandPreserveCaseMode";
 import { DEFAULT_ATTACK_COMMAND, normalizeAttackCommand } from "./utils/attackCommand";
 import TriggerLine from "./triggers/TriggerLine";
 import {parseAnsiPatterns} from "front-client/src/ansiParser";
+import SoundManager from "./SoundManager";
 
 const ANSI_SGR_REGEX = /\x1b\[[0-9;]*m/g;
 const ANSI_RESET = "\x1b[0m";
@@ -82,12 +81,7 @@ export default class Client {
     inlineCompassRose = new InlineCompassRose(this);
     panel = document.getElementById("panel_buttons_bottom");
     contentWidth = 0;
-    sounds: Record<string, Howl> = {
-        beep: new Howl({
-            src: beepSound,
-            preload: true,
-        }),
-    };
+    private soundManager = new SoundManager(this.eventTarget);
     aliases: { pattern: RegExp; callback: Function }[] = [];
     lampBind = {key: "Digit4", ctrl: true} as {
         key: string;
@@ -144,8 +138,6 @@ export default class Client {
         this.updateContentWidth()
         window.addEventListener('resize', () => this.updateContentWidth())
         this.addEventListener('uiSettings', () => this.updateContentWidth())
-
-        Object.values(this.sounds).forEach((sound) => sound.load())
 
         window.addEventListener('keydown', (ev) => {
             if (
@@ -579,21 +571,8 @@ export default class Client {
         return button
     }
 
-    playSound(key: string) {
-        const sound = this.sounds[key]
-        if (!sound) {
-            return
-        }
-        const play = () => {
-            sound.stop()
-            sound.play()
-        }
-        if (sound.state() === 'loaded') {
-            play()
-        } else {
-            sound.once('load', play)
-            sound.load()
-        }
+    prepareSounds(): Promise<void> {
+        return this.soundManager.prepare()
     }
 
     enableNotifications() {

--- a/client/src/SoundManager.ts
+++ b/client/src/SoundManager.ts
@@ -1,0 +1,98 @@
+import type {Howl} from "howler";
+
+export type SoundKey = "beep";
+
+interface PlaySoundDetail {
+    key: SoundKey;
+}
+
+export default class SoundManager {
+    private sounds: Partial<Record<SoundKey, Howl>> = {};
+    private soundLoaders: Partial<Record<SoundKey, Promise<Howl | undefined>>> = {};
+    private howlConstructorPromise: Promise<typeof import('howler').Howl> | null = null;
+    private readonly playHandler: (event: Event) => void;
+
+    constructor(private readonly eventTarget: EventTarget) {
+        this.playHandler = (event: Event) => {
+            const detail = (event as CustomEvent<PlaySoundDetail>).detail;
+            const key = detail?.key;
+            if (!key) {
+                return;
+            }
+            void this.play(key);
+        };
+        this.eventTarget.addEventListener("sound:play", this.playHandler as EventListener);
+    }
+
+    async prepare(): Promise<void> {
+        const sound = await this.ensureSound("beep");
+        sound?.load();
+    }
+
+    private async loadHowler(): Promise<typeof import('howler').Howl> {
+        if (!this.howlConstructorPromise) {
+            this.howlConstructorPromise = import('howler').then((module: any) => {
+                const constructor = module?.Howl ?? module?.default?.Howl ?? module?.default ?? module;
+                return constructor as typeof import('howler').Howl;
+            });
+        }
+        return this.howlConstructorPromise;
+    }
+
+    private async ensureSound(key: SoundKey): Promise<Howl | undefined> {
+        const existing = this.sounds[key];
+        if (existing) {
+            return existing;
+        }
+        if (!this.soundLoaders[key]) {
+            this.soundLoaders[key] = this.createSound(key);
+        }
+        return this.soundLoaders[key];
+    }
+
+    private async createSound(key: SoundKey): Promise<Howl | undefined> {
+        const HowlConstructor = await this.loadHowler();
+        switch (key) {
+            case "beep": {
+                const {beepSound} = await import("./sounds");
+                const sound = new HowlConstructor({
+                    src: beepSound,
+                    preload: false,
+                });
+                this.sounds[key] = sound;
+                return sound;
+            }
+            default:
+                return undefined;
+        }
+    }
+
+    private playLoadedSound(sound: Howl) {
+        const play = () => {
+            sound.stop();
+            sound.play();
+        };
+        if (sound.state() === 'loaded') {
+            play();
+        } else {
+            sound.once('load', play);
+            sound.load();
+        }
+    }
+
+    private async play(key: SoundKey) {
+        const existing = this.sounds[key];
+        if (existing) {
+            this.playLoadedSound(existing);
+            return;
+        }
+        try {
+            const sound = await this.ensureSound(key);
+            if (sound) {
+                this.playLoadedSound(sound);
+            }
+        } catch (error) {
+            console.error("Failed to play sound", error);
+        }
+    }
+}

--- a/client/src/scripts/attackBeep.ts
+++ b/client/src/scripts/attackBeep.ts
@@ -61,7 +61,7 @@ export default function initAttackBeep(client: Client) {
             return highlightAttack(raw, upper);
         }
 
-        client.playSound("beep");
+        client.sendEvent("sound:play", { key: "beep" });
         const upper = (matches.groups && (matches.groups as any).upper) as string | undefined;
         return highlightAttack(raw, upper);
     };

--- a/client/src/scripts/breakItem.ts
+++ b/client/src/scripts/breakItem.ts
@@ -21,7 +21,7 @@ export default function initBreakItem(client: Client) {
 
     entries.forEach(({ pattern, command }) => {
         client.Triggers.registerTrigger(pattern, (_raw, line) => {
-            client.playSound("beep");
+            client.sendEvent("sound:play", { key: "beep" });
             client.sendEvent('breakItem', { text: line, command });
             const label = command ? ` >> ${command}` : " >> Sprzet zniszczony";
             client.FunctionalBind.set(label, () => {

--- a/client/src/scripts/buses.ts
+++ b/client/src/scripts/buses.ts
@@ -11,7 +11,7 @@ const BRYCZKA_LABEL = BRYCZKA_CMDS.join(";");
 
 function bindBus(client: Client, commands: string[], label: string, beep: boolean) {
     if (beep) {
-        client.playSound("beep");
+        client.sendEvent("sound:play", { key: "beep" });
     }
     client.FunctionalBind.set(label, () => {
         commands.forEach(cmd => client.sendCommand(cmd));

--- a/client/src/scripts/hpAlert.ts
+++ b/client/src/scripts/hpAlert.ts
@@ -42,7 +42,7 @@ export default function initHpAlert(client: Client) {
         if (hp < prev && hp <= alertLevel) {
             const plain = `Jestes ${CONDITIONS[hp] ?? ''}`;
             const msg = colorString(plain, ORANGE);
-            client.playSound('beep');
+            client.sendEvent("sound:play", { key: "beep" });
             client.println(`\n\n${msg}\n\n`);
             client.notify(plain);
         }

--- a/client/src/scripts/lamp.ts
+++ b/client/src/scripts/lamp.ts
@@ -23,7 +23,7 @@ export default function initLamp(client: Client) {
             client.println(` >> W lampie zostalo oleju na ${secondsToClock(seconds)}.`)
         }
         if (BEEP_TIMES.includes(seconds)) {
-            client.playSound('beep')
+            client.sendEvent("sound:play", { key: "beep" })
         }
         if (seconds <= 0) {
             stopTimer()

--- a/client/src/scripts/luaGags.ts
+++ b/client/src/scripts/luaGags.ts
@@ -446,7 +446,7 @@ export default function registerLuaGagTriggers(client: Client) {
 
     (gagsData as GagNode[]).forEach(group => registerNode(client.Triggers, group));
     client.addEventListener("playBeep", () => {
-        client.playSound("beep")
+        client.sendEvent("sound:play", { key: "beep" })
     })
 
     let {global, luaEnv} = createLuaEnv();

--- a/client/src/scripts/ships.ts
+++ b/client/src/scripts/ships.ts
@@ -11,7 +11,7 @@ const BOARD_LABEL = BOARD_CMDS.join(";");
 
 function bindShip(client: Client, commands: string[], label: string, beep: boolean) {
     if (beep) {
-        client.playSound("beep");
+        client.sendEvent("sound:play", { key: "beep" });
     }
     client.FunctionalBind.set(label, () => {
         client.sendEvent("refreshPositionWhenAble");

--- a/client/src/scripts/userTriggers.ts
+++ b/client/src/scripts/userTriggers.ts
@@ -53,7 +53,7 @@ export default function initUserTriggers(client: Client) {
                                 result = m.to || '';
                                 break;
                             case 'beep':
-                                client.playSound('beep');
+                                client.sendEvent("sound:play", { key: "beep" });
                                 break;
                             case 'command':
                                 if (m.command) {

--- a/client/test/Client.test.ts
+++ b/client/test/Client.test.ts
@@ -18,6 +18,11 @@ import Client from '../src/Client';
 import { mudletColorLine } from '../src/Colors';
 import { Howl } from 'howler';
 
+jest.mock('../src/sounds', () => ({
+  __esModule: true,
+  beepSound: 'mock-sound',
+}));
+
 jest.mock('howler', () => {
   const instance = {
     state: jest.fn(() => 'loaded'),
@@ -301,12 +306,13 @@ test('onLine preserves final reset at line end', () => {
   expect(result).toBe(line);
 });
 
-test('playSound restarts sound when called twice', () => {
+test('sound playback restarts when triggered twice', async () => {
   const client = new Client((global as any).clientAdapterMock as any, (global as any).portMock);
+  await client.prepareSounds();
   const sound = (Howl as jest.Mock).mock.results[0].value;
 
-  client.playSound('beep');
-  client.playSound('beep');
+  client.sendEvent('sound:play', { key: 'beep' });
+  client.sendEvent('sound:play', { key: 'beep' });
 
   expect(sound.stop).toHaveBeenCalledTimes(2);
   expect(sound.play).toHaveBeenCalledTimes(2);

--- a/client/test/attackBeep.test.ts
+++ b/client/test/attackBeep.test.ts
@@ -18,7 +18,7 @@ const MOCK_PEOPLE = [
 
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
-  playSound = jest.fn();
+  sendEvent = jest.fn();
   addEventListener = jest.fn();
 }
 
@@ -63,7 +63,9 @@ describe('attack beep triggers', () => {
 
   test('beeps and highlights on attack', () => {
     const result = parse('Intia atakuje cie!');
-    expect(client.playSound).toHaveBeenCalledTimes(1);
+    const beepCalls = client.sendEvent.mock.calls.filter(call => call[0] === 'sound:play');
+    expect(beepCalls).toHaveLength(1);
+    expect(beepCalls[0][1]).toEqual({ key: 'beep' });
     const prefix = `\x1B[22;38;5;${findClosestColor('#ff0000')}m`;
     expect(result.startsWith(prefix)).toBe(true);
     expect(result).toContain('Intia ATAKUJE CIE!');
@@ -78,7 +80,8 @@ describe('attack beep triggers', () => {
 
   test('does not beep on plain phrase trigger', () => {
     const result = parse('atakuje cie!');
-    expect(client.playSound).not.toHaveBeenCalled();
+    const beepCalls = client.sendEvent.mock.calls.filter(call => call[0] === 'sound:play');
+    expect(beepCalls).toHaveLength(0);
     const prefix = `\x1B[22;38;5;${findClosestColor('#ff0000')}m`;
     expect(result.startsWith(prefix)).toBe(true);
     expect(result).toContain('ATAKUJE CIE');

--- a/client/test/breakItem.test.ts
+++ b/client/test/breakItem.test.ts
@@ -5,7 +5,6 @@ import { colorString, findClosestColor } from '../src/Colors';
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
   FunctionalBind = { set: jest.fn() } as any;
-  playSound = jest.fn();
   sendCommand = jest.fn();
   sendEvent = jest.fn();
   prefix = (line: string, prefix: string) => prefix + line;
@@ -25,7 +24,9 @@ describe('break item triggers', () => {
   test('replaces line and beeps', () => {
     const line = 'Nagle topor rozpruwa sie.';
     const result = parse(line);
-    expect(client.playSound).toHaveBeenCalledTimes(1);
+    const beepCalls = client.sendEvent.mock.calls.filter(call => call[0] === 'sound:play');
+    expect(beepCalls).toHaveLength(1);
+    expect(beepCalls[0][1]).toEqual({ key: 'beep' });
     expect(client.sendEvent).toHaveBeenCalledWith('breakItem', { text: line, command: undefined });
     const color = findClosestColor('#ff6347');
     const expected = `\n\n${client.prefix(line, colorString('[  SPRZET  ] ', color))}\n\n`;

--- a/client/test/buses.test.ts
+++ b/client/test/buses.test.ts
@@ -4,7 +4,7 @@ import Triggers from '../src/Triggers';
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
   FunctionalBind = { set: jest.fn(), clear: jest.fn(), newMessage: jest.fn() };
-  playSound = jest.fn();
+  sendEvent = jest.fn();
   sendCommand = jest.fn();
 }
 
@@ -22,7 +22,9 @@ describe('buses triggers', () => {
 
   test('exit trigger binds command and beeps', () => {
     parse('Otwarty jadacy powoz powoli zatrzymuje sie.');
-    expect(client.playSound).toHaveBeenCalledTimes(1);
+    const beepCalls = client.sendEvent.mock.calls.filter(call => call[0] === 'sound:play');
+    expect(beepCalls).toHaveLength(1);
+    expect(beepCalls[0][1]).toEqual({ key: 'beep' });
     expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
     const [label, callback] = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
     expect(label).toBe('wyjscie');
@@ -32,7 +34,7 @@ describe('buses triggers', () => {
 
   test('boarding trigger binds commands', () => {
     parse('dylizans powoli zatrzymuje sie.');
-    expect(client.playSound).not.toHaveBeenCalled();
+    expect(client.sendEvent).not.toHaveBeenCalledWith('sound:play', expect.anything());
     expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
     const [label, callback] = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
     expect(label).toBe('wem;wsiadz do dylizansu;wlm');

--- a/client/test/hpAlert.test.ts
+++ b/client/test/hpAlert.test.ts
@@ -5,14 +5,13 @@ import { EventEmitter } from 'events';
 class FakeClient {
   private emitter = new EventEmitter();
   println = jest.fn();
-  playSound = jest.fn();
   notify = jest.fn();
   addEventListener(event: string, cb: any) {
     this.emitter.on(event, cb);
   }
-  sendEvent(type: string, detail?: any) {
+  sendEvent = jest.fn((type: string, detail?: any) => {
     this.emitter.emit(type, { detail });
-  }
+  });
 }
 
 describe('hp alert', () => {
@@ -33,7 +32,9 @@ describe('hp alert', () => {
   test('beeps and prints when hp drops to configured threshold', () => {
     send(3);
     send(1);
-    expect(client.playSound).toHaveBeenCalledTimes(1);
+    const beepCalls = client.sendEvent.mock.calls.filter(call => call[0] === 'sound:play');
+    expect(beepCalls).toHaveLength(1);
+    expect(beepCalls[0][1]).toEqual({ key: 'beep' });
     const plain = 'Jestes ciezko ranny';
     const msg = colorString(plain, color);
     expect(client.println).toHaveBeenCalledWith(`\n\n${msg}\n\n`);
@@ -44,7 +45,11 @@ describe('hp alert', () => {
     send(2);
     send(1);
     send(0);
-    expect(client.playSound).toHaveBeenCalledTimes(2);
+    const beepCalls = client.sendEvent.mock.calls.filter(call => call[0] === 'sound:play');
+    expect(beepCalls).toHaveLength(2);
+    beepCalls.forEach(call => {
+      expect(call[1]).toEqual({ key: 'beep' });
+    });
     const first = colorString('Jestes ciezko ranny', color);
     const second = colorString('Jestes ledwo zywy', color);
     expect(client.println).toHaveBeenNthCalledWith(1, `\n\n${first}\n\n`);
@@ -56,10 +61,10 @@ describe('hp alert', () => {
   test('does not trigger when hp rises', () => {
     send(2);
     client.println.mockClear();
-    client.playSound.mockClear();
+    client.sendEvent.mockClear();
     client.notify.mockClear();
     send(4);
-    expect(client.playSound).not.toHaveBeenCalled();
+    expect(client.sendEvent).not.toHaveBeenCalledWith('sound:play', expect.anything());
     expect(client.println).not.toHaveBeenCalled();
     expect(client.notify).not.toHaveBeenCalled();
   });
@@ -68,7 +73,7 @@ describe('hp alert', () => {
     client.sendEvent('settings', { lowHpAlert: 0 });
     send(3);
     send(1);
-    expect(client.playSound).not.toHaveBeenCalled();
+    expect(client.sendEvent).not.toHaveBeenCalledWith('sound:play', expect.anything());
     expect(client.println).not.toHaveBeenCalled();
     expect(client.notify).not.toHaveBeenCalled();
   });
@@ -77,7 +82,9 @@ describe('hp alert', () => {
     client.sendEvent('settings', { lowHpAlert: 3 });
     send(4);
     send(2);
-    expect(client.playSound).toHaveBeenCalledTimes(1);
+    const beepCalls = client.sendEvent.mock.calls.filter(call => call[0] === 'sound:play');
+    expect(beepCalls).toHaveLength(1);
+    expect(beepCalls[0][1]).toEqual({ key: 'beep' });
     const plain = 'Jestes w zlej kondycji';
     const msg = colorString(plain, color);
     expect(client.println).toHaveBeenCalledWith(`\n\n${msg}\n\n`);

--- a/client/test/lamp.test.ts
+++ b/client/test/lamp.test.ts
@@ -9,10 +9,10 @@ jest.mock('../src/scripts/bagManager', () => ({
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
   FunctionalBind = { set: jest.fn(), clear: jest.fn(), newMessage: jest.fn() };
-  playSound = jest.fn();
   println = jest.fn();
   aliases: { pattern: RegExp; callback: Function }[] = [];
   sendCommand = jest.fn();
+  sendEvent = jest.fn();
 }
 
 describe('lamp triggers', () => {

--- a/client/test/noWeaponAlert.test.ts
+++ b/client/test/noWeaponAlert.test.ts
@@ -4,7 +4,7 @@ import { colorString, findClosestColor } from '../src/Colors';
 
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
-  playSound = jest.fn();
+  sendEvent = jest.fn();
   println = jest.fn();
 }
 
@@ -27,7 +27,7 @@ describe('no weapon alert', () => {
 
   test('prints colored message on match', () => {
     parse('Probujesz trafic Orka lewym piescia');
-    expect(client.playSound).not.toHaveBeenCalled();
+    expect(client.sendEvent).not.toHaveBeenCalledWith('sound:play', expect.anything());
     const expected = colorString(' >> Walczysz bez broni!', color);
     expect(client.println).toHaveBeenCalledWith(expected);
   });
@@ -36,11 +36,11 @@ describe('no weapon alert', () => {
     parse('Probujesz trafic Orka lewym piescia');
     jest.advanceTimersByTime(1000);
     parse('Ledwo muskasz Orka prawym kolanem');
-    expect(client.playSound).not.toHaveBeenCalled();
+    expect(client.sendEvent).not.toHaveBeenCalledWith('sound:play', expect.anything());
     expect(client.println).toHaveBeenCalledTimes(1);
     jest.advanceTimersByTime(5000);
     parse('Lekko ranisz Orka lewym stopa');
-    expect(client.playSound).not.toHaveBeenCalled();
+    expect(client.sendEvent).not.toHaveBeenCalledWith('sound:play', expect.anything());
     expect(client.println).toHaveBeenCalledTimes(2);
   });
 });

--- a/client/test/ships.test.ts
+++ b/client/test/ships.test.ts
@@ -4,7 +4,6 @@ import Triggers from '../src/Triggers';
 class FakeClient {
   Triggers = new Triggers(({} as unknown) as any);
   FunctionalBind = { set: jest.fn(), clear: jest.fn(), newMessage: jest.fn() };
-  playSound = jest.fn();
   sendEvent = jest.fn();
   sendCommand = jest.fn();
 }
@@ -23,7 +22,9 @@ describe('ships triggers', () => {
 
   test('boarding trigger binds command and beeps', () => {
     parse('Tratwa przybija do brzegu.');
-    expect(client.playSound).toHaveBeenCalledTimes(1);
+    const beepCalls = client.sendEvent.mock.calls.filter(call => call[0] === 'sound:play');
+    expect(beepCalls).toHaveLength(1);
+    expect(beepCalls[0][1]).toEqual({ key: 'beep' });
     expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
     const [label, callback] = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
     expect(label).toBe('wem;kup bilet;wsiadz na statek;wlm');
@@ -36,16 +37,16 @@ describe('ships triggers', () => {
 
   test('galeon boarding trigger binds command without beep', () => {
     parse('Wielki trojmasztowy galeon.', 'room.contents.object');
-    expect(client.playSound).not.toHaveBeenCalled();
+    expect(client.sendEvent).not.toHaveBeenCalledWith('sound:play', expect.anything());
     expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
     const [label] = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
     expect(label).toBe('wem;kup bilet;wsiadz na statek;wlm');
   });
 
   test('statki trigger binds without beep', () => {
-    client.playSound.mockClear();
+    client.sendEvent.mockClear();
     parse('Tajemniczy okret', 'room.contents.object');
-    expect(client.playSound).not.toHaveBeenCalled();
+    expect(client.sendEvent).not.toHaveBeenCalledWith('sound:play', expect.anything());
     expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
     const [label, callback] = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
     expect(label).toBe('wem;kup bilet;wsiadz na statek;wlm');
@@ -99,7 +100,9 @@ describe('ships triggers', () => {
 
   test('prom without punctuation binds and beeps', () => {
     parse('Szeroki zielony prom.');
-    expect(client.playSound).toHaveBeenCalledTimes(1);
+    const beepCalls = client.sendEvent.mock.calls.filter(call => call[0] === 'sound:play');
+    expect(beepCalls).toHaveLength(1);
+    expect(beepCalls[0][1]).toEqual({ key: 'beep' });
     expect(client.FunctionalBind.set).toHaveBeenCalledTimes(1);
     const [label] = (client.FunctionalBind.set as jest.Mock).mock.calls[0];
     expect(label).toBe('wem;kup bilet;wsiadz na statek;wlm');

--- a/client/test/userTriggers.test.ts
+++ b/client/test/userTriggers.test.ts
@@ -7,7 +7,7 @@ class FakeClient {
   addEventListener = jest.fn();
   removeEventListener = jest.fn();
   port = { postMessage: jest.fn() } as any;
-  playSound = jest.fn();
+  sendEvent = jest.fn();
   sendCommand = jest.fn();
 }
 
@@ -51,7 +51,7 @@ describe('userTriggers', () => {
     apply({ detail: { key: 'triggers', value: list } } as any);
     const result = client.Triggers.parseLine('foo', '');
     expect(result).toBe('foo');
-    expect(client.playSound).toHaveBeenCalledWith('beep');
+    expect(client.sendEvent).toHaveBeenCalledWith('sound:play', { key: 'beep' });
   });
 
   test('command sends command', () => {

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -961,6 +961,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 arkadiaClient.on('client.connect', sendCreds);
                 isConnecting = true;
                 updateConnectButtons();
+                void client.prepareSounds();
                 arkadiaClient.connect();
             } else {
                 sendCreds();
@@ -1130,6 +1131,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             isConnecting = true;
             updateConnectButtons();
+            void client.prepareSounds();
             arkadiaClient.connect();
         }
     };


### PR DESCRIPTION
## Summary
- introduce a dedicated `SoundManager` that lazily loads Howler and listens for `sound:play` events from the client event bus
- update client scripts to emit `sound:play` instead of calling `playSound`, keeping audio triggers reactive to events
- adjust unit tests to assert sound events rather than direct method calls

## Testing
- yarn --cwd client test
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_6900a64ffb00832a97e755a035d19a92