### PR TITLE
Prevent context menu on mobile devices

### DIFF
--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -303,6 +303,10 @@ outputWrapper.addEventListener('contextmenu', event => {
     if (event.defaultPrevented) {
         return;
     }
+    const isMobileLike = window.innerWidth < 768 || isLikelyTouchDevice();
+    if (isMobileLike) {
+        return;
+    }
     const target = event.target as HTMLElement | null;
     if (target && target.closest('a, [data-output-clickable]')) {
         return;


### PR DESCRIPTION
## Summary
- skip rendering the output context menu on mobile-like devices to avoid conflicts with the radial menu

## Testing
- yarn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912445555cc832a8097fa0608374e73)