### PR TITLE
Mock magic data downloads in Playwright tests

### DIFF
--- a/web-client/e2e/gmcp-mock.spec.ts
+++ b/web-client/e2e/gmcp-mock.spec.ts
@@ -3,12 +3,16 @@ import {
     ensureGameSocket,
     GMCP_PATHS,
     installMockWebSocket,
+    mockMagicKeysDownload,
+    mockMagicsDownload,
     mockNpcDownload,
     pushGmcp,
     waitForClientReady,
 } from './support/mocks';
 
 test.beforeEach(async ({context}) => {
+    await mockMagicsDownload(context);
+    await mockMagicKeysDownload(context);
     await mockNpcDownload(context);
     await installMockWebSocket(context);
 });

--- a/web-client/e2e/magic-highlights.spec.ts
+++ b/web-client/e2e/magic-highlights.spec.ts
@@ -1,0 +1,67 @@
+import {expect, test} from '@playwright/test';
+import type {Page} from '@playwright/test';
+import {
+    ensureGameSocket,
+    installMockWebSocket,
+    mockMagicKeysDownload,
+    mockMagicsDownload,
+    mockNpcDownload,
+    pushText,
+    waitForClientReady,
+} from './support/mocks';
+
+async function waitForTokenTrigger(page: Page, tag: string): Promise<void> {
+    await page.waitForFunction((expectedTag) => {
+        const client: any = (window as any).clientExtension;
+        const triggers: any = client?.Triggers;
+        const tokenTriggers: any = triggers?.tokenTriggers;
+        if (!tokenTriggers || typeof tokenTriggers.values !== 'function') {
+            return false;
+        }
+        for (const bucket of Array.from(tokenTriggers.values())) {
+            if (Array.isArray(bucket) && bucket.some((entry) => entry?.trigger?.tag === expectedTag)) {
+                return true;
+            }
+        }
+        return false;
+    }, tag);
+}
+
+test.beforeEach(async ({context}) => {
+    await mockMagicsDownload(context);
+    await mockMagicKeysDownload(context);
+    await mockNpcDownload(context);
+    await installMockWebSocket(context);
+});
+
+test.describe('Magic and key highlights', () => {
+    test('colors magic items using configured palette', async ({page}) => {
+        await page.goto('/');
+        await waitForClientReady(page);
+        await ensureGameSocket(page);
+        await waitForTokenTrigger(page, 'magics');
+
+        await pushText(page, 'Na ziemi lezy magiczny miecz.');
+
+        const output = page.locator('#main_text_output_msg_wrapper');
+        await expect(output).toContainText('magiczny miecz');
+
+        const magicSpan = output.locator('span', { hasText: 'magiczny miecz' }).last();
+        await expect(magicSpan).toHaveCSS('color', 'rgb(223, 95, 95)');
+    });
+
+    test('colors magic keys using configured palette', async ({page}) => {
+        await page.goto('/');
+        await waitForClientReady(page);
+        await ensureGameSocket(page);
+        await waitForTokenTrigger(page, 'magicKeys');
+
+        await pushText(page, 'Sekretny klucz lezy tutaj.');
+
+        const output = page.locator('#main_text_output_msg_wrapper');
+        await expect(output).toContainText('Sekretny klucz');
+
+        const keySpan = output.locator('span', { hasText: 'Sekretny klucz' }).last();
+        await expect(keySpan).toHaveCSS('color', 'rgb(0, 255, 135)');
+    });
+});

