### PR TITLE
Clarify Playwright assertion messages

### DIFF
--- a/web-client/e2e/gmcp-mock.spec.ts
+++ b/web-client/e2e/gmcp-mock.spec.ts
@@ -29,7 +29,10 @@ test.describe('GMCP-driven interactions', () => {
             const sockets: any[] = (window as any).__mockSockets ?? [];
             return sockets.map((socket) => socket?.url);
         });
-        expect(attemptedUrls.some((url: string | null | undefined) => typeof url === 'string' && url.includes('arkadia.rpg.pl'))).toBe(true);
+        expect(
+            attemptedUrls.some((url: string | null | undefined) => typeof url === 'string' && url.includes('arkadia.rpg.pl')),
+            'should attempt to connect to Arkadia GMCP endpoint'
+        ).toBe(true);
 
         await pushGmcp(page, GMCP_PATHS.CHAR_INFO, { name: 'Player', object_num: 100 });
         await pushGmcp(page, GMCP_PATHS.OBJECTS_DATA, {
@@ -40,21 +43,21 @@ test.describe('GMCP-driven interactions', () => {
         await pushGmcp(page, GMCP_PATHS.OBJECTS_NUMS, [100, 101, 102]);
 
         const teamMembers = page.locator('#objects-list .object-desc[data-teammate="true"]');
-        await expect(teamMembers).toHaveCount(1);
-        await expect(teamMembers.first()).toContainText('Scout');
+        await expect(teamMembers, 'should render a single teammate entry').toHaveCount(1);
+        await expect(teamMembers.first(), 'should show teammate name from GMCP data').toContainText('Scout');
 
         const shortcuts = page.locator('#objects-list .object-num');
-        await expect(shortcuts.first()).toContainText('A');
+        await expect(shortcuts.first(), 'should map teammate to shortcut key').toContainText('A');
 
         const content = page.locator('#objects-list .objects-list-content');
         const healthyBar = content.locator('span[style*="color:springgreen"]').filter({ hasText: '#######' });
-        await expect(healthyBar).toHaveCount(1);
+        await expect(healthyBar, 'should show healthy teammate health bar').toHaveCount(1);
 
         const woundedBar = content.locator('span[style*="color:yellow"]').filter({ hasText: '####---' });
-        await expect(woundedBar).toHaveCount(1);
+        await expect(woundedBar, 'should show wounded opponent health bar').toHaveCount(1);
 
         const criticalBar = content.locator('span[style*="color:tomato"]').filter({ hasText: '##-----' });
-        await expect(criticalBar).toHaveCount(1);
+        await expect(criticalBar, 'should show critically wounded opponent health bar').toHaveCount(1);
     });
 
     test('removes enemies when they disappear from GMCP objects.nums', async ({page}) => {
@@ -79,9 +82,9 @@ test.describe('GMCP-driven interactions', () => {
         });
 
         const enemies = page.locator('#objects-list .object-desc').filter({ hasText: 'Goblin Scout' });
-        await expect(enemies).toHaveCount(1);
+        await expect(enemies, 'should render GMCP-listed enemy before removal').toHaveCount(1);
 
         await pushGmcp(page, GMCP_PATHS.OBJECTS_NUMS, [200]);
-        await expect(enemies).toHaveCount(0);
+        await expect(enemies, 'should remove enemy when omitted from GMCP update').toHaveCount(0);
     });
 });

