### PR TITLE
Force list-only object list view when layout manager is disabled

### DIFF
--- a/src/web/ObjectList.ts
+++ b/src/web/ObjectList.ts
@@ -36,6 +36,7 @@ export default class ObjectList {
     private attackController: ReturnType<typeof createAttackController>;
     private contextMenuCommands: string[] = DEFAULT_CONTEXT_MENU_COMMANDS;
     private viewMode: 'list' | 'card' | 'compact' = 'list';
+    private isLayoutManagerEnabled = false;
 
     constructor(client: Client) {
         this.client = client;
@@ -76,11 +77,12 @@ export default class ObjectList {
     }
 
     private initializeCardViewMode() {
-        this.syncViewModeWithLayoutState();
+        const layoutState = loadLayoutState();
+        this.isLayoutManagerEnabled = layoutState.enabled;
+        this.syncViewModeWithLayoutState(this.isLayoutManagerEnabled);
         // Subscribe to view mode changes from the header toggle
         eventBus.on('objectListViewMode', (mode: 'list' | 'card' | 'compact') => {
-            const layoutState = loadLayoutState();
-            if (!layoutState.enabled) {
+            if (!this.isLayoutManagerEnabled) {
                 return;
             }
             if (this.viewMode !== mode) {
@@ -91,12 +93,16 @@ export default class ObjectList {
     }
 
     private handleLayoutManagerStateChange = () => {
-        this.syncViewModeWithLayoutState();
+        const isEnabled = document.body.classList.contains('layout-manager-enabled');
+        if (isEnabled === this.isLayoutManagerEnabled) {
+            return;
+        }
+        this.isLayoutManagerEnabled = isEnabled;
+        this.syncViewModeWithLayoutState(isEnabled);
     };
 
-    private syncViewModeWithLayoutState() {
-        const layoutState = loadLayoutState();
-        const nextViewMode = layoutState.enabled
+    private syncViewModeWithLayoutState(isLayoutEnabled: boolean) {
+        const nextViewMode = isLayoutEnabled
             ? getBuiltInPanelSetting<'list' | 'card' | 'compact'>('objectList', 'viewMode', 'list')
             : 'list';
         if (this.viewMode !== nextViewMode) {


### PR DESCRIPTION
### Motivation
- Ensure the object list always uses `list` view when the layout manager is turned off so toggles from the header don't persist outside layout mode.
- Keep the UI consistent when switching between layout-managed and non-managed modes.
- Avoid applying header `objectListViewMode` events while layout manager is disabled.

### Description
- Import `loadLayoutState` and add a `layoutManagerStateChanged` listener to resync view mode when layout state changes.
- Replace direct initial load with `syncViewModeWithLayoutState()` so view is `list` when layout manager is disabled and otherwise reads `builtIn` setting via `getBuiltInPanelSetting`.
- Ignore `objectListViewMode` events if `loadLayoutState().enabled` is `false`, and only apply/render mode changes when the view actually changes.
- Added helper methods `handleLayoutManagerStateChange` and `syncViewModeWithLayoutState` and updated `initializeCardViewMode` to use them.

### Testing
- Ran unit tests with `yarn test` and all test suites passed (120 suites, 677 tests).
- Ran `yarn test:e2e` which failed due to Playwright browsers not being installed (message suggests running `yarn playwright install`).
- Built production bundle with `yarn build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a3448c650832aafac416e0537bc40)