### PR TITLE
Add map mocks for package helper E2E test

### DIFF
--- a/web-client/e2e/package-helper.spec.ts
+++ b/web-client/e2e/package-helper.spec.ts
@@ -2,46 +2,48 @@ import {expect, test} from '@playwright/test';
 import {
     ensureGameSocket,
     getLastOutgoingCommand,
-    GMCP_PATHS,
     installMockWebSocket,
+    mockMapDownloads,
     mockMagicKeysDownload,
     mockMagicsDownload,
     mockNpcDownload,
-    pushGmcp,
+    primeCharInfo,
     pushText,
     waitForClientReady,
+    waitForMapReady,
 } from './support/mocks';
 
 test.beforeEach(async ({context}) => {
+    await mockMapDownloads(context);
     await mockMagicsDownload(context);
     await mockMagicKeysDownload(context);
     await mockNpcDownload(context);
     await installMockWebSocket(context);
+    await primeCharInfo(context);
 });
 
 test('Package helper highlights NPCs and guides selected deliveries', async ({page}) => {
     await page.goto('/');
     await waitForClientReady(page);
     await ensureGameSocket(page);
-    await pushGmcp(page, GMCP_PATHS.CHAR_INFO, {name: 'Tester'});
+    await waitForMapReady(page);
+    await waitForClientReady(page);
 
     await page.evaluate(() => {
         const client: any = (window as any).clientExtension;
         client.contentWidth = 140;
-        client.Map.currentRoom = {id: 101};
+        client.Map.renderRoomByIdSilently?.(101);
         (window as any).__leadToEvents = [];
-        (window as any).__findPathCalls = [];
         window.addEventListener('leadTo', (event: any) => {
             (window as any).__leadToEvents.push(event.detail);
         });
-        client.Map.findPath = (from, to) => {
-            (window as any).__findPathCalls.push([from, to]);
-            if (from === 101 && to === 200) {
-                return [101, 150, 175, 200];
-            }
-            return null;
-        };
     });
+
+    const path = await page.evaluate(() => {
+        const client: any = (window as any).clientExtension;
+        return client.Map.findPath(101, 200);
+    });
+    expect(path).toEqual([101, 150, 175, 200]);
 
     const boardText = [
         'Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:',
@@ -91,27 +93,20 @@ test('Package helper highlights NPCs and guides selected deliveries', async ({pa
             return events.length ? events[events.length - 1] : null;
         });
     }).toBe(200);
-
-    await expect.poll(async () => {
-        return await page.evaluate(() => {
-            const calls = (window as any).__findPathCalls ?? [];
-            return calls.some((entry) => Array.isArray(entry) && entry[0] === 101 && entry[1] === 200);
-        });
-    }).toBe(true);
 });
 
 test('Package helper respects disabled setting and avoids assisting deliveries', async ({page}) => {
     await page.goto('/');
     await waitForClientReady(page);
     await ensureGameSocket(page);
-    await pushGmcp(page, GMCP_PATHS.CHAR_INFO, {name: 'Tester'});
+    await waitForMapReady(page);
+    await waitForClientReady(page);
 
     await page.evaluate(() => {
         const client: any = (window as any).clientExtension;
         client.contentWidth = 140;
-        client.Map.currentRoom = {id: 101};
+        client.Map.renderRoomByIdSilently?.(101);
         (window as any).__leadToEvents = [];
-        (window as any).__findPathCalls = [];
         window.addEventListener('leadTo', (event: any) => {
             (window as any).__leadToEvents.push(event.detail);
         });
@@ -179,12 +174,6 @@ test('Package helper respects disabled setting and avoids assisting deliveries',
     await expect
         .poll(async () => {
             return await page.evaluate(() => (window as any).__leadToEvents?.length ?? 0);
-        })
-        .toBe(0);
-
-    await expect
-        .poll(async () => {
-            return await page.evaluate(() => (window as any).__findPathCalls?.length ?? 0);
         })
         .toBe(0);
 });

--- a/web-client/e2e/support/mocks.ts
+++ b/web-client/e2e/support/mocks.ts
@@ -188,9 +188,259 @@ export async function installMockWebSocket(context: BrowserContext): Promise<voi
     });
 }
 