--- a/web-client/e2e/magic-highlights.spec.ts
+++ b/web-client/e2e/magic-highlights.spec.ts
@@ -46,10 +46,13 @@ test.describe('Magic and key highlights', () => {
         await pushText(page, 'Na ziemi lezy magiczny miecz.');
 
         const output = page.locator('#main_text_output_msg_wrapper');
-        await expect(output).toContainText('magiczny miecz');
+        await expect(output, 'should display magic item text in output').toContainText('magiczny miecz');
 
         const magicSpan = output.locator('span', { hasText: 'magiczny miecz' }).last();
-        await expect(magicSpan).toHaveCSS('color', 'rgb(223, 95, 95)');
+        await expect(magicSpan, 'should style magic item text using configured palette').toHaveCSS(
+            'color',
+            'rgb(223, 95, 95)'
+        );
     });
 
     test('colors magic keys using configured palette', async ({page}) => {
@@ -61,9 +64,12 @@ test.describe('Magic and key highlights', () => {
         await pushText(page, 'Sekretny klucz lezy tutaj.');
 
         const output = page.locator('#main_text_output_msg_wrapper');
-        await expect(output).toContainText('Sekretny klucz');
+        await expect(output, 'should display magic key text in output').toContainText('Sekretny klucz');
 
         const keySpan = output.locator('span', { hasText: 'Sekretny klucz' }).last();
-        await expect(keySpan).toHaveCSS('color', 'rgb(0, 255, 135)');
+        await expect(keySpan, 'should style magic key text using configured palette').toHaveCSS(
+            'color',
+            'rgb(0, 255, 135)'
+        );
     });
 });

--- a/web-client/e2e/multibind-import.spec.ts
+++ b/web-client/e2e/multibind-import.spec.ts
@@ -20,7 +20,7 @@ async function openBindsModal(page: Page) {
     await page.click('#menu-button');
     await page.click('#binds-button');
     const modal = page.locator('#binds-modal');
-    await expect(modal).toBeVisible();
+    await expect(modal, 'should display binds modal after navigation').toBeVisible();
     return modal;
 }
 
