### PR TITLE
Prevent split view from closing when clicking sticky history

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -607,6 +607,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
 
+            if (target.closest('#split-bottom')) {
+                return;
+            }
+
             messageInput.focus();
             setTimeout(() => {messageInput.focus()}, 1)
         };


### PR DESCRIPTION
## Summary
- stop focusing the message input when clicking inside the split view history
- keep the sticky history visible while interacting with the split view on desktop

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_6902c0137bc4832ab988c4fe3c41320e