### PR TITLE
Hide UI buttons when layout is enabled

### DIFF
--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -1584,6 +1584,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 state.enabled = true;
                 saveLayoutState(state);
                 invalidateLayoutCache();
+                const uiSettings = globalStorage.get('uiSettings');
+                if (uiSettings) {
+                    uiSettings.showButtons = false;
+                    globalStorage.set('uiSettings', uiSettings);
+                }
                 suggestionEl.style.display = 'none';
             });
 

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -1584,11 +1584,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 state.enabled = true;
                 saveLayoutState(state);
                 invalidateLayoutCache();
-                const uiSettings = globalStorage.get('uiSettings');
-                if (uiSettings) {
-                    uiSettings.showButtons = false;
-                    globalStorage.set('uiSettings', uiSettings);
-                }
+                const uiSettings = { ...defaultUiSettings, ...(globalStorage.get('uiSettings') ?? {}) };
+                uiSettings.showButtons = false;
+                globalStorage.set('uiSettings', uiSettings);
                 suggestionEl.style.display = 'none';
             });
 


### PR DESCRIPTION
## Summary
This change adds logic to hide UI buttons when the layout is enabled, improving the user interface by reducing visual clutter when the layout feature is activated.

## Key Changes
- Added code to retrieve the `uiSettings` from global storage when layout is enabled
- Set `showButtons` to `false` in the UI settings to hide buttons
- Persist the updated settings back to global storage

## Implementation Details
The change is integrated into the existing layout enable handler, executing after the layout state is saved and the cache is invalidated. This ensures that button visibility is synchronized with the layout enabled state and persists across sessions.

https://claude.ai/code/session_01H7aDN5cEHYr31D7CHND62F