@@ -61,28 +61,31 @@ test.describe('Multibind import', () => {
         const importModal = page.locator('.modal.show').filter({
             has: page.locator('.modal-title:has-text("Importuj bazę multibindów")'),
         });
-        await expect(importModal).toBeVisible();
-        await expect(importModal).toContainText('Łącznie wierszy: 5');
-        await expect(importModal).toContainText('Wiersze do importu: 3');
-        await expect(importModal).toContainText('Nowe wpisy: 3');
-        await expect(importModal).toContainText('Aktualizacje: 0');
-        await expect(importModal).toContainText('Pominięte: 2');
-        await expect(importModal).toContainText('Nieprawidłowe wiersze: 1');
-        await expect(importModal).toContainText('Usunięte konflikty: 1');
+        await expect(importModal, 'should show import summary modal').toBeVisible();
+        await expect(importModal, 'should summarize total rows to process').toContainText('Łącznie wierszy: 5');
+        await expect(importModal, 'should list rows selected for import').toContainText('Wiersze do importu: 3');
+        await expect(importModal, 'should count new entries to import').toContainText('Nowe wpisy: 3');
+        await expect(importModal, 'should report number of updates').toContainText('Aktualizacje: 0');
+        await expect(importModal, 'should report skipped rows').toContainText('Pominięte: 2');
+        await expect(importModal, 'should report invalid rows').toContainText('Nieprawidłowe wiersze: 1');
+        await expect(importModal, 'should report resolved conflicts').toContainText('Usunięte konflikty: 1');
 
         await importModal.getByRole('button', { name: 'Importuj' }).click();
-        await expect(importModal.getByText('Importowanie…')).toBeVisible();
-        await expect(importModal.getByText('Importowanie…')).not.toBeVisible({ timeout: 10_000 });
-        await expect(importModal.getByText('Import zakończony.')).toBeVisible();
-        await expect(importModal).toContainText('Nowe wpisy: 3');
-        await expect(importModal).toContainText('Zaktualizowane: 0');
-        await expect(importModal).toContainText('Pominięte: 2');
+        await expect(importModal.getByText('Importowanie…'), 'should show import in progress').toBeVisible();
+        await expect(importModal.getByText('Importowanie…'), 'should hide progress indicator after completion').not.toBeVisible({ timeout: 10_000 });
+        await expect(importModal.getByText('Import zakończony.'), 'should confirm import completion').toBeVisible();
+        await expect(importModal, 'should reiterate new entries count after import').toContainText('Nowe wpisy: 3');
+        await expect(importModal, 'should reiterate updated entries count after import').toContainText('Zaktualizowane: 0');
+        await expect(importModal, 'should reiterate skipped entries count after import').toContainText('Pominięte: 2');
 
         await importModal.getByRole('button', { name: 'Zamknij' }).click();
-        await expect(importModal).not.toBeVisible();
+        await expect(importModal, 'should close import modal after acknowledgement').not.toBeVisible();
 
         const requests = await getMultibindRequests(page);
-        expect(requests.some((request) => request?.type === 'parse')).toBe(true);
+        expect(
+            requests.some((request) => request?.type === 'parse'),
+            'should send parse request to multibind worker'
+        ).toBe(true);
 
         await page.evaluate(() => {
             const client: any = (window as any).clientExtension;
@@ -91,21 +94,21 @@ test.describe('Multibind import', () => {
         });
 
         const multiBinds = page.locator('#multi-binds');
-        await expect(multiBinds).toHaveClass(/active/);
+        await expect(multiBinds, 'should activate multi-bind list for current room').toHaveClass(/active/);
         const entries = multiBinds.locator('.multi-bind');
-        await expect(entries).toHaveCount(2);
-        await expect(entries.nth(0)).toContainText('[ALT+1]');
-        await expect(entries.nth(0)).toContainText('atak toporem');
-        await expect(entries.nth(1)).toContainText('[ALT+2]');
-        await expect(entries.nth(1)).toContainText('osloń mnie');
+        await expect(entries, 'should render entries for current room').toHaveCount(2);
+        await expect(entries.nth(0), 'should display hotkey for first multibind').toContainText('[ALT+1]');
+        await expect(entries.nth(0), 'should display action text for first multibind').toContainText('atak toporem');
+        await expect(entries.nth(1), 'should display hotkey for second multibind').toContainText('[ALT+2]');
+        await expect(entries.nth(1), 'should display action text for second multibind').toContainText('osloń mnie');
 
         await page.evaluate(() => {
             const client: any = (window as any).clientExtension;
             client.Map.currentRoom = { id: 200 } as any;
             client.eventTarget.emit('enterLocation', { id: 200, room: {} });
         });
-        await expect(entries).toHaveCount(1);
-        await expect(entries.first()).toContainText('skradanie');
+        await expect(entries, 'should update entries when entering different room').toHaveCount(1);
+        await expect(entries.first(), 'should show action for room-specific bind').toContainText('skradanie');
     });
 
     test('surfaced worker errors render an inline alert', async ({page}) => {
@@ -125,14 +128,17 @@ test.describe('Multibind import', () => {
         });
 
         const errorAlert = page.locator('#binds-modal .alert-danger');
-        await expect(errorAlert).toBeVisible();
-        await expect(errorAlert).toHaveText('Nie udało się sparsować bazy.');
-        await expect(triggerButton).toBeEnabled();
+        await expect(errorAlert, 'should display worker error alert').toBeVisible();
+        await expect(errorAlert, 'should show worker error message').toHaveText('Nie udało się sparsować bazy.');
+        await expect(triggerButton, 'should re-enable import trigger after failure').toBeEnabled();
 
         const multiBinds = page.locator('#multi-binds .multi-bind');
-        await expect(multiBinds).toHaveCount(0);
+        await expect(multiBinds, 'should not list multibinds when import fails').toHaveCount(0);
 
         const requests = await getMultibindRequests(page);
-        expect(requests.some((request) => request?.type === 'parse')).toBe(true);
+        expect(
+            requests.some((request) => request?.type === 'parse'),
+            'should still send parse request despite failure'
+        ).toBe(true);
     });
 });

