### PR TITLE
Add map loading e2e test

### DIFF
--- a/e2e/map-loading.spec.ts
+++ b/e2e/map-loading.spec.ts
@@ -1,0 +1,17 @@
+import {expect, test} from './support/fixtures';
+import {waitForCommandInput, waitForMapReady} from './support/mocks';
+
+test.describe('Map loading', () => {
+    test('should render map and hide loading progress after initialization', async ({page}) => {
+        await page.goto('/');
+        await waitForCommandInput(page);
+
+        const progressContainer = page.locator('#map-progress-container');
+        const mapCanvas = page.locator('#map canvas').first();
+
+        await waitForMapReady(page);
+
+        await expect(mapCanvas, 'should show rendered map canvas after loading').toBeVisible();
+        await expect(progressContainer, 'should hide map loading progress once map is ready').toBeHidden({ timeout: 10000 });
+    });
+});


### PR DESCRIPTION
## Summary
- add an end-to-end test ensuring the map renders
- verify the map loading progress indicator hides after initialization

## Testing
- yarn test:e2e e2e/map-loading.spec.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e06e73e0c832a97a6036f3a501648)