### PR TITLE
Make lamp timer clickable to send refill command

### DIFF
--- a/src/ui/web/components/timers/LampTimer.tsx
+++ b/src/ui/web/components/timers/LampTimer.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
 import { useClientEvent } from "../../hooks";
+import eventBus from "@modules/core/eventBus";
 
 /**
  * LampTimer component - displays remaining time for lamp
  * Color-coded: red (<30s), yellow (<60s), green (>=60s)
+ * Click to refill lamp
  */
 export const LampTimer: React.FC = () => {
   const [seconds, setSeconds] = useState<number | null>(null);
@@ -30,6 +32,10 @@ export const LampTimer: React.FC = () => {
     }
   }, [seconds]);
 
+  const handleClick = () => {
+    eventBus.emit("sendCommand", { command: "napelnij lampe olejem" });
+  };
+
   if (seconds == null || seconds <= 0) {
     return null;
   }
@@ -40,8 +46,12 @@ export const LampTimer: React.FC = () => {
 
   return (
     <>
-      <span style={{ color: "white" }}>lamp </span>
-      <span>{timeValue}</span>
+      <span style={{ color: "white", cursor: "pointer" }} onClick={handleClick}>
+        lamp{" "}
+      </span>
+      <span style={{ cursor: "pointer" }} onClick={handleClick}>
+        {timeValue}
+      </span>
     </>
   );
 };


### PR DESCRIPTION
**UI Improvement**

*LampTimer usability:*

- Updated `LampTimer.tsx` to allow the user to refill the lamp by clicking the timer or label, emitting a command via the event bus. [[1]](diffhunk://#diff-e345465239ed880e8e14ec1455b966b26acb321975b75ef30f7f5837190f4ff6R3-R8) [[2]](diffhunk://#diff-e345465239ed880e8e14ec1455b966b26acb321975b75ef30f7f5837190f4ff6R35-R38) [[3]](diffhunk://#diff-e345465239ed880e8e14ec1455b966b26acb321975b75ef30f7f5837190f4ff6L43-R54)