--- a/web-client/e2e/package-helper.spec.ts
+++ b/web-client/e2e/package-helper.spec.ts
@@ -45,7 +45,7 @@ test('Package helper highlights NPCs and guides selected deliveries', async ({pa
         const client: any = (window as any).clientExtension;
         return client.Map.findPath(101, 200);
     });
-    expect(path).toEqual([101, 150, 175, 200]);
+    expect(path, 'should calculate path to selected delivery destination').toEqual([101, 150, 175, 200]);
 
     const boardText = [
         'Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:',
@@ -67,34 +67,40 @@ test('Package helper highlights NPCs and guides selected deliveries', async ({pa
         .filter({hasText: 'Borgaf Kriegmann'})
         .last();
 
-    await expect(boardMessage).toContainText('Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:');
-    await expect(boardMessage).toContainText('dystans: 3');
-    await expect(boardMessage).toContainText('dystans: --');
+    await expect(boardMessage, 'should display delivery board header').toContainText(
+        'Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:'
+    );
+    await expect(boardMessage, 'should indicate known NPC delivery distance').toContainText('dystans: 3');
+    await expect(boardMessage, 'should indicate unknown NPC delivery distance as unavailable').toContainText('dystans: --');
 
     const knownNpc = boardMessage.locator('span[data-output-clickable="true"]', {hasText: 'Borgaf Kriegmann'});
     const unknownNpc = boardMessage.locator('span[data-output-clickable="true"]', {hasText: 'Georg Blaskovitz'});
 
-    await expect(knownNpc).toHaveCSS('color', 'rgb(95, 175, 95)');
-    await expect(unknownNpc).toHaveCSS('color', 'rgb(168, 168, 168)');
+    await expect(knownNpc, 'should highlight known NPC name in green').toHaveCSS('color', 'rgb(95, 175, 95)');
+    await expect(unknownNpc, 'should gray out unknown NPC name').toHaveCSS('color', 'rgb(168, 168, 168)');
 
     await knownNpc.click();
 
-    await expect.poll(async () => {
-        return await getLastOutgoingCommand(page);
-    }).toBe('wybierz paczke 1');
+    await expect
+        .poll(async () => {
+            return await getLastOutgoingCommand(page);
+        }, {message: 'should send command selecting known NPC package'})
+        .toBe('wybierz paczke 1');
 
     await pushText(page, 'Uprzejmy urzednik przekazuje ci jakas paczke.');
 
     const status = page.locator('#package-status');
-    await expect(status).toBeVisible();
-    await expect(status).toHaveText('📦: Borgaf Kriegmann');
+    await expect(status, 'should reveal package status after collection').toBeVisible();
+    await expect(status, 'should show selected NPC in package status').toHaveText('📦: Borgaf Kriegmann');
 
-    await expect.poll(async () => {
-        return await page.evaluate(() => {
-            const events = (window as any).__leadToEvents ?? [];
-            return events.length ? events[events.length - 1] : null;
-        });
-    }).toBe(200);
+    await expect
+        .poll(async () => {
+            return await page.evaluate(() => {
+                const events = (window as any).__leadToEvents ?? [];
+                return events.length ? events[events.length - 1] : null;
+            });
+        }, {message: 'should trigger lead to event for target location'})
+        .toBe(200);
 });
 
 test('Package helper respects disabled setting and avoids assisting deliveries', async ({page}) => {
@@ -117,14 +123,14 @@ test('Package helper respects disabled setting and avoids assisting deliveries',
     const optionsModal = page.locator('#options-modal');
     await page.click('#menu-button');
     await page.click('#options-button');
-    await expect(optionsModal).toBeVisible();
+    await expect(optionsModal, 'should open options modal').toBeVisible();
 
     const packageHelperToggle = optionsModal.locator('#packageHelper');
-    await expect(packageHelperToggle).toBeChecked();
+    await expect(packageHelperToggle, 'should enable package helper by default').toBeChecked();
     await packageHelperToggle.uncheck();
 
     await optionsModal.locator('#options-save').click();
-    await expect(optionsModal).not.toBeVisible();
+    await expect(optionsModal, 'should close options modal after saving').not.toBeVisible();
 
     const boardText = [
         'Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:',
@@ -146,9 +152,14 @@ test('Package helper respects disabled setting and avoids assisting deliveries',
         .filter({hasText: 'Borgaf Kriegmann'})
         .last();
 
-    await expect(boardMessage).toContainText('Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:');
-    await expect(boardMessage).not.toContainText('dystans:');
-    await expect(boardMessage.locator('span[data-output-clickable="true"]')).toHaveCount(0);
+    await expect(boardMessage, 'should still display delivery board text').toContainText(
+        'Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:'
+    );
+    await expect(boardMessage, 'should not display distance annotations when helper disabled').not.toContainText('dystans:');
+    await expect(
+        boardMessage.locator('span[data-output-clickable="true"]'),
+        'should keep delivery NPCs non-clickable when helper disabled'
+    ).toHaveCount(0);
 
     await page.evaluate(async () => {
         const client: any = (window as any).clientExtension;
@@ -170,12 +181,12 @@ test('Package helper respects disabled setting and avoids assisting deliveries',
                 }
                 return Boolean(element.textContent?.trim());
             });
-        })
+        }, {message: 'should hide package status when helper disabled'})
         .toBe(false);
 
     await expect
         .poll(async () => {
             return await page.evaluate(() => (window as any).__leadToEvents?.length ?? 0);
-        })
+        }, {message: 'should not emit lead to events when helper disabled'})
         .toBe(0);
 });

