### PR TITLE
Fix mobile button long-press dragging on mobile

### DIFF
--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -2726,7 +2726,8 @@ body.mobile-command-radial-active {
   justify-content: center;
   align-items: center;
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.25);
-  touch-action: manipulation; /* Improve touch behavior */
+  touch-action: none; /* Allow long-press dragging without native gesture interference */
+  -webkit-touch-callout: none; /* Prevent iOS context menu during drag */
 }
 
 .mobile-button.empty {


### PR DESCRIPTION
## Summary
- prevent native touch gestures on individual mobile buttons so the direction pad can be dragged after a long press

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_6905017012b8832a9ea47d8dfcfe33e2