### PR TITLE
Add Playwright test for package helper character persistence

### DIFF
--- a/web-client/e2e/package-helper.spec.ts
+++ b/web-client/e2e/package-helper.spec.ts
@@ -2,10 +2,12 @@ import {expect, test} from './support/fixtures';
 import {
     ensureGameSocket,
     getLastOutgoingCommand,
+    pushGmcp,
     pushText,
     submitCommand,
     waitForClientReady,
     waitForMapReady,
+    GMCP_PATHS,
 } from './support/mocks';
 
 test('Package helper highlights NPCs and guides selected deliveries', async ({page}) => {
@@ -170,4 +172,121 @@ test('Package helper respects disabled setting and avoids assisting deliveries',
             return await page.evaluate(() => (window as any).__leadToEvents?.length ?? 0);
         }, {message: 'should not emit lead to events when helper disabled'})
         .toBe(0);
+});
+
+// Ensures the package helper remembers per-character preferences and toggles as characters change.
+test('Package helper persists disabled state per character and defaults for new characters', async ({page}) => {
+    await page.goto('/');
+    await waitForClientReady(page);
+    await ensureGameSocket(page);
+    await waitForMapReady(page);
+    await waitForClientReady(page);
+
+    await page.evaluate(() => {
+        const client: any = (window as any).clientExtension;
+        client.contentWidth = 140;
+        client.Map.renderRoomByIdSilently?.(1);
+        (window as any).__leadToEvents = [];
+        window.addEventListener('leadTo', (event: any) => {
+            (window as any).__leadToEvents.push(event.detail);
+        });
+    });
+
+    const boardText = [
+        'Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:',
+        ' o============================================================================o',
+        ' |                Adresat badz                     Cena          Czas na      |',
+        ' |               urzad pocztowy                  zl/sr/md      dostarczenie   |',
+        ' o -------------------------------------------------------------------------- o',
+        ' |   1. Borgaf Kriegmann                          0/ 4/ 2        nieogr.      |',
+        " | * 2. Georg Blaskovitz                        0/ 5/ 0        8 godzin     |",
+        ' o -------------------------------------------------------------------------- o',
+        ' |      Symbolem * oznaczono przesylki ciezkie.                               |',
+        ' o============================================================================o',
+    ].join('\n');
+
+    const renderBoard = async () => {
+        await pushText(page, boardText);
+        return page
+            .locator('#main_text_output_msg_wrapper .output_msg')
+            .filter({hasText: 'Borgaf Kriegmann'})
+            .last();
+    };
+
+    const optionsModal = page.locator('#options-modal');
+    await page.click('#menu-button');
+    await page.click('#options-button');
+    await expect(optionsModal, 'should open options modal').toBeVisible();
+
+    const packageHelperToggle = optionsModal.locator('#packageHelper');
+    await expect(packageHelperToggle, 'should start enabled for Tester').toBeChecked();
+    await packageHelperToggle.uncheck();
+    await optionsModal.locator('#options-save').click();
+    await expect(optionsModal, 'should close options modal after saving').not.toBeVisible();
+
+    let boardMessage = await renderBoard();
+    await expect(boardMessage, 'should show delivery board text for Tester').toContainText(
+        'Tablica zawiera liste adresatow przesylek, ktore mozesz tutaj pobrac:'
+    );
+    await expect(boardMessage, 'should hide helper annotations for Tester when disabled').not.toContainText('dystans:');
+    await expect(
+        boardMessage.locator('span[data-output-clickable="true"]'),
+        'should remove clickable NPCs for Tester when helper disabled'
+    ).toHaveCount(0);
+
+    await pushGmcp(page, GMCP_PATHS.CHAR_INFO, {name: 'Alt'});
+
+    boardMessage = await renderBoard();
+    await expect(boardMessage, 'should restore helper annotations for new character').toContainText('dystans:');
+    await expect(
+        boardMessage.locator('span[data-output-clickable="true"]'),
+        'should restore clickable NPCs for Alt by default'
+    ).toHaveCount(2);
+
+    await page.click('#menu-button');
+    await page.click('#options-button');
+    await expect(optionsModal, 'should reopen options modal for Alt').toBeVisible();
+
+    await expect(packageHelperToggle, 'should default to enabled for Alt').toBeChecked();
+    await packageHelperToggle.uncheck();
+    await optionsModal.locator('#options-save').click();
+    await expect(optionsModal, 'should close options modal for Alt after saving').not.toBeVisible();
+
+    boardMessage = await renderBoard();
+    await expect(boardMessage, 'should hide helper annotations for Alt after disabling').not.toContainText('dystans:');
+    await expect(
+        boardMessage.locator('span[data-output-clickable="true"]'),
+        'should remove clickable NPCs for Alt after disabling'
+    ).toHaveCount(0);
+
+    await pushGmcp(page, GMCP_PATHS.CHAR_INFO, {name: 'Tester'});
+
+    await page.click('#menu-button');
+    await page.click('#options-button');
+    await expect(optionsModal, 'should reopen options modal for Tester').toBeVisible();
+    await expect(packageHelperToggle, 'should remember disabled state for Tester').not.toBeChecked();
+    await optionsModal.locator('.btn-close').click();
+
+    boardMessage = await renderBoard();
+    await expect(boardMessage, 'should keep helper disabled for Tester without re-saving').not.toContainText('dystans:');
+    await expect(
+        boardMessage.locator('span[data-output-clickable="true"]'),
+        'should keep NPCs non-clickable for Tester without re-saving'
+    ).toHaveCount(0);
+
+    const [testerSettings, altSettings] = await page.evaluate(() => {
+        return [
+            localStorage.getItem('Tester:settings'),
+            localStorage.getItem('Alt:settings'),
+        ];
+    });
+
+    expect(testerSettings, 'should persist Tester settings in local storage').toBeTruthy();
+    expect(altSettings, 'should persist Alt settings in local storage').toBeTruthy();
+
+    const parsedTester = testerSettings ? JSON.parse(testerSettings) : {};
+    const parsedAlt = altSettings ? JSON.parse(altSettings) : {};
+
+    expect(parsedTester.packageHelper, 'should store disabled package helper for Tester').toBe(false);
+    expect(parsedAlt.packageHelper, 'should store disabled package helper for Alt').toBe(false);
 });


### PR DESCRIPTION
## Summary
- document character-specific package helper behavior within the existing e2e spec
- add a Playwright flow that toggles the helper off per character, swaps characters via GMCP, and validates localStorage persistence
- extend the spec imports to include GMCP helpers for character swapping

## Testing
- yarn --cwd web-client test:e2e package-helper.spec.ts *(fails: missing system dependencies for Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_69022bda69f8832ab525404bafb19de1