### PR TITLE
Allow multi-word container in /przejrzyj alias

### DIFF
--- a/src/client/scripts/prettyContainers.ts
+++ b/src/client/scripts/prettyContainers.ts
@@ -806,7 +806,7 @@ export default function initContainers(client: Client) {
     characterStorage.onChange('settings', applyContainerSettings);
 
     client.aliases.push({
-        pattern: /^\/przejrzyj(?: (\w+))?$/,
+        pattern: /^\/przejrzyj(?: (.+))?$/,
         callback: (m?: RegExpMatchArray) => {
             filter = magicAndKeysFilter;
             plugLinks = true;

--- a/test/client/scripts/prettyContainers.test.ts
+++ b/test/client/scripts/prettyContainers.test.ts
@@ -312,6 +312,19 @@ describe('prettyContainers with real Client', () => {
       expect(sendSpy).toHaveBeenCalled();
       expect(sendSpy.mock.calls[0][0]).toBe('ob plecak');
     });
+
+    test('sends ob command with multi-word target', () => {
+      const sendSpy = jest.spyOn(mockAdapter, 'send');
+
+      const alias = client.aliases.find(a => a.pattern.test('/przejrzyj drugi stojak'));
+      expect(alias).toBeDefined();
+
+      const match = '/przejrzyj drugi stojak'.match(alias!.pattern);
+      alias!.callback(match!);
+
+      expect(sendSpy).toHaveBeenCalled();
+      expect(sendSpy.mock.calls[0][0]).toBe('ob drugi stojak');
+    });
   });
 
   describe('item categorization', () => {


### PR DESCRIPTION
The /przejrzyj alias only accepted a single \w+ token as the optional
container, so names with spaces (e.g. "drugi stojak") or Polish
diacritics failed to match and the alias silently did nothing. Capture
the rest of the line with (.+) instead so multi-word containers reach
the "ob" command.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0118Ztmvpns5S6nSE7VfSV9s