### PR TITLE
Refactor e2e tests to reuse shared fixture

### DIFF
--- a/web-client/e2e/gmcp-mock.spec.ts
+++ b/web-client/e2e/gmcp-mock.spec.ts
@@ -1,25 +1,5 @@
-import {expect, test} from '@playwright/test';
-import {
-    ensureGameSocket,
-    GMCP_PATHS,
-    installMockWebSocket,
-    mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload,
-    mockPeopleDownload,
-    mockNpcDownload,
-    pushGmcp,
-    waitForClientReady,
-} from './support/mocks';
-
-test.beforeEach(async ({context}) => {
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await installMockWebSocket(context);
-});
+import {expect, test} from './support/test-fixture';
+import {ensureGameSocket, GMCP_PATHS, pushGmcp, waitForClientReady} from './support/mocks';
 
 test.describe('GMCP-driven interactions', () => {
     test('renders team members and leader from GMCP updates', async ({page}) => {

--- a/web-client/e2e/knowledge-details.spec.ts
+++ b/web-client/e2e/knowledge-details.spec.ts
@@ -1,27 +1,7 @@
-import {expect, test} from '@playwright/test';
-import {
-    ensureGameSocket,
-    installMockWebSocket,
-    mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload,
-    mockPeopleDownload,
-    mockNpcDownload,
-    pushText,
-    submitCommand,
-    waitForClientReady,
-} from './support/mocks';
+import {expect, test} from './support/test-fixture';
+import {ensureGameSocket, pushText, submitCommand, waitForClientReady} from './support/mocks';
 
 const KNOWLEDGE_ENTRY_TEXT = 'Byles w samym sercu zamku Drachenfels';
-
-test.beforeEach(async ({context}) => {
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await installMockWebSocket(context);
-});
 
 test.describe('Knowledge details', () => {
     test('builds report via /wiedza_buduj and displays popup', async ({page}) => {

--- a/web-client/e2e/magic-highlights.spec.ts
+++ b/web-client/e2e/magic-highlights.spec.ts
@@ -1,16 +1,6 @@
-import {expect, test} from '@playwright/test';
 import type {Page} from '@playwright/test';
-import {
-    ensureGameSocket,
-    installMockWebSocket,
-    mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload,
-    mockPeopleDownload,
-    mockNpcDownload,
-    pushText,
-    waitForClientReady,
-} from './support/mocks';
+import {expect, test} from './support/test-fixture';
+import {ensureGameSocket, pushText, waitForClientReady} from './support/mocks';
 
 async function waitForTokenTrigger(page: Page, tag: string): Promise<void> {
     await page.waitForFunction((expectedTag) => {
@@ -28,15 +18,6 @@ async function waitForTokenTrigger(page: Page, tag: string): Promise<void> {
         return false;
     }, tag);
 }
-
-test.beforeEach(async ({context}) => {
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await installMockWebSocket(context);
-});
 
 test.describe('Magic and key highlights', () => {
     test('colors magic items using configured palette', async ({page}) => {

--- a/web-client/e2e/multibind-import.spec.ts
+++ b/web-client/e2e/multibind-import.spec.ts
@@ -1,15 +1,9 @@
-import {expect, test} from '@playwright/test';
 import type {Page} from '@playwright/test';
+import {expect, test} from './support/test-fixture';
 import {
     ensureGameSocket,
     getMultibindRequests,
-    installMockWebSocket,
     installMultibindWorkerMock,
-    mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload,
-    mockPeopleDownload,
-    mockNpcDownload,
     queueMultibindResponse,
     waitForClientReady,
 } from './support/mocks';
@@ -26,12 +20,6 @@ async function openBindsModal(page: Page) {
 }
 
 test.beforeEach(async ({context}) => {
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await installMockWebSocket(context);
     await installMultibindWorkerMock(context);
 });
 

--- a/web-client/e2e/package-helper.spec.ts
+++ b/web-client/e2e/package-helper.spec.ts
@@ -1,14 +1,8 @@
-import {expect, test} from '@playwright/test';
+import {expect, test} from './support/test-fixture';
 import {
     ensureGameSocket,
     getLastOutgoingCommand,
-    installMockWebSocket,
     mockMapDownloads,
-    mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload,
-    mockPeopleDownload,
-    mockNpcDownload,
     primeCharInfo,
     pushText,
     submitCommand,
@@ -18,12 +12,6 @@ import {
 
 test.beforeEach(async ({context}) => {
     await mockMapDownloads(context);
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await installMockWebSocket(context);
     await primeCharInfo(context);
 });
 

--- a/web-client/e2e/people-highlights.spec.ts
+++ b/web-client/e2e/people-highlights.spec.ts
@@ -1,17 +1,6 @@
-import {expect, test} from '@playwright/test';
 import type {Page} from '@playwright/test';
-import {
-    ensureGameSocket,
-    installMockWebSocket,
-    mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload,
-    mockPeopleDownload,
-    mockNpcDownload,
-    primeCharInfo,
-    pushText,
-    waitForClientReady,
-} from './support/mocks';
+import {expect, test} from './support/test-fixture';
+import {ensureGameSocket, primeCharInfo, pushText, waitForClientReady} from './support/mocks';
 
 const PERSON_NAME = 'Aldous';
 const PERSON_DESCRIPTION = 'wysoki wojownik';
@@ -92,12 +81,6 @@ async function pushAndWaitForNoHighlight(
 }
 
 test.beforeEach(async ({context, page}) => {
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await installMockWebSocket(context);
     await primeCharInfo(context);
     await page.addInitScript(() => {
         localStorage.setItem('currentCharacter', 'Tester');

--- a/web-client/e2e/support/test-fixture.ts
+++ b/web-client/e2e/support/test-fixture.ts
@@ -1,0 +1,24 @@
+import {test as base} from '@playwright/test';
+import {
+    installMockWebSocket,
+    mockKnowledgeDownload,
+    mockMagicKeysDownload,
+    mockMagicsDownload,
+    mockPeopleDownload,
+    mockNpcDownload,
+} from './mocks';
+
+const test = base.extend({
+    context: async ({context}, use) => {
+        await mockMagicsDownload(context);
+        await mockMagicKeysDownload(context);
+        await mockNpcDownload(context);
+        await mockPeopleDownload(context);
+        await mockKnowledgeDownload(context);
+        await installMockWebSocket(context);
+        await use(context);
+    },
+});
+
+export {test};
+export {expect} from '@playwright/test';

--- a/web-client/e2e/ui-settings.spec.ts
+++ b/web-client/e2e/ui-settings.spec.ts
@@ -1,15 +1,9 @@
-import {expect, test} from '@playwright/test';
 import type {Page} from '@playwright/test';
+import {expect, test} from './support/test-fixture';
 import {
     ensureGameSocket,
     getEmbeddedCalls,
     installEmbeddedMock,
-    installMockWebSocket,
-    mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload,
-    mockPeopleDownload,
-    mockNpcDownload,
     resetEmbeddedCalls,
     waitForClientReady,
 } from './support/mocks';
@@ -27,12 +21,6 @@ async function openUiSettings(page: Page) {
 }
 
 test.beforeEach(async ({context}) => {
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await installMockWebSocket(context);
     await installEmbeddedMock(context);
 });
 


### PR DESCRIPTION
## Summary
- add a shared Playwright test fixture that preloads mock downloads and sockets
- update e2e specs to consume the shared fixture and keep per-suite setup minimal

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_6901fc0d394c832aa3b3bacaa20548e3