### PR TITLE
Fix location-bound functional bind clearing on same location

### DIFF
--- a/src/client/scripts/functionalBind.ts
+++ b/src/client/scripts/functionalBind.ts
@@ -67,6 +67,7 @@ export class FunctionalBind {
     private currentPrintable: string | null = null;
     private printedInMessage = false;
     private isLocationBound = false;
+    private boundLocationId: number | null = null;
     private key: string;
     private label: string;
     private ctrl: boolean;
@@ -88,11 +89,25 @@ export class FunctionalBind {
         })
 
         this.client.on(LINE_START_EVENT, () => this.newMessage());
-        this.client.on('enterLocation', () => this.onLocationChange());
+        this.client.on('enterLocation', (detail) => {
+            const payload = detail as { id?: number };
+            const newId = typeof payload?.id === 'number' ? payload.id : null;
+            this.onLocationChange(newId);
+        });
     }
 
-    private onLocationChange() {
+    private onLocationChange(newLocationId: number | null) {
         if (this.isLocationBound) {
+            if (this.boundLocationId === null) {
+                // Bind was set before room was resolved (e.g. transport trigger
+                // from room description arriving before gmcp.room.info).
+                // Adopt the incoming location so the bind clears on the *next* move.
+                this.boundLocationId = newLocationId;
+                return;
+            }
+            if (newLocationId === this.boundLocationId) {
+                return;
+            }
             this.clear();
         }
     }
@@ -103,6 +118,7 @@ export class FunctionalBind {
 
     set(printable: string | null, callback?: () => void, clearAfterUse: boolean = false, locationBound: boolean = false) {
         this.isLocationBound = locationBound;
+        this.boundLocationId = locationBound ? (this.client.Map?.currentRoom?.id ?? null) : null;
         if (callback) {
             this.functionalBind = () => {
                 callback();
@@ -141,6 +157,7 @@ export class FunctionalBind {
         this.currentPrintable = null;
         this.printedInMessage = false;
         this.isLocationBound = false;
+        this.boundLocationId = null;
     }
 
     updateOptions(options: FunctionalBindOptions = {}) {


### PR DESCRIPTION
## Summary
Fixed an issue where location-bound functional binds would incorrectly clear when re-entering the same location, and improved handling of binds set before the location is resolved.

## Key Changes
- Added `boundLocationId` property to track the specific location where a bind was set
- Modified `onLocationChange()` to accept the new location ID and only clear the bind when moving to a *different* location
- Implemented special handling for binds set before room information is available (e.g., transport triggers from room descriptions arriving before GMCP data):
  - If a bind is set with `locationBound=true` but the location hasn't been resolved yet, the bind now adopts the incoming location ID
  - This ensures the bind clears on the *next* location change, not immediately
- Updated the `set()` method to capture the current room ID when a location-bound bind is created
- Ensured `boundLocationId` is properly reset in the `clear()` method

## Implementation Details
The fix addresses a race condition where location-bound binds could be triggered before the client's map/room information was fully initialized. By deferring the location ID capture until the first location change event, binds set during early game events (like transport triggers) now behave correctly.

https://claude.ai/code/session_01GmfZyXDk9XWK1bYAQeut16