+export async function primeCharInfo(
+    context: BrowserContext,
+    data: {name: string} = {name: 'Tester'},
+): Promise<void> {
+    await context.addInitScript(([payload]) => {
+        const charInfo = payload;
+        const attemptSend = () => {
+            const client = (window as any).clientExtension;
+            if (client?.sendEvent) {
+                client.sendEvent('gmcp.char.info', charInfo);
+                return true;
+            }
+            return false;
+        };
+        if (!attemptSend()) {
+            const interval = setInterval(() => {
+                if (attemptSend()) {
+                    clearInterval(interval);
+                }
+            }, 50);
+        }
+    }, [data]);
+}
+
+type MockMapRoom = {
+    area: number;
+    x: number;
+    y: number;
+    z: number;
+    weight: number;
+    name: string;
+    rawSpecialExits: Record<string, unknown>;
+    symbol: string;
+    userData: Record<string, unknown>;
+    customLines: Record<string, unknown>;
+    stubs: unknown[];
+    doors: Record<string, unknown>;
+    id: number;
+    env: number;
+    exits: Record<string, number>;
+    specialExits: Record<string, unknown>;
+    hash: string;
+};
+
+type MockMapArea = {
+    areaName: string;
+    areaId: string;
+    rooms: MockMapRoom[];
+    labels: unknown[];
+};
+
+type MockMapData = MockMapArea[];
+
+type MockMapColor = {
+    envId: number;
+    colors: [number, number, number];
+};
+
+const MAP_DATA_ROUTE = '**/arkadia-mapa/data/mapExport.json';
+const MAP_COLORS_ROUTE = '**/arkadia-mapa/data/colors.json';
 const NPC_DATA_ROUTE = '**/arkadia-mapa/data/npc.json';
 const MAGICS_DATA_ROUTE = '**/magics_data.json';
 const MAGIC_KEYS_DATA_ROUTE = '**/magic_keys.json';
