### PR TITLE
Fix forge poczta letter popup drag offset and output leak

### DIFF
--- a/forge-ui/layout-theme.css
+++ b/forge-ui/layout-theme.css
@@ -95,6 +95,16 @@ body.layout-manager-enabled #content-area > .world {
 }
 
 .managed-panel.floating-panel {
+  /* Re-assert `position: fixed` from layout.css's `.floating-panel`. The
+     `.managed-panel { position: relative }` rule above is sourced AFTER the
+     @import at equal specificity, so it would otherwise win and make floating
+     windows `position: relative` — their `left/top` would then offset from
+     their normal-flow position inside `.floating-window-root` instead of the
+     viewport. The first floating window (flow origin 0,0) still lands right,
+     but a second one (e.g. the letter popup opened over the poczta popup) gets
+     shoved down by the first window's box, and dragging jumps by that offset.
+     This compound selector (0,2,0) outranks `.managed-panel` (0,1,0). */
+  position: fixed;
   border: 1px solid var(--iron-lo);
   border-radius: 9px;
 }

--- a/src/client/scripts/poczta.ts
+++ b/src/client/scripts/poczta.ts
@@ -75,7 +75,13 @@ export default function initPoczta(client: Client, aliases: { pattern: RegExp; c
 
     const finishReadingLetter = () => {
         if (currentLetter && currentLetter.number !== undefined) {
-            currentLetter.body = [...letterBodyLines];
+            // Drop the blank padding lines the pager prints around the body so
+            // the letter view doesn't open with stray empty rows above/below the
+            // text. Internal blanks (paragraph breaks) are preserved.
+            const body = [...letterBodyLines];
+            while (body.length && body[0].trim() === '') body.shift();
+            while (body.length && body[body.length - 1].trim() === '') body.pop();
+            currentLetter.body = body;
             eventBus.emit("poczta.letter.loaded", currentLetter as LetterContent);
         }
         isReadingLetter = false;
@@ -231,7 +237,19 @@ export default function initPoczta(client: Client, aliases: { pattern: RegExp; c
     }, tag);
 
     client.Triggers.registerTrigger(/^/, (line) => {
-        if (!isReadingLetter || !currentLetter) return line;
+        if (!isReadingLetter) return line;
+
+        if (!currentLetter) {
+            // We've issued `przeczytaj list N` but the "List: N" header hasn't
+            // arrived yet. The pager emits blank padding lines here that would
+            // otherwise leak into the main game output — swallow them. A
+            // non-blank line at this point means the letter isn't loading (e.g.
+            // "Nie ma takiego listu."), so stop capturing and let it through.
+            if (line.text.trim() === '') return null;
+            isReadingLetter = false;
+            return line;
+        }
+
         if (!currentLetter.date) return null;
 
         letterBodyLines.push(line.text);


### PR DESCRIPTION
Two issues when reading letters from the forge-ui poczta popup:

- Floating popups dragged offset from the cursor. layout-theme.css's
  `.managed-panel { position: relative }` is sourced after the @import'd
  `.floating-panel { position: fixed }` at equal specificity, so it won
  and floating windows became `position: relative` — positioning their
  `left/top` against their normal-flow slot instead of the viewport. The
  first float (flow origin 0,0) still landed right, but a second float
  (the letter popup over the poczta popup) was shoved down by the first
  window's box, and dragging jumped by that offset. Re-assert
  `position: fixed` on the higher-specificity `.managed-panel.floating-panel`.

- Blank padding lines leaked into the main game output when opening a
  letter: the catch-all trigger passed lines through while reading a
  letter until the "List: N" header arrived. Swallow those pre-header
  blanks (and bail out on a non-blank line so a failed load can't eat
  output). Also trim stray leading/trailing blank lines from the captured
  body so the letter view opens without empty rows.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TTaXwpJnJGUuHFbG1Dntz4