### PR TITLE
Refactor e2e tests to share common Playwright fixture

### DIFF
--- a/web-client/e2e/gmcp-mock.spec.ts
+++ b/web-client/e2e/gmcp-mock.spec.ts
@@ -1,26 +1,5 @@
-import {expect, test} from '@playwright/test';
-import {
-    ensureGameSocket,
-    GMCP_PATHS,
-    installMockWebSocket,
-    mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload,
-    mockPeopleDownload,
-    mockNpcDownload,
-    pushGmcp,
-    waitForClientReady, mockMapDownloads,
-} from './support/mocks';
-
-test.beforeEach(async ({context}) => {
-    await mockMapDownloads(context);
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await installMockWebSocket(context);
-});
+import {expect, test} from './support/fixtures';
+import {ensureGameSocket, GMCP_PATHS, pushGmcp, waitForClientReady} from './support/mocks';
 
 test.describe('GMCP-driven interactions', () => {
     test('renders team members and leader from GMCP updates', async ({page}) => {

--- a/web-client/e2e/knowledge-details.spec.ts
+++ b/web-client/e2e/knowledge-details.spec.ts
@@ -1,27 +1,12 @@
-import {expect, test} from '@playwright/test';
+import {expect, test} from './support/fixtures';
 import {
     ensureGameSocket,
-    installMockWebSocket,
-    mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload,
-    mockPeopleDownload,
-    mockNpcDownload,
     pushText,
     submitCommand,
     waitForClientReady,
 } from './support/mocks';
 
 const KNOWLEDGE_ENTRY_TEXT = 'Byles w samym sercu zamku Drachenfels';
-
-test.beforeEach(async ({context}) => {
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await installMockWebSocket(context);
-});
 
 test.describe('Knowledge details', () => {
     test('builds report via /wiedza_buduj and displays popup', async ({page}) => {

--- a/web-client/e2e/magic-highlights.spec.ts
+++ b/web-client/e2e/magic-highlights.spec.ts
@@ -1,16 +1,6 @@
-import {expect, test} from '@playwright/test';
+import {expect, test} from './support/fixtures';
 import type {Page} from '@playwright/test';
-import {
-    ensureGameSocket,
-    installMockWebSocket,
-    mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload,
-    mockPeopleDownload,
-    mockNpcDownload,
-    pushText,
-    waitForClientReady, mockMapDownloads,
-} from './support/mocks';
+import {ensureGameSocket, pushText, waitForClientReady} from './support/mocks';
 
 async function waitForTokenTrigger(page: Page, tag: string): Promise<void> {
     await page.waitForFunction((expectedTag) => {
@@ -28,16 +18,6 @@ async function waitForTokenTrigger(page: Page, tag: string): Promise<void> {
         return false;
     }, tag);
 }
-
-test.beforeEach(async ({context}) => {
-    await mockMapDownloads(context)
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await installMockWebSocket(context);
-});
 
 test.describe('Magic and key highlights', () => {
     test('colors magic items using configured palette', async ({page}) => {

--- a/web-client/e2e/mobile-buttons-drag.spec.ts
+++ b/web-client/e2e/mobile-buttons-drag.spec.ts
@@ -1,11 +1,6 @@
-import {Page, expect, test} from '@playwright/test';
-import {
-    ensureGameSocket, installMockWebSocket, mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload, mockMapDownloads,
-    mockNpcDownload, mockPeopleDownload,
-    waitForClientReady
-} from './support/mocks';
+import {expect, test} from './support/fixtures';
+import type {Page} from '@playwright/test';
+import {ensureGameSocket, waitForClientReady} from './support/mocks';
 
 type Orientation = 'portrait' | 'landscape';
 type StoredPosition = {x: number; y: number; origin: 'left' | 'right'};
@@ -266,16 +261,6 @@ async function dragAndAssertPersistence(page: Page, method: InputMethod) {
     expect(reloadedPosition.left, 'should restore stored horizontal position after reload').toBe(storedPosition.x);
     expect(reloadedPosition.top, 'should restore stored vertical position after reload').toBe(storedPosition.y);
 }
-
-test.beforeEach(async ({context}) => {
-    await mockMapDownloads(context)
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await installMockWebSocket(context);
-});
 
 test.describe('Mobile direction buttons drag', () => {
     const prepare = async ({page}: {page: Page}) => {

--- a/web-client/e2e/multibind-import.spec.ts
+++ b/web-client/e2e/multibind-import.spec.ts
@@ -1,17 +1,10 @@
-import {expect, test} from '@playwright/test';
+import {expect, test} from './support/fixtures';
 import type {Page} from '@playwright/test';
 import {
     ensureGameSocket,
     getMultibindRequests,
-    installMockWebSocket,
     installMultibindWorkerMock,
     submitCommand,
-    mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload,
-    mockMapDownloads,
-    mockPeopleDownload,
-    mockNpcDownload,
     queueMultibindResponse,
     waitForClientReady,
 } from './support/mocks';
@@ -34,13 +27,6 @@ async function closeBindsModal(page: Page) {
 }
 
 test.beforeEach(async ({context}) => {
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await mockMapDownloads(context);
-    await installMockWebSocket(context);
     await installMultibindWorkerMock(context);
 });
 

--- a/web-client/e2e/package-helper.spec.ts
+++ b/web-client/e2e/package-helper.spec.ts
@@ -1,14 +1,7 @@
-import {expect, test} from '@playwright/test';
+import {expect, test} from './support/fixtures';
 import {
     ensureGameSocket,
     getLastOutgoingCommand,
-    installMockWebSocket,
-    mockMapDownloads,
-    mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload,
-    mockPeopleDownload,
-    mockNpcDownload,
     primeCharInfo,
     pushText,
     submitCommand,
@@ -17,13 +10,6 @@ import {
 } from './support/mocks';
 
 test.beforeEach(async ({context}) => {
-    await mockMapDownloads(context);
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await installMockWebSocket(context);
     await primeCharInfo(context);
 });
 

--- a/web-client/e2e/people-highlights.spec.ts
+++ b/web-client/e2e/people-highlights.spec.ts
@@ -1,16 +1,10 @@
-import {expect, test} from '@playwright/test';
+import {expect, test} from './support/fixtures';
 import type {Page} from '@playwright/test';
 import {
     ensureGameSocket,
-    installMockWebSocket,
-    mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload,
-    mockPeopleDownload,
-    mockNpcDownload,
     primeCharInfo,
     pushText,
-    waitForClientReady, mockMapDownloads,
+    waitForClientReady,
 } from './support/mocks';
 
 const PERSON_NAME = 'Aldous';
@@ -92,13 +86,6 @@ async function pushAndWaitForNoHighlight(
 }
 
 test.beforeEach(async ({context, page}) => {
-    await mockMapDownloads(context);
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await installMockWebSocket(context);
     await primeCharInfo(context);
     await page.addInitScript(() => {
         localStorage.setItem('currentCharacter', 'Tester');

--- a/web-client/e2e/support/fixtures.ts
+++ b/web-client/e2e/support/fixtures.ts
@@ -1,0 +1,25 @@
+import {expect, test as base} from '@playwright/test';
+import {
+    installMockWebSocket,
+    mockKnowledgeDownload,
+    mockMagicKeysDownload,
+    mockMagicsDownload,
+    mockMapDownloads,
+    mockNpcDownload,
+    mockPeopleDownload,
+} from './mocks';
+
+const test = base.extend({
+    context: async ({context}, use) => {
+        await mockMapDownloads(context);
+        await mockMagicsDownload(context);
+        await mockMagicKeysDownload(context);
+        await mockNpcDownload(context);
+        await mockPeopleDownload(context);
+        await mockKnowledgeDownload(context);
+        await installMockWebSocket(context);
+        await use(context);
+    },
+});
+
+export {expect, test};

--- a/web-client/e2e/ui-settings.spec.ts
+++ b/web-client/e2e/ui-settings.spec.ts
@@ -1,17 +1,11 @@
-import {expect, test} from '@playwright/test';
+import {expect, test} from './support/fixtures';
 import type {Page} from '@playwright/test';
 import {
     ensureGameSocket,
     getEmbeddedCalls,
     installEmbeddedMock,
-    installMockWebSocket,
-    mockKnowledgeDownload,
-    mockMagicKeysDownload,
-    mockMagicsDownload,
-    mockPeopleDownload,
-    mockNpcDownload,
     resetEmbeddedCalls,
-    waitForClientReady, mockMapDownloads,
+    waitForClientReady,
 } from './support/mocks';
 
 const MENU_BUTTON = '#menu-button';
@@ -27,13 +21,6 @@ async function openUiSettings(page: Page) {
 }
 
 test.beforeEach(async ({context}) => {
-    await mockMapDownloads(context,)
-    await mockMagicsDownload(context);
-    await mockMagicKeysDownload(context);
-    await mockNpcDownload(context);
-    await mockPeopleDownload(context);
-    await mockKnowledgeDownload(context);
-    await installMockWebSocket(context);
     await installEmbeddedMock(context);
 });
 


### PR DESCRIPTION
## Summary
- add a shared Playwright test fixture that prepares mocked downloads and sockets
- update end-to-end specs to consume the shared fixture and keep only test-specific setup

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_690231668e34832abedab76b45fdc59c