### PR TITLE
Ensure desktop output clicks always focus input

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -607,9 +607,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
 
-            if (document.activeElement !== messageInput) {
-                messageInput.focus();
-            }
+            messageInput.focus();
         };
 
         if (window.PointerEvent) {


### PR DESCRIPTION
## Summary
- ensure desktop content area clicks always invoke focusing the message input so it regains focus even when already focused

## Testing
- yarn --cwd web-client test --runTestsByPath

------
https://chatgpt.com/codex/tasks/task_e_69027736a104832aade95f637fb2b9c1