--- a/web-client/e2e/people-highlights.spec.ts
+++ b/web-client/e2e/people-highlights.spec.ts
@@ -28,13 +28,13 @@ async function openGuildSettings(page: Page) {
     await page.click('#options-button');
 
     const optionsModal = page.locator('#options-modal');
-    await expect(optionsModal).toBeVisible();
+    await expect(optionsModal, 'should open options modal from menu').toBeVisible();
 
     const guildTab = optionsModal.locator('button', {hasText: 'Gildie'});
     await guildTab.click();
 
     const guildToggle = optionsModal.locator('#guild-CKN');
-    await expect(guildToggle).toBeEnabled();
+    await expect(guildToggle, 'should allow enabling guild highlight').toBeEnabled();
 
     return optionsModal;
 }
@@ -51,7 +51,7 @@ async function pushAndWaitForHighlight(
             .filter({hasText: PERSON_DESCRIPTION})
             .last();
         try {
-            await expect(entry).toContainText(expected, {timeout: 2000});
+            await expect(entry, 'should display expected guild suffix highlight').toContainText(expected, {timeout: 2000});
             return entry;
         } catch (error) {
             if (attempt === 9) {
@@ -75,8 +75,10 @@ async function pushAndWaitForNoHighlight(
             .filter({hasText: PERSON_DESCRIPTION})
             .last();
         try {
-            await expect(entry).toContainText(PERSON_DESCRIPTION, {timeout: 2000});
-            await expect(entry).not.toContainText(unexpected, {timeout: 2000});
+            await expect(entry, 'should display base person description').toContainText(PERSON_DESCRIPTION, {timeout: 2000});
+            await expect(entry, 'should not display unexpected highlight suffix').not.toContainText(unexpected, {
+                timeout: 2000,
+            });
             return entry;
         } catch (error) {
             if (attempt === 9) {
@@ -109,7 +111,7 @@ test.describe('People highlights', () => {
         await optionsModal.locator('#guild-color-enabled-CKN').check();
         await optionsModal.locator('#guild-color-CKN').fill('#00ff00');
         await optionsModal.locator('#options-save').click();
-        await expect(optionsModal).not.toBeVisible();
+        await expect(optionsModal, 'should close options modal after enabling highlights').not.toBeVisible();
 
         const allyDescription = await pushAndWaitForHighlight(
             page,
@@ -117,12 +119,12 @@ test.describe('People highlights', () => {
             PERSON_SUFFIX,
         );
         const allySuffix = allyDescription.locator('span', {hasText: PERSON_SUFFIX}).last();
-        await expect(allySuffix).toHaveCSS('color', 'rgb(0, 255, 0)');
+        await expect(allySuffix, 'should color ally suffix using configured highlight').toHaveCSS('color', 'rgb(0, 255, 0)');
 
         const optionsModalSecond = await openGuildSettings(page);
         await optionsModalSecond.locator('#guild-color-CKN').fill('#0000ff');
         await optionsModalSecond.locator('#options-save').click();
-        await expect(optionsModalSecond).not.toBeVisible();
+        await expect(optionsModalSecond, 'should close options modal after updating highlight color').not.toBeVisible();
 
         const updatedDescription = await pushAndWaitForHighlight(
             page,
@@ -130,7 +132,7 @@ test.describe('People highlights', () => {
             PERSON_SUFFIX,
         );
         const updatedSuffix = updatedDescription.locator('span', {hasText: PERSON_SUFFIX}).last();
-        await expect(updatedSuffix).toHaveCSS('color', 'rgb(0, 0, 255)');
+        await expect(updatedSuffix, 'should update ally suffix color after reconfiguration').toHaveCSS('color', 'rgb(0, 0, 255)');
 
         const optionsModalFinal = await openGuildSettings(page);
         const guildToggle = optionsModalFinal.locator('#guild-CKN');
@@ -142,14 +144,14 @@ test.describe('People highlights', () => {
             await colorToggle.uncheck();
         }
         await optionsModalFinal.locator('#options-save').click();
-        await expect(optionsModalFinal).not.toBeVisible();
+        await expect(optionsModalFinal, 'should close options modal after disabling highlights').not.toBeVisible();
 
         const neutralDescription = await pushAndWaitForNoHighlight(
             page,
             'Widzisz wysoki wojownik tutaj.',
             PERSON_NAME,
         );
-        await expect(neutralDescription).not.toContainText(PERSON_SUFFIX);
+        await expect(neutralDescription, 'should remove guild suffix once highlight disabled').not.toContainText(PERSON_SUFFIX);
     });
 
     test('marks enemy guild members in red until disabled', async ({page}) => {
@@ -158,9 +160,9 @@ test.describe('People highlights', () => {
         const optionsModal = await openGuildSettings(page);
         await optionsModal.locator('#enemy-guild-CKN').check();
         const guildColorToggle = optionsModal.locator('#guild-color-enabled-CKN');
-        await expect(guildColorToggle).toBeDisabled();
+        await expect(guildColorToggle, 'should prevent manual color selection for enemy highlight').toBeDisabled();
         await optionsModal.locator('#options-save').click();
-        await expect(optionsModal).not.toBeVisible();
+        await expect(optionsModal, 'should close options modal after configuring enemy highlight').not.toBeVisible();
 
         const enemyDescription = await pushAndWaitForHighlight(
             page,
@@ -168,18 +170,18 @@ test.describe('People highlights', () => {
             PERSON_SUFFIX,
         );
         const enemySuffix = enemyDescription.locator('span', {hasText: PERSON_SUFFIX}).last();
-        await expect(enemySuffix).toHaveCSS('color', 'rgb(255, 0, 0)');
+        await expect(enemySuffix, 'should color enemy suffix with warning color').toHaveCSS('color', 'rgb(255, 0, 0)');
 
         const optionsModalSecond = await openGuildSettings(page);
         await optionsModalSecond.locator('#enemy-guild-CKN').uncheck();
         await optionsModalSecond.locator('#options-save').click();
-        await expect(optionsModalSecond).not.toBeVisible();
+        await expect(optionsModalSecond, 'should close options modal after disabling enemy highlight').not.toBeVisible();
 
         const neutralDescription = await pushAndWaitForNoHighlight(
             page,
             'Widzisz wysoki wojownik tutaj.',
             PERSON_NAME,
         );
-        await expect(neutralDescription).not.toContainText(PERSON_SUFFIX);
+        await expect(neutralDescription, 'should remove enemy suffix once highlight disabled').not.toContainText(PERSON_SUFFIX);
     });
 });

--- a/web-client/e2e/ui-settings.spec.ts
+++ b/web-client/e2e/ui-settings.spec.ts
@@ -21,7 +21,7 @@ async function openUiSettings(page: Page) {
     await page.click(MENU_BUTTON);
     await page.click(UI_SETTINGS_BUTTON);
     const modal = page.locator(UI_MODAL);
-    await expect(modal).toBeVisible();
+    await expect(modal, 'should open UI settings modal').toBeVisible();
     return modal;
 }
 
@@ -96,7 +96,7 @@ test.describe('UI settings', () => {
         await ensureUnchecked('#ui-show-combat-timer');
 
         await modal.locator('#ui-settings-save').click();
-        await expect(modal).not.toBeVisible();
+        await expect(modal, 'should close UI settings modal after saving').not.toBeVisible();
 
         await page.waitForFunction(() => (window as any).__lastUiSettingsEvent !== null);
 
@@ -127,24 +127,27 @@ test.describe('UI settings', () => {
             };
         });
 
-        expect(styles.contentFontSize).toBe('24px');
-        expect(styles.charStateFontSize).toBe('24px');
-        expect(styles.objectsFontSize).toBe('20px');
-        expect(styles.objectsFontFamily).toBe('"Cascadia Mono", monospace');
-        expect(styles.contentBackground).toBe('rgb(18, 52, 86)');
-        expect(styles.splitBackground).toBe('rgb(18, 52, 86)');
-        expect(styles.footerMode).toBe('2');
-        expect(styles.combatTimerDisplay).toBe('none');
-        expect(styles.combatTimerEnabled).toBe('0');
-        expect(styles.bodyMapPosition).toBe('bottom');
-        expect(styles.contentMapPosition).toBe('bottom');
-        expect(styles.mapSize).toBe('40vh');
-        expect(styles.mobileButtonWidth).toBe('54px');
-        expect(styles.mobileButtonHeight).toBe('54px');
-        expect(styles.mobileButtonFont).toBe('21px');
+        expect(styles.contentFontSize, 'should apply content font size multiplier').toBe('24px');
+        expect(styles.charStateFontSize, 'should apply footer font size multiplier').toBe('24px');
+        expect(styles.objectsFontSize, 'should apply objects font size multiplier').toBe('20px');
+        expect(styles.objectsFontFamily, 'should apply configured font family').toBe('"Cascadia Mono", monospace');
+        expect(styles.contentBackground, 'should apply configured output background color').toBe('rgb(18, 52, 86)');
+        expect(styles.splitBackground, 'should sync split background with output background').toBe('rgb(18, 52, 86)');
+        expect(styles.footerMode, 'should persist selected footer mode').toBe('2');
+        expect(styles.combatTimerDisplay, 'should hide combat timer when disabled').toBe('none');
+        expect(styles.combatTimerEnabled, 'should mark combat timer disabled state').toBe('0');
+        expect(styles.bodyMapPosition, 'should update body map position data attribute').toBe('bottom');
+        expect(styles.contentMapPosition, 'should update content map position attribute').toBe('bottom');
+        expect(styles.mapSize, 'should apply configured map height').toBe('40vh');
+        expect(styles.mobileButtonWidth, 'should scale mobile button width').toBe('54px');
+        expect(styles.mobileButtonHeight, 'should scale mobile button height').toBe('54px');
+        expect(styles.mobileButtonFont, 'should scale mobile button font size').toBe('21px');
 
         const embeddedCalls = await getEmbeddedCalls(page);
-        expect(embeddedCalls).toEqual(
+        expect(
+            embeddedCalls,
+            'should invoke embedded client with updated UI configuration'
+        ).toEqual(
             expect.arrayContaining([
                 { method: 'setZoom', value: 0.5 },
                 { method: 'setExplorationMode', value: true },
@@ -157,7 +160,10 @@ test.describe('UI settings', () => {
         );
 
         const uiSettingsEvent = await page.evaluate(() => (window as any).__lastUiSettingsEvent);
-        expect(uiSettingsEvent).toEqual(
+        expect(
+            uiSettingsEvent,
+            'should emit uiSettings event reflecting applied preferences'
+        ).toEqual(
             expect.objectContaining({
                 mobileDirectionButtons: false,
                 hapticFeedback: false,


### PR DESCRIPTION
## Summary
- add descriptive labels to Playwright expectations across gmcp, magic highlight, multibind, package helper, people highlight, and UI settings e2e specs to clarify intent of each assertion

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_6901d6c0f224832a9941b93ab7f0535e