--- a/web-client/e2e/multibind-import.spec.ts
+++ b/web-client/e2e/multibind-import.spec.ts
@@ -5,6 +5,8 @@ import {
     getMultibindRequests,
     installMockWebSocket,
     installMultibindWorkerMock,
+    mockMagicKeysDownload,
+    mockMagicsDownload,
     mockNpcDownload,
     queueMultibindResponse,
     waitForClientReady,
@@ -22,6 +24,8 @@ async function openBindsModal(page: Page) {
 }
 
 test.beforeEach(async ({context}) => {
+    await mockMagicsDownload(context);
+    await mockMagicKeysDownload(context);
     await mockNpcDownload(context);
     await installMockWebSocket(context);
     await installMultibindWorkerMock(context);

--- a/web-client/e2e/package-helper.spec.ts
+++ b/web-client/e2e/package-helper.spec.ts
@@ -4,6 +4,8 @@ import {
     getLastOutgoingCommand,
     GMCP_PATHS,
     installMockWebSocket,
+    mockMagicKeysDownload,
+    mockMagicsDownload,
     mockNpcDownload,
     pushGmcp,
     pushText,
@@ -11,6 +13,8 @@ import {
 } from './support/mocks';
 
 test.beforeEach(async ({context}) => {
+    await mockMagicsDownload(context);
+    await mockMagicKeysDownload(context);
     await mockNpcDownload(context);
     await installMockWebSocket(context);
 });

--- a/web-client/e2e/support/mocks.ts
+++ b/web-client/e2e/support/mocks.ts
@@ -189,15 +189,54 @@ export async function installMockWebSocket(context: BrowserContext): Promise<voi
 }
 
 const NPC_DATA_ROUTE = '**/arkadia-mapa/data/npc.json';
+const MAGICS_DATA_ROUTE = '**/magics_data.json';
+const MAGIC_KEYS_DATA_ROUTE = '**/magic_keys.json';
+
 const DEFAULT_NPC_DATA = [
     {name: 'Borgaf Kriegmann', loc: 200},
 ];
+
+const DEFAULT_MAGICS_DATA = {
+    magics: {
+        'ancient-blade': {regexps: ['magiczny miecz']},
+    },
+};
+
+const DEFAULT_MAGIC_KEYS_DATA = {
+    magic_keys: ['sekretny klucz'],
+};
 
 export async function mockNpcDownload(
     context: BrowserContext,
     data: {name: string; loc: number}[] = DEFAULT_NPC_DATA,
 ): Promise<void> {
     await context.route(NPC_DATA_ROUTE, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(data),
+        });
+    });
+}
+
+export async function mockMagicsDownload(
+    context: BrowserContext,
+    data: {magics: Record<string, {regexps?: string[]}>} = DEFAULT_MAGICS_DATA,
+): Promise<void> {
+    await context.route(MAGICS_DATA_ROUTE, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(data),
+        });
+    });
+}
+
+export async function mockMagicKeysDownload(
+    context: BrowserContext,
+    data: {magic_keys: string[]} = DEFAULT_MAGIC_KEYS_DATA,
+): Promise<void> {
+    await context.route(MAGIC_KEYS_DATA_ROUTE, async (route) => {
         await route.fulfill({
             status: 200,
             contentType: 'application/json',

--- a/web-client/e2e/ui-settings.spec.ts
+++ b/web-client/e2e/ui-settings.spec.ts
@@ -5,6 +5,8 @@ import {
     getEmbeddedCalls,
     installEmbeddedMock,
     installMockWebSocket,
+    mockMagicKeysDownload,
+    mockMagicsDownload,
     mockNpcDownload,
     resetEmbeddedCalls,
     waitForClientReady,
@@ -23,6 +25,8 @@ async function openUiSettings(page: Page) {
 }
 
 test.beforeEach(async ({context}) => {
+    await mockMagicsDownload(context);
+    await mockMagicKeysDownload(context);
     await mockNpcDownload(context);
     await installMockWebSocket(context);
     await installEmbeddedMock(context);


### PR DESCRIPTION
## Summary
- stub the magics and magic key fetches in Playwright via dedicated helpers to keep runs offline
- update existing e2e suites so every test uses the new magics and magic key mocks
- add a Playwright spec that asserts magic items and keys render with the expected highlight colors

## Testing
- yarn --cwd web-client test:e2e

------
https://chatgpt.com/codex/tasks/task_e_69013e494fa0832ab5ea53bbecf3dcee