### PR TITLE
Prevent split view focus on output links

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -603,7 +603,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
 
-            if (target.closest('a, button, input, textarea, select')) {
+            if (target.closest('a, button, input, textarea, select, [data-output-clickable]')) {
                 return;
             }
 


### PR DESCRIPTION
## Summary
- treat output elements marked with `data-output-clickable` as interactive so they no longer trigger automatic message input focus

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_6902b710a28c832aad535285d6524304