### PR TITLE
Clamp map zoom to minimum scale

### DIFF
--- a/web-client/src/embed.ts
+++ b/web-client/src/embed.ts
@@ -1,6 +1,8 @@
 import {MapReader, Renderer, PathFinder, Settings, RoomContextMenuEventDetail, LabelRenderMode} from "mudlet-map-renderer";
 import {getCurrentCharacter, getItemSync, setItemSync} from "@client/src/storage";
 
+const MIN_ZOOM = 0.01;
+
 const STORAGE_KEY = 'mapperRoomId';
 const VISITED_DB_NAME = 'ArkadiaVisitedRoomsDB';
 const VISITED_STORE_NAME = 'visitedRooms';
@@ -132,7 +134,7 @@ export class EmbeddedMap {
             }
         } catch {
         }
-        this.zoom = zoom;
+        this.zoom = this.clampZoom(zoom);
         if (transparentLabels) {
             labelRenderMode = 'data';
         }
@@ -182,8 +184,13 @@ export class EmbeddedMap {
     }
 
     private onZoom() {
-        let shouldSave = this.renderer.getZoom() !== this.zoom;
-        this.zoom = this.renderer.getZoom();
+        const rendererZoom = this.renderer.getZoom();
+        const clampedZoom = this.clampZoom(rendererZoom);
+        const shouldSave = clampedZoom !== this.zoom;
+        if (rendererZoom !== clampedZoom) {
+            this.renderer.setZoom(clampedZoom);
+        }
+        this.zoom = clampedZoom;
         if (shouldSave) {
             this.saveZoom();
         }
@@ -266,8 +273,16 @@ export class EmbeddedMap {
     }
 
     setZoom(zoom: number) {
-        this.zoom = zoom;
-        this.renderer.setZoom(zoom);
+        const clampedZoom = this.clampZoom(zoom);
+        this.zoom = clampedZoom;
+        this.renderer.setZoom(clampedZoom);
+    }
+
+    private clampZoom(zoom: number): number {
+        if (!Number.isFinite(zoom)) {
+            return MIN_ZOOM;
+        }
+        return zoom >= MIN_ZOOM ? zoom : MIN_ZOOM;
     }
 
     setInstantMove(on: boolean) {

--- a/web-client/src/uiSettings.ts
+++ b/web-client/src/uiSettings.ts
@@ -69,6 +69,24 @@ const defaultSettings: UiSettings = {
     customFontFamily: '',
 };
 
+const MIN_MAP_SCALE = 0.01;
+
+function clampMapScale(value: number): number {
+    if (!Number.isFinite(value)) {
+        return MIN_MAP_SCALE;
+    }
+    const normalized = Math.abs(value);
+    return normalized >= MIN_MAP_SCALE ? normalized : MIN_MAP_SCALE;
+}
+
+function normalizeMapScale(value: unknown, fallback = defaultSettings.mapScale): number {
+    const numericValue = typeof value === 'number' ? value : parseFloat(String(value));
+    if (!Number.isFinite(numericValue) || numericValue <= 0) {
+        return Math.max(fallback, MIN_MAP_SCALE);
+    }
+    return clampMapScale(numericValue);
+}
+
 const genericFontFamilyNames = new Set([
     'serif',
     'sans-serif',
@@ -177,6 +195,7 @@ function apply(settings: UiSettings) {
     const normalizedHref = customHref && /^https?:\/\//i.test(customHref) ? customHref : undefined;
     ensureFontLoaded(settings.fontFamily, normalizedHref);
     const resolvedFontFamily = resolveOutputFontFamily(settings.fontFamily, settings.customFontFamily ?? '');
+    const mapScale = normalizeMapScale(settings.mapScale);
     const contentArea = document.getElementById('content-area');
     if (contentArea) {
         contentArea.style.setProperty('--map-size', settings.mapHeight + 'vh');
@@ -261,7 +280,7 @@ function apply(settings: UiSettings) {
         div.style.gridAutoRows = baseRow * settings.buttonSize + 'px';
     });
     if ((window as any).embedded?.renderer) {
-        (window as any).embedded.setZoom?.(settings.mapScale);
+        (window as any).embedded.setZoom?.(mapScale);
         (window as any).embedded.setExplorationMode?.(settings.explorationMode);
         (window as any).embedded.refresh();
     }
@@ -307,10 +326,7 @@ async function load(): Promise<UiSettings> {
             parsed = raw as any;
         }
         if (raw || Object.keys(parsed).length > 0) {
-            const mapScale = (() => {
-                const value = Math.abs(parseFloat(parsed.mapScale));
-                return value > 0 ? value : defaultSettings.mapScale;
-            })();
+            const mapScale = normalizeMapScale(parsed.mapScale);
             const mapPosition = mapPositions.includes(parsed.mapPosition as MapPosition)
                 ? (parsed.mapPosition as MapPosition)
                 : defaultSettings.mapPosition;
@@ -577,8 +593,9 @@ export default async function initUiSettings() {
     });
 
     const updateMapScale = (scale: number) => {
-        mapInput.value = String(scale);
-        current = { ...current, mapScale: scale };
+        const normalizedScale = normalizeMapScale(scale, current.mapScale ?? defaultSettings.mapScale);
+        mapInput.value = String(normalizedScale);
+        current = { ...current, mapScale: normalizedScale };
     };
 
     const handleStorageChange = (changes: { [key: string]: { oldValue: any; newValue: any } }) => {
@@ -590,9 +607,7 @@ export default async function initUiSettings() {
         const scaleValue = typeof newValue.mapScale === 'number'
             ? newValue.mapScale
             : parseFloat(newValue.mapScale);
-        const normalizedScale = Number.isFinite(scaleValue) && scaleValue > 0
-            ? scaleValue
-            : defaultSettings.mapScale;
+        const normalizedScale = normalizeMapScale(scaleValue, current.mapScale ?? defaultSettings.mapScale);
         updateMapScale(normalizedScale);
     };
 
@@ -609,8 +624,7 @@ export default async function initUiSettings() {
 
     function read(): UiSettings {
         const mapScale = (() => {
-            const value = Math.abs(parseFloat(mapInput.value));
-            const scale = value > 0 ? value : defaultSettings.mapScale;
+            const scale = normalizeMapScale(mapInput.value);
             mapInput.value = String(scale);
             return scale;
         })();


### PR DESCRIPTION
## Summary
- enforce a minimum zoom level of 0.01 inside the embedded map renderer
- normalize map scale values loaded or saved through UI settings so they never drop below the minimum

## Testing
- yarn --cwd web-client test
- yarn --cwd web-client build

------
https://chatgpt.com/codex/tasks/task_e_690c6bd1b184832a92eceded2940ce03