### PR TITLE
Prevent split scroll closing on text selection

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -261,7 +261,21 @@ outputWrapper.addEventListener('contextmenu', event => {
     handler.showContextMenu(items, event.clientX, event.clientY);
 });
 
-function closeHistoryScrollback() {
+function selectionWithin(element: HTMLElement, selection: Selection): boolean {
+    const { anchorNode, focusNode } = selection;
+    if (!anchorNode || !focusNode) {
+        return false;
+    }
+    return element.contains(anchorNode) && element.contains(focusNode);
+}
+
+function closeHistoryScrollback(event?: MouseEvent | TouchEvent) {
+    if (event instanceof MouseEvent && event.type === 'dblclick') {
+        const selection = window.getSelection();
+        if (selection && !selection.isCollapsed && selectionWithin(outputWrapper, selection)) {
+            return;
+        }
+    }
     outputWrapper.scrollTop = outputWrapper.scrollHeight;
 }
 


### PR DESCRIPTION
## Summary
- ignore double-click scrollback closing when text selection exists inside the output wrapper
- keep scrollback closing behavior for double taps and double-clicks without a selection

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_6901ec46eed0832a841f98b8ca53c3fa