### PR TITLE
Allow full history traversal after sending command

### DIFF
--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -1238,7 +1238,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (historyIndex === -1) {
             currentInput = messageInput.value;
-            historySearchTerm = messageInput.value;
+            let searchTerm = messageInput.value;
+            const selectionStart = messageInput.selectionStart;
+            const selectionEnd = messageInput.selectionEnd;
+            if (
+                document.activeElement === messageInput &&
+                selectionStart !== null &&
+                selectionEnd !== null &&
+                selectionStart === 0 &&
+                selectionEnd === searchTerm.length
+            ) {
+                searchTerm = '';
+            }
+            historySearchTerm = searchTerm;
             historyMatches = computeHistoryMatches(historySearchTerm);
         } else if (!historyMatches.length && historySearchTerm !== null) {
             historyMatches = computeHistoryMatches(historySearchTerm);


### PR DESCRIPTION
## Summary
- reset the command history search term when the input text is fully selected
- allow freshly sent commands to traverse the entire history immediately

## Testing
- yarn --cwd web-client test

------
https://chatgpt.com/codex/tasks/task_e_6903c5d9d56c832a8d3f9cb197ca6a91