### PR TITLE
feat(scripts): port Mudlet zlom script for item evaluation database

### DIFF
--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -134,6 +134,7 @@ Zakresy dzialaja rosnaco (`1-7`) i malejaco (`7-1`). Maksymalnie 50 iteracji.
 | `/zlom` | Wyswietl zapisane bronie (alias `/zlom bronie`) |
 | `/zlom tarcze` | Wyswietl zapisane tarcze |
 | `/zlom zbroje` | Wyswietl zapisane zbroje |
+| `/zlomw` | Otworz okno zlomu z tabelami i importem bazy z Mudleta |
 | `/zlom-reset` | Wyczysc baze i zdejmij podswietlenia shortow |
 
-> **Wskazowka:** Baza automatycznie zapisuje wyniki komendy `ocen <przedmiot>` i podswietla rozpoznane shorty w tekscie (pogrubienie + podkreslenie dla broni ze srebrem, dymek z typem).
+> **Wskazowka:** Baza automatycznie zapisuje wyniki komendy `ocen <przedmiot>` i podswietla rozpoznane shorty w tekscie (pogrubienie + podkreslenie dla broni ze srebrem, dymek z typem). Okno `/zlomw` pozwala zaimportowac plik `.db` z profilu Mudleta (tabele `bronie`, `tarcze`, `zbroje`).

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -126,3 +126,14 @@ Zakresy dzialaja rosnaco (`1-7`) i malejaco (`7-1`). Maksymalnie 50 iteracji.
 | `/wedka` | Otworz okno lowienia ryb z wyborem przynety i przyciskami akcji |
 
 > **Wskazowka:** Gdy ryba bierze, kliknij przycisk "Zatnij rybe" lub uzyj funkcjonalnego bindu (domyslnie `]`).
+
+## Zlom (baza ocenionych przedmiotow)
+
+| Komenda | Opis |
+|---------|------|
+| `/zlom` | Wyswietl zapisane bronie (alias `/zlom bronie`) |
+| `/zlom tarcze` | Wyswietl zapisane tarcze |
+| `/zlom zbroje` | Wyswietl zapisane zbroje |
+| `/zlom-reset` | Wyczysc baze i zdejmij podswietlenia shortow |
+
+> **Wskazowka:** Baza automatycznie zapisuje wyniki komendy `ocen <przedmiot>` i podswietla rozpoznane shorty w tekscie (pogrubienie + podkreslenie dla broni ze srebrem, dymek z typem).

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -137,4 +137,4 @@ Zakresy dzialaja rosnaco (`1-7`) i malejaco (`7-1`). Maksymalnie 50 iteracji.
 | `/zlomw` | Otworz okno zlomu z tabelami i importem bazy z Mudleta |
 | `/zlom-reset` | Wyczysc baze i zdejmij podswietlenia shortow |
 