+
+const DEFAULT_MAP_DATA: MockMapData = [
+    {
+        areaName: 'Miasteczko Poslan',
+        areaId: 'area-1',
+        rooms: [
+            {
+                area: 1,
+                x: 0,
+                y: 0,
+                z: 0,
+                weight: 1,
+                name: 'Poczta',
+                rawSpecialExits: {},
+                symbol: '',
+                userData: {},
+                customLines: {},
+                stubs: [],
+                doors: {},
+                id: 101,
+                env: 1,
+                exits: {
+                    east: 150,
+                },
+                specialExits: {},
+                hash: '0:0:0:Miasteczko Poslan',
+            },
+            {
+                area: 1,
+                x: 1,
+                y: 0,
+                z: 0,
+                weight: 1,
+                name: 'Rynek',
+                rawSpecialExits: {},
+                symbol: '',
+                userData: {},
+                customLines: {},
+                stubs: [],
+                doors: {},
+                id: 150,
+                env: 1,
+                exits: {
+                    west: 101,
+                    east: 175,
+                },
+                specialExits: {},
+                hash: '1:0:0:Miasteczko Poslan',
+            },
+            {
+                area: 1,
+                x: 2,
+                y: 0,
+                z: 0,
+                weight: 1,
+                name: 'Kamienny Most',
+                rawSpecialExits: {},
+                symbol: '',
+                userData: {},
+                customLines: {},
+                stubs: [],
+                doors: {},
+                id: 175,
+                env: 1,
+                exits: {
+                    west: 150,
+                    north: 200,
+                    south: 300,
+                },
+                specialExits: {},
+                hash: '2:0:0:Miasteczko Poslan',
+            },
+            {
+                area: 1,
+                x: 2,
+                y: -1,
+                z: 0,
+                weight: 1,
+                name: 'Rezydencja Borgafa',
+                rawSpecialExits: {},
+                symbol: '',
+                userData: {},
+                customLines: {},
+                stubs: [],
+                doors: {},
+                id: 200,
+                env: 1,
+                exits: {
+                    south: 175,
+                },
+                specialExits: {},
+                hash: '2:1:0:Miasteczko Poslan',
+            },
+            {
+                area: 1,
+                x: 4,
+                y: 4,
+                z: 0,
+                weight: 1,
+                name: 'Opuszczona Altana',
+                rawSpecialExits: {},
+                symbol: '',
+                userData: {},
+                customLines: {},
+                stubs: [],
+                doors: {},
+                id: 999,
+                env: 1,
+                exits: {},
+                specialExits: {},
+                hash: '4:4:0:Miasteczko Poslan',
+            },
+        ],
+        labels: [],
+    },
+    {
+        areaName: 'Zapomniane Jaskinie',
+        areaId: 'area-2',
+        rooms: [
+            {
+                area: 2,
+                x: 0,
+                y: 1,
+                z: 0,
+                weight: 1,
+                name: 'Wejscie do Jaskin',
+                rawSpecialExits: {},
+                symbol: '',
+                userData: {},
+                customLines: {},
+                stubs: [],
+                doors: {},
+                id: 300,
+                env: 2,
+                exits: {
+                    north: 175,
+                    east: 400,
+                },
+                specialExits: {},
+                hash: '0:1:0:Zapomniane Jaskinie',
+            },
+            {
+                area: 2,
+                x: 1,
+                y: 1,
+                z: 0,
+                weight: 1,
+                name: 'Podziemna Sala',
+                rawSpecialExits: {},
+                symbol: '',
+                userData: {},
+                customLines: {},
+                stubs: [],
+                doors: {},
+                id: 400,
+                env: 2,
+                exits: {
+                    west: 300,
+                },
+                specialExits: {},
+                hash: '1:1:0:Zapomniane Jaskinie',
+            },
+            {
+                area: 2,
+                x: -2,
+                y: -1,
+                z: 0,
+                weight: 1,
+                name: 'Zapomniana Komnata',
+                rawSpecialExits: {},
+                symbol: '',
+                userData: {},
+                customLines: {},
+                stubs: [],
+                doors: {},
+                id: 500,
+                env: 2,
+                exits: {},
+                specialExits: {},
+                hash: '2:1:0:Zapomniane Jaskinie',
+            },
+        ],
+        labels: [],
+    },
+];
+
+const DEFAULT_MAP_COLORS: MockMapColor[] = [
+    {envId: 1, colors: [80, 160, 80]},
+    {envId: 2, colors: [80, 80, 160]},
+];
 
 const DEFAULT_NPC_DATA = [
     {name: 'Borgaf Kriegmann', loc: 200},
@@ -205,6 +455,30 @@ const DEFAULT_MAGICS_DATA = {
 const DEFAULT_MAGIC_KEYS_DATA = {
     magic_keys: ['sekretny klucz'],
 };
+
+export async function mockMapDownloads(
+    context: BrowserContext,
+    options: {mapData?: MockMapData; colorsData?: MockMapColor[]} = {},
+): Promise<void> {
+    const mapData = options.mapData ?? DEFAULT_MAP_DATA;
+    const colorsData = options.colorsData ?? DEFAULT_MAP_COLORS;
+
+    await context.route(MAP_DATA_ROUTE, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(mapData),
+        });
+    });
+
+    await context.route(MAP_COLORS_ROUTE, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(colorsData),
+        });
+    });
+}
 
 export async function mockNpcDownload(
     context: BrowserContext,
@@ -248,6 +522,7 @@ export async function mockMagicKeysDownload(
 export async function waitForClientReady(page: Page): Promise<void> {
     await page.waitForFunction(() => Boolean((window as any).clientExtension));
     await page.waitForFunction(() => Array.isArray((window as any).__mockSockets) && (window as any).__mockSockets.length > 0);
+    await page.waitForFunction(() => typeof (window as any).__pushGmcp === 'function');
 
     const overlay = page.locator('#auth-overlay');
     if (await overlay.isVisible()) {
@@ -282,7 +557,19 @@ export async function waitForClientReady(page: Page): Promise<void> {
     });
 }
 
+export async function waitForMapReady(page: Page): Promise<void> {
+    await page.waitForFunction(() => {
+        const client = (window as any).clientExtension;
+        if (!client || !client.Map) {
+            return false;
+        }
+        const map = client.Map as {pathFinder?: unknown; findPath?: unknown};
+        return Boolean(map.pathFinder && typeof map.findPath === 'function');
+    });
+}
+
 export async function pushGmcp(page: Page, path: string, payload: unknown): Promise<void> {
+    await page.waitForFunction(() => typeof (window as any).__pushGmcp === 'function');
     await page.evaluate(([gmcpPath, data]) => {
         (window as any).__pushGmcp(gmcpPath, data);
     }, [path, payload]);


### PR DESCRIPTION
## Summary
- mock map and colors downloads for E2E tests with deterministic data
- auto prime GMCP char info and wait for map readiness in Playwright helpers
- update package helper E2E specs to rely on real map paths instead of mocking

## Testing
- yarn --cwd web-client test:e2e -- package-helper.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_69014545b688832a91401192348f4c1e