### PR TITLE
fix: Safari-compatible clipboard image copy

### DIFF
--- a/src/shared/dom/contextMenu.ts
+++ b/src/shared/dom/contextMenu.ts
@@ -85,8 +85,12 @@ export function showContextMenu(
             btn.appendChild(item.label.cloneNode(true));
         }
         btn.onclick = () => {
-            hideContextMenu();
+            // Run action BEFORE hiding the menu. hideContextMenu() destroys the
+            // clicked button via innerHTML='', which in Safari invalidates the
+            // transient user activation — clipboard.write() and similar APIs
+            // that require a user gesture would then fail with NotAllowedError.
             item.action();
+            hideContextMenu();
             const input = document.getElementById('message-input') as HTMLTextAreaElement | null;
             if (input) {
                 input.focus();

--- a/src/shared/dom/copyCanvasToClipboard.ts
+++ b/src/shared/dom/copyCanvasToClipboard.ts
@@ -1,0 +1,32 @@
+/**
+ * Copies a canvas element to the clipboard as a PNG image.
+ *
+ * Uses `Promise<Blob>` inside `ClipboardItem` so that `clipboard.write()`
+ * is called synchronously within the user gesture — required by Safari.
+ *
+ * Requires a secure context (HTTPS). Falls back to an error message on HTTP.
+ */
+export function copyCanvasToClipboard(canvas: HTMLCanvasElement): Promise<void> {
+    if (!navigator.clipboard?.write || typeof ClipboardItem === 'undefined') {
+        return Promise.reject(new Error(
+            'Kopiowanie do schowka wymaga HTTPS'
+        ));
+    }
+
+    return navigator.clipboard.write([
+        new ClipboardItem({
+            'image/png': new Promise<Blob>((resolve, reject) => {
+                canvas.toBlob(
+                    b => {
+                        if (b) {
+                            resolve(b);
+                        } else {
+                            reject(new Error('Failed to create image blob'));
+                        }
+                    },
+                    'image/png',
+                );
+            }),
+        }),
+    ]);
+}

--- a/src/web/StaticMapPopup.tsx
+++ b/src/web/StaticMapPopup.tsx
@@ -7,6 +7,7 @@ import { getNote, type LocationNote } from '@web/options/locationNotesStorage';
 import { openMapContextMenu } from '@modules/core/contextMenus';
 import { getPluginLocationNotes, type PluginLocationNote } from '@modules/core/pluginLocationNotesRegistry';
 import { getPinnedPopupsByPrefix, getPopupLockedState, getPopupSetting, setPopupSetting, setBuiltInPanelSetting, shouldPopupAutoOpen } from './layout/utils/layoutStorage';
+import { copyCanvasToClipboard } from '@shared/dom/copyCanvasToClipboard.ts';
 import { showMapNoteTooltipForRoom } from './mapNoteTooltip';
 
 interface StaticMapInstance {
@@ -875,18 +876,7 @@ function StaticMapWindow({ instance, onClose }: { instance: StaticMapInstance; o
                 ctx.drawImage(canvas, 0, 0);
             }
 
-            const blob = await new Promise<Blob>((resolve, reject) => {
-                compositeCanvas.toBlob(
-                    (b) => {
-                        if (b) resolve(b);
-                        else reject(new Error('Failed to create image blob'));
-                    },
-                    'image/png'
-                );
-            });
-            await navigator.clipboard.write([
-                new ClipboardItem({ 'image/png': blob }),
-            ]);
+            await copyCanvasToClipboard(compositeCanvas);
         } catch (err) {
             console.error('Failed to copy map as image:', err);
         }

--- a/src/web/bufferToImage.ts
+++ b/src/web/bufferToImage.ts
@@ -1,5 +1,6 @@
 import {AnsiAwareBuffer, FormatColor} from "@client/ansi/FormatState";
 import {colorCodes} from "@modules/core/Colors";
+import {copyCanvasToClipboard} from "@shared/dom/copyCanvasToClipboard.ts";
 
 export interface BufferToImageOptions {
     /** Background color (default: from output window) */
@@ -57,13 +58,10 @@ function colorToHex(color: FormatColor): string {
     return "#000000";
 }
 
-/**
- * Converts an AnsiAwareBuffer to a PNG image blob.
- */
-export async function bufferToImage(
+function bufferToCanvas(
     buffer: AnsiAwareBuffer,
     options: BufferToImageOptions = {}
-): Promise<Blob> {
+): HTMLCanvasElement {
     const outputStyles = getOutputWindowStyles();
     const {
         backgroundColor = outputStyles.backgroundColor,
@@ -195,6 +193,17 @@ export async function bufferToImage(
         }
     }
 
+    return canvas;
+}
+
+/**
+ * Converts an AnsiAwareBuffer to a PNG image blob.
+ */
+export function bufferToImage(
+    buffer: AnsiAwareBuffer,
+    options: BufferToImageOptions = {}
+): Promise<Blob> {
+    const canvas = bufferToCanvas(buffer, options);
     return new Promise<Blob>((resolve, reject) => {
         canvas.toBlob(
             (blob) => {
@@ -212,12 +221,10 @@ export async function bufferToImage(
 /**
  * Converts an AnsiAwareBuffer to a PNG image and copies it to clipboard.
  */
-export async function copyBufferAsImage(
+export function copyBufferAsImage(
     buffer: AnsiAwareBuffer,
     options: BufferToImageOptions = {}
 ): Promise<void> {
-    const blob = await bufferToImage(buffer, options);
-    await navigator.clipboard.write([
-        new ClipboardItem({'image/png': blob}),
-    ]);
+    const canvas = bufferToCanvas(buffer, options);
+    return copyCanvasToClipboard(canvas);
 }

--- a/src/web/copyOutputAsImage.ts
+++ b/src/web/copyOutputAsImage.ts
@@ -1,4 +1,5 @@
 import {areOutputTimestampsVisible} from "@shared/dom/outputMessageHandler";
+import {copyCanvasToClipboard} from "@shared/dom/copyCanvasToClipboard.ts";
 
 type UnderlineStyle = 'solid' | 'dotted';
 
@@ -448,22 +449,7 @@ export async function copyOutputAsImage(): Promise<void> {
         }
     }
 
-    const blob = await new Promise<Blob>((resolve, reject) => {
-        canvas.toBlob(
-            b => {
-                if (b) {
-                    resolve(b);
-                } else {
-                    reject(new Error('Nie udało się utworzyć obrazu'));
-                }
-            },
-            'image/png',
-        );
-    });
-
-    await navigator.clipboard.write([
-        new ClipboardItem({ 'image/png': blob }),
-    ]);
+    await copyCanvasToClipboard(canvas);
 }
 
 export async function saveOutputAsHtml(): Promise<void> {

--- a/src/web/layout/components/MapHeaderMenu.tsx
+++ b/src/web/layout/components/MapHeaderMenu.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import eventBus from '@modules/core/eventBus';
 import { useBuiltInPanelSetting } from '../../hooks/useBuiltInPanelSetting';
+import { copyCanvasToClipboard } from '@shared/dom/copyCanvasToClipboard.ts';
 import { getPopupSetting, setPopupSetting } from '../../layout/utils/layoutStorage';
 
 interface MapHeaderMenuProps {
@@ -288,8 +289,6 @@ export function MapHeaderMenu({ className = '' }: MapHeaderMenuProps) {
     const canvases = mapContainer.querySelectorAll('canvas');
     if (canvases.length === 0) return;
 
-    closeMenu();
-
     try {
       // Get dimensions from the first canvas
       const width = canvases[0].width;
@@ -311,21 +310,14 @@ export function MapHeaderMenu({ className = '' }: MapHeaderMenuProps) {
         ctx.drawImage(canvas, 0, 0);
       }
 
-      const blob = await new Promise<Blob>((resolve, reject) => {
-        compositeCanvas.toBlob(
-          (b) => {
-            if (b) resolve(b);
-            else reject(new Error('Failed to create image blob'));
-          },
-          'image/png'
-        );
-      });
-      await navigator.clipboard.write([
-        new ClipboardItem({ 'image/png': blob }),
-      ]);
+      // clipboard.write() must be called before closeMenu() — closing the
+      // menu triggers a React re-render that can invalidate the transient
+      // user activation required by Safari for clipboard access.
+      await copyCanvasToClipboard(compositeCanvas);
     } catch (err) {
       console.error('Failed to copy map as image:', err);
     }
+    closeMenu();
   }, [closeMenu]);
 
   return (


### PR DESCRIPTION
- Extract copyCanvasToClipboard helper using ClipboardItem with Promise<Blob> so clipboard.write() is called synchronously within the user gesture (Safari requirement)
- Reorder context menu: run action before hideContextMenu() to preserve transient activation (innerHTML='' destroys clicked button)
- Move closeMenu() after clipboard write in MapHeaderMenu
- Refactor bufferToImage to expose bufferToCanvas for direct canvas access without async blob conversion