### PR TITLE
Focus desktop command input after connecting

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -596,6 +596,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const enableNotificationsSettings = document.getElementById('ui-enable-notifications') as HTMLButtonElement | null;
     const contentArea = document.getElementById('content-area') as HTMLElement | null;
 
+    const focusCommandInputOnConnect = () => {
+        if (!messageInput) return;
+        const isMobileLike = window.innerWidth < 768 || isLikelyTouchDevice();
+        if (isMobileLike) return;
+        if (document.hidden) return;
+        messageInput.focus();
+    };
+    arkadiaClient.on('client.connect', focusCommandInputOnConnect);
+
     if (contentArea) {
         const focusMessageInput = (target: EventTarget | null) => {
             if (!target || !(target instanceof Element)) {


### PR DESCRIPTION
## Summary
- focus the command line input after connecting on desktop devices so players can type immediately

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_690376d9eab0832aa9530796541fc033