### PR TITLE
fix audio playback reliability by properly awaiting AudioContext resume

### DIFF
--- a/src/client/SoundManager.ts
+++ b/src/client/SoundManager.ts
@@ -22,7 +22,7 @@ function loadHowlerModule(): Promise<typeof import('howler').Howl> {
                 (howlerGlobal as any).autoSuspend = false;
             }
             // Try to resume immediately after loading (may work if close to a user gesture)
-            resumeAudioContext();
+            void resumeAudioContext();
             const constructor = module?.Howl ?? module?.default?.Howl ?? module?.default ?? module;
             return constructor as typeof import('howler').Howl;
         });
@@ -41,15 +41,17 @@ export function preloadHowler(): void {
 /**
  * Resume the audio context if it's suspended.
  * Should be called on user interaction to ensure sounds can play.
+ * Returns a promise that resolves when the context is running.
  */
-export function resumeAudioContext(): void {
-    if (!howlerGlobal) return;
+export function resumeAudioContext(): Promise<void> {
+    if (!howlerGlobal) return Promise.resolve();
     const ctx = (howlerGlobal as any).ctx as AudioContext | undefined;
     if (ctx && ctx.state === 'suspended') {
-        ctx.resume().catch((err: unknown) => {
+        return ctx.resume().catch((err: unknown) => {
             console.warn('Failed to resume audio context:', err);
         });
     }
+    return Promise.resolve();
 }
 
 export default class SoundManager {
@@ -93,6 +95,9 @@ export default class SoundManager {
     }
 
     async prepare(): Promise<void> {
+        // Resume audio context first (prepare is typically called from a click handler)
+        await resumeAudioContext();
+
         const keys = this.getKeysToPreload();
         await Promise.all(
             Array.from(keys).map(async key => {
@@ -196,7 +201,15 @@ export default class SoundManager {
     private playLoadedSound(sound: Howl) {
         const play = () => {
             sound.stop();
-            sound.play();
+            const id = sound.play();
+            // Handle play errors (e.g. AudioContext still locked) by retrying
+            // after resuming the audio context
+            sound.once('playerror', (_soundId: number) => {
+                void resumeAudioContext().then(() => {
+                    sound.stop();
+                    sound.play();
+                });
+            }, id);
         };
         if (sound.state() === 'loaded') {
             play();
@@ -209,8 +222,8 @@ export default class SoundManager {
     private async play(key: SoundKey) {
         if (this.muted) return;
 
-        // Resume audio context if suspended (browser autoplay policy)
-        resumeAudioContext();
+        // Ensure audio context is running before attempting playback
+        await resumeAudioContext();
 
         const existing = this.sounds[key];
         if (existing) {

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -203,7 +203,7 @@ function preventTabSleep() {
 function setupAudioContextResume() {
     const resumeOnInteraction = () => {
         preloadHowler();
-        resumeAudioContext();
+        void resumeAudioContext();
     };
     document.addEventListener('click', resumeOnInteraction);
     document.addEventListener('keydown', resumeOnInteraction);
@@ -212,9 +212,15 @@ function setupAudioContextResume() {
     // Also resume when returning to the tab
     document.addEventListener('visibilitychange', () => {
         if (document.visibilityState === 'visible') {
-            resumeAudioContext();
+            void resumeAudioContext();
         }
     });
+
+    // Periodic keepalive: browsers can re-suspend the AudioContext after
+    // ~30-60 s of inactivity. Check every 15 s and resume if needed.
+    setInterval(() => {
+        void resumeAudioContext();
+    }, 15_000);
 }
 
 setupAudioContextResume();


### PR DESCRIPTION
- Make resumeAudioContext() return a Promise and await it in play() so the context is actually running before attempting playback
- Add playerror handler to Howl instances to retry after context unlock
- Resume AudioContext in prepare() before playing the silent unlock sound
- Add 15s periodic keepalive to prevent browser from re-suspending context

https://claude.ai/code/session_015rhm7qTGL8EtaRxUD8am6S