### PR TITLE
Fix multibind button handling for alias actions

### DIFF
--- a/web-client/src/MultiBinds.ts
+++ b/web-client/src/MultiBinds.ts
@@ -1,4 +1,7 @@
-import ArkadiaClient from "./ArkadiaClient";
+interface MultiBindsClient {
+  on(event: "multibinds", handler: (payload: { list?: DisplayMultibind[] }) => void): void;
+  send(command: string): void;
+}
 
 interface DisplayMultibind {
   index: number;
@@ -9,7 +12,7 @@ interface DisplayMultibind {
 export default class MultiBinds {
   private container: HTMLElement | null;
 
-  constructor(private readonly client: ArkadiaClient) {
+  constructor(private readonly client: MultiBindsClient) {
     this.container = document.getElementById("multi-binds");
     this.client.on(
       "multibinds",
@@ -49,6 +52,15 @@ export default class MultiBinds {
         if (action.trim()) {
           wrapper.addEventListener("click", (event) => {
             event.preventDefault();
+            const clientExtension = (window as any).clientExtension as {
+              sendCommand?: (command: string) => Promise<void>;
+            } | undefined;
+
+            if (clientExtension?.sendCommand) {
+              void clientExtension.sendCommand(action);
+              return;
+            }
+
             this.client.send(action);
           });
         } else {

--- a/web-client/test/MultiBinds.test.ts
+++ b/web-client/test/MultiBinds.test.ts
@@ -1,0 +1,69 @@
+import MultiBinds from "../src/MultiBinds";
+
+describe("MultiBinds", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="multi-binds"></div>';
+  });
+
+  afterEach(() => {
+    delete (window as any).clientExtension;
+  });
+
+  it("uses clientExtension.sendCommand when available", () => {
+    const listeners: Record<string, (payload: unknown) => void> = {};
+    const client = {
+      on: (event: string, handler: (payload: unknown) => void) => {
+        listeners[event] = handler;
+      },
+      send: jest.fn(),
+    } as any;
+
+    const sendCommand = jest.fn().mockResolvedValue(undefined);
+    (window as any).clientExtension = { sendCommand };
+
+    new MultiBinds(client);
+
+    const payload = {
+      list: [
+        { index: 1, action: "=aliasRun", label: "ALT+1" },
+      ],
+    };
+
+    listeners.multibinds?.(payload);
+
+    const button = document.querySelector<HTMLButtonElement>("#multi-binds .multi-bind");
+    expect(button).not.toBeNull();
+    button!.click();
+
+    expect(sendCommand).toHaveBeenCalledWith("=aliasRun");
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it("falls back to ArkadiaClient.send when clientExtension is missing", () => {
+    const listeners: Record<string, (payload: unknown) => void> = {};
+    const send = jest.fn();
+    const client = {
+      on: (event: string, handler: (payload: unknown) => void) => {
+        listeners[event] = handler;
+      },
+      send,
+    } as any;
+
+    new MultiBinds(client);
+
+    const payload = {
+      list: [
+        { index: 2, action: "say hello", label: "ALT+2" },
+      ],
+    };
+
+    listeners.multibinds?.(payload);
+
+    const button = document.querySelector<HTMLButtonElement>("#multi-binds .multi-bind");
+    expect(button).not.toBeNull();
+    button!.click();
+
+    expect(send).toHaveBeenCalledWith("say hello");
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure multibind buttons call the extension's alias-aware command sender when available
- fall back to the Arkadia client send method when the extension is missing
- add unit coverage for both alias and fallback paths

## Testing
- yarn --cwd web-client test MultiBinds
- yarn --cwd client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_6903528934f0832ab061fe5fb75ba05b