### PR TITLE
Add keymap support for binds

### DIFF
--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -7,6 +7,7 @@ import TeamManager from "./TeamManager";
 import ObjectManager from "./ObjectManager";
 import {attachGmcpListener} from "./gmcp";
 import {getItemSync, setCurrentCharacter, setItemSync} from "@modules/core/storage";
+import {defaultBinds, resolveActiveBinds} from "@shared/binds";
 import {stripPolishCharacters} from "./stripPolishCharacters";
 import eventBus from "@modules/core/eventBus";
 import type {ClientEvents} from "@shared/events";
@@ -202,7 +203,9 @@ export default class Client {
             if (!b) {
                 return
             }
-            const bind = b?.main
+            const activeKeymapId = getItemSync('bindsKeymapId')?.bindsKeymapId ?? null
+            const resolved = resolveActiveBinds(b, activeKeymapId, defaultBinds)
+            const bind = resolved?.main
             if (bind) {
                 this.FunctionalBind.updateOptions({
                     key: bind.key,
@@ -212,23 +215,23 @@ export default class Client {
                     label: formatLabel(bind)
                 })
             }
-            const lamp = b?.lamp
+            const lamp = resolved?.lamp
             if (lamp) {
                 this.lampBind = { ...lamp }
             }
-            const attack = b?.attack
+            const attack = resolved?.attack
             if (attack) {
                 this.attackBind = { ...attack }
             }
-            const support = b?.support
+            const support = resolved?.support
             if (support) {
                 this.supportBind = { ...support }
             }
-            const moveMode = b?.moveMode
+            const moveMode = resolved?.moveMode
             if (moveMode) {
                 this.moveModeBind = { ...moveMode }
             }
-            const temp = b?.temp
+            const temp = resolved?.temp
             if (Array.isArray(temp)) {
                 temp.forEach((tempBind: any, index: number) => {
                     if (!tempBind || typeof tempBind !== 'object') {
@@ -254,7 +257,7 @@ export default class Client {
                     }
                 })
             }
-            const custom = b?.custom
+            const custom = resolved?.custom
             if (custom) {
                 this.customBinds = [...custom]
             } else {

--- a/src/client/scripts/enemyBinds.ts
+++ b/src/client/scripts/enemyBinds.ts
@@ -5,6 +5,7 @@ import type { PersonEntry } from '../types/people';
 import { colorString, createColorFormat } from '@modules/core/Colors';
 import { AnsiAwareBuffer } from '@client/ansi/FormatState';
 import storage from '@modules/core/storage';
+import { defaultBinds, resolveActiveBinds } from '@shared/binds';
 
 const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform);
 const ALT_LABEL = isMac ? '⌥' : 'ALT';
@@ -21,18 +22,6 @@ interface Bind {
     shift?: boolean;
 }
 
-const defaultEnemyBinds: Bind[] = [
-    { key: 'F1' },
-    { key: 'F2' },
-    { key: 'F3' },
-];
-
-const defaultEnemyBlockBinds: Bind[] = [
-    { key: 'F1', ctrl: true },
-    { key: 'F2', ctrl: true },
-    { key: 'F3', ctrl: true },
-];
-
 export default function initEnemyBinds(
     client: Client,
     aliases?: { pattern: RegExp; callback: Function }[]
@@ -47,8 +36,8 @@ export default function initEnemyBinds(
     let keepUnchanged = false;
     let showMode: 'always' | 'whenBound' | 'never' = 'always';
     let enabledSlots: [boolean, boolean, boolean] = [true, true, true];
-    let enemyBindKeys: Bind[] = [...defaultEnemyBinds];
-    let enemyBlockBindKeys: Bind[] = [...defaultEnemyBlockBinds];
+    let enemyBindKeys: Bind[] = [...defaultBinds.enemy];
+    let enemyBlockBindKeys: Bind[] = [...defaultBinds.enemyBlock];
 
     subscribeToPeopleStore(snapshot => {
         peopleCache = snapshot ?? [];
@@ -64,17 +53,19 @@ export default function initEnemyBinds(
     ensurePeopleLoaded().catch(() => undefined);
 
     // Load enemy binds keys from storage
-    storage.getItem('binds').then(res => {
-        if (res?.binds?.enemy && Array.isArray(res.binds.enemy) && res.binds.enemy.length === 3) {
-            enemyBindKeys = res.binds.enemy.map((bind: any) => ({
+    Promise.all([storage.getItem('binds'), storage.getItem('bindsKeymapId')]).then(([bindsRes, keymapRes]) => {
+        const activeKeymapId = typeof keymapRes?.bindsKeymapId === 'string' ? keymapRes.bindsKeymapId : null;
+        const resolved = resolveActiveBinds(bindsRes?.binds, activeKeymapId, defaultBinds);
+        if (Array.isArray(resolved.enemy) && resolved.enemy.length === 3) {
+            enemyBindKeys = resolved.enemy.map((bind: any) => ({
                 key: bind.key || 'F1',
                 ctrl: bind.ctrl,
                 alt: bind.alt,
                 shift: bind.shift,
             }));
         }
-        if (res?.binds?.enemyBlock && Array.isArray(res.binds.enemyBlock) && res.binds.enemyBlock.length === 3) {
-            enemyBlockBindKeys = res.binds.enemyBlock.map((bind: any) => ({
+        if (Array.isArray(resolved.enemyBlock) && resolved.enemyBlock.length === 3) {
+            enemyBlockBindKeys = resolved.enemyBlock.map((bind: any) => ({
                 key: bind.key || 'F1',
                 ctrl: bind.ctrl,
                 alt: bind.alt,

--- a/src/client/scripts/multibinds.ts
+++ b/src/client/scripts/multibinds.ts
@@ -6,6 +6,7 @@ import {
     type StoredMultibindRecord,
 } from "@web/dataStores/multibindStore";
 import storage from "@modules/core/storage";
+import { defaultBinds, resolveActiveBinds } from "@shared/binds";
 
 const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform);
 const ALT_LABEL = isMac ? '⌥' : 'ALT';
@@ -59,12 +60,14 @@ export default function initMultibinds(client: Client, aliases?: { pattern: RegE
     let roomBind: Bind = { key: 'KeyP', alt: true };
     let drinkableBind: Bind = { key: 'KeyN', alt: true };
 
-    storage.getItem('binds').then(res => {
-        if (res?.binds?.roomBind) {
-            roomBind = res.binds.roomBind;
+    Promise.all([storage.getItem('binds'), storage.getItem('bindsKeymapId')]).then(([bindsRes, keymapRes]) => {
+        const activeKeymapId = typeof keymapRes?.bindsKeymapId === 'string' ? keymapRes.bindsKeymapId : null;
+        const resolved = resolveActiveBinds(bindsRes?.binds, activeKeymapId, defaultBinds);
+        if (resolved?.roomBind) {
+            roomBind = resolved.roomBind;
         }
-        if (res?.binds?.drinkable) {
-            drinkableBind = res.binds.drinkable;
+        if (resolved?.drinkable) {
+            drinkableBind = resolved.drinkable;
         }
     });
 

--- a/src/modules/device/deviceSettingsBundle.ts
+++ b/src/modules/device/deviceSettingsBundle.ts
@@ -43,11 +43,12 @@ function saveUiSettings(settings: UiSettings): void {
 export async function exportDeviceSettings(): Promise<DeviceSettings> {
     const deviceInfo = getDeviceInfo();
 
-    const [layoutManagerState, uiSettings, desktopButtonSettings, mobileButtonSettings] = await Promise.all([
+    const [layoutManagerState, uiSettings, desktopButtonSettings, mobileButtonSettings, bindsKeymapId] = await Promise.all([
         Promise.resolve(loadLayoutState()),
         loadUiSettings(),
         loadDesktopButtonSettings(),
         loadMobileButtonSettings(),
+        storage.getItem('bindsKeymapId').then(res => res?.bindsKeymapId as string | undefined),
     ]);
 
     return {
@@ -58,6 +59,7 @@ export async function exportDeviceSettings(): Promise<DeviceSettings> {
         uiSettings,
         desktopButtonSettings,
         mobileButtonSettings,
+        bindsKeymapId,
     };
 }
 
@@ -87,6 +89,10 @@ export async function importDeviceSettings(settings: DeviceSettings): Promise<vo
     // Apply mobile button settings
     if (settings.mobileButtonSettings) {
         saveMobileButtonSettings(settings.mobileButtonSettings);
+    }
+
+    if (settings.bindsKeymapId) {
+        storage.setItem('bindsKeymapId', settings.bindsKeymapId);
     }
 }
 
@@ -166,6 +172,7 @@ export async function exportPartialDeviceSettings(options: {
     uiSettings?: boolean;
     desktopButtonSettings?: boolean;
     mobileButtonSettings?: boolean;
+    bindsKeymapId?: boolean;
 }): Promise<Partial<DeviceSettings>> {
     const deviceInfo = getDeviceInfo();
     const result: Partial<DeviceSettings> = {
@@ -188,6 +195,13 @@ export async function exportPartialDeviceSettings(options: {
 
     if (options.mobileButtonSettings) {
         result.mobileButtonSettings = await loadMobileButtonSettings();
+    }
+
+    if (options.bindsKeymapId) {
+        const stored = await storage.getItem('bindsKeymapId');
+        if (stored?.bindsKeymapId) {
+            result.bindsKeymapId = stored.bindsKeymapId as string;
+        }
     }
 
     return result;

--- a/src/modules/device/deviceStorage.ts
+++ b/src/modules/device/deviceStorage.ts
@@ -323,6 +323,9 @@ export function applyImportedDeviceSettings(deviceId: string): boolean {
         if (entry.settings.mobileButtonSettings) {
             localStorage.setItem('mobileButtonSettings', entry.settings.mobileButtonSettings);
         }
+        if (entry.settings.bindsKeymapId) {
+            localStorage.setItem('bindsKeymapId', entry.settings.bindsKeymapId);
+        }
 
         // Trigger dynamic reload of settings
         triggerSettingsReload();

--- a/src/modules/device/deviceTypes.ts
+++ b/src/modules/device/deviceTypes.ts
@@ -44,6 +44,8 @@ export interface DeviceSettings {
     desktopButtonSettings?: DesktopButtonsSettings;
     /** Mobile button settings */
     mobileButtonSettings?: MobileButtonsSettings;
+    /** Selected keymap id for binds */
+    bindsKeymapId?: string;
 }
 
 /**
@@ -85,6 +87,7 @@ export interface ImportedDeviceEntry {
         uiSettings?: string;
         desktopButtonSettings?: string;
         mobileButtonSettings?: string;
+        bindsKeymapId?: string;
     };
     /** ISO timestamp when imported */
     importedAt: string;
@@ -128,6 +131,7 @@ export interface SyncedDeviceSettings {
         uiSettings?: string;
         desktopButtonSettings?: string;
         mobileButtonSettings?: string;
+        bindsKeymapId?: string;
     };
 }
 

--- a/src/modules/device/syncGroup.ts
+++ b/src/modules/device/syncGroup.ts
@@ -179,6 +179,7 @@ export function getRawDeviceSettings(): SyncedDeviceSettings['settings'] {
         uiSettings: localStorage.getItem('uiSettings') || undefined,
         desktopButtonSettings: localStorage.getItem('desktopButtonSettings') || undefined,
         mobileButtonSettings: localStorage.getItem('mobileButtonSettings') || undefined,
+        bindsKeymapId: localStorage.getItem('bindsKeymapId') || undefined,
     };
 }
 
@@ -235,6 +236,9 @@ export function applySyncedSettings(syncedSettings: SyncedDeviceSettings): void 
         }
         if (settings.mobileButtonSettings) {
             localStorage.setItem('mobileButtonSettings', settings.mobileButtonSettings);
+        }
+        if (settings.bindsKeymapId) {
+            localStorage.setItem('bindsKeymapId', settings.bindsKeymapId);
         }
 
         // Update local version to match remote

--- a/src/shared/binds.ts
+++ b/src/shared/binds.ts
@@ -1,0 +1,235 @@
+export interface Bind {
+    key: string;
+    ctrl?: boolean;
+    alt?: boolean;
+    shift?: boolean;
+}
+
+export interface CustomBind extends Bind {
+    command: string;
+}
+
+export interface DirectionBinds {
+    n: Bind;
+    s: Bind;
+    w: Bind;
+    e: Bind;
+    nw: Bind;
+    ne: Bind;
+    sw: Bind;
+    se: Bind;
+    u: Bind;
+    d: Bind;
+    special: Bind;
+}
+
+export interface BindSettings {
+    main: Bind;
+    lamp: Bind;
+    attack: Bind;
+    support: Bind;
+    moveMode: Bind;
+    roomBind: Bind;
+    drinkable: Bind;
+    directions: DirectionBinds;
+    custom: CustomBind[];
+    temp: Bind[];
+    enemy: Bind[];
+    enemyBlock: Bind[];
+}
+
+export interface KeymapEntry {
+    id: string;
+    name: string;
+    binds: BindSettings;
+}
+
+export interface BindsStore {
+    version: 2;
+    keymaps: KeymapEntry[];
+}
+
+export const BINDS_STORAGE_VERSION = 2 as const;
+export const BINDS_KEYMAP_ID_STORAGE_KEY = 'bindsKeymapId';
+export const DEFAULT_KEYMAP_NAME = 'Domyslna';
+
+export const defaultBinds: BindSettings = {
+    main: { key: 'BracketRight' },
+    lamp: { key: 'Digit4', ctrl: true },
+    attack: { key: 'Digit1', ctrl: true },
+    support: { key: 'KeyQ', ctrl: true },
+    moveMode: { key: 'Backquote' },
+    roomBind: { key: 'KeyP', alt: true },
+    drinkable: { key: 'KeyN', alt: true },
+    temp: [
+        { key: 'F4' },
+        { key: 'F5' },
+    ],
+    enemy: [
+        { key: 'F1' },
+        { key: 'F2' },
+        { key: 'F3' },
+    ],
+    enemyBlock: [
+        { key: 'F1', ctrl: true },
+        { key: 'F2', ctrl: true },
+        { key: 'F3', ctrl: true },
+    ],
+    directions: {
+        n: { key: 'Numpad8' },
+        s: { key: 'Numpad2' },
+        w: { key: 'Numpad4' },
+        e: { key: 'Numpad6' },
+        nw: { key: 'Numpad7' },
+        ne: { key: 'Numpad9' },
+        sw: { key: 'Numpad1' },
+        se: { key: 'Numpad3' },
+        u: { key: 'NumpadMultiply' },
+        d: { key: 'NumpadSubtract' },
+        special: { key: 'Numpad0' },
+    },
+    custom: [],
+};
+
+const directionKeys: Array<keyof DirectionBinds> = [
+    'n',
+    's',
+    'w',
+    'e',
+    'nw',
+    'ne',
+    'sw',
+    'se',
+    'u',
+    'd',
+    'special',
+];
+
+export function mergeBindSettings(
+    base: BindSettings,
+    overrides?: Partial<BindSettings>
+): BindSettings {
+    const temp = overrides?.temp ?? [];
+    const enemy = overrides?.enemy ?? [];
+    const enemyBlock = overrides?.enemyBlock ?? [];
+    const directionsOverrides = overrides?.directions ?? {};
+
+    return {
+        ...base,
+        main: { ...base.main, ...(overrides?.main ?? {}) },
+        lamp: { ...base.lamp, ...(overrides?.lamp ?? {}) },
+        attack: { ...base.attack, ...(overrides?.attack ?? {}) },
+        support: { ...base.support, ...(overrides?.support ?? {}) },
+        moveMode: { ...base.moveMode, ...(overrides?.moveMode ?? {}) },
+        roomBind: { ...base.roomBind, ...(overrides?.roomBind ?? {}) },
+        drinkable: { ...base.drinkable, ...(overrides?.drinkable ?? {}) },
+        temp: base.temp.map((item, index) => ({ ...item, ...(temp[index] ?? {}) })),
+        enemy: base.enemy.map((item, index) => ({ ...item, ...(enemy[index] ?? {}) })),
+        enemyBlock: base.enemyBlock.map((item, index) => ({ ...item, ...(enemyBlock[index] ?? {}) })),
+        directions: directionKeys.reduce<DirectionBinds>((acc, key) => {
+            acc[key] = { ...base.directions[key], ...(directionsOverrides[key] ?? {}) };
+            return acc;
+        }, {} as DirectionBinds),
+        custom: Array.isArray(overrides?.custom) ? overrides?.custom ?? [] : base.custom,
+    };
+}
+
+export function cloneBindSettings(binds: BindSettings): BindSettings {
+    if (typeof structuredClone === 'function') {
+        return structuredClone(binds);
+    }
+    return JSON.parse(JSON.stringify(binds)) as BindSettings;
+}
+
+const bindSettingsKeys: Array<keyof BindSettings> = [
+    'main',
+    'lamp',
+    'attack',
+    'support',
+    'moveMode',
+    'roomBind',
+    'drinkable',
+    'directions',
+    'custom',
+    'temp',
+    'enemy',
+    'enemyBlock',
+];
+
+function isBindSettingsCandidate(value: unknown): value is Partial<BindSettings> {
+    if (!value || typeof value !== 'object') return false;
+    const candidate = value as Record<string, unknown>;
+    return bindSettingsKeys.some(key => key in candidate);
+}
+
+function buildKeymapName(index: number): string {
+    if (index === 0) return DEFAULT_KEYMAP_NAME;
+    return `Mapa ${index + 1}`;
+}
+
+function ensureKeymapId(entry: Partial<KeymapEntry> | null | undefined, index: number): string {
+    if (entry?.id && typeof entry.id === 'string') return entry.id;
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+    return `keymap-${Date.now()}-${index}`;
+}
+
+export function normalizeBindsStore(raw: unknown, fallback: BindSettings = defaultBinds): BindsStore {
+    if (raw && typeof raw === 'object' && 'version' in raw && (raw as BindsStore).version === 2) {
+        const entries = Array.isArray((raw as BindsStore).keymaps) ? (raw as BindsStore).keymaps : [];
+        const normalized = entries
+            .map((entry, index) => {
+                if (!entry || typeof entry !== 'object') return null;
+                const candidate = entry as Partial<KeymapEntry>;
+                const binds = mergeBindSettings(fallback, candidate.binds as Partial<BindSettings> | undefined);
+                return {
+                    id: ensureKeymapId(candidate, index),
+                    name: typeof candidate.name === 'string' && candidate.name.trim() ? candidate.name : buildKeymapName(index),
+                    binds,
+                } as KeymapEntry;
+            })
+            .filter((entry): entry is KeymapEntry => entry !== null);
+        if (normalized.length > 0) {
+            return { version: BINDS_STORAGE_VERSION, keymaps: normalized };
+        }
+    }
+
+    if (isBindSettingsCandidate(raw)) {
+        return {
+            version: BINDS_STORAGE_VERSION,
+            keymaps: [{
+                id: 'default',
+                name: DEFAULT_KEYMAP_NAME,
+                binds: mergeBindSettings(fallback, raw),
+            }],
+        };
+    }
+
+    return {
+        version: BINDS_STORAGE_VERSION,
+        keymaps: [{
+            id: 'default',
+            name: DEFAULT_KEYMAP_NAME,
+            binds: cloneBindSettings(fallback),
+        }],
+    };
+}
+
+export function resolveActiveKeymapId(store: BindsStore, preferredId?: string | null): string {
+    if (preferredId && store.keymaps.some(entry => entry.id === preferredId)) {
+        return preferredId;
+    }
+    return store.keymaps[0]?.id ?? 'default';
+}
+
+export function resolveActiveBinds(
+    raw: unknown,
+    preferredId?: string | null,
+    fallback: BindSettings = defaultBinds
+): BindSettings {
+    const store = normalizeBindsStore(raw, fallback);
+    const activeId = resolveActiveKeymapId(store, preferredId);
+    const entry = store.keymaps.find(item => item.id === activeId) ?? store.keymaps[0];
+    return entry?.binds ?? cloneBindSettings(fallback);
+}

--- a/src/web/MockPort.ts
+++ b/src/web/MockPort.ts
@@ -13,8 +13,17 @@ export default class MockPort {
         storage.onChanged?.addListener(changes => {
             Object.entries(changes).forEach(([key, {newValue}]) => {
                 this.dispatch({storage: {key, value: newValue}});
-                if (key === 'settings' || key === 'uiSettings' || key === 'binds') {
+                if (key === 'settings' || key === 'uiSettings') {
                     this.dispatch({[key]: newValue});
+                }
+                if (key === 'binds') {
+                    this.dispatch({binds: newValue});
+                }
+                if (key === 'bindsKeymapId') {
+                    const binds = getItemSync('binds')?.binds;
+                    if (binds) {
+                        this.dispatch({binds});
+                    }
                 }
             });
         });
@@ -28,8 +37,17 @@ export default class MockPort {
         if (message.type === 'SET_STORAGE') {
             setItemSync(message.key, message.value);
             this.dispatch({storage: {key: message.key, value: message.value}});
-            if (message.key === 'settings' || message.key === 'uiSettings' || message.key === 'binds') {
+            if (message.key === 'settings' || message.key === 'uiSettings') {
                 this.dispatch({[message.key]: message.value});
+            }
+            if (message.key === 'binds') {
+                this.dispatch({binds: message.value});
+            }
+            if (message.key === 'bindsKeymapId') {
+                const binds = getItemSync('binds')?.binds;
+                if (binds) {
+                    this.dispatch({binds});
+                }
             }
             return;
         }
@@ -42,8 +60,11 @@ export default class MockPort {
         const data = getItemSync(key);
         const value = data ? data[key] : {};
         this.dispatch({ storage: { key, value } });
-        if (key === 'settings' || key === 'uiSettings' || key === 'binds') {
+        if (key === 'settings' || key === 'uiSettings') {
             this.dispatch({ [key]: value });
+        }
+        if (key === 'binds') {
+            this.dispatch({ binds: value });
         }
     };
 }

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -58,6 +58,7 @@ import {
     setupOutputMessageHandler,
 } from "@shared/dom/outputMessageHandler";
 import {refresh as refreshNpcStore, subscribe as subscribeNpcStore} from "./dataStores/npcStore";
+import { defaultBinds, resolveActiveBinds } from "@shared/binds";
 
 initSessionLogger(arkadiaClient).catch(err => console.error('Logger init failed', err));
 
@@ -191,10 +192,10 @@ arkadiaClient.on('settings', (detail) => {
 });
 
 client.on('binds', (detail) => {
-    const payload = detail as { directions?: unknown } | undefined;
-    const directions = payload?.directions;
-    if (isDirectionMap(directions)) {
-        applyDirectionBinds(directions);
+    const activeKeymapId = getItemSync('bindsKeymapId')?.bindsKeymapId ?? null;
+    const resolved = resolveActiveBinds(detail, activeKeymapId, defaultBinds);
+    if (isDirectionMap(resolved?.directions)) {
+        applyDirectionBinds(resolved.directions);
     }
 });
 

--- a/src/web/options/Binds.tsx
+++ b/src/web/options/Binds.tsx
@@ -2,6 +2,19 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {Alert, Button, Form, Modal, ProgressBar, Spinner, Table} from 'react-bootstrap';
 import storage from "@modules/core/storage";
 import {
+    BINDS_KEYMAP_ID_STORAGE_KEY,
+    BINDS_STORAGE_VERSION,
+    type Bind,
+    type BindSettings,
+    type CustomBind,
+    type DirectionBinds,
+    defaultBinds,
+    type KeymapEntry,
+    cloneBindSettings,
+    normalizeBindsStore,
+    resolveActiveKeymapId,
+} from "@shared/binds";
+import {
     type MultibindImportRow,
     type MultibindImportWorkerRequest,
     type MultibindImportWorkerResponse,
@@ -16,84 +29,6 @@ import {
 
 const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform);
 const ALT_LABEL = isMac ? '⌥' : 'ALT';
-
-interface Bind {
-    key: string;
-    ctrl?: boolean;
-    alt?: boolean;
-    shift?: boolean;
-}
-
-interface CustomBind extends Bind {
-    command: string;
-}
-
-interface DirectionBinds {
-    n: Bind;
-    s: Bind;
-    w: Bind;
-    e: Bind;
-    nw: Bind;
-    ne: Bind;
-    sw: Bind;
-    se: Bind;
-    u: Bind;
-    d: Bind;
-    special: Bind;
-}
-
-interface BindSettings {
-    main: Bind;
-    lamp: Bind;
-    attack: Bind;
-    support: Bind;
-    moveMode: Bind;
-    roomBind: Bind;
-    drinkable: Bind;
-    directions: DirectionBinds;
-    custom: CustomBind[];
-    temp: Bind[];
-    enemy: Bind[];
-    enemyBlock: Bind[];
-}
-
-const defaultBinds: BindSettings = {
-    main: { key: 'BracketRight' },
-    lamp: { key: 'Digit4', ctrl: true },
-    attack: { key: 'Digit1', ctrl: true },
-    support: { key: 'KeyQ', ctrl: true },
-    moveMode: { key: 'Backquote' },
-    roomBind: { key: 'KeyP', alt: true },
-    drinkable: { key: 'KeyN', alt: true },
-    temp: [
-        { key: 'F4' },
-        { key: 'F5' },
-    ],
-    enemy: [
-        { key: 'F1' },
-        { key: 'F2' },
-        { key: 'F3' },
-    ],
-    enemyBlock: [
-        { key: 'F1', ctrl: true },
-        { key: 'F2', ctrl: true },
-        { key: 'F3', ctrl: true },
-    ],
-    directions: {
-        n: { key: 'Numpad8' },
-        s: { key: 'Numpad2' },
-        w: { key: 'Numpad4' },
-        e: { key: 'Numpad6' },
-        nw: { key: 'Numpad7' },
-        ne: { key: 'Numpad9' },
-        sw: { key: 'Numpad1' },
-        se: { key: 'Numpad3' },
-        u: { key: 'NumpadMultiply' },
-        d: { key: 'NumpadSubtract' },
-        special: { key: 'Numpad0' },
-    },
-    custom: [],
-};
 
 type ConflictPolicy = 'keep-last' | 'keep-first' | 'skip-conflicts';
 
@@ -169,6 +104,9 @@ function label(bind: Bind) {
 
 function Binds() {
     const [binds, setBinds] = useState<BindSettings>(defaultBinds);
+    const [keymaps, setKeymaps] = useState<KeymapEntry[]>([]);
+    const [activeKeymapId, setActiveKeymapId] = useState<string>('');
+    const [newKeymapName, setNewKeymapName] = useState('');
     const [multibinds, setMultibinds] = useState<StoredMultibindRecord[]>([]);
     const [importData, setImportData] = useState<ImportData | null>(null);
     const [conflictPolicy, setConflictPolicy] = useState<ConflictPolicy>('keep-last');
@@ -244,37 +182,22 @@ function Binds() {
     }
 
     useEffect(() => {
-        storage.getItem('binds').then(res => {
-            setBinds({
-                ...defaultBinds,
-                main: res?.binds?.main || defaultBinds.main,
-                lamp: res?.binds?.lamp || defaultBinds.lamp,
-                attack: res?.binds?.attack || defaultBinds.attack,
-                support: res?.binds?.support || defaultBinds.support,
-                moveMode: res?.binds?.moveMode || defaultBinds.moveMode,
-                roomBind: res?.binds?.roomBind || defaultBinds.roomBind,
-                drinkable: res?.binds?.drinkable || defaultBinds.drinkable,
-                temp: [
-                    { ...defaultBinds.temp[0], ...(res?.binds?.temp?.[0] || {}) },
-                    { ...defaultBinds.temp[1], ...(res?.binds?.temp?.[1] || {}) },
-                ],
-                enemy: [
-                    { ...defaultBinds.enemy[0], ...(res?.binds?.enemy?.[0] || {}) },
-                    { ...defaultBinds.enemy[1], ...(res?.binds?.enemy?.[1] || {}) },
-                    { ...defaultBinds.enemy[2], ...(res?.binds?.enemy?.[2] || {}) },
-                ],
-                enemyBlock: [
-                    { ...defaultBinds.enemyBlock[0], ...(res?.binds?.enemyBlock?.[0] || {}) },
-                    { ...defaultBinds.enemyBlock[1], ...(res?.binds?.enemyBlock?.[1] || {}) },
-                    { ...defaultBinds.enemyBlock[2], ...(res?.binds?.enemyBlock?.[2] || {}) },
-                ],
-                directions: {
-                    ...defaultBinds.directions,
-                    ...res?.binds?.directions,
-                },
-                custom: res?.binds?.custom || [],
-            });
+        let mounted = true;
+        Promise.all([storage.getItem('binds'), storage.getItem(BINDS_KEYMAP_ID_STORAGE_KEY)]).then(([bindsRes, keymapRes]) => {
+            if (!mounted) return;
+            const store = normalizeBindsStore(bindsRes?.binds, defaultBinds);
+            const preferred = typeof keymapRes?.[BINDS_KEYMAP_ID_STORAGE_KEY] === 'string'
+                ? keymapRes[BINDS_KEYMAP_ID_STORAGE_KEY]
+                : null;
+            const resolvedId = resolveActiveKeymapId(store, preferred);
+            setKeymaps(store.keymaps);
+            setActiveKeymapId(resolvedId);
+            const activeEntry = store.keymaps.find(entry => entry.id === resolvedId) ?? store.keymaps[0];
+            setBinds(activeEntry?.binds ?? defaultBinds);
         });
+        return () => {
+            mounted = false;
+        };
     }, []);
 
     useEffect(() => {
@@ -283,6 +206,13 @@ function Binds() {
             unsubscribe();
         };
     }, []);
+
+    useEffect(() => {
+        if (!activeKeymapId) return;
+        setKeymaps(prev => prev.map(entry => (
+            entry.id === activeKeymapId ? { ...entry, binds } : entry
+        )));
+    }, [activeKeymapId, binds]);
 
     const importPlan = useMemo<ImportPlan | null>(() => {
         if (!importData) {
@@ -524,8 +454,63 @@ function Binds() {
         }));
     }
 
+    function handleActiveKeymapChange(nextId: string) {
+        setActiveKeymapId(nextId);
+        const entry = keymaps.find(item => item.id === nextId);
+        if (entry) {
+            setBinds(entry.binds);
+        }
+    }
+
+    function handleKeymapNameChange(name: string) {
+        setKeymaps(prev => prev.map(entry => (
+            entry.id === activeKeymapId ? { ...entry, name } : entry
+        )));
+    }
+
+    function handleAddKeymap() {
+        const trimmed = newKeymapName.trim();
+        const baseName = trimmed || `Mapa ${keymaps.length + 1}`;
+        const id = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+            ? crypto.randomUUID()
+            : `keymap-${Date.now()}-${keymaps.length + 1}`;
+        const entry: KeymapEntry = {
+            id,
+            name: baseName,
+            binds: cloneBindSettings(binds),
+        };
+        setKeymaps(prev => [...prev, entry]);
+        setActiveKeymapId(id);
+        setNewKeymapName('');
+    }
+
+    function handleRemoveKeymap() {
+        if (keymaps.length <= 1) {
+            return;
+        }
+        const remaining = keymaps.filter(entry => entry.id !== activeKeymapId);
+        const next = remaining[0];
+        setKeymaps(remaining);
+        if (next) {
+            setActiveKeymapId(next.id);
+            setBinds(next.binds);
+        }
+    }
+
     function save() {
-        storage.setItem('binds', binds).then(() => {
+        const store = {
+            version: BINDS_STORAGE_VERSION,
+            keymaps: keymaps.length > 0 ? keymaps : [{
+                id: 'default',
+                name: 'Domyslna',
+                binds: cloneBindSettings(binds),
+            }],
+        };
+        const resolvedActiveId = activeKeymapId || store.keymaps[0]?.id || 'default';
+        Promise.all([
+            storage.setItem('binds', store),
+            storage.setItem(BINDS_KEYMAP_ID_STORAGE_KEY, resolvedActiveId),
+        ]).then(() => {
             window.dispatchEvent(new Event('close-options'));
         });
     }
@@ -637,6 +622,52 @@ function Binds() {
                 <Alert variant="danger" className="mb-0">{importError}</Alert>
             )}
             <fieldset className="p-0 border-0 m-0">
+                <div className="d-flex flex-column gap-2 mb-2">
+                    <Form.Group>
+                        <Form.Label>Mapa klawiszy</Form.Label>
+                        <div className="d-flex gap-2">
+                            <Form.Select
+                                size="sm"
+                                value={activeKeymapId}
+                                onChange={ev => handleActiveKeymapChange(ev.target.value)}
+                            >
+                                {keymaps.map(entry => (
+                                    <option key={entry.id} value={entry.id}>{entry.name}</option>
+                                ))}
+                            </Form.Select>
+                            <Button
+                                size="sm"
+                                variant="outline-danger"
+                                onClick={handleRemoveKeymap}
+                                disabled={keymaps.length <= 1}
+                            >
+                                Usuń
+                            </Button>
+                        </div>
+                    </Form.Group>
+                    <Form.Group>
+                        <Form.Label>Nazwa mapy</Form.Label>
+                        <Form.Control
+                            size="sm"
+                            type="text"
+                            value={keymaps.find(entry => entry.id === activeKeymapId)?.name ?? ''}
+                            onChange={ev => handleKeymapNameChange(ev.target.value)}
+                        />
+                    </Form.Group>
+                    <Form.Group>
+                        <Form.Label>Nowa mapa (kopiuje bieżące bindy)</Form.Label>
+                        <div className="d-flex gap-2">
+                            <Form.Control
+                                size="sm"
+                                type="text"
+                                value={newKeymapName}
+                                onChange={ev => setNewKeymapName(ev.target.value)}
+                                placeholder="Nazwa nowej mapy"
+                            />
+                            <Button size="sm" onClick={handleAddKeymap}>Dodaj</Button>
+                        </div>
+                    </Form.Group>
+                </div>
                 <Table bordered size="sm" hover className="table-modern table-zebra mb-2">
                     <tbody className="align-middle">
                         <tr>

--- a/src/web/options/exportUtils.ts
+++ b/src/web/options/exportUtils.ts
@@ -93,6 +93,7 @@ export interface ExportedDeviceInfo {
         uiSettings?: string;
         desktopButtonSettings?: string;
         mobileButtonSettings?: string;
+        bindsKeymapId?: string;
     };
     syncGroup?: SyncGroup;
 }
@@ -393,6 +394,7 @@ export async function buildExport(selectedCharacters: string[], options: ExportO
             uiSettings: localStorage.getItem('uiSettings') || undefined,
             desktopButtonSettings: localStorage.getItem('desktopButtonSettings') || undefined,
             mobileButtonSettings: localStorage.getItem('mobileButtonSettings') || undefined,
+            bindsKeymapId: localStorage.getItem('bindsKeymapId') || undefined,
         },
         syncGroup: syncGroup || undefined,
     };
@@ -468,6 +470,9 @@ export async function applyImportedData(payload: ExportPayload): Promise<void> {
             if (settings.mobileButtonSettings) {
                 localStorage.setItem('mobileButtonSettings', settings.mobileButtonSettings);
             }
+            if (settings.bindsKeymapId) {
+                localStorage.setItem('bindsKeymapId', settings.bindsKeymapId);
+            }
             await triggerSettingsReload();
         } else {
             // Different device - save to imported devices list (user can copy settings later)
@@ -496,6 +501,7 @@ export interface CategoryData {
         layoutManagerState?: string;
         desktopButtonSettings?: string;
         mobileButtonSettings?: string;  // includes radial
+        bindsKeymapId?: string;
     };
     binds?: { binds?: string };
     shortcuts?: { shortcuts?: string };
@@ -535,6 +541,8 @@ export async function exportCategory(
                 if (desktopButtonSettings) data.desktopButtonSettings = desktopButtonSettings;
                 const mobileButtonSettings = localStorage.getItem('mobileButtonSettings');
                 if (mobileButtonSettings) data.mobileButtonSettings = mobileButtonSettings;
+                const bindsKeymapId = localStorage.getItem('bindsKeymapId');
+                if (bindsKeymapId) data.bindsKeymapId = bindsKeymapId;
                 return Object.keys(data).length > 0 ? JSON.stringify(data) : null;
             }
             case 'binds': {
@@ -706,6 +714,7 @@ export async function importCategory(
                 if (data.layoutManagerState) localStorage.setItem('layoutManagerState', data.layoutManagerState);
                 if (data.desktopButtonSettings) localStorage.setItem('desktopButtonSettings', data.desktopButtonSettings);
                 if (data.mobileButtonSettings) localStorage.setItem('mobileButtonSettings', data.mobileButtonSettings);
+                if (data.bindsKeymapId) localStorage.setItem('bindsKeymapId', data.bindsKeymapId);
                 // Notify layout system of changes
                 if (data.layoutManagerState && typeof window !== 'undefined') {
                     window.dispatchEvent(new CustomEvent('layoutManagerStateChanged', { detail: { type: 'import' } }));


### PR DESCRIPTION
### Motivation
- Introduce first-class keymap support so users can maintain multiple bind sets for different contexts.
- When creating a new keymap it should copy the currently active binds so users don't start from scratch.
- Keymap selection should be device-scoped and flow through sync/export/import so different devices can preserve their preferred keymap.
- Consumers of binds (direction keys, multibinds, enemy binds, functional bind, etc.) must resolve the active keymap transparently.

### Description
- Add a new shared module `@shared/binds` implementing `BindSettings`, versioned `BindsStore`, helpers `normalizeBindsStore`, `mergeBindSettings`, `resolveActiveBinds`, and `cloneBindSettings` and expose `defaultBinds` and keymap helpers.
- Update Bindowanie UI (`src/web/options/Binds.tsx`) to manage keymaps: list/select keymaps, rename, add (copies current binds), remove, and persist a `binds` store (versioned keymaps) plus the active id under `bindsKeymapId`.
- Make bind consumers resolve the active keymap using `resolveActiveBinds` (changes in `src/client/Client.ts`, `src/client/scripts/multibinds.ts`, `src/client/scripts/enemyBinds.ts`, `src/web/main.ts`, and `src/web/MockPort.ts` to notify clients when keymap changes).
- Include the selected keymap id in device settings, sync and export flows by adding `bindsKeymapId` to device settings/sync/export (`src/modules/device/*`, `src/web/options/exportUtils.ts`), and ensure imports/apply restore it.

### Testing
- Ran unit tests with `yarn test` and all test suites passed (`120` suites, `677` tests — success).
- Ran end-to-end tests with `yarn test:e2e` but they failed to start due to missing Playwright browsers; message: run `yarn playwright install` to download browsers (environment issue, not code failure).
- Built the application with `yarn build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953e3ceeae4832a9804aeb4bcd5f4d5)