### PR TITLE
Add Playwright coverage for user alias workflow

### DIFF
--- a/web-client/e2e/user-aliases.spec.ts
+++ b/web-client/e2e/user-aliases.spec.ts
@@ -35,7 +35,7 @@ test.describe('User aliases', () => {
 
         await patternInput.fill(aliasPattern);
         await commandInput.fill(aliasCommand);
-        await aliasesModal.getByRole('button', { name: 'Dodaj' }).click();
+        await aliasesModal.getByRole('button', { name: 'Dodaj', exact: true }).click();
 
         const createdAlias = aliasesModal.locator('.alias-list-item').filter({ hasText: aliasPattern });
         await expect(createdAlias, 'should list newly created alias entry').toContainText(aliasCommand);


### PR DESCRIPTION
## Summary
- add a Playwright end-to-end test that exercises creating a user alias through the UI
- verify the alias executes the mapped command and is persisted across reloads

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_69027ad44064832a82071e75f5b6166c