### PR TITLE
Add builtin GMCP debugging plugin

### DIFF
--- a/src/client/PluginApi.ts
+++ b/src/client/PluginApi.ts
@@ -842,6 +842,26 @@ export class PluginApiImpl implements PluginApi {
     actions.className = "window-header-actions";
     actions.addEventListener("pointerdown", event => event.stopPropagation());
 
+    let isPinned = false;
+
+    const pinButton = document.createElement("button");
+    pinButton.type = "button";
+    pinButton.className = "window-pin-button";
+
+    const updatePinnedState = () => {
+      pinButton.classList.toggle("window-pin-button--active", isPinned);
+      overlay.classList.toggle("herb-overlay--pinned", isPinned);
+      pinButton.title = isPinned ? "Odepnij okno" : "Przypnij okno";
+    };
+
+    const togglePinned = () => {
+      isPinned = !isPinned;
+      updatePinnedState();
+    };
+
+    pinButton.addEventListener("click", togglePinned);
+    actions.appendChild(pinButton);
+
     const closeButton = document.createElement("button");
     closeButton.type = "button";
     closeButton.className = "btn-close";
@@ -926,7 +946,7 @@ export class PluginApiImpl implements PluginApi {
     let handle: PopupHandle;
 
     const overlayListener = (event: MouseEvent) => {
-      if (event.target === overlay) {
+      if (!isPinned && event.target === overlay) {
         closePopup();
       }
     };
@@ -953,6 +973,7 @@ export class PluginApiImpl implements PluginApi {
       window.removeEventListener("keydown", keyListener);
       overlay.removeEventListener("click", overlayListener);
       closeButton.removeEventListener("click", closeButtonListener);
+      pinButton.removeEventListener("click", togglePinned);
       overlay.remove();
       windowEl.remove();
       this.popupHandles.delete(handle);
@@ -976,6 +997,8 @@ export class PluginApiImpl implements PluginApi {
     document.body.appendChild(overlay);
     document.body.appendChild(windowEl);
     windowEl.focus();
+
+    updatePinnedState();
 
     this.popupHandles.add(handle);
 

--- a/src/client/PluginManager.ts
+++ b/src/client/PluginManager.ts
@@ -2,6 +2,9 @@ import type Client from '@client/Client'
 import type { Plugin, LoadedPlugin } from '@shared/types/Plugin'
 import { PluginApiImpl } from '@client/PluginApi'
 import eventBus from '@modules/core/eventBus'
+const builtinPluginLoaders: Record<string, () => Promise<any>> = {
+  'builtin:debugging': async () => import('./plugins/debuggingPlugin'),
+}
 
 /**
  * Manages external plugins and scripts
@@ -19,6 +22,24 @@ export class PluginManager {
    * Attempts to load as ES module first, falls back to legacy script injection
    */
   async loadPlugin(url: string): Promise<LoadedPlugin> {
+    if (url.startsWith('builtin:') && !builtinPluginLoaders[url]) {
+      const errorMessage = 'Unknown builtin plugin'
+      const plugin: LoadedPlugin = {
+        url,
+        status: 'error',
+        error: errorMessage,
+        loadedAt: Date.now(),
+        origin: 'builtin',
+      }
+      this.plugins.set(url, plugin)
+      eventBus.emit('plugin:error', { url, error: errorMessage })
+      return plugin
+    }
+
+    if (builtinPluginLoaders[url]) {
+      return this.loadBuiltinPlugin(url, builtinPluginLoaders[url])
+    }
+
     // Check if already loaded
     if (this.plugins.has(url)) {
       const existing = this.plugins.get(url)!
@@ -31,6 +52,7 @@ export class PluginManager {
       url,
       status: 'loading',
       loadedAt: Date.now(),
+      origin: 'external',
     }
     this.plugins.set(url, plugin)
 
@@ -83,6 +105,51 @@ export class PluginManager {
     }
 
     this.plugins.set(url, plugin)
+    return plugin
+  }
+
+  private async loadBuiltinPlugin(url: string, loader: () => Promise<any>): Promise<LoadedPlugin> {
+    if (this.plugins.has(url)) {
+      return this.plugins.get(url)!
+    }
+
+    const plugin: LoadedPlugin = {
+      url,
+      status: 'loading',
+      loadedAt: Date.now(),
+      origin: 'builtin',
+    }
+
+    this.plugins.set(url, plugin)
+
+    try {
+      const module = await loader()
+      const pluginModule = module?.default ?? module
+
+      if (!this.isPlugin(pluginModule)) {
+        throw new Error('Module does not implement Plugin interface')
+      }
+
+      const apiInstance = new PluginApiImpl(this.client)
+      plugin.apiInstance = apiInstance
+
+      const info = await pluginModule.init(apiInstance)
+      plugin.info = info
+      plugin.status = 'loaded'
+      plugin.instance = pluginModule
+
+      console.log(`[PluginManager] Builtin plugin loaded: ${info.name} v${info.version}`)
+      eventBus.emit('plugin:loaded', { url, info })
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      plugin.status = 'error'
+      plugin.error = `Init failed: ${errorMsg}`
+      console.error(`[PluginManager] Builtin plugin init failed for ${url}:`, error)
+      eventBus.emit('plugin:error', { url, error: errorMsg })
+    }
+
+    this.plugins.set(url, plugin)
+
     return plugin
   }
 

--- a/src/client/plugins/debuggingPlugin.ts
+++ b/src/client/plugins/debuggingPlugin.ts
@@ -78,7 +78,7 @@ export const debuggingPlugin: Plugin = {
       }
     }
 
-    const ensurePopupOpen = () => {
+    const openPopup = () => {
       if (popupHandle && popupHandle.element.isConnected) {
         popupHandle.element.focus()
         return
@@ -109,9 +109,7 @@ export const debuggingPlugin: Plugin = {
 
     api.events.on('gmcp', gmcpListener)
 
-    menuEntry = api.ui.addPopupMenuEntry('Debugging plugin', ensurePopupOpen)
-
-    ensurePopupOpen()
+    menuEntry = api.ui.addPopupMenuEntry('Debugging plugin', openPopup)
 
     teardown = () => {
       api.events.off('gmcp', gmcpListener)

--- a/src/client/plugins/debuggingPlugin.ts
+++ b/src/client/plugins/debuggingPlugin.ts
@@ -1,0 +1,146 @@
+import type { PopupHandle, PopupMenuEntryHandle } from '@client/PluginApi'
+import type { Plugin } from '@shared/types/Plugin'
+
+interface GmcpEventPayload {
+  path?: string
+  value?: unknown
+}
+
+const MAX_ENTRIES = 200
+
+function formatEntry({ path, value }: Required<Pick<GmcpEventPayload, 'path' | 'value'>>) {
+  const timestamp = new Date().toLocaleTimeString()
+  const json = (() => {
+    try {
+      return JSON.stringify(value, null, 2)
+    } catch (error) {
+      return `Nie udało się sformatować danych: ${String(error)}`
+    }
+  })()
+
+  return `[#${timestamp}] ${path}\n${json}`
+}
+
+let teardown: (() => void) | null = null
+
+export const debuggingPlugin: Plugin = {
+  async init(api) {
+    const entries: Required<Pick<GmcpEventPayload, 'path' | 'value'>>[] = []
+    let popupHandle: PopupHandle | null = null
+    let menuEntry: PopupMenuEntryHandle | null = null
+
+    const scrollContainer = document.createElement('div')
+    scrollContainer.style.height = '20rem'
+    scrollContainer.style.overflowY = 'auto'
+    scrollContainer.style.background = 'var(--bs-body-bg, #111)'
+    scrollContainer.style.border = '1px solid rgba(255, 255, 255, 0.1)'
+    scrollContainer.style.padding = '0.5rem'
+    scrollContainer.style.borderRadius = '0.25rem'
+
+    const logElement = document.createElement('pre')
+    logElement.className = 'debugging-plugin__log'
+    logElement.style.margin = '0'
+    logElement.style.whiteSpace = 'pre-wrap'
+    logElement.style.wordBreak = 'break-word'
+
+    scrollContainer.appendChild(logElement)
+
+    const container = document.createElement('div')
+    container.className = 'd-flex flex-column gap-2'
+
+    const description = document.createElement('p')
+    description.className = 'mb-0'
+    description.textContent = 'Nasłuchiwanie wszystkich zdarzeń GMCP. Najnowsze wpisy pojawiają się na końcu.'
+
+    const controls = document.createElement('div')
+    controls.className = 'd-flex gap-2 align-items-center'
+
+    const clearButton = document.createElement('button')
+    clearButton.type = 'button'
+    clearButton.className = 'btn btn-sm btn-secondary'
+    clearButton.textContent = 'Wyczyść'
+    clearButton.addEventListener('click', () => {
+      entries.length = 0
+      render()
+    })
+
+    controls.appendChild(clearButton)
+
+    container.appendChild(description)
+    container.appendChild(controls)
+    container.appendChild(scrollContainer)
+
+    const render = () => {
+      const shouldStickToBottom = Math.abs(scrollContainer.scrollTop - (scrollContainer.scrollHeight - scrollContainer.clientHeight)) < 4
+      logElement.textContent = entries.map(formatEntry).join('\n\n')
+      if (shouldStickToBottom) {
+        scrollContainer.scrollTop = scrollContainer.scrollHeight
+      }
+    }
+
+    const ensurePopupOpen = () => {
+      if (popupHandle && popupHandle.element.isConnected) {
+        popupHandle.element.focus()
+        return
+      }
+
+      popupHandle = api.ui.createPopup('Debugging plugin', container)
+      render()
+    }
+
+    const gmcpListener = ({ path, value }: GmcpEventPayload = {}) => {
+      if (!path) {
+        return
+      }
+
+      entries.push({ path, value })
+      if (entries.length > MAX_ENTRIES) {
+        entries.splice(0, entries.length - MAX_ENTRIES)
+      }
+
+      if (popupHandle && !popupHandle.element.isConnected) {
+        popupHandle = null
+      }
+
+      if (popupHandle) {
+        render()
+      }
+    }
+
+    api.events.on('gmcp', gmcpListener)
+
+    menuEntry = api.ui.addPopupMenuEntry('Debugging plugin', ensurePopupOpen)
+
+    ensurePopupOpen()
+
+    teardown = () => {
+      api.events.off('gmcp', gmcpListener)
+      if (popupHandle) {
+        if (popupHandle.element.isConnected) {
+          popupHandle.close()
+        }
+        popupHandle = null
+      }
+      if (menuEntry) {
+        menuEntry.remove()
+        menuEntry = null
+      }
+    }
+
+    return {
+      name: 'Debugging plugin',
+      version: '1.0.0',
+      description: 'Wyświetla w czasie rzeczywistym surowe wiadomości GMCP.',
+      author: 'Arkadia',
+    }
+  },
+
+  async destroy() {
+    if (teardown) {
+      teardown()
+      teardown = null
+    }
+  },
+}
+
+export default debuggingPlugin

--- a/src/client/scripts/externalScripts.ts
+++ b/src/client/scripts/externalScripts.ts
@@ -1,17 +1,23 @@
 import Client from "../Client";
 import { PluginManager } from "../PluginManager";
+import { BUILTIN_PLUGIN_ID_SET } from "@shared/constants/builtinPlugins";
 
 const STORAGE_KEY = "scripts";
+const BUILTIN_STORAGE_KEY = "builtinScripts";
 
 export default function initExternalScripts(client: Client) {
     // Create PluginManager instance
     const pluginManager = new PluginManager(client);
 
     let known: string[] = [];
+    let enabledBuiltins: string[] = [];
 
     const apply = async (list: string[] = []) => {
-        // Get currently loaded plugins
-        const currentlyLoaded = pluginManager.getLoadedPlugins().map(p => p.url);
+        // Get currently loaded external plugins
+        const currentlyLoaded = pluginManager
+            .getLoadedPlugins()
+            .filter(plugin => plugin.origin !== "builtin")
+            .map(p => p.url);
 
         // Unload plugins that are no longer in the list
         const toUnload = currentlyLoaded.filter(url => !list.includes(url));
@@ -20,6 +26,21 @@ export default function initExternalScripts(client: Client) {
         // Load new plugins
         const toLoad = list.filter(url => !pluginManager.isLoaded(url));
         await Promise.all(toLoad.map(url => pluginManager.loadPlugin(url)));
+    };
+
+    const applyBuiltins = async (list: string[] = []) => {
+        const validIds = list.filter(id => BUILTIN_PLUGIN_ID_SET.has(id));
+
+        const loadedBuiltinIds = pluginManager
+            .getLoadedPlugins()
+            .filter(plugin => plugin.origin === "builtin" && BUILTIN_PLUGIN_ID_SET.has(plugin.url))
+            .map(plugin => plugin.url);
+
+        const toUnload = loadedBuiltinIds.filter(id => !validIds.includes(id));
+        await Promise.all(toUnload.map(id => pluginManager.unloadPlugin(id)));
+
+        const toLoad = validIds.filter(id => !pluginManager.isLoaded(id));
+        await Promise.all(toLoad.map(id => pluginManager.loadPlugin(id)));
     };
 
     const param = new URLSearchParams(window.location.search).get("add-script");
@@ -49,10 +70,18 @@ export default function initExternalScripts(client: Client) {
             known = Array.isArray(value) ? value : [];
             apply(known);
         }
+
+        if (key === BUILTIN_STORAGE_KEY) {
+            enabledBuiltins = Array.isArray(value)
+                ? value.filter((id: unknown): id is string => typeof id === "string" && BUILTIN_PLUGIN_ID_SET.has(id))
+                : [];
+            applyBuiltins(enabledBuiltins);
+        }
     });
 
     client.on("port-connected", () => {
         checkParam();
+        applyBuiltins(enabledBuiltins);
     })
 
     // Return plugin manager for access by other modules

--- a/src/shared/constants/builtinPlugins.ts
+++ b/src/shared/constants/builtinPlugins.ts
@@ -1,0 +1,20 @@
+export interface BuiltinPluginDefinition {
+  /** Unique identifier used to reference the builtin plugin */
+  id: string
+  /** Display name shown in UI before plugin is loaded */
+  name: string
+  /** Short description of the builtin plugin */
+  description?: string
+}
+
+export const BUILTIN_PLUGIN_DEFINITIONS: BuiltinPluginDefinition[] = [
+  {
+    id: 'builtin:debugging',
+    name: 'Debugging plugin',
+    description: 'Wyświetla surowe zdarzenia GMCP w wyskakującym oknie.',
+  },
+]
+
+export const BUILTIN_PLUGIN_ID_SET = new Set(
+  BUILTIN_PLUGIN_DEFINITIONS.map(definition => definition.id),
+)

--- a/src/shared/types/Plugin.ts
+++ b/src/shared/types/Plugin.ts
@@ -56,4 +56,6 @@ export interface LoadedPlugin {
   scriptElement?: HTMLScriptElement
   /** Timestamp when plugin was loaded */
   loadedAt: number
+  /** Indicates if plugin originates from external URL or is bundled */
+  origin?: 'external' | 'builtin'
 }

--- a/src/web/options/Scripts.tsx
+++ b/src/web/options/Scripts.tsx
@@ -4,9 +4,11 @@ import { TiDelete } from "react-icons/ti";
 import storage from "@modules/core/storage";
 import { getPluginManager } from "@client/main";
 import type { LoadedPlugin } from "@shared/types/Plugin";
+import { BUILTIN_PLUGIN_DEFINITIONS } from "@shared/constants/builtinPlugins";
 
 function Scripts() {
     const [scripts, setScripts] = useState<string[]>([]);
+    const [builtinScripts, setBuiltinScripts] = useState<string[]>([]);
     const [pluginInfo, setPluginInfo] = useState<Map<string, LoadedPlugin>>(new Map());
     const [input, setInput] = useState("");
 
@@ -27,6 +29,15 @@ function Scripts() {
         storage.getItem("scripts").then(res => {
             if (res && Array.isArray(res.scripts)) {
                 setScripts(res.scripts);
+            }
+        });
+
+        storage.getItem("builtinScripts").then(res => {
+            if (res && Array.isArray(res.builtinScripts)) {
+                const valid = res.builtinScripts.filter((id: unknown): id is string => (
+                    typeof id === "string" && BUILTIN_PLUGIN_DEFINITIONS.some(def => def.id === id)
+                ));
+                setBuiltinScripts(valid);
             }
         });
 
@@ -56,6 +67,11 @@ function Scripts() {
         storage.setItem("scripts", list);
     }
 
+    function saveBuiltin(list: string[]) {
+        setBuiltinScripts(list);
+        storage.setItem("builtinScripts", list);
+    }
+
     function add() {
         const url = input.trim();
         if (!url) return;
@@ -71,8 +87,71 @@ function Scripts() {
         save(updated);
     }
 
+    function toggleBuiltin(id: string, enabled: boolean) {
+        if (enabled) {
+            if (!builtinScripts.includes(id)) {
+                const updated = [...builtinScripts, id];
+                saveBuiltin(updated);
+            }
+        } else {
+            if (builtinScripts.includes(id)) {
+                const updated = builtinScripts.filter(item => item !== id);
+                saveBuiltin(updated);
+            }
+        }
+    }
+
     return (
         <div className="m-2 d-flex flex-column gap-2">
+            <section>
+                <h6 className="text-uppercase text-muted small mb-2">Wbudowane pluginy</h6>
+                <ul className="list-unstyled ms-3">
+                    {BUILTIN_PLUGIN_DEFINITIONS.map(def => {
+                        const plugin = pluginInfo.get(def.id);
+                        const enabled = builtinScripts.includes(def.id);
+                        const isLoading = plugin?.status === 'loading';
+                        const hasError = plugin?.status === 'error';
+                        const info = plugin?.info;
+
+                        return (
+                            <li key={def.id} className="d-flex flex-column gap-1 mb-3">
+                                <div className="d-flex align-items-start gap-2">
+                                    <Form.Check
+                                        type="switch"
+                                        id={`builtin-${def.id}`}
+                                        checked={enabled}
+                                        onChange={event => toggleBuiltin(def.id, event.target.checked)}
+                                        label={(
+                                            <div className="d-flex flex-column">
+                                            <div className="d-flex align-items-center gap-2">
+                                                <strong>{info?.name ?? def.name}</strong>
+                                                {(info?.version) && (
+                                                    <Badge bg="primary" pill>v{info.version}</Badge>
+                                                )}
+                                                {info?.author && (
+                                                    <small className="text-muted">by {info.author}</small>
+                                                )}
+                                            </div>
+                                                {(info?.description ?? def.description) && (
+                                                    <small className="text-muted">
+                                                        {info?.description ?? def.description}
+                                                    </small>
+                                                )}
+                                            </div>
+                                        )}
+                                    />
+                                    {isLoading && <Spinner animation="border" size="sm" />}
+                                </div>
+                                {hasError && (
+                                    <small className="text-danger">
+                                        {plugin?.error}
+                                    </small>
+                                )}
+                            </li>
+                        );
+                    })}
+                </ul>
+            </section>
             <Form.Group className="d-flex align-items-center gap-2">
                 <Form.Control
                     type="text"


### PR DESCRIPTION
## Summary
- add a bundled "Debugging plugin" that streams GMCP events into a popup and integrates with the plugin manager
- expose bundled plugin metadata and extend scripts management to toggle built-in entries alongside external URLs
- ensure built-in selections persist via storage and update the plugin manager to recognize bundled sources

## Testing
- yarn test
- yarn build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e2821a6c0832ab48b328af1fcab33)