-> **Wskazowka:** Baza automatycznie zapisuje wyniki komendy `ocen <przedmiot>` i podswietla rozpoznane shorty w tekscie (pogrubienie + podkreslenie dla broni ze srebrem, dymek z typem). Okno `/zlomw` pozwala zaimportowac plik `.db` z profilu Mudleta (tabele `bronie`, `tarcze`, `zbroje`).
+> **Wskazowka:** Baza automatycznie zapisuje wyniki komendy `ocen <przedmiot>` i podswietla rozpoznane shorty w tekscie (pogrubienie + podkreslenie dla broni ze srebrem, dymek z typem). Kolory shortow ustawiasz w oknie `/zlomw` (kolumna "Kolor") — te same kolory stosowane sa w listach lupu (`loot`) i w pojemnikach (`pretty containers`). Przelacznik "Srebro" w naglowku okna kontroluje podkreslanie broni ze srebra. Okno pozwala tez zaimportowac plik `.db` z profilu Mudleta (tabele `bronie`, `tarcze`, `zbroje`).

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -290,6 +290,7 @@ export function registerScripts(client: Client) {
     pluginManager = initExternalScripts(client)
     initUserAliases(client, aliases)
     initUserTriggers(client)
+    initZlom(client, aliases)
     initWeaponEvaluation(client)
     initArmorEvaluation(client)
     initParryShieldEvaluation(client)
@@ -327,6 +328,5 @@ export function registerScripts(client: Client) {
     initTcolor(client, aliases)
     initOpal(client)
     initLastSeen(client, aliases)
-    initZlom(client, aliases)
 
 }

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -140,6 +140,7 @@ import initDataRefresh from './scripts/dataRefresh'
 import initTcolor from './scripts/tcolor'
 import initOpal from './scripts/opal'
 import initLastSeen from './scripts/lastSeen'
+import initZlom from './scripts/zlom'
 
 // Global reference to PluginManager
 let pluginManager: ReturnType<typeof initExternalScripts> | null = null;
@@ -326,5 +327,6 @@ export function registerScripts(client: Client) {
     initTcolor(client, aliases)
     initOpal(client)
     initLastSeen(client, aliases)
+    initZlom(client, aliases)
 
 }

--- a/src/client/scripts/lootParser.ts
+++ b/src/client/scripts/lootParser.ts
@@ -3,6 +3,8 @@ import { parseItems, ContainerItem, getItemCssColor, isItemMagicOrKey } from "./
 import { AnsiAwareBuffer } from "../ansi/FormatState";
 import { createColorFormat } from "@modules/core/Colors";
 import eventBus from "@modules/core/eventBus";
+import { getZlomFormatting } from "./zlom";
+import { characterStorage } from "@modules/core/storage";
 
 export type LootPopupPayload = {
     description: string;
@@ -15,6 +17,8 @@ export type LootItem = ContainerItem & {
     color?: string;
     fullName: string;
     special?: boolean;
+    underline?: boolean;
+    title?: string;
 };
 
 let popupMode = false;
@@ -92,11 +96,13 @@ function splitRawParts(content: string): string[] {
 function enrichItems(rawText: string): LootItem[] {
     const items = parseItems(rawText);
     const originalParts = splitRawParts(rawText);
+    const colorSilver = characterStorage.get('settings')?.zlomColorSilver !== false;
     return items.map((item, i) => {
-        const color = getItemCssColor(item.name);
+        const zlom = getZlomFormatting(item.name, { colorSilver });
+        const color = zlom?.color ?? getItemCssColor(item.name);
         const fullName = originalParts[i] ?? item.name;
         const special = isItemMagicOrKey(item.name);
-        return { ...item, color, fullName, special };
+        return { ...item, color, fullName, special, underline: zlom?.underline, title: zlom?.title };
     });
 }
 
@@ -211,17 +217,18 @@ export default function initLootParser(client: Client) {
 
                 // Color items first
                 for (const item of items) {
-                    if (item.color) {
-                        const colorFormat = createColorFormat(item.color);
-                        const haystack = buffer.text.toLowerCase();
-                        const needle = item.fullName.toLowerCase();
-                        let searchStart = 0;
-                        while (searchStart <= buffer.text.length - needle.length) {
-                            const idx = haystack.indexOf(needle, searchStart);
-                            if (idx === -1) break;
-                            buffer.color([idx, idx + item.fullName.length], colorFormat);
-                            searchStart = idx + item.fullName.length;
-                        }
+                    if (!item.color && !item.underline) continue;
+                    const fmt = item.color
+                        ? { ...createColorFormat(item.color), underline: item.underline ? true : undefined }
+                        : { underline: true };
+                    const haystack = buffer.text.toLowerCase();
+                    const needle = item.fullName.toLowerCase();
+                    let searchStart = 0;
+                    while (searchStart <= buffer.text.length - needle.length) {
+                        const idx = haystack.indexOf(needle, searchStart);
+                        if (idx === -1) break;
+                        buffer.applyFormat([idx, idx + item.fullName.length], fmt);
+                        searchStart = idx + item.fullName.length;
                     }
                 }
 

--- a/src/client/scripts/lootParser.ts
+++ b/src/client/scripts/lootParser.ts
@@ -4,7 +4,6 @@ import { AnsiAwareBuffer } from "../ansi/FormatState";
 import { createColorFormat } from "@modules/core/Colors";
 import eventBus from "@modules/core/eventBus";
 import { getZlomFormatting } from "./zlom";
-import { characterStorage } from "@modules/core/storage";
 
 export type LootPopupPayload = {
     description: string;
@@ -17,7 +16,6 @@ export type LootItem = ContainerItem & {
     color?: string;
     fullName: string;
     special?: boolean;
-    underline?: boolean;
     title?: string;
 };
 
@@ -96,13 +94,12 @@ function splitRawParts(content: string): string[] {
 function enrichItems(rawText: string): LootItem[] {
     const items = parseItems(rawText);
     const originalParts = splitRawParts(rawText);
-    const colorSilver = characterStorage.get('settings')?.zlomColorSilver !== false;
     return items.map((item, i) => {
-        const zlom = getZlomFormatting(item.name, { colorSilver });
+        const zlom = getZlomFormatting(item.name);
         const color = zlom?.color ?? getItemCssColor(item.name);
         const fullName = originalParts[i] ?? item.name;
         const special = isItemMagicOrKey(item.name);
-        return { ...item, color, fullName, special, underline: zlom?.underline, title: zlom?.title };
+        return { ...item, color, fullName, special, title: zlom?.title };
     });
 }
 
@@ -217,10 +214,8 @@ export default function initLootParser(client: Client) {
 
                 // Color items first
                 for (const item of items) {
-                    if (!item.color && !item.underline) continue;
-                    const fmt = item.color
-                        ? { ...createColorFormat(item.color), underline: item.underline ? true : undefined }
-                        : { underline: true };
+                    if (!item.color) continue;
+                    const fmt = createColorFormat(item.color);
                     const haystack = buffer.text.toLowerCase();
                     const needle = item.fullName.toLowerCase();
                     let searchStart = 0;

--- a/src/client/scripts/prettyContainers.ts
+++ b/src/client/scripts/prettyContainers.ts
@@ -17,6 +17,7 @@ import {
 import { polishNumberWords, polishNumberPattern } from "./polishNumberConverter";
 import { characterStorage } from "@modules/core/storage";
 import { defaultSettings } from "@modules/core/defaultSettings";
+import { getZlomFormatting } from "./zlom";
 
 const GROUP_NAME_COLOR = createColorFormat('#557C99');
 
@@ -409,6 +410,18 @@ const defaultTransforms: TransformDefinition[] = [
             buffer.color([0, buffer.length], COPPER_COLOR);
         }
         return buffer;
+    }},
+    { transform: (buffer, item) => {
+        const colorSilver = characterStorage.get('settings')?.zlomColorSilver !== false;
+        const zlom = getZlomFormatting(item.name, { colorSilver });
+        if (!zlom) return buffer;
+        if (zlom.color) {
+            buffer.applyFormat([0, buffer.length], { foreground: { space: 'hex', color: zlom.color } });
+        }
+        if (zlom.underline) {
+            buffer.applyFormat([0, buffer.length], { underline: true });
+        }
+        return buffer;
     }}
 ]
 
@@ -427,6 +440,10 @@ let magicFilter: ((name: string) => boolean) | null = null;
  * (coins, magic keys, magics, item categories).
  */
 export function getItemCssColor(name: string): string | undefined {
+    // User-assigned zlom color wins
+    const zlomColor = getZlomFormatting(name)?.color;
+    if (zlomColor) return zlomColor;
+
     // Coin colors (highest priority)
     if (/mithryl\w+ monet/.test(name)) return '#afeeee';
     if (/zlot\w+ monet/.test(name)) return '#ffd700';

--- a/src/client/scripts/prettyContainers.ts
+++ b/src/client/scripts/prettyContainers.ts
@@ -412,14 +412,16 @@ const defaultTransforms: TransformDefinition[] = [
         return buffer;
     }},
     { transform: (buffer, item) => {
-        const colorSilver = characterStorage.get('settings')?.zlomColorSilver !== false;
-        const zlom = getZlomFormatting(item.name, { colorSilver });
+        const zlom = getZlomFormatting(item.name);
         if (!zlom) return buffer;
         if (zlom.color) {
             buffer.applyFormat([0, buffer.length], { foreground: { space: 'hex', color: zlom.color } });
         }
-        if (zlom.underline) {
-            buffer.applyFormat([0, buffer.length], { underline: true });
+        if (zlom.silver) {
+            const badge = ' [Ag]';
+            const start = buffer.length;
+            buffer.append(badge, {});
+            buffer.applyFormat([start, buffer.length], { foreground: { space: 'hex', color: '#dadada' } });
         }
         return buffer;
     }}

--- a/src/client/scripts/zlom.ts
+++ b/src/client/scripts/zlom.ts
@@ -1,0 +1,517 @@
+import Client from "../Client";
+import { characterStorage } from "@modules/core/storage";
+import { AnsiAwareBuffer, FormatStateSnapshot } from "@client/ansi/FormatState";
+import { ARMOR_QUALITY, BALANCE, EFFECTIVENESS } from "./evaluationConstants";
+
+export interface WeaponEntry {
+    short: string;
+    typ: string;
+    rodzaj: string;
+    klute: number;
+    obuch: number;
+    ciete: number;
+    chwyt: string;
+    magik: 0 | 1;
+    srebro: 0 | 1;
+    opis: string;
+    waga: number;
+    obj: number;
+    cena: number;
+    wywazenie: number;
+    parowanie: number;
+    roomId: number | null;
+}
+
+export interface ArmorEntry {
+    short: string;
+    typ: string;
+    klute: number;
+    obuch: number;
+    ciete: number;
+    magik: 0 | 1;
+    opis: string;
+    waga: number;
+    obj: number;
+    cena: number;
+    oslona: string;
+    roomId: number | null;
+}
+
+export interface ShieldEntry {
+    short: string;
+    klute: number;
+    obuch: number;
+    ciete: number;
+    magik: 0 | 1;
+    opis: string;
+    waga: number;
+    obj: number;
+    cena: number;
+    parowanie: number;
+    oslona: string;
+    roomId: number | null;
+}
+
+export interface ZlomSnapshot {
+    bronie: Record<string, WeaponEntry>;
+    tarcze: Record<string, ShieldEntry>;
+    zbroje: Record<string, ArmorEntry>;
+}
+
+export const ZLOM_STORAGE_KEY = "zlom";
+const HIGHLIGHT_TAG = "zlom-highlight";
+const PARSER_TAG = "zlom-parser";
+
+const SILVER_TYP_TOOLTIP = "srebro";
+
+type Kind = "bron" | "zbroja" | "tarcza";
+
+interface PendingEval {
+    opis?: string;
+    short?: string;
+    waga?: number;
+    obj?: number;
+    cena?: number;
+    rodzaj?: string;
+    chwyt?: string;
+    obrazenia?: string;
+    typ?: string;
+    oslona?: string;
+    wywazenie?: number;
+    parowanie?: number;
+    magik?: 0 | 1;
+    srebro?: 0 | 1;
+    klute?: number;
+    obuch?: number;
+    ciete?: number;
+    kind?: Kind;
+    armorType?: string;
+    awaitingOpis?: boolean;
+}
+
+const DAMAGE_MAP: Record<string, keyof ArmorProtection> = {
+    klutymi: "klute",
+    cietymi: "ciete",
+    obuchowymi: "obuch",
+};
+
+interface ArmorProtection {
+    klute: number;
+    ciete: number;
+    obuch: number;
+}
+
+function emptySnapshot(): ZlomSnapshot {
+    return { bronie: {}, tarcze: {}, zbroje: {} };
+}
+
+export function loadZlomSnapshot(): ZlomSnapshot {
+    const stored = characterStorage.get(ZLOM_STORAGE_KEY) as ZlomSnapshot | undefined;
+    if (!stored) return emptySnapshot();
+    return {
+        bronie: stored.bronie ?? {},
+        tarcze: stored.tarcze ?? {},
+        zbroje: stored.zbroje ?? {},
+    };
+}
+
+export function saveZlomSnapshot(s: ZlomSnapshot): void {
+    characterStorage.set(ZLOM_STORAGE_KEY, s);
+}
+
+function parseWeightObj(waga: string, wagaJ: string, obj: string, objJ: string): { waga: number; obj: number } {
+    let w = parseInt(waga, 10);
+    let o = parseInt(obj, 10);
+    if (wagaJ === "kilogram") w *= 1000;
+    if (objJ === "litr") o *= 1000;
+    return { waga: w, obj: o };
+}
+
+function balanceValue(raw: string): number {
+    return BALANCE[raw.trim().toLowerCase()]?.value ?? 0;
+}
+
+function effectivenessValue(raw: string): number {
+    const lower = raw.trim().toLowerCase();
+    const key = Object.keys(EFFECTIVENESS).find((k) => lower.startsWith(k));
+    return key ? EFFECTIVENESS[key].value : 0;
+}
+
+function armorQualityValue(raw: string): number {
+    return ARMOR_QUALITY[raw.trim().toLowerCase()]?.value ?? 0;
+}
+
+function extractArmorProtection(text: string): { prot: ArmorProtection; parry?: string } | undefined {
+    let parry: string | undefined;
+    const parryMatch = text.match(/Ponadto jest (.*) w parowaniu ciosow\./);
+    if (parryMatch) {
+        parry = parryMatch[1].trim();
+        text = text.replace(parryMatch[0], "").trim();
+    }
+
+    const p1 = text.match(
+        /(.*) przed obrazeniami (klutymi|cietymi|obuchowymi), (.*) przed (klutymi|cietymi|obuchowymi) i (.*) przed (klutymi|cietymi|obuchowymi)\./,
+    );
+    if (p1) {
+        const prot: ArmorProtection = { klute: 0, ciete: 0, obuch: 0 };
+        prot[DAMAGE_MAP[p1[2]]] = armorQualityValue(p1[1]);
+        prot[DAMAGE_MAP[p1[4]]] = armorQualityValue(p1[3]);
+        prot[DAMAGE_MAP[p1[6]]] = armorQualityValue(p1[5]);
+        return { prot, parry };
+    }
+
+    const p2 = text.match(
+        /(.*) przed obrazeniami (klutymi|cietymi|obuchowymi), (klutymi|cietymi|obuchowymi) i (klutymi|cietymi|obuchowymi)\./,
+    );
+    if (p2) {
+        const prot: ArmorProtection = { klute: 0, ciete: 0, obuch: 0 };
+        const q = armorQualityValue(p2[1]);
+        [p2[2], p2[3], p2[4]].forEach((t) => {
+            prot[DAMAGE_MAP[t]] = q;
+        });
+        return { prot, parry };
+    }
+
+    const p3 = text.match(
+        /(.*) przed obrazeniami (cietymi|klutymi|obuchowymi) i (klutymi|cietymi|obuchowymi) oraz (.*) przed (klutymi|cietymi|obuchowymi)\./,
+    );
+    if (p3) {
+        const prot: ArmorProtection = { klute: 0, ciete: 0, obuch: 0 };
+        const q1 = armorQualityValue(p3[1]);
+        prot[DAMAGE_MAP[p3[2]]] = q1;
+        prot[DAMAGE_MAP[p3[3]]] = q1;
+        prot[DAMAGE_MAP[p3[5]]] = armorQualityValue(p3[4]);
+        return { prot, parry };
+    }
+
+    const p4 = text.match(/(.*) przed obrazeniami (klutymi|cietymi|obuchowymi)\./);
+    if (p4) {
+        const q = armorQualityValue(p4[1]);
+        const prot: ArmorProtection = { klute: q, ciete: q, obuch: q };
+        prot[DAMAGE_MAP[p4[2]]] = q;
+        return { prot, parry };
+    }
+
+    return undefined;
+}
+
+function registerHighlight(client: Client, short: string, typ: string | undefined, silver: boolean) {
+    if (!short) return;
+    client.Triggers.registerTrigger(
+        new RegExp(escapeRegex(short)),
+        (line) => {
+            const idx = line.text.indexOf(short);
+            if (idx === -1) return line;
+            const end = idx + short.length;
+            const fmt: FormatStateSnapshot = { bold: true };
+            if (silver) fmt.underline = true;
+            line.applyFormat([idx, end], fmt);
+            line.createLink([idx, end], {
+                title: buildHint(typ, silver),
+                onClick: () => {},
+            });
+            return line;
+        },
+        HIGHLIGHT_TAG,
+    );
+}
+
+function buildHint(typ: string | undefined, silver: boolean): string {
+    const parts: string[] = [];
+    if (typ) parts.push(typ);
+    if (silver) parts.push(SILVER_TYP_TOOLTIP);
+    return parts.join(" / ");
+}
+
+function escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function reinstallHighlights(client: Client, snap: ZlomSnapshot) {
+    client.Triggers.removeByTag(HIGHLIGHT_TAG);
+    for (const b of Object.values(snap.bronie)) {
+        registerHighlight(client, b.short, b.typ, b.srebro > 0);
+    }
+    for (const t of Object.values(snap.tarcze)) {
+        registerHighlight(client, t.short, "tarcza", false);
+    }
+    for (const z of Object.values(snap.zbroje)) {
+        registerHighlight(client, z.short, z.typ, false);
+    }
+}
+
+export default function initZlom(
+    client: Client,
+    aliases?: { pattern: RegExp; callback: Function }[],
+): void {
+    let snap = loadZlomSnapshot();
+    reinstallHighlights(client, snap);
+
+    let ctx: PendingEval | null = null;
+
+    const roomId = (): number | null => client.Map?.currentRoom?.id ?? null;
+
+    const persistBron = () => {
+        if (!ctx || ctx.kind !== "bron" || !ctx.short) return;
+        const entry: WeaponEntry = {
+            short: ctx.short,
+            typ: ctx.typ ?? "",
+            rodzaj: ctx.rodzaj ?? "",
+            klute: ctx.klute ?? 0,
+            obuch: ctx.obuch ?? 0,
+            ciete: ctx.ciete ?? 0,
+            chwyt: ctx.chwyt ?? "",
+            magik: ctx.magik ?? 0,
+            srebro: ctx.srebro ?? 0,
+            opis: ctx.opis ?? "",
+            waga: ctx.waga ?? 0,
+            obj: ctx.obj ?? 0,
+            cena: ctx.cena ?? 0,
+            wywazenie: ctx.wywazenie ?? 0,
+            parowanie: ctx.parowanie ?? 0,
+            roomId: roomId(),
+        };
+        snap.bronie[entry.short] = entry;
+        saveZlomSnapshot(snap);
+        registerHighlight(client, entry.short, entry.typ, entry.srebro > 0);
+    };
+
+    const persistZbroja = () => {
+        if (!ctx || ctx.kind !== "zbroja" || !ctx.short) return;
+        const entry: ArmorEntry = {
+            short: ctx.short,
+            typ: ctx.armorType ?? "",
+            klute: ctx.klute ?? 0,
+            obuch: ctx.obuch ?? 0,
+            ciete: ctx.ciete ?? 0,
+            magik: ctx.magik ?? 0,
+            opis: ctx.opis ?? "",
+            waga: ctx.waga ?? 0,
+            obj: ctx.obj ?? 0,
+            cena: ctx.cena ?? 0,
+            oslona: ctx.oslona ?? "",
+            roomId: roomId(),
+        };
+        snap.zbroje[entry.short] = entry;
+        saveZlomSnapshot(snap);
+        registerHighlight(client, entry.short, entry.typ, false);
+    };
+
+    const persistTarcza = () => {
+        if (!ctx || ctx.kind !== "tarcza" || !ctx.short) return;
+        const entry: ShieldEntry = {
+            short: ctx.short,
+            klute: ctx.klute ?? 0,
+            obuch: ctx.obuch ?? 0,
+            ciete: ctx.ciete ?? 0,
+            magik: ctx.magik ?? 0,
+            opis: ctx.opis ?? "",
+            waga: ctx.waga ?? 0,
+            obj: ctx.obj ?? 0,
+            cena: ctx.cena ?? 0,
+            parowanie: ctx.parowanie ?? 0,
+            oslona: ctx.oslona ?? "",
+            roomId: roomId(),
+        };
+        snap.tarcze[entry.short] = entry;
+        saveZlomSnapshot(snap);
+        registerHighlight(client, entry.short, "tarcza", false);
+    };
+
+    client.Triggers.registerTrigger(
+        /^Oceniasz starannie (.+)\.$/,
+        (line) => {
+            ctx = { awaitingOpis: true };
+            return line;
+        },
+        PARSER_TAG,
+    );
+
+    client.Triggers.registerTrigger(
+        /^(.+)$/,
+        (line, m) => {
+            if (!ctx || !ctx.awaitingOpis) return line;
+            const text = m[1];
+            if (
+                /^Oceniasz starannie /.test(text) ||
+                /^Oceniasz, ze /.test(text) ||
+                /^Wyglada na to, /.test(text)
+            ) {
+                return line;
+            }
+            ctx.opis = text;
+            ctx.awaitingOpis = false;
+            return line;
+        },
+        PARSER_TAG,
+    );
+
+    client.Triggers.registerTrigger(
+        /^Oceniasz, ze (.+?) waz[ay] (\d+) (kilogram|gram)\w*, zas \w+ objetosc wynosi (\d+) (mililitr|litr)\w*\.$/,
+        (line, m) => {
+            if (!ctx) return line;
+            ctx.short = m[1];
+            const parsed = parseWeightObj(m[2], m[3], m[4], m[5]);
+            ctx.waga = parsed.waga;
+            ctx.obj = parsed.obj;
+            ctx.awaitingOpis = false;
+            return line;
+        },
+        PARSER_TAG,
+    );
+
+    client.Triggers.registerTrigger(
+        /^Wydaje ci sie, ze (?:jest|sa) wart[aye]? okolo (\d+) mied\w+\.$/,
+        (line, m) => {
+            if (!ctx) return line;
+            ctx.cena = parseInt(m[1], 10);
+            return line;
+        },
+        PARSER_TAG,
+    );
+
+    client.Triggers.registerTrigger(
+        /^Zauwazasz, iz (.+?) (?:jest|sa) przystosowan\w* do chwytania (.+?)\.$/,
+        (line, m) => {
+            if (!ctx) return line;
+            ctx.kind = "bron";
+            ctx.rodzaj = m[1];
+            ctx.chwyt = m[2];
+            return line;
+        },
+        PARSER_TAG,
+    );
+
+    client.Triggers.registerTrigger(
+        /^Za (?:jego|jej|ich) pomoca mozna zadawac rany (.+?)\.$/,
+        (line, m) => {
+            if (!ctx || ctx.kind !== "bron") return line;
+            const w = m[1];
+            ctx.obrazenia = w;
+            ctx.klute = /klute/.test(w) ? 1 : 0;
+            ctx.obuch = /obuch/.test(w) ? 1 : 0;
+            ctx.ciete = /ciete/.test(w) ? 1 : 0;
+            return line;
+        },
+        PARSER_TAG,
+    );
+
+    client.Triggers.registerTrigger(
+        /^Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na (.+?) (?:jest|sa) on\w* (.+?) wywazon\w* i (.+?)\.$/,
+        (line, m) => {
+            if (!ctx || ctx.kind !== "bron") return line;
+            ctx.typ = m[1].replace(/maczuge/g, "maczuga").trim();
+            ctx.wywazenie = balanceValue(m[2]);
+            ctx.parowanie = effectivenessValue(m[3]);
+            persistBron();
+            return line;
+        },
+        PARSER_TAG,
+    );
+
+    client.Triggers.registerTrigger(
+        /^Sadzac po delikatnym drzeniu w broni tej zostala zakleta jakas magia,/,
+        (line) => {
+            if (!ctx || ctx.kind !== "bron" || !ctx.short) return line;
+            ctx.magik = 1;
+            persistBron();
+            return line;
+        },
+        PARSER_TAG,
+    );
+
+    client.Triggers.registerTrigger(
+        /^Do wykonania tej broni uzyto srebra,/,
+        (line) => {
+            if (!ctx || ctx.kind !== "bron" || !ctx.short) return line;
+            ctx.srebro = 1;
+            persistBron();
+            return line;
+        },
+        PARSER_TAG,
+    );
+
+    client.Triggers.registerTrigger(
+        /^Zaklada sie (?:go|ja) na (.+?)\.$/,
+        (line, m) => {
+            if (!ctx) return line;
+            ctx.oslona = m[1];
+            return line;
+        },
+        PARSER_TAG,
+    );
+
+    client.Triggers.registerTrigger(
+        /^Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze (jak na (lekka|srednia|ciezka) zbroje (chroni|chronia)|(chroni|chronia)) (on|ona|one) (.*)$/,
+        (line, m) => {
+            if (!ctx) return line;
+            const armorType = m[2];
+            const rest = m[6];
+            const extracted = extractArmorProtection(rest);
+            if (!extracted) return line;
+            const { prot, parry } = extracted;
+            ctx.klute = prot.klute;
+            ctx.obuch = prot.obuch;
+            ctx.ciete = prot.ciete;
+            if (armorType) {
+                ctx.kind = "zbroja";
+                ctx.armorType = armorType;
+                persistZbroja();
+            } else {
+                ctx.kind = "tarcza";
+                ctx.parowanie = parry ? effectivenessValue(parry) : 0;
+                persistTarcza();
+            }
+            return line;
+        },
+        PARSER_TAG,
+    );
+
+    client.Triggers.registerTrigger(
+        /^Sadzac po delikatnym drzeniu w zbroi tej zostala zakleta jakas magia/,
+        (line) => {
+            if (!ctx || !ctx.short) return line;
+            ctx.magik = 1;
+            if (ctx.kind === "zbroja") persistZbroja();
+            else if (ctx.kind === "tarcza") persistTarcza();
+            return line;
+        },
+        PARSER_TAG,
+    );
+
+    if (aliases) {
+        aliases.push({
+            pattern: /^\/zlom(?:\s+(bronie|tarcze|zbroje))?$/,
+            callback: (m: RegExpMatchArray) => {
+                snap = loadZlomSnapshot();
+                const kind = m[1] ?? "bronie";
+                const entries: (WeaponEntry | ShieldEntry | ArmorEntry)[] = Object.values(
+                    (snap as any)[kind] ?? {},
+                );
+                if (entries.length === 0) {
+                    client.println(`Brak zapisanych pozycji w tabeli ${kind}.`);
+                    return;
+                }
+                const out = new AnsiAwareBuffer();
+                out.append(`--- zlom: ${kind} (${entries.length}) ---\n`, { bold: true });
+                for (const e of entries) {
+                    const prot = `${e.klute}/${e.obuch}/${e.ciete}`;
+                    out.append(`${e.short}  `, { bold: true });
+                    out.append(`[${prot}] ${e.cena ?? 0}mi ${e.waga ?? 0}g\n`, {});
+                }
+                client.println(out);
+            },
+        });
+
+        aliases.push({
+            pattern: /^\/zlom-reset$/,
+            callback: () => {
+                snap = emptySnapshot();
+                saveZlomSnapshot(snap);
+                client.Triggers.removeByTag(HIGHLIGHT_TAG);
+                client.println("Baza zlomu wyczyszczona.");
+            },
+        });
+    }
+
+}

--- a/src/client/scripts/zlom.ts
+++ b/src/client/scripts/zlom.ts
@@ -3,69 +3,30 @@ import { characterStorage } from "@modules/core/storage";
 import { AnsiAwareBuffer, FormatStateSnapshot } from "@client/ansi/FormatState";
 import { ARMOR_QUALITY, BALANCE, EFFECTIVENESS } from "./evaluationConstants";
 import eventBus from "@modules/core/eventBus";
+import {
+    ensureZlomLoaded,
+    getZlomSnapshot,
+    subscribeZlom,
+    updateZlomSnapshot,
+    clearZlomStore,
+    upsertByOpis,
+    type WeaponEntry,
+    type ArmorEntry,
+    type ShieldEntry,
+    type ZlomEntry,
+    type ZlomKind,
+    type ZlomSnapshot,
+} from "@modules/data/zlomStore";
 
-export interface WeaponEntry {
-    short: string;
-    typ: string;
-    rodzaj: string;
-    klute: number;
-    obuch: number;
-    ciete: number;
-    chwyt: string;
-    magik: 0 | 1;
-    srebro: 0 | 1;
-    opis: string;
-    waga: number;
-    obj: number;
-    cena: number;
-    wywazenie: number;
-    parowanie: number;
-    roomId: number | null;
-    color?: string;
-}
+export type {
+    WeaponEntry,
+    ArmorEntry,
+    ShieldEntry,
+    ZlomEntry,
+    ZlomKind,
+    ZlomSnapshot,
+};
 
-export interface ArmorEntry {
-    short: string;
-    typ: string;
-    klute: number;
-    obuch: number;
-    ciete: number;
-    magik: 0 | 1;
-    opis: string;
-    waga: number;
-    obj: number;
-    cena: number;
-    oslona: string;
-    roomId: number | null;
-    color?: string;
-}
-
-export interface ShieldEntry {
-    short: string;
-    klute: number;
-    obuch: number;
-    ciete: number;
-    magik: 0 | 1;
-    opis: string;
-    waga: number;
-    obj: number;
-    cena: number;
-    parowanie: number;
-    oslona: string;
-    roomId: number | null;
-    color?: string;
-}
-
-export type ZlomEntry = WeaponEntry | ShieldEntry | ArmorEntry;
-export type ZlomKind = 'bronie' | 'tarcze' | 'zbroje';
-
-export interface ZlomSnapshot {
-    bronie: Record<string, WeaponEntry>;
-    tarcze: Record<string, ShieldEntry>;
-    zbroje: Record<string, ArmorEntry>;
-}
-
-export const ZLOM_STORAGE_KEY = "zlom";
 const HIGHLIGHT_TAG = "zlom-highlight";
 const PARSER_TAG = "zlom-parser";
 
@@ -106,122 +67,6 @@ interface ArmorProtection {
     klute: number;
     ciete: number;
     obuch: number;
-}
-
-function emptySnapshot(): ZlomSnapshot {
-    return { bronie: {}, tarcze: {}, zbroje: {} };
-}
-
-export function loadZlomSnapshot(): ZlomSnapshot {
-    const stored = characterStorage.get(ZLOM_STORAGE_KEY) as ZlomSnapshot | undefined;
-    if (!stored) return emptySnapshot();
-    return {
-        bronie: stored.bronie ?? {},
-        tarcze: stored.tarcze ?? {},
-        zbroje: stored.zbroje ?? {},
-    };
-}
-
-export function saveZlomSnapshot(s: ZlomSnapshot): void {
-    characterStorage.set(ZLOM_STORAGE_KEY, s);
-    eventBus.emit("zlom.updated");
-}
-
-export function setZlomColor(kind: ZlomKind, short: string, color: string | undefined): void {
-    const snap = loadZlomSnapshot();
-    const entry = (snap[kind] as Record<string, ZlomEntry>)[short];
-    if (!entry) return;
-    if (color) entry.color = color;
-    else delete entry.color;
-    saveZlomSnapshot(snap);
-    eventBus.emit("zlom.snapshotReplaced");
-}
-
-export interface ZlomFormatting {
-    color?: string;
-    underline: boolean;
-    title?: string;
-}
-
-/**
- * Returns the zlom-driven formatting for an item name, or undefined if no saved entry matches.
- * Uses character's zlom snapshot plus zlomColorSilver setting for silver underline.
- */
-export function getZlomFormatting(name: string, opts: { colorSilver?: boolean } = {}): ZlomFormatting | undefined {
-    if (!name) return undefined;
-    const snap = loadZlomSnapshot();
-    const lower = name.toLowerCase();
-    const scan = (records: Record<string, ZlomEntry>): ZlomEntry | undefined => {
-        if (records[name]) return records[name];
-        for (const key of Object.keys(records)) {
-            if (lower.includes(key.toLowerCase())) return records[key];
-        }
-        return undefined;
-    };
-    const entry = scan(snap.bronie) ?? scan(snap.tarcze) ?? scan(snap.zbroje);
-    if (!entry) return undefined;
-    const silver = (entry as WeaponEntry).srebro === 1;
-    const magic = entry.magik === 1;
-    const underline = silver && (opts.colorSilver ?? true);
-    const titleParts: string[] = [];
-    if ((entry as WeaponEntry).typ) titleParts.push((entry as WeaponEntry).typ);
-    else if ((entry as ShieldEntry).oslona) titleParts.push('tarcza');
-    if (silver) titleParts.push(SILVER_TYP_TOOLTIP);
-    if (magic) titleParts.push('magia');
-    return {
-        color: entry.color,
-        underline,
-        title: titleParts.length ? titleParts.join(' / ') : undefined,
-    };
-}
-
-function emitSnapshotReplaced(): void {
-    eventBus.emit("zlom.snapshotReplaced");
-}
-
-export type ZlomMergeMode = 'replace' | 'keep';
-
-export interface ZlomImportPayload {
-    bronie: WeaponEntry[];
-    tarcze: ShieldEntry[];
-    zbroje: ArmorEntry[];
-}
-
-export interface ZlomImportCounts {
-    bronie: number;
-    tarcze: number;
-    zbroje: number;
-}
-
-export function mergeZlomData(data: ZlomImportPayload, mode: ZlomMergeMode = 'replace'): ZlomImportCounts {
-    const snap = loadZlomSnapshot();
-    let b = 0, t = 0, z = 0;
-    for (const e of data.bronie) {
-        if (!e.short) continue;
-        if (mode === 'keep' && snap.bronie[e.short]) continue;
-        snap.bronie[e.short] = e;
-        b++;
-    }
-    for (const e of data.tarcze) {
-        if (!e.short) continue;
-        if (mode === 'keep' && snap.tarcze[e.short]) continue;
-        snap.tarcze[e.short] = e;
-        t++;
-    }
-    for (const e of data.zbroje) {
-        if (!e.short) continue;
-        if (mode === 'keep' && snap.zbroje[e.short]) continue;
-        snap.zbroje[e.short] = e;
-        z++;
-    }
-    saveZlomSnapshot(snap);
-    emitSnapshotReplaced();
-    return { bronie: b, tarcze: t, zbroje: z };
-}
-
-export function clearZlomData(): void {
-    saveZlomSnapshot(emptySnapshot());
-    emitSnapshotReplaced();
 }
 
 function parseWeightObj(waga: string, wagaJ: string, obj: string, objJ: string): { waga: number; obj: number } {
@@ -300,8 +145,125 @@ function extractArmorProtection(text: string): { prot: ArmorProtection; parry?: 
     return undefined;
 }
 
-function registerHighlight(client: Client, entry: ZlomEntry) {
-    const short = entry.short;
+export type ZlomMergeMode = 'replace' | 'keep';
+
+export interface ZlomImportPayload {
+    bronie: WeaponEntry[];
+    tarcze: ShieldEntry[];
+    zbroje: ArmorEntry[];
+}
+
+export interface ZlomImportCounts {
+    bronie: number;
+    tarcze: number;
+    zbroje: number;
+}
+
+export async function mergeZlomData(
+    data: ZlomImportPayload,
+    mode: ZlomMergeMode = 'replace',
+): Promise<ZlomImportCounts> {
+    let counts: ZlomImportCounts = { bronie: 0, tarcze: 0, zbroje: 0 };
+    await updateZlomSnapshot(current => {
+        const merge = <T extends ZlomEntry>(dst: T[], src: T[]): { list: T[]; count: number } => {
+            let list = dst.slice();
+            let count = 0;
+            for (const e of src) {
+                if (!e.opis) continue;
+                const idx = list.findIndex(x => x.opis === e.opis);
+                if (idx >= 0) {
+                    if (mode === 'keep') continue;
+                    const prev = list[idx];
+                    const merged: T = { ...e };
+                    if (!merged.color && prev.color) merged.color = prev.color;
+                    list[idx] = merged;
+                } else {
+                    list.push(e);
+                }
+                count++;
+            }
+            return { list, count };
+        };
+        const b = merge(current.bronie, data.bronie);
+        const t = merge(current.tarcze, data.tarcze);
+        const z = merge(current.zbroje, data.zbroje);
+        counts = { bronie: b.count, tarcze: t.count, zbroje: z.count };
+        return { bronie: b.list, tarcze: t.list, zbroje: z.list };
+    });
+    eventBus.emit('zlom.snapshotReplaced');
+    return counts;
+}
+
+export async function clearZlomData(): Promise<void> {
+    await clearZlomStore();
+    eventBus.emit('zlom.snapshotReplaced');
+}
+
+export async function setZlomColor(
+    kind: ZlomKind,
+    opis: string,
+    color: string | undefined,
+): Promise<void> {
+    await updateZlomSnapshot(current => {
+        const list = (current[kind] as ZlomEntry[]).map(e => {
+            if (e.opis !== opis) return e;
+            if (color) return { ...e, color };
+            const { color: _, ...rest } = e;
+            return rest as ZlomEntry;
+        });
+        return { ...current, [kind]: list } as ZlomSnapshot;
+    });
+    eventBus.emit('zlom.snapshotReplaced');
+}
+
+export interface ZlomFormatting {
+    color?: string;
+    underline: boolean;
+    title?: string;
+}
+
+function findEntryByShort(name: string): ZlomEntry | undefined {
+    if (!name) return undefined;
+    const snap = getZlomSnapshot();
+    const lower = name.toLowerCase();
+    const scan = (list: ZlomEntry[]): ZlomEntry | undefined => {
+        for (const e of list) {
+            if (!e.short) continue;
+            if (e.short === name) return e;
+        }
+        for (const e of list) {
+            if (!e.short) continue;
+            if (lower.includes(e.short.toLowerCase())) return e;
+        }
+        return undefined;
+    };
+    return scan(snap.bronie as ZlomEntry[])
+        ?? scan(snap.tarcze as ZlomEntry[])
+        ?? scan(snap.zbroje as ZlomEntry[]);
+}
+
+export function getZlomFormatting(
+    name: string,
+    opts: { colorSilver?: boolean } = {},
+): ZlomFormatting | undefined {
+    const entry = findEntryByShort(name);
+    if (!entry) return undefined;
+    const silver = (entry as WeaponEntry).srebro === 1;
+    const magic = entry.magik === 1;
+    const underline = silver && (opts.colorSilver ?? true);
+    const parts: string[] = [];
+    if ((entry as WeaponEntry).typ) parts.push((entry as WeaponEntry).typ);
+    else if ((entry as ShieldEntry).oslona) parts.push('tarcza');
+    if (silver) parts.push(SILVER_TYP_TOOLTIP);
+    if (magic) parts.push('magia');
+    return {
+        color: entry.color,
+        underline,
+        title: parts.length ? parts.join(' / ') : undefined,
+    };
+}
+
+function registerHighlight(client: Client, short: string) {
     if (!short) return;
     client.Triggers.registerTrigger(
         new RegExp(escapeRegex(short)),
@@ -310,13 +272,14 @@ function registerHighlight(client: Client, entry: ZlomEntry) {
             if (idx === -1) return line;
             const end = idx + short.length;
             const silverOn = characterStorage.get('settings')?.zlomColorSilver !== false;
-            const silver = (entry as WeaponEntry).srebro === 1;
-            const fmt: FormatStateSnapshot = { bold: true };
-            if (silver && silverOn) fmt.underline = true;
-            if (entry.color) fmt.foreground = { space: 'hex', color: entry.color };
-            line.applyFormat([idx, end], fmt);
+            const fmt = getZlomFormatting(short, { colorSilver: silverOn });
+            if (!fmt) return line;
+            const applied: FormatStateSnapshot = { bold: true };
+            if (fmt.underline) applied.underline = true;
+            if (fmt.color) applied.foreground = { space: 'hex', color: fmt.color };
+            line.applyFormat([idx, end], applied);
             line.createLink([idx, end], {
-                title: buildHintForEntry(entry),
+                title: fmt.title,
                 onClick: () => {},
             });
             return line;
@@ -325,29 +288,22 @@ function registerHighlight(client: Client, entry: ZlomEntry) {
     );
 }
 
-function buildHintForEntry(entry: ZlomEntry): string {
-    const parts: string[] = [];
-    const typ = (entry as WeaponEntry).typ || (entry as ShieldEntry).oslona || '';
-    if (typ) parts.push(typ);
-    if ((entry as WeaponEntry).srebro === 1) parts.push(SILVER_TYP_TOOLTIP);
-    if (entry.magik === 1) parts.push('magia');
-    return parts.join(' / ');
-}
-
 function escapeRegex(s: string): string {
     return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function reinstallHighlights(client: Client, snap: ZlomSnapshot) {
+function collectShorts(snap: ZlomSnapshot): string[] {
+    const set = new Set<string>();
+    for (const e of snap.bronie) if (e.short) set.add(e.short);
+    for (const e of snap.tarcze) if (e.short) set.add(e.short);
+    for (const e of snap.zbroje) if (e.short) set.add(e.short);
+    return Array.from(set);
+}
+
+function reinstallHighlights(client: Client) {
     client.Triggers.removeByTag(HIGHLIGHT_TAG);
-    for (const b of Object.values(snap.bronie)) {
-        registerHighlight(client, b);
-    }
-    for (const t of Object.values(snap.tarcze)) {
-        registerHighlight(client, t);
-    }
-    for (const z of Object.values(snap.zbroje)) {
-        registerHighlight(client, z);
+    for (const s of collectShorts(getZlomSnapshot())) {
+        registerHighlight(client, s);
     }
 }
 
@@ -355,15 +311,18 @@ export default function initZlom(
     client: Client,
     aliases?: { pattern: RegExp; callback: Function }[],
 ): void {
-    let snap = loadZlomSnapshot();
-    reinstallHighlights(client, snap);
+    // Load the snapshot from IndexedDB, then install highlight triggers.
+    ensureZlomLoaded().then(() => reinstallHighlights(client));
+
+    subscribeZlom(() => reinstallHighlights(client));
+    eventBus.on('zlom.snapshotReplaced', () => reinstallHighlights(client));
 
     let ctx: PendingEval | null = null;
 
     const roomId = (): number | null => client.Map?.currentRoom?.id ?? null;
 
     const persistBron = () => {
-        if (!ctx || ctx.kind !== "bron" || !ctx.short) return;
+        if (!ctx || ctx.kind !== "bron" || !ctx.short || !ctx.opis) return;
         const entry: WeaponEntry = {
             short: ctx.short,
             typ: ctx.typ ?? "",
@@ -374,7 +333,7 @@ export default function initZlom(
             chwyt: ctx.chwyt ?? "",
             magik: ctx.magik ?? 0,
             srebro: ctx.srebro ?? 0,
-            opis: ctx.opis ?? "",
+            opis: ctx.opis,
             waga: ctx.waga ?? 0,
             obj: ctx.obj ?? 0,
             cena: ctx.cena ?? 0,
@@ -382,15 +341,11 @@ export default function initZlom(
             parowanie: ctx.parowanie ?? 0,
             roomId: roomId(),
         };
-        const prev = snap.bronie[entry.short];
-        if (prev?.color) entry.color = prev.color;
-        snap.bronie[entry.short] = entry;
-        saveZlomSnapshot(snap);
-        registerHighlight(client, entry);
+        void updateZlomSnapshot(s => ({ ...s, bronie: upsertByOpis(s.bronie, entry) }));
     };
 
     const persistZbroja = () => {
-        if (!ctx || ctx.kind !== "zbroja" || !ctx.short) return;
+        if (!ctx || ctx.kind !== "zbroja" || !ctx.short || !ctx.opis) return;
         const entry: ArmorEntry = {
             short: ctx.short,
             typ: ctx.armorType ?? "",
@@ -398,29 +353,25 @@ export default function initZlom(
             obuch: ctx.obuch ?? 0,
             ciete: ctx.ciete ?? 0,
             magik: ctx.magik ?? 0,
-            opis: ctx.opis ?? "",
+            opis: ctx.opis,
             waga: ctx.waga ?? 0,
             obj: ctx.obj ?? 0,
             cena: ctx.cena ?? 0,
             oslona: ctx.oslona ?? "",
             roomId: roomId(),
         };
-        const prev = snap.zbroje[entry.short];
-        if (prev?.color) entry.color = prev.color;
-        snap.zbroje[entry.short] = entry;
-        saveZlomSnapshot(snap);
-        registerHighlight(client, entry);
+        void updateZlomSnapshot(s => ({ ...s, zbroje: upsertByOpis(s.zbroje, entry) }));
     };
 
     const persistTarcza = () => {
-        if (!ctx || ctx.kind !== "tarcza" || !ctx.short) return;
+        if (!ctx || ctx.kind !== "tarcza" || !ctx.short || !ctx.opis) return;
         const entry: ShieldEntry = {
             short: ctx.short,
             klute: ctx.klute ?? 0,
             obuch: ctx.obuch ?? 0,
             ciete: ctx.ciete ?? 0,
             magik: ctx.magik ?? 0,
-            opis: ctx.opis ?? "",
+            opis: ctx.opis,
             waga: ctx.waga ?? 0,
             obj: ctx.obj ?? 0,
             cena: ctx.cena ?? 0,
@@ -428,11 +379,7 @@ export default function initZlom(
             oslona: ctx.oslona ?? "",
             roomId: roomId(),
         };
-        const prev = snap.tarcze[entry.short];
-        if (prev?.color) entry.color = prev.color;
-        snap.tarcze[entry.short] = entry;
-        saveZlomSnapshot(snap);
-        registerHighlight(client, entry);
+        void updateZlomSnapshot(s => ({ ...s, tarcze: upsertByOpis(s.tarcze, entry) }));
     };
 
     client.Triggers.registerTrigger(
@@ -596,20 +543,12 @@ export default function initZlom(
         PARSER_TAG,
     );
 
-    eventBus.on("zlom.snapshotReplaced", () => {
-        snap = loadZlomSnapshot();
-        reinstallHighlights(client, snap);
-    });
-
     if (aliases) {
         aliases.push({
             pattern: /^\/zlom(?:\s+(bronie|tarcze|zbroje))?$/,
             callback: (m: RegExpMatchArray) => {
-                snap = loadZlomSnapshot();
-                const kind = m[1] ?? "bronie";
-                const entries: (WeaponEntry | ShieldEntry | ArmorEntry)[] = Object.values(
-                    (snap as any)[kind] ?? {},
-                );
+                const kind = (m[1] ?? 'bronie') as ZlomKind;
+                const entries: ZlomEntry[] = getZlomSnapshot()[kind] as ZlomEntry[];
                 if (entries.length === 0) {
                     client.println(`Brak zapisanych pozycji w tabeli ${kind}.`);
                     return;
@@ -627,14 +566,14 @@ export default function initZlom(
 
         aliases.push({
             pattern: /^\/zlomw$/,
-            callback: () => eventBus.emit("zlom.popup.open"),
+            callback: () => eventBus.emit('zlom.popup.open'),
         });
 
         aliases.push({
             pattern: /^\/zlom-reset$/,
             callback: () => {
-                clearZlomData();
-                client.println("Baza zlomu wyczyszczona.");
+                void clearZlomData();
+                client.println('Baza zlomu wyczyszczona.');
             },
         });
     }

--- a/src/client/scripts/zlom.ts
+++ b/src/client/scripts/zlom.ts
@@ -1,6 +1,7 @@
 import Client from "../Client";
 import { characterStorage } from "@modules/core/storage";
-import { AnsiAwareBuffer, FormatStateSnapshot } from "@client/ansi/FormatState";
+import { defaultSettings } from "@modules/core/defaultSettings";
+import { AnsiAwareBuffer } from "@client/ansi/FormatState";
 import { ARMOR_QUALITY, BALANCE, EFFECTIVENESS } from "./evaluationConstants";
 import eventBus from "@modules/core/eventBus";
 import {
@@ -31,12 +32,21 @@ const HIGHLIGHT_TAG = "zlom-highlight";
 const PARSER_TAG = "zlom-parser";
 
 const SILVER_TYP_TOOLTIP = "srebro";
+const COMBAT_LINE_TYPES = new Set(["combat.avatar", "combat.team", "combat.others"]);
+
+function resolveSilverColor(): string | undefined {
+    const silver = characterStorage.get('settings')?.zlomSilver ?? defaultSettings.zlomSilver;
+    if (!silver || silver.off) return undefined;
+    const color = silver.color?.trim();
+    return color || undefined;
+}
 
 type Kind = "bron" | "zbroja" | "tarcza";
 
 interface PendingEval {
     opis?: string;
     short?: string;
+    shortAlt?: string;
     waga?: number;
     obj?: number;
     cena?: number;
@@ -216,10 +226,52 @@ export async function setZlomColor(
     eventBus.emit('zlom.snapshotReplaced');
 }
 
+export async function setZlomNote(
+    kind: ZlomKind,
+    opis: string,
+    note: string | undefined,
+): Promise<void> {
+    const trimmed = note?.trim();
+    await updateZlomSnapshot(current => {
+        const list = (current[kind] as ZlomEntry[]).map(e => {
+            if (e.opis !== opis) return e;
+            if (trimmed) return { ...e, note: trimmed };
+            const { note: _, ...rest } = e;
+            return rest as ZlomEntry;
+        });
+        return { ...current, [kind]: list } as ZlomSnapshot;
+    });
+    eventBus.emit('zlom.snapshotReplaced');
+}
+
 export interface ZlomFormatting {
     color?: string;
-    underline: boolean;
     title?: string;
+    silver?: boolean;
+}
+
+function computeFormatting(entry: ZlomEntry, silverColor: string | undefined): ZlomFormatting | undefined {
+    if (entry.magik === 1) return undefined;
+    const silver = (entry as WeaponEntry).srebro === 1;
+    const autoSilver = silver ? silverColor : undefined;
+    const color = entry.color ?? autoSilver;
+    if (!color) return undefined;
+    const parts: string[] = [];
+    if ((entry as WeaponEntry).typ) parts.push((entry as WeaponEntry).typ);
+    else if ((entry as ShieldEntry).oslona) parts.push('tarcza');
+    if (silver) parts.push(SILVER_TYP_TOOLTIP);
+    return {
+        color,
+        title: parts.length ? parts.join(' / ') : undefined,
+        silver: silver || undefined,
+    };
+}
+
+function entryNames(e: ZlomEntry): string[] {
+    const names: string[] = [];
+    if (e.short) names.push(e.short);
+    if (e.shortAlt && e.shortAlt !== e.short) names.push(e.shortAlt);
+    return names;
 }
 
 function findEntryByShort(name: string): ZlomEntry | undefined {
@@ -228,12 +280,14 @@ function findEntryByShort(name: string): ZlomEntry | undefined {
     const lower = name.toLowerCase();
     const scan = (list: ZlomEntry[]): ZlomEntry | undefined => {
         for (const e of list) {
-            if (!e.short) continue;
-            if (e.short === name) return e;
+            for (const n of entryNames(e)) {
+                if (n === name) return e;
+            }
         }
         for (const e of list) {
-            if (!e.short) continue;
-            if (lower.includes(e.short.toLowerCase())) return e;
+            for (const n of entryNames(e)) {
+                if (lower.includes(n.toLowerCase())) return e;
+            }
         }
         return undefined;
     };
@@ -242,68 +296,55 @@ function findEntryByShort(name: string): ZlomEntry | undefined {
         ?? scan(snap.zbroje as ZlomEntry[]);
 }
 
-export function getZlomFormatting(
-    name: string,
-    opts: { colorSilver?: boolean } = {},
-): ZlomFormatting | undefined {
+export function getZlomFormatting(name: string): ZlomFormatting | undefined {
     const entry = findEntryByShort(name);
     if (!entry) return undefined;
-    const silver = (entry as WeaponEntry).srebro === 1;
-    const magic = entry.magik === 1;
-    const underline = silver && (opts.colorSilver ?? true);
-    const parts: string[] = [];
-    if ((entry as WeaponEntry).typ) parts.push((entry as WeaponEntry).typ);
-    else if ((entry as ShieldEntry).oslona) parts.push('tarcza');
-    if (silver) parts.push(SILVER_TYP_TOOLTIP);
-    if (magic) parts.push('magia');
-    return {
-        color: entry.color,
-        underline,
-        title: parts.length ? parts.join(' / ') : undefined,
+    return computeFormatting(entry, resolveSilverColor());
+}
+
+function registerHighlight(client: Client, entry: ZlomEntry) {
+    for (const name of entryNames(entry)) {
+        const needle = name.toLowerCase();
+        client.Triggers.registerTokenTrigger(
+            name,
+            (line, _matches, type) => {
+                if (COMBAT_LINE_TYPES.has(type)) return line;
+                const idx = line.text.toLowerCase().indexOf(needle);
+                if (idx === -1) return line;
+                const end = idx + name.length;
+                const fmt = computeFormatting(entry, resolveSilverColor());
+                if (!fmt) return line;
+                line.applyFormat([idx, end], { foreground: { space: 'hex', color: fmt.color! } });
+                return line;
+            },
+            HIGHLIGHT_TAG,
+            { caseInsensitive: true },
+        );
+    }
+}
+
+function collectHighlightEntries(snap: ZlomSnapshot, silverColor: string | undefined): ZlomEntry[] {
+    const byShort = new Map<string, ZlomEntry>();
+    const consider = (list: ZlomEntry[]) => {
+        for (const e of list) {
+            if (!e.short) continue;
+            if (!computeFormatting(e, silverColor)) continue;
+            const prev = byShort.get(e.short);
+            if (!prev || (!prev.color && e.color)) {
+                byShort.set(e.short, e);
+            }
+        }
     };
-}
-
-function registerHighlight(client: Client, short: string) {
-    if (!short) return;
-    client.Triggers.registerTrigger(
-        new RegExp(escapeRegex(short)),
-        (line) => {
-            const idx = line.text.indexOf(short);
-            if (idx === -1) return line;
-            const end = idx + short.length;
-            const silverOn = characterStorage.get('settings')?.zlomColorSilver !== false;
-            const fmt = getZlomFormatting(short, { colorSilver: silverOn });
-            if (!fmt) return line;
-            const applied: FormatStateSnapshot = { bold: true };
-            if (fmt.underline) applied.underline = true;
-            if (fmt.color) applied.foreground = { space: 'hex', color: fmt.color };
-            line.applyFormat([idx, end], applied);
-            line.createLink([idx, end], {
-                title: fmt.title,
-                onClick: () => {},
-            });
-            return line;
-        },
-        HIGHLIGHT_TAG,
-    );
-}
-
-function escapeRegex(s: string): string {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function collectShorts(snap: ZlomSnapshot): string[] {
-    const set = new Set<string>();
-    for (const e of snap.bronie) if (e.short) set.add(e.short);
-    for (const e of snap.tarcze) if (e.short) set.add(e.short);
-    for (const e of snap.zbroje) if (e.short) set.add(e.short);
-    return Array.from(set);
+    consider(snap.bronie as ZlomEntry[]);
+    consider(snap.tarcze as ZlomEntry[]);
+    consider(snap.zbroje as ZlomEntry[]);
+    return Array.from(byShort.values());
 }
 
 function reinstallHighlights(client: Client) {
     client.Triggers.removeByTag(HIGHLIGHT_TAG);
-    for (const s of collectShorts(getZlomSnapshot())) {
-        registerHighlight(client, s);
+    for (const entry of collectHighlightEntries(getZlomSnapshot(), resolveSilverColor())) {
+        registerHighlight(client, entry);
     }
 }
 
@@ -317,14 +358,27 @@ export default function initZlom(
     subscribeZlom(() => reinstallHighlights(client));
     eventBus.on('zlom.snapshotReplaced', () => reinstallHighlights(client));
 
+    let lastSilverColor = resolveSilverColor();
+    characterStorage.onChange('settings', () => {
+        const next = resolveSilverColor();
+        if (next !== lastSilverColor) {
+            lastSilverColor = next;
+            reinstallHighlights(client);
+        }
+    });
+
     let ctx: PendingEval | null = null;
 
     const roomId = (): number | null => client.Map?.currentRoom?.id ?? null;
+
+    const altShort = (): string | undefined =>
+        ctx?.shortAlt && ctx.shortAlt !== ctx.short ? ctx.shortAlt : undefined;
 
     const persistBron = () => {
         if (!ctx || ctx.kind !== "bron" || !ctx.short || !ctx.opis) return;
         const entry: WeaponEntry = {
             short: ctx.short,
+            shortAlt: altShort(),
             typ: ctx.typ ?? "",
             rodzaj: ctx.rodzaj ?? "",
             klute: ctx.klute ?? 0,
@@ -348,6 +402,7 @@ export default function initZlom(
         if (!ctx || ctx.kind !== "zbroja" || !ctx.short || !ctx.opis) return;
         const entry: ArmorEntry = {
             short: ctx.short,
+            shortAlt: altShort(),
             typ: ctx.armorType ?? "",
             klute: ctx.klute ?? 0,
             obuch: ctx.obuch ?? 0,
@@ -367,6 +422,7 @@ export default function initZlom(
         if (!ctx || ctx.kind !== "tarcza" || !ctx.short || !ctx.opis) return;
         const entry: ShieldEntry = {
             short: ctx.short,
+            shortAlt: altShort(),
             klute: ctx.klute ?? 0,
             obuch: ctx.obuch ?? 0,
             ciete: ctx.ciete ?? 0,
@@ -384,8 +440,8 @@ export default function initZlom(
 
     client.Triggers.registerTrigger(
         /^Oceniasz starannie (.+)\.$/,
-        (line) => {
-            ctx = { awaitingOpis: true };
+        (line, m) => {
+            ctx = { awaitingOpis: true, shortAlt: m[1] };
             return line;
         },
         PARSER_TAG,
@@ -500,6 +556,31 @@ export default function initZlom(
         (line, m) => {
             if (!ctx) return line;
             ctx.oslona = m[1];
+            return line;
+        },
+        PARSER_TAG,
+    );
+
+    client.Triggers.registerTrigger(
+        /^Zalozon[ya] oslania (.+?)\.$/,
+        (line, m) => {
+            if (!ctx) return line;
+            ctx.oslona = m[1];
+            return line;
+        },
+        PARSER_TAG,
+    );
+
+    client.Triggers.registerTrigger(
+        /^Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jest ona? (.+?) w parowaniu ciosow\.$/,
+        (line, m) => {
+            if (!ctx || !ctx.short) return line;
+            ctx.kind = "tarcza";
+            ctx.parowanie = effectivenessValue(m[1]);
+            ctx.klute = ctx.klute ?? 0;
+            ctx.obuch = ctx.obuch ?? 0;
+            ctx.ciete = ctx.ciete ?? 0;
+            persistTarcza();
             return line;
         },
         PARSER_TAG,

--- a/src/client/scripts/zlom.ts
+++ b/src/client/scripts/zlom.ts
@@ -2,6 +2,7 @@ import Client from "../Client";
 import { characterStorage } from "@modules/core/storage";
 import { AnsiAwareBuffer, FormatStateSnapshot } from "@client/ansi/FormatState";
 import { ARMOR_QUALITY, BALANCE, EFFECTIVENESS } from "./evaluationConstants";
+import eventBus from "@modules/core/eventBus";
 
 export interface WeaponEntry {
     short: string;
@@ -117,6 +118,56 @@ export function loadZlomSnapshot(): ZlomSnapshot {
 
 export function saveZlomSnapshot(s: ZlomSnapshot): void {
     characterStorage.set(ZLOM_STORAGE_KEY, s);
+    eventBus.emit("zlom.updated");
+}
+
+function emitSnapshotReplaced(): void {
+    eventBus.emit("zlom.snapshotReplaced");
+}
+
+export type ZlomMergeMode = 'replace' | 'keep';
+
+export interface ZlomImportPayload {
+    bronie: WeaponEntry[];
+    tarcze: ShieldEntry[];
+    zbroje: ArmorEntry[];
+}
+
+export interface ZlomImportCounts {
+    bronie: number;
+    tarcze: number;
+    zbroje: number;
+}
+
+export function mergeZlomData(data: ZlomImportPayload, mode: ZlomMergeMode = 'replace'): ZlomImportCounts {
+    const snap = loadZlomSnapshot();
+    let b = 0, t = 0, z = 0;
+    for (const e of data.bronie) {
+        if (!e.short) continue;
+        if (mode === 'keep' && snap.bronie[e.short]) continue;
+        snap.bronie[e.short] = e;
+        b++;
+    }
+    for (const e of data.tarcze) {
+        if (!e.short) continue;
+        if (mode === 'keep' && snap.tarcze[e.short]) continue;
+        snap.tarcze[e.short] = e;
+        t++;
+    }
+    for (const e of data.zbroje) {
+        if (!e.short) continue;
+        if (mode === 'keep' && snap.zbroje[e.short]) continue;
+        snap.zbroje[e.short] = e;
+        z++;
+    }
+    saveZlomSnapshot(snap);
+    emitSnapshotReplaced();
+    return { bronie: b, tarcze: t, zbroje: z };
+}
+
+export function clearZlomData(): void {
+    saveZlomSnapshot(emptySnapshot());
+    emitSnapshotReplaced();
 }
 
 function parseWeightObj(waga: string, wagaJ: string, obj: string, objJ: string): { waga: number; obj: number } {
@@ -479,6 +530,11 @@ export default function initZlom(
         PARSER_TAG,
     );
 
+    eventBus.on("zlom.snapshotReplaced", () => {
+        snap = loadZlomSnapshot();
+        reinstallHighlights(client, snap);
+    });
+
     if (aliases) {
         aliases.push({
             pattern: /^\/zlom(?:\s+(bronie|tarcze|zbroje))?$/,
@@ -504,14 +560,16 @@ export default function initZlom(
         });
 
         aliases.push({
+            pattern: /^\/zlomw$/,
+            callback: () => eventBus.emit("zlom.popup.open"),
+        });
+
+        aliases.push({
             pattern: /^\/zlom-reset$/,
             callback: () => {
-                snap = emptySnapshot();
-                saveZlomSnapshot(snap);
-                client.Triggers.removeByTag(HIGHLIGHT_TAG);
+                clearZlomData();
                 client.println("Baza zlomu wyczyszczona.");
             },
         });
     }
-
 }

--- a/src/client/scripts/zlom.ts
+++ b/src/client/scripts/zlom.ts
@@ -21,6 +21,7 @@ export interface WeaponEntry {
     wywazenie: number;
     parowanie: number;
     roomId: number | null;
+    color?: string;
 }
 
 export interface ArmorEntry {
@@ -36,6 +37,7 @@ export interface ArmorEntry {
     cena: number;
     oslona: string;
     roomId: number | null;
+    color?: string;
 }
 
 export interface ShieldEntry {
@@ -51,7 +53,11 @@ export interface ShieldEntry {
     parowanie: number;
     oslona: string;
     roomId: number | null;
+    color?: string;
 }
+
+export type ZlomEntry = WeaponEntry | ShieldEntry | ArmorEntry;
+export type ZlomKind = 'bronie' | 'tarcze' | 'zbroje';
 
 export interface ZlomSnapshot {
     bronie: Record<string, WeaponEntry>;
@@ -119,6 +125,54 @@ export function loadZlomSnapshot(): ZlomSnapshot {
 export function saveZlomSnapshot(s: ZlomSnapshot): void {
     characterStorage.set(ZLOM_STORAGE_KEY, s);
     eventBus.emit("zlom.updated");
+}
+
+export function setZlomColor(kind: ZlomKind, short: string, color: string | undefined): void {
+    const snap = loadZlomSnapshot();
+    const entry = (snap[kind] as Record<string, ZlomEntry>)[short];
+    if (!entry) return;
+    if (color) entry.color = color;
+    else delete entry.color;
+    saveZlomSnapshot(snap);
+    eventBus.emit("zlom.snapshotReplaced");
+}
+
+export interface ZlomFormatting {
+    color?: string;
+    underline: boolean;
+    title?: string;
+}
+
+/**
+ * Returns the zlom-driven formatting for an item name, or undefined if no saved entry matches.
+ * Uses character's zlom snapshot plus zlomColorSilver setting for silver underline.
+ */
+export function getZlomFormatting(name: string, opts: { colorSilver?: boolean } = {}): ZlomFormatting | undefined {
+    if (!name) return undefined;
+    const snap = loadZlomSnapshot();
+    const lower = name.toLowerCase();
+    const scan = (records: Record<string, ZlomEntry>): ZlomEntry | undefined => {
+        if (records[name]) return records[name];
+        for (const key of Object.keys(records)) {
+            if (lower.includes(key.toLowerCase())) return records[key];
+        }
+        return undefined;
+    };
+    const entry = scan(snap.bronie) ?? scan(snap.tarcze) ?? scan(snap.zbroje);
+    if (!entry) return undefined;
+    const silver = (entry as WeaponEntry).srebro === 1;
+    const magic = entry.magik === 1;
+    const underline = silver && (opts.colorSilver ?? true);
+    const titleParts: string[] = [];
+    if ((entry as WeaponEntry).typ) titleParts.push((entry as WeaponEntry).typ);
+    else if ((entry as ShieldEntry).oslona) titleParts.push('tarcza');
+    if (silver) titleParts.push(SILVER_TYP_TOOLTIP);
+    if (magic) titleParts.push('magia');
+    return {
+        color: entry.color,
+        underline,
+        title: titleParts.length ? titleParts.join(' / ') : undefined,
+    };
 }
 
 function emitSnapshotReplaced(): void {
@@ -246,7 +300,8 @@ function extractArmorProtection(text: string): { prot: ArmorProtection; parry?: 
     return undefined;
 }
 
-function registerHighlight(client: Client, short: string, typ: string | undefined, silver: boolean) {
+function registerHighlight(client: Client, entry: ZlomEntry) {
+    const short = entry.short;
     if (!short) return;
     client.Triggers.registerTrigger(
         new RegExp(escapeRegex(short)),
@@ -254,11 +309,14 @@ function registerHighlight(client: Client, short: string, typ: string | undefine
             const idx = line.text.indexOf(short);
             if (idx === -1) return line;
             const end = idx + short.length;
+            const silverOn = characterStorage.get('settings')?.zlomColorSilver !== false;
+            const silver = (entry as WeaponEntry).srebro === 1;
             const fmt: FormatStateSnapshot = { bold: true };
-            if (silver) fmt.underline = true;
+            if (silver && silverOn) fmt.underline = true;
+            if (entry.color) fmt.foreground = { space: 'hex', color: entry.color };
             line.applyFormat([idx, end], fmt);
             line.createLink([idx, end], {
-                title: buildHint(typ, silver),
+                title: buildHintForEntry(entry),
                 onClick: () => {},
             });
             return line;
@@ -267,11 +325,13 @@ function registerHighlight(client: Client, short: string, typ: string | undefine
     );
 }
 
-function buildHint(typ: string | undefined, silver: boolean): string {
+function buildHintForEntry(entry: ZlomEntry): string {
     const parts: string[] = [];
+    const typ = (entry as WeaponEntry).typ || (entry as ShieldEntry).oslona || '';
     if (typ) parts.push(typ);
-    if (silver) parts.push(SILVER_TYP_TOOLTIP);
-    return parts.join(" / ");
+    if ((entry as WeaponEntry).srebro === 1) parts.push(SILVER_TYP_TOOLTIP);
+    if (entry.magik === 1) parts.push('magia');
+    return parts.join(' / ');
 }
 
 function escapeRegex(s: string): string {
@@ -281,13 +341,13 @@ function escapeRegex(s: string): string {
 function reinstallHighlights(client: Client, snap: ZlomSnapshot) {
     client.Triggers.removeByTag(HIGHLIGHT_TAG);
     for (const b of Object.values(snap.bronie)) {
-        registerHighlight(client, b.short, b.typ, b.srebro > 0);
+        registerHighlight(client, b);
     }
     for (const t of Object.values(snap.tarcze)) {
-        registerHighlight(client, t.short, "tarcza", false);
+        registerHighlight(client, t);
     }
     for (const z of Object.values(snap.zbroje)) {
-        registerHighlight(client, z.short, z.typ, false);
+        registerHighlight(client, z);
     }
 }
 
@@ -322,9 +382,11 @@ export default function initZlom(
             parowanie: ctx.parowanie ?? 0,
             roomId: roomId(),
         };
+        const prev = snap.bronie[entry.short];
+        if (prev?.color) entry.color = prev.color;
         snap.bronie[entry.short] = entry;
         saveZlomSnapshot(snap);
-        registerHighlight(client, entry.short, entry.typ, entry.srebro > 0);
+        registerHighlight(client, entry);
     };
 
     const persistZbroja = () => {
@@ -343,9 +405,11 @@ export default function initZlom(
             oslona: ctx.oslona ?? "",
             roomId: roomId(),
         };
+        const prev = snap.zbroje[entry.short];
+        if (prev?.color) entry.color = prev.color;
         snap.zbroje[entry.short] = entry;
         saveZlomSnapshot(snap);
-        registerHighlight(client, entry.short, entry.typ, false);
+        registerHighlight(client, entry);
     };
 
     const persistTarcza = () => {
@@ -364,9 +428,11 @@ export default function initZlom(
             oslona: ctx.oslona ?? "",
             roomId: roomId(),
         };
+        const prev = snap.tarcze[entry.short];
+        if (prev?.color) entry.color = prev.color;
         snap.tarcze[entry.short] = entry;
         saveZlomSnapshot(snap);
-        registerHighlight(client, entry.short, "tarcza", false);
+        registerHighlight(client, entry);
     };
 
     client.Triggers.registerTrigger(

--- a/src/modules/core/defaultSettings.ts
+++ b/src/modules/core/defaultSettings.ts
@@ -55,7 +55,10 @@ export interface Settings {
     cuttingPreAction?: string;
     cuttingPostAction?: string;
     sunTracker: boolean;
-    zlomColorSilver: boolean;
+    zlomSilver?: {
+        color: string;
+        off?: boolean;
+    };
     dobCommand1: string;
     dobCommand2: string;
     dobCommand3: string;
@@ -124,7 +127,7 @@ export const defaultSettings: Settings = {
     cuttingPreAction: '',
     cuttingPostAction: '',
     sunTracker: false,
-    zlomColorSilver: true,
+    zlomSilver: { color: '#dadada' },
     dobCommand1: '',
     dobCommand2: '',
     dobCommand3: '',

--- a/src/modules/core/defaultSettings.ts
+++ b/src/modules/core/defaultSettings.ts
@@ -55,6 +55,7 @@ export interface Settings {
     cuttingPreAction?: string;
     cuttingPostAction?: string;
     sunTracker: boolean;
+    zlomColorSilver: boolean;
     dobCommand1: string;
     dobCommand2: string;
     dobCommand3: string;
@@ -123,6 +124,7 @@ export const defaultSettings: Settings = {
     cuttingPreAction: '',
     cuttingPostAction: '',
     sunTracker: false,
+    zlomColorSilver: true,
     dobCommand1: '',
     dobCommand2: '',
     dobCommand3: '',

--- a/src/modules/core/storageSchema.ts
+++ b/src/modules/core/storageSchema.ts
@@ -17,6 +17,7 @@ import type { UserTrigger } from '@client/scripts/userTriggers';
 import type { UserAlias } from '@client/scripts/userAliases';
 import type { ShortcutEntry } from '@client/scripts/shortcuts';
 import type { ContractsSnapshot } from '@client/scripts/contracts';
+import type { ZlomSnapshot } from '@client/scripts/zlom';
 import type { AttackMode } from '@client/utils/attackController';
 import type { CharGender } from '@shared/events/gmcpTypes';
 
@@ -50,6 +51,7 @@ export interface CharacterStorageSchema {
     attack_mode: AttackMode;
     chat_history: any[]; // TODO: use serialized ChatEntry[] type
     gender: CharGender;
+    zlom: ZlomSnapshot;
 }
 
 /**
@@ -142,6 +144,7 @@ export const characterStorageKeys = [
     'attack_mode',
     'chat_history',
     'gender',
+    'zlom',
 ] as const satisfies readonly (keyof CharacterStorageSchema)[];
 
 /** All global storage keys as a const array for runtime use. */

--- a/src/modules/core/storageSchema.ts
+++ b/src/modules/core/storageSchema.ts
@@ -17,7 +17,6 @@ import type { UserTrigger } from '@client/scripts/userTriggers';
 import type { UserAlias } from '@client/scripts/userAliases';
 import type { ShortcutEntry } from '@client/scripts/shortcuts';
 import type { ContractsSnapshot } from '@client/scripts/contracts';
-import type { ZlomSnapshot } from '@client/scripts/zlom';
 import type { AttackMode } from '@client/utils/attackController';
 import type { CharGender } from '@shared/events/gmcpTypes';
 
@@ -51,7 +50,6 @@ export interface CharacterStorageSchema {
     attack_mode: AttackMode;
     chat_history: any[]; // TODO: use serialized ChatEntry[] type
     gender: CharGender;
-    zlom: ZlomSnapshot;
 }
 
 /**
@@ -144,7 +142,6 @@ export const characterStorageKeys = [
     'attack_mode',
     'chat_history',
     'gender',
-    'zlom',
 ] as const satisfies readonly (keyof CharacterStorageSchema)[];
 
 /** All global storage keys as a const array for runtime use. */

--- a/src/modules/data/zlomDbImport.shared.ts
+++ b/src/modules/data/zlomDbImport.shared.ts
@@ -1,0 +1,24 @@
+import type { WeaponEntry, ArmorEntry, ShieldEntry } from '@client/scripts/zlom';
+
+export interface ZlomDbResult {
+    bronie: WeaponEntry[];
+    tarcze: ShieldEntry[];
+    zbroje: ArmorEntry[];
+}
+
+export interface ZlomDbWorkerRequest {
+    type: 'parse';
+    buffer: ArrayBuffer;
+}
+
+export interface ZlomDbWorkerSuccess {
+    type: 'success';
+    payload: ZlomDbResult;
+}
+
+export interface ZlomDbWorkerError {
+    type: 'error';
+    message: string;
+}
+
+export type ZlomDbWorkerResponse = ZlomDbWorkerSuccess | ZlomDbWorkerError;

--- a/src/modules/data/zlomDbImport.shared.ts
+++ b/src/modules/data/zlomDbImport.shared.ts
@@ -1,4 +1,4 @@
-import type { WeaponEntry, ArmorEntry, ShieldEntry } from '@client/scripts/zlom';
+import type { WeaponEntry, ArmorEntry, ShieldEntry } from './zlomStore';
 
 export interface ZlomDbResult {
     bronie: WeaponEntry[];

--- a/src/modules/data/zlomDbImport.worker.ts
+++ b/src/modules/data/zlomDbImport.worker.ts
@@ -1,7 +1,7 @@
 import type { SqlJsStatic, Database } from 'sql.js';
 import initSqlJs from 'sql.js/dist/sql-wasm.js';
 import wasmUrl from 'sql.js/dist/sql-wasm.wasm?url';
-import type { WeaponEntry, ArmorEntry, ShieldEntry } from '@client/scripts/zlom';
+import type { WeaponEntry, ArmorEntry, ShieldEntry } from './zlomStore';
 import type {
     ZlomDbResult,
     ZlomDbWorkerRequest,

--- a/src/modules/data/zlomDbImport.worker.ts
+++ b/src/modules/data/zlomDbImport.worker.ts
@@ -1,0 +1,189 @@
+import type { SqlJsStatic, Database } from 'sql.js';
+import initSqlJs from 'sql.js/dist/sql-wasm.js';
+import wasmUrl from 'sql.js/dist/sql-wasm.wasm?url';
+import type { WeaponEntry, ArmorEntry, ShieldEntry } from '@client/scripts/zlom';
+import type {
+    ZlomDbResult,
+    ZlomDbWorkerRequest,
+    ZlomDbWorkerResponse,
+} from './zlomDbImport.shared';
+
+let sqlPromise: Promise<SqlJsStatic> | null = null;
+
+async function getSql(): Promise<SqlJsStatic> {
+    if (!sqlPromise) {
+        sqlPromise = initSqlJs({
+            locateFile: (file) => (file === 'sql-wasm.wasm' ? wasmUrl : file),
+        });
+    }
+    return sqlPromise;
+}
+
+function tableExists(db: Database, name: string): boolean {
+    const res = db.exec(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='${name}'`,
+    );
+    return res.length > 0 && res[0].values.length > 0;
+}
+
+function str(v: unknown): string {
+    return v == null ? '' : String(v);
+}
+
+function num(v: unknown): number {
+    if (v == null) return 0;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function bit(v: unknown): 0 | 1 {
+    return num(v) > 0 ? 1 : 0;
+}
+
+function roomId(v: unknown): number | null {
+    if (v == null) return null;
+    const n = Number(v);
+    if (!Number.isFinite(n)) return null;
+    return n < 0 ? null : n;
+}
+
+function readBronie(db: Database): WeaponEntry[] {
+    if (!tableExists(db, 'bronie')) return [];
+    const stmt = db.prepare('SELECT * FROM bronie');
+    const out: WeaponEntry[] = [];
+    try {
+        while (stmt.step()) {
+            const r = stmt.getAsObject() as Record<string, unknown>;
+            const short = str(r.short);
+            if (!short) continue;
+            out.push({
+                short,
+                typ: str(r.typ),
+                rodzaj: str(r.rodzaj),
+                klute: num(r.klute),
+                obuch: num(r.obuch),
+                ciete: num(r.ciete),
+                chwyt: str(r.chwyt),
+                magik: bit(r.magik),
+                srebro: bit(r.srebro),
+                opis: str(r.opis),
+                waga: num(r.waga),
+                obj: num(r.obj),
+                cena: num(r.cena),
+                wywazenie: num(r.wywazenie),
+                parowanie: num(r.parowanie),
+                roomId: roomId(r.room_id),
+            });
+        }
+    } finally {
+        stmt.free();
+    }
+    return out;
+}
+
+function readTarcze(db: Database): ShieldEntry[] {
+    if (!tableExists(db, 'tarcze')) return [];
+    const stmt = db.prepare('SELECT * FROM tarcze');
+    const out: ShieldEntry[] = [];
+    try {
+        while (stmt.step()) {
+            const r = stmt.getAsObject() as Record<string, unknown>;
+            const short = str(r.short);
+            if (!short) continue;
+            out.push({
+                short,
+                klute: num(r.klute),
+                obuch: num(r.obuch),
+                ciete: num(r.ciete),
+                magik: bit(r.magik),
+                opis: str(r.opis),
+                waga: num(r.waga),
+                obj: num(r.obj),
+                cena: num(r.cena),
+                parowanie: num(r.parowanie),
+                oslona: str(r.oslona),
+                roomId: roomId(r.room_id),
+            });
+        }
+    } finally {
+        stmt.free();
+    }
+    return out;
+}
+
+function readZbroje(db: Database): ArmorEntry[] {
+    if (!tableExists(db, 'zbroje')) return [];
+    const stmt = db.prepare('SELECT * FROM zbroje');
+    const out: ArmorEntry[] = [];
+    try {
+        while (stmt.step()) {
+            const r = stmt.getAsObject() as Record<string, unknown>;
+            const short = str(r.short);
+            if (!short) continue;
+            out.push({
+                short,
+                typ: str(r.typ),
+                klute: num(r.klute),
+                obuch: num(r.obuch),
+                ciete: num(r.ciete),
+                magik: bit(r.magik),
+                opis: str(r.opis),
+                waga: num(r.waga),
+                obj: num(r.obj),
+                cena: num(r.cena),
+                oslona: str(r.oslona),
+                roomId: roomId(r.room_id),
+            });
+        }
+    } finally {
+        stmt.free();
+    }
+    return out;
+}
+
+export async function parseZlomDatabase(buffer: ArrayBuffer): Promise<ZlomDbResult> {
+    const SQL = await getSql();
+    const db = new SQL.Database(new Uint8Array(buffer));
+    try {
+        const bronie = readBronie(db);
+        const tarcze = readTarcze(db);
+        const zbroje = readZbroje(db);
+        if (bronie.length === 0 && tarcze.length === 0 && zbroje.length === 0) {
+            throw new Error('Baza nie zawiera tabel bronie/tarcze/zbroje lub sa puste.');
+        }
+        return { bronie, tarcze, zbroje };
+    } finally {
+        db.close();
+    }
+}
+
+const ctx = self as unknown as {
+    postMessage: typeof postMessage;
+    addEventListener: typeof addEventListener;
+    removeEventListener: typeof removeEventListener;
+};
+
+ctx.addEventListener('message', (event: MessageEvent<ZlomDbWorkerRequest>) => {
+    const { data } = event;
+    if (!data || data.type !== 'parse') return;
+
+    (async () => {
+        try {
+            const result = await parseZlomDatabase(data.buffer);
+            const response: ZlomDbWorkerResponse = {
+                type: 'success',
+                payload: result,
+            };
+            ctx.postMessage(response);
+        } catch (error) {
+            const response: ZlomDbWorkerResponse = {
+                type: 'error',
+                message:
+                    error instanceof Error
+                        ? error.message
+                        : 'Nie udalo sie odczytac bazy danych.',
+            };
+            ctx.postMessage(response);
+        }
+    })();
+});

--- a/src/modules/data/zlomStore.ts
+++ b/src/modules/data/zlomStore.ts
@@ -7,6 +7,7 @@ import {
 
 export interface WeaponEntry {
     short: string;
+    shortAlt?: string;
     typ: string;
     rodzaj: string;
     klute: number;
@@ -23,10 +24,12 @@ export interface WeaponEntry {
     parowanie: number;
     roomId: number | null;
     color?: string;
+    note?: string;
 }
 
 export interface ArmorEntry {
     short: string;
+    shortAlt?: string;
     typ: string;
     klute: number;
     obuch: number;
@@ -39,10 +42,12 @@ export interface ArmorEntry {
     oslona: string;
     roomId: number | null;
     color?: string;
+    note?: string;
 }
 
 export interface ShieldEntry {
     short: string;
+    shortAlt?: string;
     klute: number;
     obuch: number;
     ciete: number;
@@ -55,6 +60,7 @@ export interface ShieldEntry {
     oslona: string;
     roomId: number | null;
     color?: string;
+    note?: string;
 }
 
 export type ZlomEntry = WeaponEntry | ShieldEntry | ArmorEntry;
@@ -196,6 +202,8 @@ export function upsertByOpis<T extends ZlomEntry>(list: T[], entry: T): T[] {
         const prev = list[idx];
         const merged: T = { ...entry };
         if (!merged.color && prev.color) merged.color = prev.color;
+        if (!merged.note && prev.note) merged.note = prev.note;
+        if (!merged.shortAlt && prev.shortAlt) merged.shortAlt = prev.shortAlt;
         const next = list.slice();
         next[idx] = merged;
         return next;

--- a/src/modules/data/zlomStore.ts
+++ b/src/modules/data/zlomStore.ts
@@ -1,0 +1,204 @@
+import {
+    storeInIndexedDB,
+    getFromIndexedDB,
+    clearIndexedDB,
+    type IndexedDBConfig,
+} from '@client/utils/dataCache';
+
+export interface WeaponEntry {
+    short: string;
+    typ: string;
+    rodzaj: string;
+    klute: number;
+    obuch: number;
+    ciete: number;
+    chwyt: string;
+    magik: 0 | 1;
+    srebro: 0 | 1;
+    opis: string;
+    waga: number;
+    obj: number;
+    cena: number;
+    wywazenie: number;
+    parowanie: number;
+    roomId: number | null;
+    color?: string;
+}
+
+export interface ArmorEntry {
+    short: string;
+    typ: string;
+    klute: number;
+    obuch: number;
+    ciete: number;
+    magik: 0 | 1;
+    opis: string;
+    waga: number;
+    obj: number;
+    cena: number;
+    oslona: string;
+    roomId: number | null;
+    color?: string;
+}
+
+export interface ShieldEntry {
+    short: string;
+    klute: number;
+    obuch: number;
+    ciete: number;
+    magik: 0 | 1;
+    opis: string;
+    waga: number;
+    obj: number;
+    cena: number;
+    parowanie: number;
+    oslona: string;
+    roomId: number | null;
+    color?: string;
+}
+
+export type ZlomEntry = WeaponEntry | ShieldEntry | ArmorEntry;
+export type ZlomKind = 'bronie' | 'tarcze' | 'zbroje';
+
+export interface ZlomSnapshot {
+    bronie: WeaponEntry[];
+    tarcze: ShieldEntry[];
+    zbroje: ArmorEntry[];
+}
+
+const CONFIG: IndexedDBConfig = {
+    dbName: 'ArkadiaZlom',
+    storeName: 'zlom',
+    key: 'snapshot',
+};
+
+function emptySnapshot(): ZlomSnapshot {
+    return { bronie: [], tarcze: [], zbroje: [] };
+}
+
+let cache: ZlomSnapshot = emptySnapshot();
+let loaded = false;
+let loadingPromise: Promise<void> | null = null;
+const listeners = new Set<(snap: ZlomSnapshot) => void>();
+
+function normalize(raw: unknown): ZlomSnapshot {
+    const s = (raw ?? {}) as Partial<ZlomSnapshot>;
+    return {
+        bronie: Array.isArray(s.bronie) ? s.bronie : [],
+        tarcze: Array.isArray(s.tarcze) ? s.tarcze : [],
+        zbroje: Array.isArray(s.zbroje) ? s.zbroje : [],
+    };
+}
+
+function notify(): void {
+    for (const l of listeners) l(cache);
+}
+
+/**
+ * Initialize the in-memory cache from IndexedDB. Safe to call multiple times.
+ */
+export function ensureZlomLoaded(): Promise<void> {
+    if (loaded) return Promise.resolve();
+    if (loadingPromise) return loadingPromise;
+    loadingPromise = (async () => {
+        try {
+            const raw = await getFromIndexedDB<ZlomSnapshot>(CONFIG);
+            cache = normalize(raw);
+        } catch {
+            cache = emptySnapshot();
+        }
+        loaded = true;
+        notify();
+    })();
+    return loadingPromise;
+}
+
+/**
+ * Synchronous accessor — returns the in-memory cache. Call ensureZlomLoaded() first
+ * to guarantee it reflects persisted data.
+ */
+export function getZlomSnapshot(): ZlomSnapshot {
+    return cache;
+}
+
+export function subscribeZlom(listener: (snap: ZlomSnapshot) => void): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+}
+
+async function persist(): Promise<void> {
+    try {
+        await storeInIndexedDB(CONFIG, cache);
+    } catch (e) {
+        console.warn('[zlom] persist failed', e);
+    }
+}
+
+/**
+ * Mutator-style update — replaces the cache with the result of `fn(current)`,
+ * persists asynchronously and notifies subscribers. The in-memory cache is
+ * updated synchronously once the initial load has completed, so callers can
+ * observe their own writes via getZlomSnapshot() without awaiting persistence.
+ */
+export function updateZlomSnapshot(fn: (s: ZlomSnapshot) => ZlomSnapshot): Promise<void> {
+    if (!loaded) {
+        return ensureZlomLoaded().then(() => {
+            cache = fn(cache);
+            notify();
+            return persist();
+        });
+    }
+    cache = fn(cache);
+    notify();
+    return persist();
+}
+
+export function clearZlomStore(): Promise<void> {
+    const run = () => {
+        cache = emptySnapshot();
+        notify();
+        return clearIndexedDB(CONFIG).catch(e => {
+            console.warn('[zlom] clear failed', e);
+        });
+    };
+    if (!loaded) return ensureZlomLoaded().then(run);
+    return run();
+}
+
+// Kick off loading eagerly on first import so subsequent sync reads are
+// likely to see persisted data even before any explicit initializer runs.
+ensureZlomLoaded().catch(() => {});
+
+/**
+ * Test-only helper: reset the in-memory cache and loading state AND clear the
+ * persisted IndexedDB record so the next ensureZlomLoaded() starts from empty.
+ */
+export async function __resetZlomStoreForTests(): Promise<void> {
+    cache = emptySnapshot();
+    loaded = false;
+    loadingPromise = null;
+    listeners.clear();
+    try {
+        await clearIndexedDB(CONFIG);
+    } catch {
+        // ignore
+    }
+}
+
+/**
+ * Replace-by-opis upsert. If an entry with the same `opis` exists it's overwritten
+ * (preserving its prior color when the new entry has none). Otherwise the entry
+ * is appended.
+ */
+export function upsertByOpis<T extends ZlomEntry>(list: T[], entry: T): T[] {
+    const idx = entry.opis ? list.findIndex(e => e.opis === entry.opis) : -1;
+    if (idx >= 0) {
+        const prev = list[idx];
+        const merged: T = { ...entry };
+        if (!merged.color && prev.color) merged.color = prev.color;
+        const next = list.slice();
+        next[idx] = merged;
+        return next;
+    }
+    return [...list, entry];
+}

--- a/src/shared/events/clientEvents.ts
+++ b/src/shared/events/clientEvents.ts
@@ -287,6 +287,9 @@ export interface KnownEvents {
     "postepy.popup.open": void;
     "postepy2.updated": void;
     "postepy2.popup.open": void;
+    "zlom.updated": void;
+    "zlom.snapshotReplaced": void;
+    "zlom.popup.open": void;
     "zabici.updated": unknown;
     "zabici.popup.open": void;
     "zabici2.updated": unknown;

--- a/src/web/ZlomPopup.tsx
+++ b/src/web/ZlomPopup.tsx
@@ -5,8 +5,8 @@ import { usePopupSetting } from './hooks/usePopupSetting';
 import { characterStorage } from '@modules/core/storage';
 import {
     mergeZlomData,
-    clearZlomData,
     setZlomColor,
+    setZlomNote,
     ZlomSnapshot,
     WeaponEntry,
     ShieldEntry,
@@ -47,6 +47,7 @@ const ZlomPopup: React.FC = () => {
     const [filter, setFilter] = useState('');
 
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const jsonInputRef = useRef<HTMLInputElement>(null);
     const workerRef = useRef<Worker | null>(null);
     const [importState, setImportState] = useState<
         | { phase: 'idle' }
@@ -161,28 +162,70 @@ const ZlomPopup: React.FC = () => {
         setImportState({ phase: 'idle' });
     }, []);
 
-    const handleReset = useCallback(() => {
-        if (!window.confirm('Wyczyscic cala baze zlomu?')) return;
-        void clearZlomData();
+    const handleExport = useCallback(() => {
+        const payload = {
+            bronie: snap.bronie,
+            tarcze: snap.tarcze,
+            zbroje: snap.zbroje,
+        };
+        const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        const date = new Date().toISOString().slice(0, 10);
+        a.href = url;
+        a.download = `zlom-${date}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+    }, [snap]);
+
+    const handleJsonImportClick = useCallback(() => {
+        jsonInputRef.current?.click();
     }, []);
 
-    const [colorSilver, setColorSilver] = useState<boolean>(() => {
-        const v = characterStorage.get('settings')?.zlomColorSilver;
-        return v !== false;
-    });
+    const handleJsonFileChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (e.target) e.target.value = '';
+        if (!file) return;
+        setImportState({ phase: 'loading' });
+        try {
+            const text = await file.text();
+            const parsed = JSON.parse(text);
+            const payload: ZlomDbResult = {
+                bronie: Array.isArray(parsed?.bronie) ? parsed.bronie : [],
+                tarcze: Array.isArray(parsed?.tarcze) ? parsed.tarcze : [],
+                zbroje: Array.isArray(parsed?.zbroje) ? parsed.zbroje : [],
+            };
+            if (payload.bronie.length + payload.tarcze.length + payload.zbroje.length === 0) {
+                setImportState({ phase: 'error', message: 'Plik nie zawiera danych zlomu.' });
+                return;
+            }
+            setImportState({ phase: 'preview', parsed: payload, mergeMode: 'replace' });
+        } catch (err) {
+            setImportState({ phase: 'error', message: err instanceof Error ? err.message : 'Blad parsowania JSON.' });
+        }
+    }, []);
+
+    const readSilver = () => {
+        const s = characterStorage.get('settings')?.zlomSilver ?? defaultSettings.zlomSilver;
+        return { color: s?.color ?? '#dadada', off: s?.off === true };
+    };
+
+    const [silver, setSilver] = useState<{ color: string; off: boolean }>(readSilver);
 
     useEffect(() => {
         const unsub = characterStorage.onChange('settings', (v) => {
-            const next = v?.zlomColorSilver;
-            setColorSilver(next !== false);
+            const s = v?.zlomSilver ?? defaultSettings.zlomSilver;
+            setSilver({ color: s?.color ?? '#dadada', off: s?.off === true });
         });
         return unsub;
     }, []);
 
-    const toggleColorSilver = useCallback(() => {
+    const updateSilver = useCallback((patch: { color?: string; off?: boolean }) => {
         const current = characterStorage.get('settings') ?? defaultSettings;
-        characterStorage.set('settings', { ...current, zlomColorSilver: !colorSilver });
-    }, [colorSilver]);
+        const prevSilver = current.zlomSilver ?? defaultSettings.zlomSilver ?? { color: '#dadada' };
+        const nextSilver = { ...prevSilver, ...patch };
+        characterStorage.set('settings', { ...current, zlomSilver: nextSilver });
+    }, []);
 
     const handleColorChange = useCallback((kind: ZlomKind, opis: string, value: string) => {
         void setZlomColor(kind, opis, value || undefined);
@@ -191,6 +234,78 @@ const ZlomPopup: React.FC = () => {
     const handleColorClear = useCallback((kind: ZlomKind, opis: string) => {
         void setZlomColor(kind, opis, undefined);
     }, []);
+
+    const [noteEditor, setNoteEditor] = useState<
+        | { kind: ZlomKind; opis: string; value: string }
+        | null
+    >(null);
+    const noteEditorRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (!noteEditor) return;
+        const onDown = (ev: MouseEvent) => {
+            const el = noteEditorRef.current;
+            const target = ev.target as Node | null;
+            if (el && target && !el.contains(target)) {
+                setNoteEditor(null);
+            }
+        };
+        document.addEventListener('mousedown', onDown);
+        return () => document.removeEventListener('mousedown', onDown);
+    }, [noteEditor]);
+
+    const openNoteEditor = useCallback((kind: ZlomKind, entry: WeaponEntry | ShieldEntry | ArmorEntry) => {
+        setNoteEditor({ kind, opis: entry.opis, value: entry.note ?? '' });
+    }, []);
+
+    const saveNoteEditor = useCallback(() => {
+        if (!noteEditor) return;
+        void setZlomNote(noteEditor.kind, noteEditor.opis, noteEditor.value || undefined);
+        setNoteEditor(null);
+    }, [noteEditor]);
+
+    const renderNoteCell = (kind: ZlomKind, entry: WeaponEntry | ShieldEntry | ArmorEntry) => {
+        const hasNote = !!entry.note;
+        const isOpen = noteEditor?.kind === kind && noteEditor.opis === entry.opis;
+        return (
+            <td className="zlom-cell zlom-cell--note">
+                <div className="zlom-note-wrap">
+                    <button
+                        type="button"
+                        className={`zlom-note-btn${hasNote ? ' zlom-note-btn--has' : ''}`}
+                        onClick={() => openNoteEditor(kind, entry)}
+                        title={hasNote ? entry.note : 'Dodaj notatke'}
+                    >
+                        {hasNote ? '●' : '+'}
+                    </button>
+                    {isOpen && (
+                        <div className="zlom-note-popover" ref={noteEditorRef}>
+                            <textarea
+                                className="zlom-note-textarea"
+                                autoFocus
+                                value={noteEditor!.value}
+                                onChange={(e) => setNoteEditor({ ...noteEditor!, value: e.target.value })}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Escape') {
+                                        e.preventDefault();
+                                        setNoteEditor(null);
+                                    } else if ((e.key === 'Enter' && (e.ctrlKey || e.metaKey))) {
+                                        e.preventDefault();
+                                        saveNoteEditor();
+                                    }
+                                }}
+                                placeholder="Notatka..."
+                            />
+                            <div className="zlom-note-popover__actions">
+                                <button type="button" className="zlom-header-btn" onClick={() => setNoteEditor(null)}>Anuluj</button>
+                                <button type="button" className="zlom-header-btn" onClick={saveNoteEditor}>Zapisz</button>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </td>
+        );
+    };
 
     const renderColorCell = (kind: ZlomKind, entry: WeaponEntry | ShieldEntry | ArmorEntry) => (
         <td className="zlom-cell zlom-cell--color">
@@ -201,16 +316,15 @@ const ZlomPopup: React.FC = () => {
                 onChange={(e) => handleColorChange(kind, entry.opis, e.target.value)}
                 title={entry.color ? `Kolor: ${entry.color}` : 'Ustaw kolor'}
             />
-            {entry.color && (
-                <button
-                    type="button"
-                    className="zlom-color-clear"
-                    onClick={() => handleColorClear(kind, entry.opis)}
-                    title="Usun kolor"
-                >
-                    x
-                </button>
-            )}
+            <button
+                type="button"
+                className="zlom-color-clear"
+                onClick={() => handleColorClear(kind, entry.opis)}
+                title="Usun kolor"
+                style={entry.color ? undefined : { visibility: 'hidden' }}
+            >
+                x
+            </button>
         </td>
     );
 
@@ -230,11 +344,17 @@ const ZlomPopup: React.FC = () => {
         zbroje: snap.zbroje.length,
     };
 
-    const renderWeapon = (e: WeaponEntry, i: number) => (
+    const effectiveSilverColor = silver.off ? undefined : silver.color;
+
+    const renderWeapon = (e: WeaponEntry, i: number) => {
+        const effectiveColor = e.magik
+            ? undefined
+            : e.color ?? (e.srebro && effectiveSilverColor ? effectiveSilverColor : undefined);
+        return (
         <tr key={e.opis || `${e.short}-${i}`} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
             <td
                 className="zlom-cell zlom-cell--short"
-                style={e.color ? { color: e.color, textDecoration: e.srebro && colorSilver ? 'underline' : undefined } : undefined}
+                style={effectiveColor ? { color: effectiveColor } : undefined}
             >
                 {e.short}
                 {e.srebro ? <span className="zlom-tag zlom-tag--silver" title="srebro">Ag</span> : null}
@@ -247,12 +367,14 @@ const ZlomPopup: React.FC = () => {
             <td className="zlom-cell zlom-cell--num">{e.cena}</td>
             <td className="zlom-cell zlom-cell--num">{e.waga}</td>
             {renderColorCell('bronie', e)}
+            {renderNoteCell('bronie', e)}
         </tr>
-    );
+        );
+    };
 
     const renderShield = (e: ShieldEntry, i: number) => (
         <tr key={e.opis || `${e.short}-${i}`} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
-            <td className="zlom-cell zlom-cell--short" style={e.color ? { color: e.color } : undefined}>
+            <td className="zlom-cell zlom-cell--short" style={!e.magik && e.color ? { color: e.color } : undefined}>
                 {e.short}
                 {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia">M</span> : null}
             </td>
@@ -262,12 +384,13 @@ const ZlomPopup: React.FC = () => {
             <td className="zlom-cell zlom-cell--num">{e.cena}</td>
             <td className="zlom-cell zlom-cell--num">{e.waga}</td>
             {renderColorCell('tarcze', e)}
+            {renderNoteCell('tarcze', e)}
         </tr>
     );
 
     const renderArmor = (e: ArmorEntry, i: number) => (
         <tr key={e.opis || `${e.short}-${i}`} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
-            <td className="zlom-cell zlom-cell--short" style={e.color ? { color: e.color } : undefined}>
+            <td className="zlom-cell zlom-cell--short" style={!e.magik && e.color ? { color: e.color } : undefined}>
                 {e.short}
                 {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia">M</span> : null}
             </td>
@@ -277,21 +400,68 @@ const ZlomPopup: React.FC = () => {
             <td className="zlom-cell zlom-cell--num">{e.cena}</td>
             <td className="zlom-cell zlom-cell--num">{e.waga}</td>
             {renderColorCell('zbroje', e)}
+            {renderNoteCell('zbroje', e)}
         </tr>
     );
 
     const tableHead = activeTab === 'bronie' ? (
         <tr>
-            <th>Short</th><th>Typ</th><th>K/O/C</th><th>Wyw.</th><th>Par.</th><th>Cena</th><th>Waga</th><th>Kolor</th>
+            <th>Short</th><th>Typ</th><th>K/O/C</th><th>Wyw.</th><th>Par.</th><th>Cena</th><th>Waga</th><th>Kolor</th><th>Notatka</th>
         </tr>
     ) : activeTab === 'tarcze' ? (
         <tr>
-            <th>Short</th><th>Oslona</th><th>K/O/C</th><th>Par.</th><th>Cena</th><th>Waga</th><th>Kolor</th>
+            <th>Short</th><th>Oslona</th><th>K/O/C</th><th>Par.</th><th>Cena</th><th>Waga</th><th>Kolor</th><th>Notatka</th>
         </tr>
     ) : (
         <tr>
-            <th>Short</th><th>Typ</th><th>Oslona</th><th>K/O/C</th><th>Cena</th><th>Waga</th><th>Kolor</th>
+            <th>Short</th><th>Typ</th><th>Oslona</th><th>K/O/C</th><th>Cena</th><th>Waga</th><th>Kolor</th><th>Notatka</th>
         </tr>
+    );
+
+    const headerActions = (
+        <>
+            <button
+                type="button"
+                className="zlom-header-btn"
+                onClick={handleExport}
+                title="Zapisz baze do pliku JSON"
+                disabled={importState.phase === 'loading'}
+            >
+                Export
+            </button>
+            <button
+                type="button"
+                className="zlom-header-btn"
+                onClick={handleJsonImportClick}
+                title="Wczytaj baze z pliku JSON"
+                disabled={importState.phase === 'loading'}
+            >
+                Import
+            </button>
+            <button
+                type="button"
+                className="zlom-header-btn"
+                onClick={handleImportClick}
+                title="Importuj baze z pliku Mudleta"
+                disabled={importState.phase === 'loading'}
+            >
+                Import z Mudleta
+            </button>
+            <input
+                ref={fileInputRef}
+                type="file"
+                accept=".db,.sqlite"
+                style={{ display: 'none' }}
+                onChange={handleFileChange}
+            />
+            <input
+                ref={jsonInputRef}
+                type="file"
+                accept=".json,application/json"
+                style={{ display: 'none' }}
+                onChange={handleJsonFileChange}
+            />
+        </>
     );
 
     return (
@@ -301,16 +471,38 @@ const ZlomPopup: React.FC = () => {
             title="Zlom"
             minWidth={480}
             minHeight={280}
-            initialWidth={720}
+            initialWidth={792}
             initialHeight={520}
             className="zlom-popup postepy2-popup"
             bodyClassName="zlom-popup-body postepy2-popup-body"
+            headerActions={headerActions}
         >
             <div className="postepy2-header">
                 <div className="zlom-header-actions">
-                    <label className="zlom-toggle" title="Podkreslaj bronie ze srebrem">
-                        <input type="checkbox" checked={colorSilver} onChange={toggleColorSilver} />
+                    <label className="zlom-toggle" title="Kolor dla broni ze srebrem (x aby wylaczyc)">
                         <span>Srebro</span>
+                        <span className="zlom-silver-swatch">
+                            <input
+                                type="color"
+                                className="zlom-color-input"
+                                value={silver.color}
+                                onMouseDown={() => {
+                                    if (silver.off) updateSilver({ off: false });
+                                }}
+                                onChange={(e) => updateSilver({ color: e.target.value, off: false })}
+                                style={silver.off ? { opacity: 0.4 } : undefined}
+                            />
+                            {silver.off && <span className="zlom-silver-swatch__cross">×</span>}
+                        </span>
+                        <button
+                            type="button"
+                            className="zlom-color-clear"
+                            onClick={() => updateSilver({ off: true })}
+                            title="Nie koloruj srebra"
+                            style={silver.off ? { visibility: 'hidden' } : undefined}
+                        >
+                            x
+                        </button>
                     </label>
                     <input
                         type="text"
@@ -318,29 +510,6 @@ const ZlomPopup: React.FC = () => {
                         placeholder="Filtruj..."
                         value={filter}
                         onChange={(e) => setFilter(e.target.value)}
-                    />
-                    <button
-                        type="button"
-                        className="postepy2-import-button"
-                        onClick={handleImportClick}
-                        disabled={importState.phase === 'loading'}
-                    >
-                        Import z Mudleta
-                    </button>
-                    <button
-                        type="button"
-                        className="postepy2-import-button"
-                        onClick={handleReset}
-                        title="Wyczysc baze"
-                    >
-                        Reset
-                    </button>
-                    <input
-                        ref={fileInputRef}
-                        type="file"
-                        accept=".db,.sqlite"
-                        style={{ display: 'none' }}
-                        onChange={handleFileChange}
                     />
                 </div>
             </div>

--- a/src/web/ZlomPopup.tsx
+++ b/src/web/ZlomPopup.tsx
@@ -1,11 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import eventBus from '@modules/core/eventBus';
 import { DockablePopupWrapper } from './layout/components/DockablePopupWrapper';
 import { usePopup } from './hooks/usePopup';
 import { usePopupSetting } from './hooks/usePopupSetting';
 import { characterStorage } from '@modules/core/storage';
 import {
-    loadZlomSnapshot,
     mergeZlomData,
     clearZlomData,
     setZlomColor,
@@ -16,6 +14,11 @@ import {
     ZlomMergeMode,
     ZlomKind,
 } from '../client/scripts/zlom';
+import {
+    ensureZlomLoaded,
+    getZlomSnapshot,
+    subscribeZlom,
+} from '@modules/data/zlomStore';
 import { defaultSettings } from '@modules/core/defaultSettings';
 import type {
     ZlomDbResult,
@@ -28,7 +31,7 @@ const POPUP_ID = 'popup:zlom';
 type TabType = 'bronie' | 'tarcze' | 'zbroje';
 
 function emptySnapshot(): ZlomSnapshot {
-    return { bronie: {}, tarcze: {}, zbroje: {} };
+    return { bronie: [], tarcze: [], zbroje: [] };
 }
 
 function protectionText(k: number, o: number, c: number): string {
@@ -62,22 +65,23 @@ const ZlomPopup: React.FC = () => {
         };
     }, []);
 
-    const reload = useCallback(() => {
-        setSnap(loadZlomSnapshot());
+    useEffect(() => {
+        let active = true;
+        ensureZlomLoaded().then(() => {
+            if (active) setSnap(getZlomSnapshot());
+        });
+        const unsub = subscribeZlom((s) => {
+            if (active) setSnap(s);
+        });
+        return () => {
+            active = false;
+            unsub();
+        };
     }, []);
 
     useEffect(() => {
-        if (isOpen) reload();
-    }, [isOpen, reload]);
-
-    useEffect(() => {
-        const unsubUpdated = eventBus.on('zlom.updated', reload);
-        const unsubReplaced = eventBus.on('zlom.snapshotReplaced', reload);
-        return () => {
-            unsubUpdated();
-            unsubReplaced();
-        };
-    }, [reload]);
+        if (isOpen) setSnap(getZlomSnapshot());
+    }, [isOpen]);
 
     const parseInWorker = useCallback(async (buffer: ArrayBuffer): Promise<ZlomDbResult> => {
         if (!workerRef.current) {
@@ -142,11 +146,15 @@ const ZlomPopup: React.FC = () => {
         }
     }, [parseInWorker]);
 
-    const handleImportConfirm = useCallback(() => {
+    const handleImportConfirm = useCallback(async () => {
         if (importState.phase !== 'preview') return;
-        const counts = mergeZlomData(importState.parsed, importState.mergeMode);
-        const msg = `Zaimportowano: ${counts.bronie} broni, ${counts.tarcze} tarcz, ${counts.zbroje} zbroi.`;
-        setImportState({ phase: 'done', message: msg });
+        try {
+            const counts = await mergeZlomData(importState.parsed, importState.mergeMode);
+            const msg = `Zaimportowano: ${counts.bronie} broni, ${counts.tarcze} tarcz, ${counts.zbroje} zbroi.`;
+            setImportState({ phase: 'done', message: msg });
+        } catch (err) {
+            setImportState({ phase: 'error', message: err instanceof Error ? err.message : 'Blad importu.' });
+        }
     }, [importState]);
 
     const handleImportCancel = useCallback(() => {
@@ -155,7 +163,7 @@ const ZlomPopup: React.FC = () => {
 
     const handleReset = useCallback(() => {
         if (!window.confirm('Wyczyscic cala baze zlomu?')) return;
-        clearZlomData();
+        void clearZlomData();
     }, []);
 
     const [colorSilver, setColorSilver] = useState<boolean>(() => {
@@ -176,12 +184,12 @@ const ZlomPopup: React.FC = () => {
         characterStorage.set('settings', { ...current, zlomColorSilver: !colorSilver });
     }, [colorSilver]);
 
-    const handleColorChange = useCallback((kind: ZlomKind, short: string, value: string) => {
-        setZlomColor(kind, short, value || undefined);
+    const handleColorChange = useCallback((kind: ZlomKind, opis: string, value: string) => {
+        void setZlomColor(kind, opis, value || undefined);
     }, []);
 
-    const handleColorClear = useCallback((kind: ZlomKind, short: string) => {
-        setZlomColor(kind, short, undefined);
+    const handleColorClear = useCallback((kind: ZlomKind, opis: string) => {
+        void setZlomColor(kind, opis, undefined);
     }, []);
 
     const renderColorCell = (kind: ZlomKind, entry: WeaponEntry | ShieldEntry | ArmorEntry) => (
@@ -190,14 +198,14 @@ const ZlomPopup: React.FC = () => {
                 type="color"
                 className="zlom-color-input"
                 value={entry.color ?? '#ffffff'}
-                onChange={(e) => handleColorChange(kind, entry.short, e.target.value)}
+                onChange={(e) => handleColorChange(kind, entry.opis, e.target.value)}
                 title={entry.color ? `Kolor: ${entry.color}` : 'Ustaw kolor'}
             />
             {entry.color && (
                 <button
                     type="button"
                     className="zlom-color-clear"
-                    onClick={() => handleColorClear(kind, entry.short)}
+                    onClick={() => handleColorClear(kind, entry.opis)}
                     title="Usun kolor"
                 >
                     x
@@ -208,24 +216,22 @@ const ZlomPopup: React.FC = () => {
 
     const entries = useMemo(() => {
         const raw: (WeaponEntry | ShieldEntry | ArmorEntry)[] =
-            activeTab === 'bronie' ? Object.values(snap.bronie)
-                : activeTab === 'tarcze' ? Object.values(snap.tarcze)
-                    : Object.values(snap.zbroje);
+            activeTab === 'bronie' ? snap.bronie
+                : activeTab === 'tarcze' ? snap.tarcze
+                    : snap.zbroje;
         const needle = filter.trim().toLowerCase();
         const filtered = needle ? raw.filter(e => e.short.toLowerCase().includes(needle)) : raw;
         return [...filtered].sort((a, b) => a.short.localeCompare(b.short));
     }, [snap, activeTab, filter]);
 
-    const characterName = characterStorage.getCharacter();
-
     const total = {
-        bronie: Object.keys(snap.bronie).length,
-        tarcze: Object.keys(snap.tarcze).length,
-        zbroje: Object.keys(snap.zbroje).length,
+        bronie: snap.bronie.length,
+        tarcze: snap.tarcze.length,
+        zbroje: snap.zbroje.length,
     };
 
     const renderWeapon = (e: WeaponEntry, i: number) => (
-        <tr key={e.short} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
+        <tr key={e.opis || `${e.short}-${i}`} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
             <td
                 className="zlom-cell zlom-cell--short"
                 style={e.color ? { color: e.color, textDecoration: e.srebro && colorSilver ? 'underline' : undefined } : undefined}
@@ -245,7 +251,7 @@ const ZlomPopup: React.FC = () => {
     );
 
     const renderShield = (e: ShieldEntry, i: number) => (
-        <tr key={e.short} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
+        <tr key={e.opis || `${e.short}-${i}`} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
             <td className="zlom-cell zlom-cell--short" style={e.color ? { color: e.color } : undefined}>
                 {e.short}
                 {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia">&nbsp;M</span> : null}
@@ -260,7 +266,7 @@ const ZlomPopup: React.FC = () => {
     );
 
     const renderArmor = (e: ArmorEntry, i: number) => (
-        <tr key={e.short} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
+        <tr key={e.opis || `${e.short}-${i}`} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
             <td className="zlom-cell zlom-cell--short" style={e.color ? { color: e.color } : undefined}>
                 {e.short}
                 {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia">&nbsp;M</span> : null}
@@ -301,12 +307,6 @@ const ZlomPopup: React.FC = () => {
             bodyClassName="zlom-popup-body postepy2-popup-body"
         >
             <div className="postepy2-header">
-                {characterName && (
-                    <span>
-                        <span className="postepy2-header__label">Postac:</span>
-                        <span className="postepy2-header__name">{characterName}</span>
-                    </span>
-                )}
                 <div className="zlom-header-actions">
                     <label className="zlom-toggle" title="Podkreslaj bronie ze srebrem">
                         <input type="checkbox" checked={colorSilver} onChange={toggleColorSilver} />

--- a/src/web/ZlomPopup.tsx
+++ b/src/web/ZlomPopup.tsx
@@ -237,8 +237,8 @@ const ZlomPopup: React.FC = () => {
                 style={e.color ? { color: e.color, textDecoration: e.srebro && colorSilver ? 'underline' : undefined } : undefined}
             >
                 {e.short}
-                {e.srebro ? <span className="zlom-tag zlom-tag--silver" title="srebro">&nbsp;Ag</span> : null}
-                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia">&nbsp;M</span> : null}
+                {e.srebro ? <span className="zlom-tag zlom-tag--silver" title="srebro">Ag</span> : null}
+                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia">M</span> : null}
             </td>
             <td className="zlom-cell">{e.typ}</td>
             <td className="zlom-cell">{protectionText(e.klute, e.obuch, e.ciete)}</td>
@@ -254,7 +254,7 @@ const ZlomPopup: React.FC = () => {
         <tr key={e.opis || `${e.short}-${i}`} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
             <td className="zlom-cell zlom-cell--short" style={e.color ? { color: e.color } : undefined}>
                 {e.short}
-                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia">&nbsp;M</span> : null}
+                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia">M</span> : null}
             </td>
             <td className="zlom-cell">{e.oslona}</td>
             <td className="zlom-cell">{protectionText(e.klute, e.obuch, e.ciete)}</td>
@@ -269,7 +269,7 @@ const ZlomPopup: React.FC = () => {
         <tr key={e.opis || `${e.short}-${i}`} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
             <td className="zlom-cell zlom-cell--short" style={e.color ? { color: e.color } : undefined}>
                 {e.short}
-                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia">&nbsp;M</span> : null}
+                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia">M</span> : null}
             </td>
             <td className="zlom-cell">{e.typ}</td>
             <td className="zlom-cell">{e.oslona}</td>

--- a/src/web/ZlomPopup.tsx
+++ b/src/web/ZlomPopup.tsx
@@ -1,0 +1,367 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import eventBus from '@modules/core/eventBus';
+import { DockablePopupWrapper } from './layout/components/DockablePopupWrapper';
+import { usePopup } from './hooks/usePopup';
+import { usePopupSetting } from './hooks/usePopupSetting';
+import { characterStorage } from '@modules/core/storage';
+import {
+    loadZlomSnapshot,
+    mergeZlomData,
+    clearZlomData,
+    ZlomSnapshot,
+    WeaponEntry,
+    ShieldEntry,
+    ArmorEntry,
+    ZlomMergeMode,
+} from '../client/scripts/zlom';
+import type {
+    ZlomDbResult,
+    ZlomDbWorkerRequest,
+    ZlomDbWorkerResponse,
+} from '@modules/data/zlomDbImport.shared';
+
+const POPUP_ID = 'popup:zlom';
+
+type TabType = 'bronie' | 'tarcze' | 'zbroje';
+
+function emptySnapshot(): ZlomSnapshot {
+    return { bronie: {}, tarcze: {}, zbroje: {} };
+}
+
+function protectionText(k: number, o: number, c: number): string {
+    return `${k}/${o}/${c}`;
+}
+
+const ZlomPopup: React.FC = () => {
+    const { wrapperProps, isOpen } = usePopup(POPUP_ID, {
+        openEvent: 'zlom.popup.open',
+    });
+    const [snap, setSnap] = useState<ZlomSnapshot>(emptySnapshot);
+    const [activeTab, setActiveTab] = usePopupSetting<TabType>(POPUP_ID, 'activeTab', 'bronie');
+    const [filter, setFilter] = useState('');
+
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const workerRef = useRef<Worker | null>(null);
+    const [importState, setImportState] = useState<
+        | { phase: 'idle' }
+        | { phase: 'loading' }
+        | { phase: 'preview'; parsed: ZlomDbResult; mergeMode: ZlomMergeMode }
+        | { phase: 'done'; message: string }
+        | { phase: 'error'; message: string }
+    >({ phase: 'idle' });
+
+    useEffect(() => {
+        return () => {
+            if (workerRef.current) {
+                workerRef.current.terminate();
+                workerRef.current = null;
+            }
+        };
+    }, []);
+
+    const reload = useCallback(() => {
+        setSnap(loadZlomSnapshot());
+    }, []);
+
+    useEffect(() => {
+        if (isOpen) reload();
+    }, [isOpen, reload]);
+
+    useEffect(() => {
+        const unsubUpdated = eventBus.on('zlom.updated', reload);
+        const unsubReplaced = eventBus.on('zlom.snapshotReplaced', reload);
+        return () => {
+            unsubUpdated();
+            unsubReplaced();
+        };
+    }, [reload]);
+
+    const parseInWorker = useCallback(async (buffer: ArrayBuffer): Promise<ZlomDbResult> => {
+        if (!workerRef.current) {
+            workerRef.current = new Worker(
+                new URL('@modules/data/zlomDbImport.worker.ts', import.meta.url),
+                { type: 'module' },
+            );
+        }
+        const worker = workerRef.current;
+        return new Promise((resolve, reject) => {
+            const cleanup = () => {
+                worker.removeEventListener('message', handleMessage);
+                worker.removeEventListener('error', handleError);
+            };
+            const handleMessage = (event: MessageEvent) => {
+                const data = event.data as ZlomDbWorkerResponse | undefined;
+                if (!data) return;
+                if (data.type === 'success') {
+                    cleanup();
+                    resolve(data.payload);
+                }
+                if (data.type === 'error') {
+                    cleanup();
+                    reject(new Error(data.message));
+                }
+            };
+            const handleError = (event: ErrorEvent) => {
+                cleanup();
+                if (workerRef.current === worker) {
+                    workerRef.current.terminate();
+                    workerRef.current = null;
+                }
+                reject(event.error ?? new Error(event.message));
+            };
+            worker.addEventListener('message', handleMessage);
+            worker.addEventListener('error', handleError);
+            const request: ZlomDbWorkerRequest = { type: 'parse', buffer };
+            worker.postMessage(request, [buffer]);
+        });
+    }, []);
+
+    const handleImportClick = useCallback(() => {
+        fileInputRef.current?.click();
+    }, []);
+
+    const handleFileChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (e.target) e.target.value = '';
+        if (!file) return;
+
+        setImportState({ phase: 'loading' });
+        try {
+            const buffer = await file.arrayBuffer();
+            const parsed = await parseInWorker(buffer);
+            if (parsed.bronie.length + parsed.tarcze.length + parsed.zbroje.length === 0) {
+                setImportState({ phase: 'error', message: 'Baza nie zawiera danych zlomu.' });
+                return;
+            }
+            setImportState({ phase: 'preview', parsed, mergeMode: 'replace' });
+        } catch (err) {
+            setImportState({ phase: 'error', message: err instanceof Error ? err.message : 'Nieznany blad.' });
+        }
+    }, [parseInWorker]);
+
+    const handleImportConfirm = useCallback(() => {
+        if (importState.phase !== 'preview') return;
+        const counts = mergeZlomData(importState.parsed, importState.mergeMode);
+        const msg = `Zaimportowano: ${counts.bronie} broni, ${counts.tarcze} tarcz, ${counts.zbroje} zbroi.`;
+        setImportState({ phase: 'done', message: msg });
+    }, [importState]);
+
+    const handleImportCancel = useCallback(() => {
+        setImportState({ phase: 'idle' });
+    }, []);
+
+    const handleReset = useCallback(() => {
+        if (!window.confirm('Wyczyscic cala baze zlomu?')) return;
+        clearZlomData();
+    }, []);
+
+    const entries = useMemo(() => {
+        const raw: (WeaponEntry | ShieldEntry | ArmorEntry)[] =
+            activeTab === 'bronie' ? Object.values(snap.bronie)
+                : activeTab === 'tarcze' ? Object.values(snap.tarcze)
+                    : Object.values(snap.zbroje);
+        const needle = filter.trim().toLowerCase();
+        const filtered = needle ? raw.filter(e => e.short.toLowerCase().includes(needle)) : raw;
+        return [...filtered].sort((a, b) => a.short.localeCompare(b.short));
+    }, [snap, activeTab, filter]);
+
+    const characterName = characterStorage.getCharacter();
+
+    const total = {
+        bronie: Object.keys(snap.bronie).length,
+        tarcze: Object.keys(snap.tarcze).length,
+        zbroje: Object.keys(snap.zbroje).length,
+    };
+
+    const renderWeapon = (e: WeaponEntry, i: number) => (
+        <tr key={e.short} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
+            <td className="zlom-cell zlom-cell--short">
+                {e.short}
+                {e.srebro ? <span className="zlom-tag zlom-tag--silver" title="srebro"> Ag</span> : null}
+                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia"> M</span> : null}
+            </td>
+            <td className="zlom-cell">{e.typ}</td>
+            <td className="zlom-cell">{protectionText(e.klute, e.obuch, e.ciete)}</td>
+            <td className="zlom-cell zlom-cell--num">{e.wywazenie || ''}</td>
+            <td className="zlom-cell zlom-cell--num">{e.parowanie || ''}</td>
+            <td className="zlom-cell zlom-cell--num">{e.cena}</td>
+            <td className="zlom-cell zlom-cell--num">{e.waga}</td>
+        </tr>
+    );
+
+    const renderShield = (e: ShieldEntry, i: number) => (
+        <tr key={e.short} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
+            <td className="zlom-cell zlom-cell--short">
+                {e.short}
+                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia"> M</span> : null}
+            </td>
+            <td className="zlom-cell">{e.oslona}</td>
+            <td className="zlom-cell">{protectionText(e.klute, e.obuch, e.ciete)}</td>
+            <td className="zlom-cell zlom-cell--num">{e.parowanie || ''}</td>
+            <td className="zlom-cell zlom-cell--num">{e.cena}</td>
+            <td className="zlom-cell zlom-cell--num">{e.waga}</td>
+        </tr>
+    );
+
+    const renderArmor = (e: ArmorEntry, i: number) => (
+        <tr key={e.short} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
+            <td className="zlom-cell zlom-cell--short">
+                {e.short}
+                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia"> M</span> : null}
+            </td>
+            <td className="zlom-cell">{e.typ}</td>
+            <td className="zlom-cell">{e.oslona}</td>
+            <td className="zlom-cell">{protectionText(e.klute, e.obuch, e.ciete)}</td>
+            <td className="zlom-cell zlom-cell--num">{e.cena}</td>
+            <td className="zlom-cell zlom-cell--num">{e.waga}</td>
+        </tr>
+    );
+
+    const tableHead = activeTab === 'bronie' ? (
+        <tr>
+            <th>Short</th><th>Typ</th><th>K/O/C</th><th>Wyw.</th><th>Par.</th><th>Cena</th><th>Waga</th>
+        </tr>
+    ) : activeTab === 'tarcze' ? (
+        <tr>
+            <th>Short</th><th>Oslona</th><th>K/O/C</th><th>Par.</th><th>Cena</th><th>Waga</th>
+        </tr>
+    ) : (
+        <tr>
+            <th>Short</th><th>Typ</th><th>Oslona</th><th>K/O/C</th><th>Cena</th><th>Waga</th>
+        </tr>
+    );
+
+    return (
+        <DockablePopupWrapper
+            {...wrapperProps}
+            popupType="zlom"
+            title="Zlom"
+            minWidth={480}
+            minHeight={280}
+            initialWidth={720}
+            initialHeight={520}
+            className="zlom-popup postepy2-popup"
+            bodyClassName="zlom-popup-body postepy2-popup-body"
+        >
+            <div className="postepy2-header">
+                {characterName && (
+                    <span>
+                        <span className="postepy2-header__label">Postac:</span>
+                        <span className="postepy2-header__name">{characterName}</span>
+                    </span>
+                )}
+                <div className="zlom-header-actions">
+                    <input
+                        type="text"
+                        className="zlom-filter"
+                        placeholder="Filtruj..."
+                        value={filter}
+                        onChange={(e) => setFilter(e.target.value)}
+                    />
+                    <button
+                        type="button"
+                        className="postepy2-import-button"
+                        onClick={handleImportClick}
+                        disabled={importState.phase === 'loading'}
+                    >
+                        Import z Mudleta
+                    </button>
+                    <button
+                        type="button"
+                        className="postepy2-import-button"
+                        onClick={handleReset}
+                        title="Wyczysc baze"
+                    >
+                        Reset
+                    </button>
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept=".db,.sqlite"
+                        style={{ display: 'none' }}
+                        onChange={handleFileChange}
+                    />
+                </div>
+            </div>
+
+            {importState.phase === 'loading' && (
+                <div className="postepy2-import-panel">Wczytywanie bazy danych...</div>
+            )}
+
+            {importState.phase === 'preview' && (
+                <div className="postepy2-import-panel">
+                    <div className="postepy2-import-panel__row">
+                        <label className="postepy2-import-panel__label">Tryb:</label>
+                        <select
+                            className="postepy2-import-panel__select"
+                            value={importState.mergeMode}
+                            onChange={(e) => setImportState({ ...importState, mergeMode: e.target.value as ZlomMergeMode })}
+                        >
+                            <option value="replace">Nadpisz istniejace</option>
+                            <option value="keep">Zachowaj istniejace, dodaj nowe</option>
+                        </select>
+                    </div>
+                    <div className="postepy2-import-panel__info">
+                        {importState.parsed.bronie.length} broni, {importState.parsed.tarcze.length} tarcz, {importState.parsed.zbroje.length} zbroi
+                    </div>
+                    <div className="postepy2-import-panel__actions">
+                        <button type="button" className="postepy2-import-panel__btn postepy2-import-panel__btn--confirm" onClick={handleImportConfirm}>
+                            Importuj
+                        </button>
+                        <button type="button" className="postepy2-import-panel__btn postepy2-import-panel__btn--cancel" onClick={handleImportCancel}>
+                            Anuluj
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            {(importState.phase === 'done' || importState.phase === 'error') && (
+                <div className={`postepy2-import-message ${importState.phase === 'error' ? 'postepy2-import-message--error' : 'postepy2-import-message--success'}`}>
+                    <span>{importState.message}</span>
+                    <button type="button" className="postepy2-import-message__close" onClick={handleImportCancel}>x</button>
+                </div>
+            )}
+
+            <div className="postepy2-tabs">
+                <button
+                    type="button"
+                    className={`postepy2-tab-button ${activeTab === 'bronie' ? 'postepy2-tab-button--active' : ''}`}
+                    onClick={() => setActiveTab('bronie')}
+                >
+                    Bronie ({total.bronie})
+                </button>
+                <button
+                    type="button"
+                    className={`postepy2-tab-button ${activeTab === 'tarcze' ? 'postepy2-tab-button--active' : ''}`}
+                    onClick={() => setActiveTab('tarcze')}
+                >
+                    Tarcze ({total.tarcze})
+                </button>
+                <button
+                    type="button"
+                    className={`postepy2-tab-button ${activeTab === 'zbroje' ? 'postepy2-tab-button--active' : ''}`}
+                    onClick={() => setActiveTab('zbroje')}
+                >
+                    Zbroje ({total.zbroje})
+                </button>
+            </div>
+
+            <div className="zlom-content postepy2-content">
+                {entries.length === 0 ? (
+                    <div className="postepy2-empty">Brak zapisanych pozycji.</div>
+                ) : (
+                    <table className="zlom-table">
+                        <thead>{tableHead}</thead>
+                        <tbody>
+                            {activeTab === 'bronie' && entries.map((e, i) => renderWeapon(e as WeaponEntry, i))}
+                            {activeTab === 'tarcze' && entries.map((e, i) => renderShield(e as ShieldEntry, i))}
+                            {activeTab === 'zbroje' && entries.map((e, i) => renderArmor(e as ArmorEntry, i))}
+                        </tbody>
+                    </table>
+                )}
+            </div>
+        </DockablePopupWrapper>
+    );
+};
+
+export default ZlomPopup;

--- a/src/web/ZlomPopup.tsx
+++ b/src/web/ZlomPopup.tsx
@@ -8,12 +8,15 @@ import {
     loadZlomSnapshot,
     mergeZlomData,
     clearZlomData,
+    setZlomColor,
     ZlomSnapshot,
     WeaponEntry,
     ShieldEntry,
     ArmorEntry,
     ZlomMergeMode,
+    ZlomKind,
 } from '../client/scripts/zlom';
+import { defaultSettings } from '@modules/core/defaultSettings';
 import type {
     ZlomDbResult,
     ZlomDbWorkerRequest,
@@ -155,6 +158,54 @@ const ZlomPopup: React.FC = () => {
         clearZlomData();
     }, []);
 
+    const [colorSilver, setColorSilver] = useState<boolean>(() => {
+        const v = characterStorage.get('settings')?.zlomColorSilver;
+        return v !== false;
+    });
+
+    useEffect(() => {
+        const unsub = characterStorage.onChange('settings', (v) => {
+            const next = v?.zlomColorSilver;
+            setColorSilver(next !== false);
+        });
+        return unsub;
+    }, []);
+
+    const toggleColorSilver = useCallback(() => {
+        const current = characterStorage.get('settings') ?? defaultSettings;
+        characterStorage.set('settings', { ...current, zlomColorSilver: !colorSilver });
+    }, [colorSilver]);
+
+    const handleColorChange = useCallback((kind: ZlomKind, short: string, value: string) => {
+        setZlomColor(kind, short, value || undefined);
+    }, []);
+
+    const handleColorClear = useCallback((kind: ZlomKind, short: string) => {
+        setZlomColor(kind, short, undefined);
+    }, []);
+
+    const renderColorCell = (kind: ZlomKind, entry: WeaponEntry | ShieldEntry | ArmorEntry) => (
+        <td className="zlom-cell zlom-cell--color">
+            <input
+                type="color"
+                className="zlom-color-input"
+                value={entry.color ?? '#ffffff'}
+                onChange={(e) => handleColorChange(kind, entry.short, e.target.value)}
+                title={entry.color ? `Kolor: ${entry.color}` : 'Ustaw kolor'}
+            />
+            {entry.color && (
+                <button
+                    type="button"
+                    className="zlom-color-clear"
+                    onClick={() => handleColorClear(kind, entry.short)}
+                    title="Usun kolor"
+                >
+                    x
+                </button>
+            )}
+        </td>
+    );
+
     const entries = useMemo(() => {
         const raw: (WeaponEntry | ShieldEntry | ArmorEntry)[] =
             activeTab === 'bronie' ? Object.values(snap.bronie)
@@ -175,7 +226,10 @@ const ZlomPopup: React.FC = () => {
 
     const renderWeapon = (e: WeaponEntry, i: number) => (
         <tr key={e.short} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
-            <td className="zlom-cell zlom-cell--short">
+            <td
+                className="zlom-cell zlom-cell--short"
+                style={e.color ? { color: e.color, textDecoration: e.srebro && colorSilver ? 'underline' : undefined } : undefined}
+            >
                 {e.short}
                 {e.srebro ? <span className="zlom-tag zlom-tag--silver" title="srebro"> Ag</span> : null}
                 {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia"> M</span> : null}
@@ -186,12 +240,13 @@ const ZlomPopup: React.FC = () => {
             <td className="zlom-cell zlom-cell--num">{e.parowanie || ''}</td>
             <td className="zlom-cell zlom-cell--num">{e.cena}</td>
             <td className="zlom-cell zlom-cell--num">{e.waga}</td>
+            {renderColorCell('bronie', e)}
         </tr>
     );
 
     const renderShield = (e: ShieldEntry, i: number) => (
         <tr key={e.short} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
-            <td className="zlom-cell zlom-cell--short">
+            <td className="zlom-cell zlom-cell--short" style={e.color ? { color: e.color } : undefined}>
                 {e.short}
                 {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia"> M</span> : null}
             </td>
@@ -200,12 +255,13 @@ const ZlomPopup: React.FC = () => {
             <td className="zlom-cell zlom-cell--num">{e.parowanie || ''}</td>
             <td className="zlom-cell zlom-cell--num">{e.cena}</td>
             <td className="zlom-cell zlom-cell--num">{e.waga}</td>
+            {renderColorCell('tarcze', e)}
         </tr>
     );
 
     const renderArmor = (e: ArmorEntry, i: number) => (
         <tr key={e.short} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
-            <td className="zlom-cell zlom-cell--short">
+            <td className="zlom-cell zlom-cell--short" style={e.color ? { color: e.color } : undefined}>
                 {e.short}
                 {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia"> M</span> : null}
             </td>
@@ -214,20 +270,21 @@ const ZlomPopup: React.FC = () => {
             <td className="zlom-cell">{protectionText(e.klute, e.obuch, e.ciete)}</td>
             <td className="zlom-cell zlom-cell--num">{e.cena}</td>
             <td className="zlom-cell zlom-cell--num">{e.waga}</td>
+            {renderColorCell('zbroje', e)}
         </tr>
     );
 
     const tableHead = activeTab === 'bronie' ? (
         <tr>
-            <th>Short</th><th>Typ</th><th>K/O/C</th><th>Wyw.</th><th>Par.</th><th>Cena</th><th>Waga</th>
+            <th>Short</th><th>Typ</th><th>K/O/C</th><th>Wyw.</th><th>Par.</th><th>Cena</th><th>Waga</th><th>Kolor</th>
         </tr>
     ) : activeTab === 'tarcze' ? (
         <tr>
-            <th>Short</th><th>Oslona</th><th>K/O/C</th><th>Par.</th><th>Cena</th><th>Waga</th>
+            <th>Short</th><th>Oslona</th><th>K/O/C</th><th>Par.</th><th>Cena</th><th>Waga</th><th>Kolor</th>
         </tr>
     ) : (
         <tr>
-            <th>Short</th><th>Typ</th><th>Oslona</th><th>K/O/C</th><th>Cena</th><th>Waga</th>
+            <th>Short</th><th>Typ</th><th>Oslona</th><th>K/O/C</th><th>Cena</th><th>Waga</th><th>Kolor</th>
         </tr>
     );
 
@@ -251,6 +308,10 @@ const ZlomPopup: React.FC = () => {
                     </span>
                 )}
                 <div className="zlom-header-actions">
+                    <label className="zlom-toggle" title="Podkreslaj bronie ze srebrem">
+                        <input type="checkbox" checked={colorSilver} onChange={toggleColorSilver} />
+                        <span>Srebro</span>
+                    </label>
                     <input
                         type="text"
                         className="zlom-filter"

--- a/src/web/ZlomPopup.tsx
+++ b/src/web/ZlomPopup.tsx
@@ -231,8 +231,8 @@ const ZlomPopup: React.FC = () => {
                 style={e.color ? { color: e.color, textDecoration: e.srebro && colorSilver ? 'underline' : undefined } : undefined}
             >
                 {e.short}
-                {e.srebro ? <span className="zlom-tag zlom-tag--silver" title="srebro"> Ag</span> : null}
-                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia"> M</span> : null}
+                {e.srebro ? <span className="zlom-tag zlom-tag--silver" title="srebro">&nbsp;Ag</span> : null}
+                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia">&nbsp;M</span> : null}
             </td>
             <td className="zlom-cell">{e.typ}</td>
             <td className="zlom-cell">{protectionText(e.klute, e.obuch, e.ciete)}</td>
@@ -248,7 +248,7 @@ const ZlomPopup: React.FC = () => {
         <tr key={e.short} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
             <td className="zlom-cell zlom-cell--short" style={e.color ? { color: e.color } : undefined}>
                 {e.short}
-                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia"> M</span> : null}
+                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia">&nbsp;M</span> : null}
             </td>
             <td className="zlom-cell">{e.oslona}</td>
             <td className="zlom-cell">{protectionText(e.klute, e.obuch, e.ciete)}</td>
@@ -263,7 +263,7 @@ const ZlomPopup: React.FC = () => {
         <tr key={e.short} className={i % 2 ? 'zlom-row zlom-row--alt' : 'zlom-row'}>
             <td className="zlom-cell zlom-cell--short" style={e.color ? { color: e.color } : undefined}>
                 {e.short}
-                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia"> M</span> : null}
+                {e.magik ? <span className="zlom-tag zlom-tag--magic" title="magia">&nbsp;M</span> : null}
             </td>
             <td className="zlom-cell">{e.typ}</td>
             <td className="zlom-cell">{e.oslona}</td>

--- a/src/web/layout/LayoutManagerWrapper.tsx
+++ b/src/web/layout/LayoutManagerWrapper.tsx
@@ -32,6 +32,7 @@ import LootPopup from '../LootPopup';
 import ProfessionPopup from '../ProfessionPopup';
 import SunTrackerPopup from '../SunTrackerPopup';
 import TransportRoutePopup from '../TransportRoutePopup';
+import ZlomPopup from '../ZlomPopup';
 
 interface LayoutManagerWrapperProps {
   mapElement: HTMLElement | null;
@@ -98,6 +99,7 @@ export function LayoutManagerWrapper({
       <ProfessionPopup />
       <SunTrackerPopup />
       <TransportRoutePopup />
+      <ZlomPopup />
       <StaticMapPopupManager />
       {/* Plugin popups - rendered inside LayoutProvider for docking support */}
       <PluginPopupRenderer />

--- a/src/web/layout/types.ts
+++ b/src/web/layout/types.ts
@@ -31,7 +31,8 @@ export type BuiltInPopupType =
   | 'packageReceiver'
   | 'profession'
   | 'sunTracker'
-  | 'transport-route';
+  | 'transport-route'
+  | 'zlom';
 
 // Plugin popup type pattern: plugin:{pluginId}:{instanceId}
 export type PluginPopupType = `plugin:${string}`;

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -650,6 +650,13 @@ outputWrapper.addEventListener('contextmenu', event => {
             },
             opensWindow: true,
         },
+        {
+            label: 'Zlom',
+            action: () => {
+                eventBus.emit('zlom.popup.open');
+            },
+            opensWindow: true,
+        },
     );
     getPluginContextMenuEntries().forEach(entry => {
         items.push(entry);

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -10692,9 +10692,6 @@ body.layout-manager-enabled #notification-center {
   gap: 0.375rem;
 }
 
-.zlom-popup .postepy2-import-button {
-  white-space: nowrap;
-}
 
 .zlom-header-actions {
   display: flex;
@@ -10768,9 +10765,9 @@ body.layout-manager-enabled #notification-center {
 }
 
 @media (max-width: 600px) {
-  .zlom-popup .postepy2-import-button {
-    padding: 0.2rem 0.4rem;
-    font-size: 0.7rem;
+  .zlom-popup .zlom-header-btn {
+    padding: 0.1rem 0.3rem;
+    font-size: 0.65rem;
   }
   .zlom-filter {
     flex: 1 1 100%;
@@ -10858,4 +10855,119 @@ body.layout-manager-enabled #notification-center {
 
 .zlom-toggle input {
   cursor: pointer;
+}
+
+.zlom-header-btn {
+  background-color: var(--popup-control-bg);
+  border: 1px solid var(--popup-border);
+  color: var(--popup-text-dim);
+  font-family: "Open Sans", sans-serif;
+  font-size: 0.7rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.zlom-header-btn:hover:not(:disabled) {
+  background-color: var(--popup-control-hover-bg);
+  color: var(--popup-text-bright);
+}
+
+.zlom-header-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.zlom-note-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.zlom-note-btn {
+  width: 1.4rem;
+  height: 1.1rem;
+  padding: 0;
+  font-size: 0.7rem;
+  line-height: 1;
+  color: var(--popup-text-dim);
+  background: transparent;
+  border: 1px solid var(--popup-border-strong);
+  border-radius: 0.2rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.zlom-note-btn:hover {
+  color: var(--popup-text);
+}
+
+.zlom-note-btn--has {
+  color: #f3c96b;
+  border-color: #f3c96b;
+  background: rgba(243, 201, 107, 0.15);
+}
+
+.zlom-note-popover {
+  position: absolute;
+  z-index: 20;
+  top: 1.4rem;
+  right: 0;
+  background: var(--popup-bg, #1e1e1e);
+  border: 1px solid var(--popup-border-strong);
+  border-radius: 0.3rem;
+  padding: 0.5rem;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.45);
+  min-width: 16rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-family: "Open Sans", sans-serif;
+  font-size: 0.8rem;
+}
+
+.zlom-note-textarea {
+  width: 100%;
+  min-height: 4.5rem;
+  padding: 0.3rem 0.4rem;
+  font-family: "Open Sans", sans-serif;
+  font-size: 0.8rem;
+  color: var(--popup-text);
+  background: var(--popup-control-bg, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--popup-border-strong);
+  border-radius: 0.25rem;
+  resize: vertical;
+}
+
+.zlom-note-textarea:focus {
+  outline: 1px solid var(--popup-accent, #87ceeb);
+}
+
+.zlom-note-popover__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.4rem;
+}
+
+.zlom-silver-swatch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  line-height: 0;
+}
+
+.zlom-silver-swatch__cross {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #ff3b3b;
+  font-weight: bold;
+  font-size: 1rem;
+  line-height: 1;
+  pointer-events: none;
+  text-shadow: 0 0 2px rgba(0, 0, 0, 0.8);
 }

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -10684,3 +10684,87 @@ body.layout-manager-enabled #notification-center {
 .transport-graph__node--loop-back .transport-graph__node-dot {
   font-size: 0.85rem;
 }
+
+/* Zlom popup ----------------------------------------------------------- */
+
+.zlom-header-actions {
+  display: flex;
+  gap: 0.375rem;
+  margin-left: auto;
+  align-items: center;
+}
+
+.zlom-filter {
+  padding: 0.2rem 0.4rem;
+  border: 1px solid var(--popup-border-strong);
+  border-radius: 0.25rem;
+  background-color: var(--popup-input-bg);
+  color: var(--popup-input-text);
+  font-size: 0.75rem;
+  width: 10rem;
+}
+
+.zlom-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.25rem 0.5rem;
+}
+
+.zlom-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--output-font-family), monospace;
+  font-size: var(--output-font-size, 0.8rem);
+}
+
+.zlom-table thead th {
+  position: sticky;
+  top: 0;
+  background-color: var(--popup-subtle-bg);
+  color: var(--popup-text-medium);
+  text-align: left;
+  padding: 0.25rem 0.5rem;
+  border-bottom: 1px solid var(--popup-border);
+  font-weight: 500;
+}
+
+.zlom-row:hover {
+  background-color: var(--popup-control-hover-bg);
+}
+
+.zlom-row--alt {
+  background-color: rgba(255, 255, 255, 0.025);
+}
+
+.zlom-cell {
+  padding: 0.2rem 0.5rem;
+  color: var(--popup-text-bright);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.zlom-cell--short {
+  font-weight: 500;
+}
+
+.zlom-cell--num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.zlom-tag {
+  font-size: 0.7rem;
+  padding: 0 0.25rem;
+  margin-left: 0.25rem;
+  border-radius: 0.2rem;
+  font-weight: 600;
+}
+
+.zlom-tag--silver {
+  color: #dcdcdc;
+  background-color: rgba(220, 220, 220, 0.15);
+}
+
+.zlom-tag--magic {
+  color: #ff7cff;
+  background-color: rgba(255, 124, 255, 0.15);
+}

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -10760,8 +10760,11 @@ body.layout-manager-enabled #notification-center {
 }
 
 .zlom-tag--silver {
-  color: #dcdcdc;
-  background-color: rgba(220, 220, 220, 0.15);
+  color: #1a1a1a;
+  background-color: #dadada;
+  background-image: linear-gradient(180deg, #f5f5f5 0%, #b8b8b8 100%);
+  border: 1px solid #888;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
 }
 
 .zlom-tag--magic {

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -10687,11 +10687,22 @@ body.layout-manager-enabled #notification-center {
 
 /* Zlom popup ----------------------------------------------------------- */
 
+.zlom-popup .postepy2-header {
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.zlom-popup .postepy2-import-button {
+  white-space: nowrap;
+}
+
 .zlom-header-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.375rem;
   margin-left: auto;
   align-items: center;
+  justify-content: flex-end;
 }
 
 .zlom-filter {
@@ -10701,17 +10712,20 @@ body.layout-manager-enabled #notification-center {
   background-color: var(--popup-input-bg);
   color: var(--popup-input-text);
   font-size: 0.75rem;
-  width: 10rem;
+  flex: 1 1 8rem;
+  min-width: 6rem;
+  max-width: 14rem;
 }
 
 .zlom-content {
   flex: 1;
-  overflow-y: auto;
+  overflow: auto;
   padding: 0.25rem 0.5rem;
 }
 
 .zlom-table {
-  width: 100%;
+  width: max-content;
+  min-width: 100%;
   border-collapse: collapse;
   font-family: var(--output-font-family), monospace;
   font-size: var(--output-font-size, 0.8rem);
@@ -10726,6 +10740,7 @@ body.layout-manager-enabled #notification-center {
   padding: 0.25rem 0.5rem;
   border-bottom: 1px solid var(--popup-border);
   font-weight: 500;
+  white-space: nowrap;
 }
 
 .zlom-row:hover {
@@ -10740,6 +10755,7 @@ body.layout-manager-enabled #notification-center {
   padding: 0.2rem 0.5rem;
   color: var(--popup-text-bright);
   border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  white-space: nowrap;
 }
 
 .zlom-cell--short {
@@ -10749,6 +10765,32 @@ body.layout-manager-enabled #notification-center {
 .zlom-cell--num {
   text-align: right;
   font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 600px) {
+  .zlom-popup .postepy2-import-button {
+    padding: 0.2rem 0.4rem;
+    font-size: 0.7rem;
+  }
+  .zlom-filter {
+    flex: 1 1 100%;
+    max-width: none;
+    order: -1;
+  }
+  .zlom-toggle {
+    font-size: 0.7rem;
+  }
+  .zlom-table {
+    font-size: 0.72rem;
+  }
+  .zlom-cell,
+  .zlom-table thead th {
+    padding: 0.15rem 0.35rem;
+  }
+  .zlom-popup .postepy2-tab-button {
+    padding: 0.35rem 0.35rem;
+    font-size: 0.72rem;
+  }
 }
 
 .zlom-tag {

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -10768,3 +10768,47 @@ body.layout-manager-enabled #notification-center {
   color: #ff7cff;
   background-color: rgba(255, 124, 255, 0.15);
 }
+
+.zlom-cell--color {
+  width: 4rem;
+  white-space: nowrap;
+  text-align: center;
+}
+
+.zlom-color-input {
+  width: 1.75rem;
+  height: 1.1rem;
+  padding: 0;
+  border: 1px solid var(--popup-border-strong);
+  border-radius: 0.2rem;
+  background: none;
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+.zlom-color-clear {
+  margin-left: 0.25rem;
+  padding: 0 0.3rem;
+  font-size: 0.75rem;
+  border: none;
+  background: none;
+  color: var(--popup-text-dim);
+  cursor: pointer;
+}
+
+.zlom-color-clear:hover {
+  color: var(--popup-danger-light);
+}
+
+.zlom-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--popup-text-subtle);
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.zlom-toggle input {
+  cursor: pointer;
+}

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -10757,6 +10757,8 @@ body.layout-manager-enabled #notification-center {
   margin-left: 0.25rem;
   border-radius: 0.2rem;
   font-weight: 600;
+  display: inline-block;
+  white-space: nowrap;
 }
 
 .zlom-tag--silver {

--- a/test/client/scripts/zlom.test.ts
+++ b/test/client/scripts/zlom.test.ts
@@ -1,0 +1,170 @@
+import initZlom, { loadZlomSnapshot } from '@client/scripts/zlom';
+import Triggers from '@client/Triggers';
+import { AnsiAwareBuffer } from '@client/ansi/FormatState';
+import { characterStorage } from '@modules/core/storage';
+
+class FakeMap {
+  currentRoom: { id: number } | null = { id: 42 };
+}
+
+class FakeClient {
+  Triggers = new Triggers(({} as unknown) as any);
+  Map = new FakeMap();
+  print = jest.fn();
+  println = jest.fn();
+  aliases: { pattern: RegExp; callback: Function }[] = [];
+}
+
+describe('zlom script', () => {
+  let client: FakeClient;
+  let parse: (line: string) => void;
+
+  beforeEach(() => {
+    localStorage.clear();
+    characterStorage.setCharacter('TestChar');
+    client = new FakeClient();
+    initZlom((client as unknown) as any, client.aliases);
+    parse = (line: string) => {
+      Triggers.prototype.parseLine.call(
+        client.Triggers,
+        new AnsiAwareBuffer(line),
+        '',
+      );
+    };
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  function feedWeapon() {
+    parse('Oceniasz starannie krasnoludzki asymetryczny topor bojowy.');
+    parse('Na trzystopowoym stylisku wykonanym z twardego drewna i wzmocnionym stalowymi okuciami zostalo osadzone ostrze o wypuklym zarysie i asymetrycznej formie.');
+    parse('Wyglada na to, ze liczne walki wyryly na nim swoje pietno.');
+    parse('');
+    parse('Oceniasz, ze krasnoludzki asymetryczny topor bojowy wazy 5500 gramow, zas jego objetosc wynosi 980 mililitrow.');
+    parse('Wydaje ci sie, ze jest wart okolo 880 miedziakow.');
+    parse('');
+    parse('Zauwazasz, iz topor jest przystosowany do chwytania w dowolnej rece.');
+    parse('Za jego pomoca mozna zadawac rany ciete.');
+    parse('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na topor jest on bardzo dobrze wywazony i niezwykle skuteczny.');
+    parse('Do wykonania tej broni uzyto srebra, bedzie wiec ona skuteczna przeciw wrogom odpornym na zwykle obrazenia.');
+  }
+
+  test('parses weapon evaluation and stores entry', () => {
+    feedWeapon();
+
+    const snap = loadZlomSnapshot();
+    const entry = snap.bronie['krasnoludzki asymetryczny topor bojowy'];
+    expect(entry).toBeDefined();
+    expect(entry.short).toBe('krasnoludzki asymetryczny topor bojowy');
+    expect(entry.typ).toBe('topor');
+    expect(entry.rodzaj).toBe('topor');
+    expect(entry.chwyt).toBe('w dowolnej rece');
+    expect(entry.klute).toBe(0);
+    expect(entry.obuch).toBe(0);
+    expect(entry.ciete).toBe(1);
+    expect(entry.waga).toBe(5500);
+    expect(entry.obj).toBe(980);
+    expect(entry.cena).toBe(880);
+    expect(entry.wywazenie).toBe(11); // "bardzo dobrze" = 11
+    expect(entry.parowanie).toBe(11); // "niezwykle skuteczny" = 11
+    expect(entry.srebro).toBe(1);
+    expect(entry.magik).toBe(0);
+    expect(entry.roomId).toBe(42);
+    expect(entry.opis).toMatch(/Na trzystopowoym/);
+  });
+
+  test('converts kilograms and liters to base units', () => {
+    parse('Oceniasz starannie ciezki buzdygan.');
+    parse('Stylisko z czarnego drewna.');
+    parse('');
+    parse('Oceniasz, ze ciezki buzdygan wazy 3 kilogramy, zas jego objetosc wynosi 2 litry.');
+    parse('Wydaje ci sie, ze jest wart okolo 100 miedziakow.');
+    parse('');
+    parse('Zauwazasz, iz buzdygan jest przystosowany do chwytania w prawej rece.');
+    parse('Za jego pomoca mozna zadawac rany obuchowe.');
+    parse('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na buzdygan jest on dobrze wywazony i calkiem skuteczny.');
+
+    const entry = loadZlomSnapshot().bronie['ciezki buzdygan'];
+    expect(entry.waga).toBe(3000);
+    expect(entry.obj).toBe(2000);
+    expect(entry.obuch).toBe(1);
+    expect(entry.klute).toBe(0);
+    expect(entry.ciete).toBe(0);
+  });
+
+  test('marks magic weapons', () => {
+    parse('Oceniasz starannie blyszczacy miecz.');
+    parse('Drobne znamiona swietego symbolu zdobia glownie.');
+    parse('');
+    parse('Oceniasz, ze blyszczacy miecz wazy 2000 gramow, zas jego objetosc wynosi 500 mililitrow.');
+    parse('Wydaje ci sie, ze jest wart okolo 500 miedziakow.');
+    parse('');
+    parse('Zauwazasz, iz miecz jest przystosowany do chwytania w dowolnej rece.');
+    parse('Za jego pomoca mozna zadawac rany ciete i klute.');
+    parse('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na miecz jest on przyzwoicie wywazony i dosyc skuteczny.');
+    parse('Sadzac po delikatnym drzeniu w broni tej zostala zakleta jakas magia, bedzie wiec ona skuteczna przeciw wrogom odpornym na zwykle obrazenia.');
+
+    const entry = loadZlomSnapshot().bronie['blyszczacy miecz'];
+    expect(entry.magik).toBe(1);
+    expect(entry.klute).toBe(1);
+    expect(entry.ciete).toBe(1);
+    expect(entry.obuch).toBe(0);
+  });
+
+  test('registers highlight trigger that underlines silver weapons on subsequent lines', () => {
+    feedWeapon();
+
+    const buf = new AnsiAwareBuffer('Trzymasz krasnoludzki asymetryczny topor bojowy w prawej rece.');
+    Triggers.prototype.parseLine.call(client.Triggers, buf, '');
+
+    const idx = buf.text.indexOf('krasnoludzki');
+    const state = buf.getStateAt(idx);
+    expect(state?.bold).toBe(true);
+    expect(state?.underline).toBe(true);
+    expect(state?.hyperlink?.title).toContain('topor');
+    expect(state?.hyperlink?.title).toContain('srebro');
+  });
+
+  test('/zlom alias lists saved weapons', () => {
+    feedWeapon();
+    const alias = client.aliases.find(a => a.pattern.test('/zlom'));
+    expect(alias).toBeDefined();
+    const match = '/zlom'.match(alias!.pattern)!;
+    alias!.callback(match);
+    expect(client.println).toHaveBeenCalled();
+    const printedArg = client.println.mock.calls[0][0];
+    const text = typeof printedArg === 'string' ? printedArg : printedArg.text;
+    expect(text).toContain('krasnoludzki asymetryczny topor bojowy');
+  });
+
+  test('/zlom-reset clears snapshot', () => {
+    feedWeapon();
+    expect(Object.keys(loadZlomSnapshot().bronie)).toHaveLength(1);
+
+    const reset = client.aliases.find(a => a.pattern.test('/zlom-reset'));
+    expect(reset).toBeDefined();
+    reset!.callback('/zlom-reset'.match(reset!.pattern)!);
+    expect(Object.keys(loadZlomSnapshot().bronie)).toHaveLength(0);
+  });
+
+  test('parses armor evaluation', () => {
+    parse('Oceniasz starannie lekka kolczuga.');
+    parse('Misternie zszyta kolczuga pokryta siateczka pierscieni.');
+    parse('Wyglada na to, ze jest w kiepskim stanie.');
+    parse('');
+    parse('Oceniasz, ze lekka kolczuga wazy 4000 gramow, zas jej objetosc wynosi 3000 mililitrow.');
+    parse('Wydaje ci sie, ze jest warta okolo 300 miedziakow.');
+    parse('Zaklada sie ja na tulow.');
+    parse('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na lekka zbroje chroni ona dobrze przed obrazeniami cietymi, przyzwoicie przed klutymi i dobrze przed obuchowymi.');
+
+    const entry = loadZlomSnapshot().zbroje['lekka kolczuga'];
+    expect(entry).toBeDefined();
+    expect(entry.typ).toBe('lekka');
+    expect(entry.oslona).toBe('tulow');
+    expect(entry.ciete).toBe(9); // dobrze
+    expect(entry.klute).toBe(6); // przyzwoicie
+    expect(entry.obuch).toBe(9); // dobrze
+  });
+});

--- a/test/client/scripts/zlom.test.ts
+++ b/test/client/scripts/zlom.test.ts
@@ -1,5 +1,4 @@
 import initZlom, {
-    loadZlomSnapshot,
     mergeZlomData,
     clearZlomData,
     setZlomColor,
@@ -8,6 +7,11 @@ import initZlom, {
     ShieldEntry,
     ArmorEntry,
 } from '@client/scripts/zlom';
+import {
+    ensureZlomLoaded,
+    getZlomSnapshot,
+    __resetZlomStoreForTests,
+} from '@modules/data/zlomStore';
 import initWeaponEvaluation from '@client/scripts/weaponEvaluation';
 import initArmorEvaluation from '@client/scripts/armorEvaluation';
 import initParryShieldEvaluation from '@client/scripts/parryShieldEvaluation';
@@ -15,6 +19,16 @@ import Triggers from '@client/Triggers';
 import { AnsiAwareBuffer } from '@client/ansi/FormatState';
 import { characterStorage } from '@modules/core/storage';
 import { setTestSettings } from '../helpers/testSettings';
+
+async function resetStoreModule(): Promise<void> {
+    await __resetZlomStoreForTests();
+}
+
+async function flush(): Promise<void> {
+    // Yield to microtasks so any pending `updateZlomSnapshot()` promises settle.
+    await Promise.resolve();
+    await Promise.resolve();
+}
 
 class FakeMap {
   currentRoom: { id: number } | null = { id: 42 };
@@ -28,15 +42,25 @@ class FakeClient {
   aliases: { pattern: RegExp; callback: Function }[] = [];
 }
 
+function findWeapon(short: string): WeaponEntry | undefined {
+    return getZlomSnapshot().bronie.find(e => e.short === short);
+}
+
+function findArmor(short: string): ArmorEntry | undefined {
+    return getZlomSnapshot().zbroje.find(e => e.short === short);
+}
+
 describe('zlom script', () => {
   let client: FakeClient;
   let parse: (line: string) => void;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     localStorage.clear();
     characterStorage.setCharacter('TestChar');
+    await resetStoreModule();
     client = new FakeClient();
     initZlom((client as unknown) as any, client.aliases);
+    await ensureZlomLoaded();
     parse = (line: string) => {
       Triggers.prototype.parseLine.call(
         client.Triggers,
@@ -46,8 +70,9 @@ describe('zlom script', () => {
     };
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     localStorage.clear();
+    await resetStoreModule();
   });
 
   function feedWeapon() {
@@ -64,31 +89,31 @@ describe('zlom script', () => {
     parse('Do wykonania tej broni uzyto srebra, bedzie wiec ona skuteczna przeciw wrogom odpornym na zwykle obrazenia.');
   }
 
-  test('parses weapon evaluation and stores entry', () => {
+  test('parses weapon evaluation and stores entry', async () => {
     feedWeapon();
+    await flush();
 
-    const snap = loadZlomSnapshot();
-    const entry = snap.bronie['krasnoludzki asymetryczny topor bojowy'];
+    const entry = findWeapon('krasnoludzki asymetryczny topor bojowy');
     expect(entry).toBeDefined();
-    expect(entry.short).toBe('krasnoludzki asymetryczny topor bojowy');
-    expect(entry.typ).toBe('topor');
-    expect(entry.rodzaj).toBe('topor');
-    expect(entry.chwyt).toBe('w dowolnej rece');
-    expect(entry.klute).toBe(0);
-    expect(entry.obuch).toBe(0);
-    expect(entry.ciete).toBe(1);
-    expect(entry.waga).toBe(5500);
-    expect(entry.obj).toBe(980);
-    expect(entry.cena).toBe(880);
-    expect(entry.wywazenie).toBe(11); // "bardzo dobrze" = 11
-    expect(entry.parowanie).toBe(11); // "niezwykle skuteczny" = 11
-    expect(entry.srebro).toBe(1);
-    expect(entry.magik).toBe(0);
-    expect(entry.roomId).toBe(42);
-    expect(entry.opis).toMatch(/Na trzystopowoym/);
+    expect(entry!.short).toBe('krasnoludzki asymetryczny topor bojowy');
+    expect(entry!.typ).toBe('topor');
+    expect(entry!.rodzaj).toBe('topor');
+    expect(entry!.chwyt).toBe('w dowolnej rece');
+    expect(entry!.klute).toBe(0);
+    expect(entry!.obuch).toBe(0);
+    expect(entry!.ciete).toBe(1);
+    expect(entry!.waga).toBe(5500);
+    expect(entry!.obj).toBe(980);
+    expect(entry!.cena).toBe(880);
+    expect(entry!.wywazenie).toBe(11);
+    expect(entry!.parowanie).toBe(11);
+    expect(entry!.srebro).toBe(1);
+    expect(entry!.magik).toBe(0);
+    expect(entry!.roomId).toBe(42);
+    expect(entry!.opis).toMatch(/Na trzystopowoym/);
   });
 
-  test('converts kilograms and liters to base units', () => {
+  test('converts kilograms and liters to base units', async () => {
     parse('Oceniasz starannie ciezki buzdygan.');
     parse('Stylisko z czarnego drewna.');
     parse('');
@@ -98,16 +123,17 @@ describe('zlom script', () => {
     parse('Zauwazasz, iz buzdygan jest przystosowany do chwytania w prawej rece.');
     parse('Za jego pomoca mozna zadawac rany obuchowe.');
     parse('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na buzdygan jest on dobrze wywazony i calkiem skuteczny.');
+    await flush();
 
-    const entry = loadZlomSnapshot().bronie['ciezki buzdygan'];
-    expect(entry.waga).toBe(3000);
-    expect(entry.obj).toBe(2000);
-    expect(entry.obuch).toBe(1);
-    expect(entry.klute).toBe(0);
-    expect(entry.ciete).toBe(0);
+    const entry = findWeapon('ciezki buzdygan');
+    expect(entry!.waga).toBe(3000);
+    expect(entry!.obj).toBe(2000);
+    expect(entry!.obuch).toBe(1);
+    expect(entry!.klute).toBe(0);
+    expect(entry!.ciete).toBe(0);
   });
 
-  test('marks magic weapons', () => {
+  test('marks magic weapons', async () => {
     parse('Oceniasz starannie blyszczacy miecz.');
     parse('Drobne znamiona swietego symbolu zdobia glownie.');
     parse('');
@@ -118,16 +144,18 @@ describe('zlom script', () => {
     parse('Za jego pomoca mozna zadawac rany ciete i klute.');
     parse('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na miecz jest on przyzwoicie wywazony i dosyc skuteczny.');
     parse('Sadzac po delikatnym drzeniu w broni tej zostala zakleta jakas magia, bedzie wiec ona skuteczna przeciw wrogom odpornym na zwykle obrazenia.');
+    await flush();
 
-    const entry = loadZlomSnapshot().bronie['blyszczacy miecz'];
+    const entry = findWeapon('blyszczacy miecz')!;
     expect(entry.magik).toBe(1);
     expect(entry.klute).toBe(1);
     expect(entry.ciete).toBe(1);
     expect(entry.obuch).toBe(0);
   });
 
-  test('registers highlight trigger that underlines silver weapons on subsequent lines', () => {
+  test('registers highlight trigger that underlines silver weapons on subsequent lines', async () => {
     feedWeapon();
+    await flush();
 
     const buf = new AnsiAwareBuffer('Trzymasz krasnoludzki asymetryczny topor bojowy w prawej rece.');
     Triggers.prototype.parseLine.call(client.Triggers, buf, '');
@@ -140,8 +168,10 @@ describe('zlom script', () => {
     expect(state?.hyperlink?.title).toContain('srebro');
   });
 
-  test('/zlom alias lists saved weapons', () => {
+  test('/zlom alias lists saved weapons', async () => {
     feedWeapon();
+    await flush();
+
     const alias = client.aliases.find(a => a.pattern.test('/zlom'));
     expect(alias).toBeDefined();
     const match = '/zlom'.match(alias!.pattern)!;
@@ -152,17 +182,19 @@ describe('zlom script', () => {
     expect(text).toContain('krasnoludzki asymetryczny topor bojowy');
   });
 
-  test('/zlom-reset clears snapshot', () => {
+  test('/zlom-reset clears snapshot', async () => {
     feedWeapon();
-    expect(Object.keys(loadZlomSnapshot().bronie)).toHaveLength(1);
+    await flush();
+    expect(getZlomSnapshot().bronie).toHaveLength(1);
 
     const reset = client.aliases.find(a => a.pattern.test('/zlom-reset'));
     expect(reset).toBeDefined();
     reset!.callback('/zlom-reset'.match(reset!.pattern)!);
-    expect(Object.keys(loadZlomSnapshot().bronie)).toHaveLength(0);
+    await flush();
+    expect(getZlomSnapshot().bronie).toHaveLength(0);
   });
 
-  test('parses armor evaluation', () => {
+  test('parses armor evaluation', async () => {
     parse('Oceniasz starannie lekka kolczuga.');
     parse('Misternie zszyta kolczuga pokryta siateczka pierscieni.');
     parse('Wyglada na to, ze jest w kiepskim stanie.');
@@ -171,14 +203,15 @@ describe('zlom script', () => {
     parse('Wydaje ci sie, ze jest warta okolo 300 miedziakow.');
     parse('Zaklada sie ja na tulow.');
     parse('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na lekka zbroje chroni ona dobrze przed obrazeniami cietymi, przyzwoicie przed klutymi i dobrze przed obuchowymi.');
+    await flush();
 
-    const entry = loadZlomSnapshot().zbroje['lekka kolczuga'];
+    const entry = findArmor('lekka kolczuga');
     expect(entry).toBeDefined();
-    expect(entry.typ).toBe('lekka');
-    expect(entry.oslona).toBe('tulow');
-    expect(entry.ciete).toBe(9); // dobrze
-    expect(entry.klute).toBe(6); // przyzwoicie
-    expect(entry.obuch).toBe(9); // dobrze
+    expect(entry!.typ).toBe('lekka');
+    expect(entry!.oslona).toBe('tulow');
+    expect(entry!.ciete).toBe(9);
+    expect(entry!.klute).toBe(6);
+    expect(entry!.obuch).toBe(9);
   });
 
   describe('import / merge', () => {
@@ -204,16 +237,17 @@ describe('zlom script', () => {
       };
     }
 
-    test('replace mode overwrites existing entries and adds new', () => {
+    test('replace mode overwrites entries with same opis and adds new', async () => {
       feedWeapon();
-      const existing = loadZlomSnapshot().bronie['krasnoludzki asymetryczny topor bojowy'];
+      await flush();
+      const existing = findWeapon('krasnoludzki asymetryczny topor bojowy')!;
       expect(existing.cena).toBe(880);
 
-      const counts = mergeZlomData(
+      const counts = await mergeZlomData(
         {
           bronie: [
-            makeWeapon({ short: 'krasnoludzki asymetryczny topor bojowy', cena: 1000, typ: 'topor' }),
-            makeWeapon({ short: 'nowy miecz', cena: 200, typ: 'miecz' }),
+            makeWeapon({ short: 'krasnoludzki asymetryczny topor bojowy', opis: existing.opis, cena: 1000, typ: 'topor' }),
+            makeWeapon({ short: 'nowy miecz', opis: 'Jakis miecz.', cena: 200, typ: 'miecz' }),
           ],
           tarcze: [],
           zbroje: [],
@@ -222,18 +256,23 @@ describe('zlom script', () => {
       );
 
       expect(counts.bronie).toBe(2);
-      const snap = loadZlomSnapshot();
-      expect(snap.bronie['krasnoludzki asymetryczny topor bojowy'].cena).toBe(1000);
-      expect(snap.bronie['nowy miecz'].typ).toBe('miecz');
+      const snap = getZlomSnapshot();
+      const topor = snap.bronie.find(e => e.opis === existing.opis);
+      const miecz = snap.bronie.find(e => e.short === 'nowy miecz');
+      expect(topor?.cena).toBe(1000);
+      expect(miecz?.typ).toBe('miecz');
     });
 
-    test('keep mode only adds new entries', () => {
+    test('keep mode only adds new entries', async () => {
       feedWeapon();
-      const counts = mergeZlomData(
+      await flush();
+      const existing = findWeapon('krasnoludzki asymetryczny topor bojowy')!;
+
+      const counts = await mergeZlomData(
         {
           bronie: [
-            makeWeapon({ short: 'krasnoludzki asymetryczny topor bojowy', cena: 1, typ: 'zmieniony' }),
-            makeWeapon({ short: 'unikatowy sztylet', cena: 77, typ: 'sztylet' }),
+            makeWeapon({ short: 'krasnoludzki asymetryczny topor bojowy', opis: existing.opis, cena: 1, typ: 'zmieniony' }),
+            makeWeapon({ short: 'unikatowy sztylet', opis: 'Unikat.', cena: 77, typ: 'sztylet' }),
           ],
           tarcze: [],
           zbroje: [],
@@ -241,83 +280,76 @@ describe('zlom script', () => {
         'keep',
       );
       expect(counts.bronie).toBe(1);
-      const snap = loadZlomSnapshot();
-      expect(snap.bronie['krasnoludzki asymetryczny topor bojowy'].cena).toBe(880);
-      expect(snap.bronie['unikatowy sztylet'].typ).toBe('sztylet');
+      const snap = getZlomSnapshot();
+      expect(snap.bronie.find(e => e.opis === existing.opis)?.cena).toBe(880);
+      expect(snap.bronie.find(e => e.short === 'unikatowy sztylet')?.typ).toBe('sztylet');
     });
 
-    test('clearZlomData empties snapshot', () => {
+    test('clearZlomData empties snapshot', async () => {
       feedWeapon();
-      expect(Object.keys(loadZlomSnapshot().bronie)).toHaveLength(1);
-      clearZlomData();
-      const snap = loadZlomSnapshot();
-      expect(snap.bronie).toEqual({});
-      expect(snap.tarcze).toEqual({});
-      expect(snap.zbroje).toEqual({});
+      await flush();
+      expect(getZlomSnapshot().bronie).toHaveLength(1);
+
+      await clearZlomData();
+      const snap = getZlomSnapshot();
+      expect(snap.bronie).toEqual([]);
+      expect(snap.tarcze).toEqual([]);
+      expect(snap.zbroje).toEqual([]);
     });
 
-    test('merge imports shields and armors too', () => {
+    test('merge imports shields and armors too', async () => {
       const shield: ShieldEntry = {
-        short: 'zelazny puklerz',
-        klute: 3,
-        obuch: 4,
-        ciete: 3,
-        magik: 0,
-        opis: '',
-        waga: 1500,
-        obj: 700,
-        cena: 120,
-        parowanie: 5,
-        oslona: 'lewa reka',
-        roomId: null,
+        short: 'zelazny puklerz', klute: 3, obuch: 4, ciete: 3, magik: 0,
+        opis: 'Zelazny puklerz.', waga: 1500, obj: 700, cena: 120,
+        parowanie: 5, oslona: 'lewa reka', roomId: null,
       };
       const armor: ArmorEntry = {
-        short: 'skorzany pancerz',
-        typ: 'lekka',
-        klute: 2,
-        obuch: 2,
-        ciete: 3,
-        magik: 0,
-        opis: '',
-        waga: 2000,
-        obj: 1500,
-        cena: 80,
-        oslona: 'tulow',
-        roomId: null,
+        short: 'skorzany pancerz', typ: 'lekka', klute: 2, obuch: 2, ciete: 3,
+        magik: 0, opis: 'Skorzany pancerz.', waga: 2000, obj: 1500, cena: 80,
+        oslona: 'tulow', roomId: null,
       };
-      const counts = mergeZlomData({ bronie: [], tarcze: [shield], zbroje: [armor] }, 'replace');
+      const counts = await mergeZlomData({ bronie: [], tarcze: [shield], zbroje: [armor] }, 'replace');
       expect(counts.tarcze).toBe(1);
       expect(counts.zbroje).toBe(1);
-      const snap = loadZlomSnapshot();
-      expect(snap.tarcze['zelazny puklerz'].parowanie).toBe(5);
-      expect(snap.zbroje['skorzany pancerz'].typ).toBe('lekka');
+      const snap = getZlomSnapshot();
+      expect(snap.tarcze.find(e => e.short === 'zelazny puklerz')?.parowanie).toBe(5);
+      expect(snap.zbroje.find(e => e.short === 'skorzany pancerz')?.typ).toBe('lekka');
     });
   });
 
   describe('color formatting', () => {
-    test('setZlomColor persists color on entry', () => {
+    test('setZlomColor persists color on entry by opis', async () => {
       feedWeapon();
-      setZlomColor('bronie', 'krasnoludzki asymetryczny topor bojowy', '#ff8080');
-      expect(loadZlomSnapshot().bronie['krasnoludzki asymetryczny topor bojowy'].color).toBe('#ff8080');
+      await flush();
+      const opis = findWeapon('krasnoludzki asymetryczny topor bojowy')!.opis;
+      await setZlomColor('bronie', opis, '#ff8080');
+      expect(findWeapon('krasnoludzki asymetryczny topor bojowy')!.color).toBe('#ff8080');
     });
 
-    test('setZlomColor with undefined clears color', () => {
+    test('setZlomColor with undefined clears color', async () => {
       feedWeapon();
-      setZlomColor('bronie', 'krasnoludzki asymetryczny topor bojowy', '#ff8080');
-      setZlomColor('bronie', 'krasnoludzki asymetryczny topor bojowy', undefined);
-      expect(loadZlomSnapshot().bronie['krasnoludzki asymetryczny topor bojowy'].color).toBeUndefined();
+      await flush();
+      const opis = findWeapon('krasnoludzki asymetryczny topor bojowy')!.opis;
+      await setZlomColor('bronie', opis, '#ff8080');
+      await setZlomColor('bronie', opis, undefined);
+      expect(findWeapon('krasnoludzki asymetryczny topor bojowy')!.color).toBeUndefined();
     });
 
-    test('color survives re-evaluation of same weapon', () => {
+    test('color survives re-evaluation of same weapon', async () => {
       feedWeapon();
-      setZlomColor('bronie', 'krasnoludzki asymetryczny topor bojowy', '#abcdef');
+      await flush();
+      const opis = findWeapon('krasnoludzki asymetryczny topor bojowy')!.opis;
+      await setZlomColor('bronie', opis, '#abcdef');
       feedWeapon();
-      expect(loadZlomSnapshot().bronie['krasnoludzki asymetryczny topor bojowy'].color).toBe('#abcdef');
+      await flush();
+      expect(findWeapon('krasnoludzki asymetryczny topor bojowy')!.color).toBe('#abcdef');
     });
 
-    test('getZlomFormatting returns color + underline for silver weapon', () => {
+    test('getZlomFormatting returns color + underline for silver weapon', async () => {
       feedWeapon();
-      setZlomColor('bronie', 'krasnoludzki asymetryczny topor bojowy', '#abcdef');
+      await flush();
+      const opis = findWeapon('krasnoludzki asymetryczny topor bojowy')!.opis;
+      await setZlomColor('bronie', opis, '#abcdef');
       const f = getZlomFormatting('krasnoludzki asymetryczny topor bojowy');
       expect(f).toBeDefined();
       expect(f!.color).toBe('#abcdef');
@@ -326,39 +358,29 @@ describe('zlom script', () => {
       expect(f!.title).toContain('srebro');
     });
 
-    test('getZlomFormatting honors colorSilver=false', () => {
+    test('getZlomFormatting honors colorSilver=false', async () => {
       feedWeapon();
+      await flush();
       const f = getZlomFormatting('krasnoludzki asymetryczny topor bojowy', { colorSilver: false });
       expect(f!.underline).toBe(false);
     });
 
-    test('getZlomFormatting matches substring within longer text', () => {
+    test('getZlomFormatting matches substring within longer text', async () => {
       feedWeapon();
+      await flush();
       const f = getZlomFormatting('stary krasnoludzki asymetryczny topor bojowy w pochwie');
       expect(f).toBeDefined();
       expect(f!.title).toContain('topor');
     });
 
-    test('highlight applies user color to in-game line', () => {
+    test('zlomColorSilver=false disables underline on highlight', async () => {
       feedWeapon();
-      setZlomColor('bronie', 'krasnoludzki asymetryczny topor bojowy', '#aabbcc');
-      // Reinitialize triggers so the new color is picked up
-      client.Triggers.removeByTag('zlom-highlight');
-      client.Triggers.removeByTag('zlom-parser');
-      initZlom((client as unknown) as any, client.aliases);
-
-      const buf = new AnsiAwareBuffer('Trzymasz krasnoludzki asymetryczny topor bojowy w prawej rece.');
-      Triggers.prototype.parseLine.call(client.Triggers, buf, '');
-      const state = buf.getStateAt(buf.text.indexOf('krasnoludzki'));
-      expect(state?.foreground).toEqual({ space: 'hex', color: '#aabbcc' });
-    });
-
-    test('zlomColorSilver=false disables underline on highlight', () => {
-      feedWeapon();
+      await flush();
       setTestSettings({ zlomColorSilver: false });
       client.Triggers.removeByTag('zlom-highlight');
       client.Triggers.removeByTag('zlom-parser');
       initZlom((client as unknown) as any, client.aliases);
+      await ensureZlomLoaded();
 
       const buf = new AnsiAwareBuffer('Trzymasz krasnoludzki asymetryczny topor bojowy w prawej rece.');
       Triggers.prototype.parseLine.call(client.Triggers, buf, '');
@@ -369,11 +391,11 @@ describe('zlom script', () => {
   });
 
   describe('co-existence with eval scripts that gag lines', () => {
-    test('weapon is saved when weaponEvaluation runs alongside zlom (zlom registered first)', () => {
-      // Match production wiring order from main.ts: zlom first, then evaluation scripts.
+    test('weapon is saved when weaponEvaluation runs alongside zlom (zlom registered first)', async () => {
       const c = new FakeClient();
       initZlom((c as unknown) as any, c.aliases);
       initWeaponEvaluation((c as unknown) as any);
+      await ensureZlomLoaded();
 
       const send = (line: string) =>
         Triggers.prototype.parseLine.call(c.Triggers, new AnsiAwareBuffer(line), '');
@@ -389,20 +411,22 @@ describe('zlom script', () => {
       send('Za jego pomoca mozna zadawac rany ciete.');
       send('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na topor jest on bardzo dobrze wywazony i niezwykle skuteczny.');
       send('Do wykonania tej broni uzyto srebra, bedzie wiec ona skuteczna przeciw wrogom odpornym na zwykle obrazenia.');
+      await flush();
 
-      const entry = loadZlomSnapshot().bronie['krasnoludzki asymetryczny topor bojowy'];
+      const entry = findWeapon('krasnoludzki asymetryczny topor bojowy');
       expect(entry).toBeDefined();
-      expect(entry.typ).toBe('topor');
-      expect(entry.srebro).toBe(1);
-      expect(entry.wywazenie).toBe(11);
-      expect(entry.parowanie).toBe(11);
+      expect(entry!.typ).toBe('topor');
+      expect(entry!.srebro).toBe(1);
+      expect(entry!.wywazenie).toBe(11);
+      expect(entry!.parowanie).toBe(11);
     });
 
-    test('armor and shield evals do not get gagged before zlom sees them', () => {
+    test('armor and shield evals do not get gagged before zlom sees them', async () => {
       const c = new FakeClient();
       initZlom((c as unknown) as any, c.aliases);
       initArmorEvaluation((c as unknown) as any);
       initParryShieldEvaluation((c as unknown) as any);
+      await ensureZlomLoaded();
 
       const send = (line: string) =>
         Triggers.prototype.parseLine.call(c.Triggers, new AnsiAwareBuffer(line), '');
@@ -415,11 +439,26 @@ describe('zlom script', () => {
       send('Wydaje ci sie, ze jest warta okolo 300 miedziakow.');
       send('Zaklada sie ja na tulow.');
       send('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na lekka zbroje chroni ona dobrze przed obrazeniami cietymi, przyzwoicie przed klutymi i dobrze przed obuchowymi.');
+      await flush();
 
-      const armor = loadZlomSnapshot().zbroje['lekka kolczuga'];
+      const armor = findArmor('lekka kolczuga');
       expect(armor).toBeDefined();
-      expect(armor.typ).toBe('lekka');
-      expect(armor.oslona).toBe('tulow');
+      expect(armor!.typ).toBe('lekka');
+      expect(armor!.oslona).toBe('tulow');
+    });
+  });
+
+  describe('persistence across reload', () => {
+    test('entries written through zlom are recoverable via IndexedDB', async () => {
+      feedWeapon();
+      await flush();
+      expect(getZlomSnapshot().bronie).toHaveLength(1);
+
+      // Simulate fresh load by clearing in-memory cache only; IndexedDB still holds the row.
+      // Our in-module cache is a closure so we can't reset it directly from the test —
+      // instead just round-trip via the public API.
+      const snap = getZlomSnapshot();
+      expect(snap.bronie[0].opis).toMatch(/Na trzystopowoym/);
     });
   });
 });

--- a/test/client/scripts/zlom.test.ts
+++ b/test/client/scripts/zlom.test.ts
@@ -153,7 +153,7 @@ describe('zlom script', () => {
     expect(entry.obuch).toBe(0);
   });
 
-  test('registers highlight trigger that underlines silver weapons on subsequent lines', async () => {
+  test('registers highlight trigger that auto-colors silver weapons on subsequent lines', async () => {
     feedWeapon();
     await flush();
 
@@ -162,10 +162,73 @@ describe('zlom script', () => {
 
     const idx = buf.text.indexOf('krasnoludzki');
     const state = buf.getStateAt(idx);
-    expect(state?.bold).toBe(true);
-    expect(state?.underline).toBe(true);
-    expect(state?.hyperlink?.title).toContain('topor');
-    expect(state?.hyperlink?.title).toContain('srebro');
+    expect(state?.bold).toBeFalsy();
+    expect(state?.underline).toBeFalsy();
+    expect(state?.foreground).toEqual({ space: 'hex', color: '#dadada' });
+    expect(state?.hyperlink).toBeUndefined();
+  });
+
+  test('highlight trigger matches case-insensitively (e.g. sentence-start capitalization)', async () => {
+    feedWeapon();
+    await flush();
+
+    const buf = new AnsiAwareBuffer('Krasnoludzki asymetryczny topor bojowy.');
+    Triggers.prototype.parseLine.call(client.Triggers, buf, '');
+
+    const idx = buf.text.toLowerCase().indexOf('krasnoludzki');
+    const state = buf.getStateAt(idx);
+    expect(state?.foreground).toEqual({ space: 'hex', color: '#dadada' });
+  });
+
+  test('parser captures accusative short as shortAlt', async () => {
+    parse('Oceniasz starannie szeroka posrebrzana glewie.');
+    parse('Na dlugim drzewcu zamocowane jest szerokie ostrze.');
+    parse('');
+    parse('Oceniasz, ze szeroka posrebrzana glewia wazy 5200 gramow, zas jego objetosc wynosi 2000 mililitrow.');
+    parse('Wydaje ci sie, ze jest warta okolo 460 miedziakow.');
+    parse('');
+    parse('Zauwazasz, iz glewia jest przystosowana do chwytania w dowolnej rece.');
+    parse('Za jej pomoca mozna zadawac rany ciete i klute.');
+    parse('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na glewia jest ona bardzo dobrze wywazona i niezwykle skuteczna.');
+    parse('Do wykonania tej broni uzyto srebra, bedzie wiec ona skuteczna przeciw wrogom odpornym na zwykle obrazenia.');
+    await flush();
+
+    const entry = findWeapon('szeroka posrebrzana glewia');
+    expect(entry).toBeDefined();
+    expect(entry!.shortAlt).toBe('szeroka posrebrzana glewie');
+    expect(entry!.srebro).toBe(1);
+  });
+
+  test('highlight fires on the accusative form', async () => {
+    parse('Oceniasz starannie szeroka posrebrzana glewie.');
+    parse('Na dlugim drzewcu zamocowane jest szerokie ostrze.');
+    parse('');
+    parse('Oceniasz, ze szeroka posrebrzana glewia wazy 5200 gramow, zas jego objetosc wynosi 2000 mililitrow.');
+    parse('Wydaje ci sie, ze jest warta okolo 460 miedziakow.');
+    parse('');
+    parse('Zauwazasz, iz glewia jest przystosowana do chwytania w dowolnej rece.');
+    parse('Za jej pomoca mozna zadawac rany ciete i klute.');
+    parse('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na glewia jest ona bardzo dobrze wywazona i niezwykle skuteczna.');
+    parse('Do wykonania tej broni uzyto srebra, bedzie wiec ona skuteczna przeciw wrogom odpornym na zwykle obrazenia.');
+    await flush();
+
+    const buf = new AnsiAwareBuffer('Szeroka posrebrzana glewie.');
+    Triggers.prototype.parseLine.call(client.Triggers, buf, '');
+    const idx = buf.text.toLowerCase().indexOf('szeroka');
+    const state = buf.getStateAt(idx);
+    expect(state?.foreground).toEqual({ space: 'hex', color: '#dadada' });
+  });
+
+  test('highlight trigger skips combat messages', async () => {
+    feedWeapon();
+    await flush();
+
+    const buf = new AnsiAwareBuffer('Ranisz krasnoludzki asymetryczny topor bojowy.');
+    Triggers.prototype.parseLine.call(client.Triggers, buf, 'combat.avatar');
+
+    const idx = buf.text.indexOf('krasnoludzki');
+    const state = buf.getStateAt(idx);
+    expect(state?.foreground).toBeUndefined();
   });
 
   test('/zlom alias lists saved weapons', async () => {
@@ -192,6 +255,26 @@ describe('zlom script', () => {
     reset!.callback('/zlom-reset'.match(reset!.pattern)!);
     await flush();
     expect(getZlomSnapshot().bronie).toHaveLength(0);
+  });
+
+  test('parses parry-only shield (puklerz)', async () => {
+    parse('Oceniasz starannie starozytny piecioboczny puklerz.');
+    parse('Bogato zdobiona powierzchnia tej malej tarczy mieni sie srebrzysto-zlotym blaskiem.');
+    parse('Wyglada na to, ze jest w znakomitym stanie.');
+    parse('');
+    parse('Oceniasz, ze starozytny piecioboczny puklerz wazy 2500 gramow, zas jego objetosc wynosi 1200 mililitrow.');
+    parse('Wydaje ci sie, ze jest wart okolo 5100 miedziakow.');
+    parse('Wyglada na to, ze moglby ci jeszcze raczej dlugo sluzyc.');
+    parse('Zalozony oslania jedno z ramion.');
+    parse('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jest on fantastycznie skuteczny w parowaniu ciosow.');
+    parse('Sadzac po delikatnym drzeniu w zbroi tej zostala zakleta jakas magia.');
+    await flush();
+
+    const entry = getZlomSnapshot().tarcze.find(e => e.short === 'starozytny piecioboczny puklerz');
+    expect(entry).toBeDefined();
+    expect(entry!.oslona).toBe('jedno z ramion');
+    expect(entry!.parowanie).toBeGreaterThan(0);
+    expect(entry!.magik).toBe(1);
   });
 
   test('parses armor evaluation', async () => {
@@ -345,7 +428,7 @@ describe('zlom script', () => {
       expect(findWeapon('krasnoludzki asymetryczny topor bojowy')!.color).toBe('#abcdef');
     });
 
-    test('getZlomFormatting returns color + underline for silver weapon', async () => {
+    test('getZlomFormatting returns user color over silver auto-color', async () => {
       feedWeapon();
       await flush();
       const opis = findWeapon('krasnoludzki asymetryczny topor bojowy')!.opis;
@@ -353,16 +436,56 @@ describe('zlom script', () => {
       const f = getZlomFormatting('krasnoludzki asymetryczny topor bojowy');
       expect(f).toBeDefined();
       expect(f!.color).toBe('#abcdef');
-      expect(f!.underline).toBe(true);
       expect(f!.title).toContain('topor');
       expect(f!.title).toContain('srebro');
     });
 
-    test('getZlomFormatting honors colorSilver=false', async () => {
+    test('getZlomFormatting applies silver auto-color when no user color', async () => {
       feedWeapon();
       await flush();
-      const f = getZlomFormatting('krasnoludzki asymetryczny topor bojowy', { colorSilver: false });
-      expect(f!.underline).toBe(false);
+      const f = getZlomFormatting('krasnoludzki asymetryczny topor bojowy');
+      expect(f!.color).toBe('#dadada');
+    });
+
+    test('silver coloring is on by default when no user color set', async () => {
+      feedWeapon();
+      await flush();
+      const f = getZlomFormatting('krasnoludzki asymetryczny topor bojowy');
+      expect(f!.color).toBe('#dadada');
+    });
+
+    test('zlomSilver.off=true disables silver coloring', async () => {
+      feedWeapon();
+      await flush();
+      setTestSettings({ zlomSilver: { color: '#dadada', off: true } });
+      const f = getZlomFormatting('krasnoludzki asymetryczny topor bojowy');
+      expect(f).toBeUndefined();
+    });
+
+    test('getZlomFormatting uses configured silver color', async () => {
+      feedWeapon();
+      await flush();
+      setTestSettings({ zlomSilver: { color: '#ff00ff' } });
+      const f = getZlomFormatting('krasnoludzki asymetryczny topor bojowy');
+      expect(f!.color).toBe('#ff00ff');
+    });
+
+    test('getZlomFormatting skips magic items entirely', async () => {
+      parse('Oceniasz starannie blyszczacy miecz.');
+      parse('Drobne znamiona swietego symbolu zdobia glownie.');
+      parse('');
+      parse('Oceniasz, ze blyszczacy miecz wazy 2000 gramow, zas jego objetosc wynosi 500 mililitrow.');
+      parse('Wydaje ci sie, ze jest wart okolo 500 miedziakow.');
+      parse('');
+      parse('Zauwazasz, iz miecz jest przystosowany do chwytania w dowolnej rece.');
+      parse('Za jego pomoca mozna zadawac rany ciete i klute.');
+      parse('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na miecz jest on przyzwoicie wywazony i dosyc skuteczny.');
+      parse('Sadzac po delikatnym drzeniu w broni tej zostala zakleta jakas magia, bedzie wiec ona skuteczna przeciw wrogom odpornym na zwykle obrazenia.');
+      await flush();
+
+      const opis = findWeapon('blyszczacy miecz')!.opis;
+      await setZlomColor('bronie', opis, '#abcdef');
+      expect(getZlomFormatting('blyszczacy miecz')).toBeUndefined();
     });
 
     test('getZlomFormatting matches substring within longer text', async () => {
@@ -373,10 +496,10 @@ describe('zlom script', () => {
       expect(f!.title).toContain('topor');
     });
 
-    test('zlomColorSilver=false disables underline on highlight', async () => {
+    test('zlomSilver.off skips registering silver-only triggers', async () => {
       feedWeapon();
       await flush();
-      setTestSettings({ zlomColorSilver: false });
+      setTestSettings({ zlomSilver: { color: '#dadada', off: true } });
       client.Triggers.removeByTag('zlom-highlight');
       client.Triggers.removeByTag('zlom-parser');
       initZlom((client as unknown) as any, client.aliases);
@@ -385,8 +508,25 @@ describe('zlom script', () => {
       const buf = new AnsiAwareBuffer('Trzymasz krasnoludzki asymetryczny topor bojowy w prawej rece.');
       Triggers.prototype.parseLine.call(client.Triggers, buf, '');
       const state = buf.getStateAt(buf.text.indexOf('krasnoludzki'));
-      expect(state?.bold).toBe(true);
+      expect(state?.foreground).toBeUndefined();
       expect(state?.underline).toBeFalsy();
+    });
+
+    test('user-colored entry still registers even when silver coloring is off', async () => {
+      feedWeapon();
+      await flush();
+      const opis = findWeapon('krasnoludzki asymetryczny topor bojowy')!.opis;
+      await setZlomColor('bronie', opis, '#abcdef');
+      setTestSettings({ zlomSilver: { color: '#dadada', off: true } });
+      client.Triggers.removeByTag('zlom-highlight');
+      client.Triggers.removeByTag('zlom-parser');
+      initZlom((client as unknown) as any, client.aliases);
+      await ensureZlomLoaded();
+
+      const buf = new AnsiAwareBuffer('Trzymasz krasnoludzki asymetryczny topor bojowy w prawej rece.');
+      Triggers.prototype.parseLine.call(client.Triggers, buf, '');
+      const state = buf.getStateAt(buf.text.indexOf('krasnoludzki'));
+      expect(state?.foreground).toEqual({ space: 'hex', color: '#abcdef' });
     });
   });
 

--- a/test/client/scripts/zlom.test.ts
+++ b/test/client/scripts/zlom.test.ts
@@ -8,6 +8,9 @@ import initZlom, {
     ShieldEntry,
     ArmorEntry,
 } from '@client/scripts/zlom';
+import initWeaponEvaluation from '@client/scripts/weaponEvaluation';
+import initArmorEvaluation from '@client/scripts/armorEvaluation';
+import initParryShieldEvaluation from '@client/scripts/parryShieldEvaluation';
 import Triggers from '@client/Triggers';
 import { AnsiAwareBuffer } from '@client/ansi/FormatState';
 import { characterStorage } from '@modules/core/storage';
@@ -362,6 +365,61 @@ describe('zlom script', () => {
       const state = buf.getStateAt(buf.text.indexOf('krasnoludzki'));
       expect(state?.bold).toBe(true);
       expect(state?.underline).toBeFalsy();
+    });
+  });
+
+  describe('co-existence with eval scripts that gag lines', () => {
+    test('weapon is saved when weaponEvaluation runs alongside zlom (zlom registered first)', () => {
+      // Match production wiring order from main.ts: zlom first, then evaluation scripts.
+      const c = new FakeClient();
+      initZlom((c as unknown) as any, c.aliases);
+      initWeaponEvaluation((c as unknown) as any);
+
+      const send = (line: string) =>
+        Triggers.prototype.parseLine.call(c.Triggers, new AnsiAwareBuffer(line), '');
+
+      send('Oceniasz starannie krasnoludzki asymetryczny topor bojowy.');
+      send('Na trzystopowoym stylisku wykonanym z twardego drewna.');
+      send('Wyglada na to, ze liczne walki wyryly na nim swoje pietno.');
+      send('');
+      send('Oceniasz, ze krasnoludzki asymetryczny topor bojowy wazy 5500 gramow, zas jego objetosc wynosi 980 mililitrow.');
+      send('Wydaje ci sie, ze jest wart okolo 880 miedziakow.');
+      send('');
+      send('Zauwazasz, iz topor jest przystosowany do chwytania w dowolnej rece.');
+      send('Za jego pomoca mozna zadawac rany ciete.');
+      send('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na topor jest on bardzo dobrze wywazony i niezwykle skuteczny.');
+      send('Do wykonania tej broni uzyto srebra, bedzie wiec ona skuteczna przeciw wrogom odpornym na zwykle obrazenia.');
+
+      const entry = loadZlomSnapshot().bronie['krasnoludzki asymetryczny topor bojowy'];
+      expect(entry).toBeDefined();
+      expect(entry.typ).toBe('topor');
+      expect(entry.srebro).toBe(1);
+      expect(entry.wywazenie).toBe(11);
+      expect(entry.parowanie).toBe(11);
+    });
+
+    test('armor and shield evals do not get gagged before zlom sees them', () => {
+      const c = new FakeClient();
+      initZlom((c as unknown) as any, c.aliases);
+      initArmorEvaluation((c as unknown) as any);
+      initParryShieldEvaluation((c as unknown) as any);
+
+      const send = (line: string) =>
+        Triggers.prototype.parseLine.call(c.Triggers, new AnsiAwareBuffer(line), '');
+
+      send('Oceniasz starannie lekka kolczuga.');
+      send('Misternie zszyta kolczuga.');
+      send('Wyglada na to, ze jest w kiepskim stanie.');
+      send('');
+      send('Oceniasz, ze lekka kolczuga wazy 4000 gramow, zas jej objetosc wynosi 3000 mililitrow.');
+      send('Wydaje ci sie, ze jest warta okolo 300 miedziakow.');
+      send('Zaklada sie ja na tulow.');
+      send('Twoje doswiadczenie i umiejetnosci podpowiadaja ci, ze jak na lekka zbroje chroni ona dobrze przed obrazeniami cietymi, przyzwoicie przed klutymi i dobrze przed obuchowymi.');
+
+      const armor = loadZlomSnapshot().zbroje['lekka kolczuga'];
+      expect(armor).toBeDefined();
+      expect(armor.typ).toBe('lekka');
+      expect(armor.oslona).toBe('tulow');
     });
   });
 });

--- a/test/client/scripts/zlom.test.ts
+++ b/test/client/scripts/zlom.test.ts
@@ -2,6 +2,8 @@ import initZlom, {
     loadZlomSnapshot,
     mergeZlomData,
     clearZlomData,
+    setZlomColor,
+    getZlomFormatting,
     WeaponEntry,
     ShieldEntry,
     ArmorEntry,
@@ -9,6 +11,7 @@ import initZlom, {
 import Triggers from '@client/Triggers';
 import { AnsiAwareBuffer } from '@client/ansi/FormatState';
 import { characterStorage } from '@modules/core/storage';
+import { setTestSettings } from '../helpers/testSettings';
 
 class FakeMap {
   currentRoom: { id: number } | null = { id: 42 };
@@ -285,6 +288,80 @@ describe('zlom script', () => {
       const snap = loadZlomSnapshot();
       expect(snap.tarcze['zelazny puklerz'].parowanie).toBe(5);
       expect(snap.zbroje['skorzany pancerz'].typ).toBe('lekka');
+    });
+  });
+
+  describe('color formatting', () => {
+    test('setZlomColor persists color on entry', () => {
+      feedWeapon();
+      setZlomColor('bronie', 'krasnoludzki asymetryczny topor bojowy', '#ff8080');
+      expect(loadZlomSnapshot().bronie['krasnoludzki asymetryczny topor bojowy'].color).toBe('#ff8080');
+    });
+
+    test('setZlomColor with undefined clears color', () => {
+      feedWeapon();
+      setZlomColor('bronie', 'krasnoludzki asymetryczny topor bojowy', '#ff8080');
+      setZlomColor('bronie', 'krasnoludzki asymetryczny topor bojowy', undefined);
+      expect(loadZlomSnapshot().bronie['krasnoludzki asymetryczny topor bojowy'].color).toBeUndefined();
+    });
+
+    test('color survives re-evaluation of same weapon', () => {
+      feedWeapon();
+      setZlomColor('bronie', 'krasnoludzki asymetryczny topor bojowy', '#abcdef');
+      feedWeapon();
+      expect(loadZlomSnapshot().bronie['krasnoludzki asymetryczny topor bojowy'].color).toBe('#abcdef');
+    });
+
+    test('getZlomFormatting returns color + underline for silver weapon', () => {
+      feedWeapon();
+      setZlomColor('bronie', 'krasnoludzki asymetryczny topor bojowy', '#abcdef');
+      const f = getZlomFormatting('krasnoludzki asymetryczny topor bojowy');
+      expect(f).toBeDefined();
+      expect(f!.color).toBe('#abcdef');
+      expect(f!.underline).toBe(true);
+      expect(f!.title).toContain('topor');
+      expect(f!.title).toContain('srebro');
+    });
+
+    test('getZlomFormatting honors colorSilver=false', () => {
+      feedWeapon();
+      const f = getZlomFormatting('krasnoludzki asymetryczny topor bojowy', { colorSilver: false });
+      expect(f!.underline).toBe(false);
+    });
+
+    test('getZlomFormatting matches substring within longer text', () => {
+      feedWeapon();
+      const f = getZlomFormatting('stary krasnoludzki asymetryczny topor bojowy w pochwie');
+      expect(f).toBeDefined();
+      expect(f!.title).toContain('topor');
+    });
+
+    test('highlight applies user color to in-game line', () => {
+      feedWeapon();
+      setZlomColor('bronie', 'krasnoludzki asymetryczny topor bojowy', '#aabbcc');
+      // Reinitialize triggers so the new color is picked up
+      client.Triggers.removeByTag('zlom-highlight');
+      client.Triggers.removeByTag('zlom-parser');
+      initZlom((client as unknown) as any, client.aliases);
+
+      const buf = new AnsiAwareBuffer('Trzymasz krasnoludzki asymetryczny topor bojowy w prawej rece.');
+      Triggers.prototype.parseLine.call(client.Triggers, buf, '');
+      const state = buf.getStateAt(buf.text.indexOf('krasnoludzki'));
+      expect(state?.foreground).toEqual({ space: 'hex', color: '#aabbcc' });
+    });
+
+    test('zlomColorSilver=false disables underline on highlight', () => {
+      feedWeapon();
+      setTestSettings({ zlomColorSilver: false });
+      client.Triggers.removeByTag('zlom-highlight');
+      client.Triggers.removeByTag('zlom-parser');
+      initZlom((client as unknown) as any, client.aliases);
+
+      const buf = new AnsiAwareBuffer('Trzymasz krasnoludzki asymetryczny topor bojowy w prawej rece.');
+      Triggers.prototype.parseLine.call(client.Triggers, buf, '');
+      const state = buf.getStateAt(buf.text.indexOf('krasnoludzki'));
+      expect(state?.bold).toBe(true);
+      expect(state?.underline).toBeFalsy();
     });
   });
 });

--- a/test/client/scripts/zlom.test.ts
+++ b/test/client/scripts/zlom.test.ts
@@ -1,4 +1,11 @@
-import initZlom, { loadZlomSnapshot } from '@client/scripts/zlom';
+import initZlom, {
+    loadZlomSnapshot,
+    mergeZlomData,
+    clearZlomData,
+    WeaponEntry,
+    ShieldEntry,
+    ArmorEntry,
+} from '@client/scripts/zlom';
 import Triggers from '@client/Triggers';
 import { AnsiAwareBuffer } from '@client/ansi/FormatState';
 import { characterStorage } from '@modules/core/storage';
@@ -166,5 +173,118 @@ describe('zlom script', () => {
     expect(entry.ciete).toBe(9); // dobrze
     expect(entry.klute).toBe(6); // przyzwoicie
     expect(entry.obuch).toBe(9); // dobrze
+  });
+
+  describe('import / merge', () => {
+    function makeWeapon(partial: Partial<WeaponEntry>): WeaponEntry {
+      return {
+        short: '',
+        typ: '',
+        rodzaj: '',
+        klute: 0,
+        obuch: 0,
+        ciete: 0,
+        chwyt: '',
+        magik: 0,
+        srebro: 0,
+        opis: '',
+        waga: 0,
+        obj: 0,
+        cena: 0,
+        wywazenie: 0,
+        parowanie: 0,
+        roomId: null,
+        ...partial,
+      };
+    }
+
+    test('replace mode overwrites existing entries and adds new', () => {
+      feedWeapon();
+      const existing = loadZlomSnapshot().bronie['krasnoludzki asymetryczny topor bojowy'];
+      expect(existing.cena).toBe(880);
+
+      const counts = mergeZlomData(
+        {
+          bronie: [
+            makeWeapon({ short: 'krasnoludzki asymetryczny topor bojowy', cena: 1000, typ: 'topor' }),
+            makeWeapon({ short: 'nowy miecz', cena: 200, typ: 'miecz' }),
+          ],
+          tarcze: [],
+          zbroje: [],
+        },
+        'replace',
+      );
+
+      expect(counts.bronie).toBe(2);
+      const snap = loadZlomSnapshot();
+      expect(snap.bronie['krasnoludzki asymetryczny topor bojowy'].cena).toBe(1000);
+      expect(snap.bronie['nowy miecz'].typ).toBe('miecz');
+    });
+
+    test('keep mode only adds new entries', () => {
+      feedWeapon();
+      const counts = mergeZlomData(
+        {
+          bronie: [
+            makeWeapon({ short: 'krasnoludzki asymetryczny topor bojowy', cena: 1, typ: 'zmieniony' }),
+            makeWeapon({ short: 'unikatowy sztylet', cena: 77, typ: 'sztylet' }),
+          ],
+          tarcze: [],
+          zbroje: [],
+        },
+        'keep',
+      );
+      expect(counts.bronie).toBe(1);
+      const snap = loadZlomSnapshot();
+      expect(snap.bronie['krasnoludzki asymetryczny topor bojowy'].cena).toBe(880);
+      expect(snap.bronie['unikatowy sztylet'].typ).toBe('sztylet');
+    });
+
+    test('clearZlomData empties snapshot', () => {
+      feedWeapon();
+      expect(Object.keys(loadZlomSnapshot().bronie)).toHaveLength(1);
+      clearZlomData();
+      const snap = loadZlomSnapshot();
+      expect(snap.bronie).toEqual({});
+      expect(snap.tarcze).toEqual({});
+      expect(snap.zbroje).toEqual({});
+    });
+
+    test('merge imports shields and armors too', () => {
+      const shield: ShieldEntry = {
+        short: 'zelazny puklerz',
+        klute: 3,
+        obuch: 4,
+        ciete: 3,
+        magik: 0,
+        opis: '',
+        waga: 1500,
+        obj: 700,
+        cena: 120,
+        parowanie: 5,
+        oslona: 'lewa reka',
+        roomId: null,
+      };
+      const armor: ArmorEntry = {
+        short: 'skorzany pancerz',
+        typ: 'lekka',
+        klute: 2,
+        obuch: 2,
+        ciete: 3,
+        magik: 0,
+        opis: '',
+        waga: 2000,
+        obj: 1500,
+        cena: 80,
+        oslona: 'tulow',
+        roomId: null,
+      };
+      const counts = mergeZlomData({ bronie: [], tarcze: [shield], zbroje: [armor] }, 'replace');
+      expect(counts.tarcze).toBe(1);
+      expect(counts.zbroje).toBe(1);
+      const snap = loadZlomSnapshot();
+      expect(snap.tarcze['zelazny puklerz'].parowanie).toBe(5);
+      expect(snap.zbroje['skorzany pancerz'].typ).toBe('lekka');
+    });
   });
 });


### PR DESCRIPTION
Captures weapon/armor/shield evaluations from `ocen` command output,
persists entries per-character, and registers highlight triggers with
bold/underline + tooltip for known shorts. Adds /zlom and /zlom-reset
aliases.