### PR TITLE
refactor(scripts): extract BaseCounter and counterTableUtils

### DIFF
--- a/src/client/scripts/BaseCounter.ts
+++ b/src/client/scripts/BaseCounter.ts
@@ -1,0 +1,30 @@
+import Client from "../Client";
+import {characterStorage} from "@modules/core/storage";
+import type {CharacterStorageSchema} from "@modules/core/storageSchema";
+
+type StorageKey = keyof CharacterStorageSchema & string;
+
+export abstract class BaseCounter {
+    protected readonly client: Client;
+    private selfPersisting = false;
+
+    constructor(client: Client) {
+        this.client = client;
+        client.on("reset", () => this.onReset());
+    }
+
+    protected abstract onReset(): void;
+
+    protected setStorage<K extends StorageKey>(key: K, value: CharacterStorageSchema[K]): void {
+        this.selfPersisting = true;
+        characterStorage.set(key, value);
+        this.selfPersisting = false;
+    }
+
+    protected onStorageChange<K extends StorageKey>(key: K, handler: (value: CharacterStorageSchema[K] | undefined) => void): void {
+        characterStorage.onChange(key, (value) => {
+            if (this.selfPersisting) return;
+            handler(value);
+        });
+    }
+}

--- a/src/client/scripts/counterTableUtils.ts
+++ b/src/client/scripts/counterTableUtils.ts
@@ -1,0 +1,54 @@
+import {colorString} from "@modules/core/Colors";
+import {AnsiAwareBuffer, FormatStateSnapshot} from "@client/ansi/FormatState";
+
+export function createPad(width: number, left: number, right: number) {
+    const contentWidth = width - left - right;
+    return (content?: AnsiAwareBuffer): AnsiAwareBuffer => {
+        const line = new AnsiAwareBuffer("|");
+        line.append(" ".repeat(left), {});
+
+        if (content) {
+            if (content.length > contentWidth) {
+                const truncated = new AnsiAwareBuffer();
+                const segments = content.getSegments();
+                let remaining = contentWidth;
+                for (const segment of segments) {
+                    if (remaining <= 0) break;
+                    if (segment.text.length <= remaining) {
+                        truncated.append(segment.text, segment.state);
+                        remaining -= segment.text.length;
+                    } else {
+                        truncated.append(segment.text.slice(0, remaining), segment.state);
+                        remaining = 0;
+                    }
+                }
+                line.appendBuffer(truncated);
+            } else {
+                line.appendBuffer(content);
+                line.append(" ".repeat(contentWidth - content.length));
+            }
+        } else {
+            line.append(" ".repeat(contentWidth), {});
+        }
+
+        line.append(" ".repeat(right), {});
+        line.append("|");
+        return line;
+    };
+}
+
+export function createHeader(width: number, offset: number, color: FormatStateSnapshot) {
+    return (title: string): AnsiAwareBuffer => {
+        const line = new AnsiAwareBuffer("+");
+        const dashes = width - title.length - offset;
+        const left = Math.floor(dashes / 2);
+        const right = dashes - left;
+        line.append("-".repeat(left));
+        line.append(" ");
+        line.appendBuffer(colorString(title, color));
+        line.append(" ");
+        line.append("-".repeat(right), {});
+        line.append("+");
+        return line;
+    };
+}

--- a/src/client/scripts/deliveryStats.ts
+++ b/src/client/scripts/deliveryStats.ts
@@ -4,6 +4,7 @@ import {AnsiAwareBuffer} from "@client/ansi/FormatState.ts";
 import {characterStorage} from "@modules/core/storage";
 import {getFromIndexedDB, storeInIndexedDB, IndexedDBConfig} from "@client/utils/dataCache.ts";
 import {GOLD_COLOR, SILVER_COLOR, COPPER_COLOR} from "../constants/colors";
+import {createPad, createHeader} from "./counterTableUtils";
 
 export interface DeliveryRecord {
     timestamp: number;
@@ -38,40 +39,6 @@ function parsePayment(text: string): { gold: number; silver: number; copper: num
     };
 }
 
-function createPad(
-    width: number,
-    left: number,
-    right: number,
-): (content?: AnsiAwareBuffer) => AnsiAwareBuffer {
-    const contentWidth = width - left - right;
-    return (content = new AnsiAwareBuffer()) => {
-        const buffer = new AnsiAwareBuffer();
-        buffer.append("|", {});
-        buffer.append(" ".repeat(left), {});
-        buffer.appendBuffer(content);
-        buffer.append(" ".repeat(Math.max(0, contentWidth - content.length)), {});
-        buffer.append(" ".repeat(right), {});
-        buffer.append("|", {});
-        return buffer;
-    };
-}
-
-function createHeader(
-    width: number,
-    offset: number,
-    color: ReturnType<typeof createColorFormat>,
-): (title: string) => AnsiAwareBuffer {
-    return (title: string) => {
-        const dashes = width - title.length - offset;
-        const left = Math.floor(dashes / 2);
-        const right = dashes - left;
-        const buffer = new AnsiAwareBuffer();
-        buffer.append(`+${"-".repeat(left)} `, {});
-        buffer.append(title, color);
-        buffer.append(` ${"-".repeat(right)}+`, {});
-        return buffer;
-    };
-}
 
 interface PeriodStats {
     total: number;

--- a/src/client/scripts/improveCounter.ts
+++ b/src/client/scripts/improveCounter.ts
@@ -1,9 +1,11 @@
 import Client from "../Client";
 import {colorString, createColorFormat} from "@modules/core/Colors";
 import {characterStorage} from "@modules/core/storage";
-import {AnsiAwareBuffer, FormatStateSnapshot} from "@client/ansi/FormatState";
+import {AnsiAwareBuffer} from "@client/ansi/FormatState";
 import eventBus from "@modules/core/eventBus";
 import {getKillData} from "./kill";
+import {BaseCounter} from "./BaseCounter";
+import {createPad, createHeader} from "./counterTableUtils";
 
 const HEADER_COLOR = createColorFormat("#90ee90");
 const SECTION_COLOR = createColorFormat("#ffa500");
@@ -72,58 +74,6 @@ export function formatDuration(ms: number): string {
     return `${m.toString().padStart(3, " ")}:${s.toString().padStart(2, "0")}`;
 }
 
-function createPad(width: number, left: number, right: number) {
-    const contentWidth = width - left - right;
-    return (content?: AnsiAwareBuffer): AnsiAwareBuffer => {
-        const line = new AnsiAwareBuffer("|");
-        line.append(" ".repeat(left), {});
-
-        if (content) {
-            if (content.length > contentWidth) {
-                // Truncate content if too long
-                const truncated = new AnsiAwareBuffer();
-                const segments = content.getSegments();
-                let remaining = contentWidth;
-                for (const segment of segments) {
-                    if (remaining <= 0) break;
-                    if (segment.text.length <= remaining) {
-                        truncated.append(segment.text, segment.state);
-                        remaining -= segment.text.length;
-                    } else {
-                        truncated.append(segment.text.slice(0, remaining), segment.state);
-                        remaining = 0;
-                    }
-                }
-                line.appendBuffer(truncated);
-            } else {
-                line.appendBuffer(content);
-                line.append(" ".repeat(contentWidth - content.length));
-            }
-        } else {
-            line.append(" ".repeat(contentWidth), {});
-        }
-
-        line.append(" ".repeat(right), {});
-        line.append("|");
-        return line;
-    };
-}
-
-function createHeader(width: number, offset: number, color: FormatStateSnapshot) {
-    return (title: string): AnsiAwareBuffer => {
-        const line = new AnsiAwareBuffer("+");
-        const dashes = width - title.length - offset;
-        const left = Math.floor(dashes / 2);
-        const right = dashes - left;
-        line.append("-".repeat(left));
-        line.append(" ");
-        line.appendBuffer(colorString(title, color));
-        line.append(" ");
-        line.append("-".repeat(right), {});
-        line.append("+");
-        return line;
-    };
-}
 
 export type ImproveEntry = {
     state: string;
@@ -179,8 +129,7 @@ export function getFormattedPostepyTable(): AnsiAwareBuffer | null {
     return improveCounterInstance?.getFormattedTable() ?? null;
 }
 
-export default class ImproveCounter {
-    private client: Client;
+export default class ImproveCounter extends BaseCounter {
     private entries: ImproveEntry[] = [];
     private lifetime: { date: string; count: number; noFormCount?: number }[] = [];
     private lifetimeEnabled = true;
@@ -196,9 +145,8 @@ export default class ImproveCounter {
     private waitingForFirstCombat = false;
     private stateForm: number = 0;
     private optionsForm: number = 0;
-    private selfPersisting = false;
     constructor(client: Client) {
-        this.client = client;
+        super(client);
         improveCounterInstance = this;
 
         const initialData = characterStorage.get('improve_counter');
@@ -209,8 +157,7 @@ export default class ImproveCounter {
         this.loadLifetime(initialLifetime ?? {});
         this.lifetimeLoaded = true;
 
-        characterStorage.onChange('improve_counter', (value) => {
-            if (this.selfPersisting) return;
+        this.onStorageChange('improve_counter', (value) => {
             this.load(value ?? {});
             this.initialized = false;
             this.loaded = true;
@@ -220,8 +167,7 @@ export default class ImproveCounter {
                 this.handleLevel(level);
             }
         });
-        characterStorage.onChange('improve_counter_lifetime', (value) => {
-            if (this.selfPersisting) return;
+        this.onStorageChange('improve_counter_lifetime', (value) => {
             this.loadLifetime(value ?? {});
             this.lifetimeLoaded = true;
             if (this.pendingLifetime.length) {
@@ -231,8 +177,6 @@ export default class ImproveCounter {
                 this.pendingLifetime = [];
             }
         });
-
-        this.client.on("reset", () => this.reset());
 
         window.addEventListener("beforeunload", this.persist);
 
@@ -488,9 +432,12 @@ export default class ImproveCounter {
         }
     }
 
+    protected onReset(): void {
+        this.reset();
+    }
+
     private persist = () => {
-        this.selfPersisting = true;
-        characterStorage.set('improve_counter', {
+        this.setStorage('improve_counter', {
             entries: this.entries,
             lastTime: this.lastTime,
             lastKills: this.lastKills,
@@ -498,13 +445,10 @@ export default class ImproveCounter {
             lastObjNum: this.lastObjNum,
             waitingForFirstCombat: this.waitingForFirstCombat,
         });
-        this.selfPersisting = false;
     };
 
     private persistLifetime = () => {
-        this.selfPersisting = true;
-        characterStorage.set('improve_counter_lifetime', {entries: this.lifetime, enabled: this.lifetimeEnabled});
-        this.selfPersisting = false;
+        this.setStorage('improve_counter_lifetime', {entries: this.lifetime, enabled: this.lifetimeEnabled});
     };
 
     addLifetime(count: number, id?: number) {

--- a/src/client/scripts/kill.ts
+++ b/src/client/scripts/kill.ts
@@ -3,6 +3,8 @@ import {createColorFormat} from "@modules/core/Colors";
 import {AnsiAwareBuffer} from "../ansi/FormatState";
 import eventBus from "@modules/core/eventBus";
 import {characterStorage} from "@modules/core/storage";
+import {BaseCounter} from "./BaseCounter";
+import {createPad, createHeader} from "./counterTableUtils";
 import {
     recordKillToDB,
     getLifetimeTotals,
@@ -103,40 +105,6 @@ function parseName(full: string): string {
     return words[words.length - 1];
 }
 
-function createPad(
-    width: number,
-    left: number,
-    right: number
-): (content?: AnsiAwareBuffer) => AnsiAwareBuffer {
-    const contentWidth = width - left - right;
-    return (content = new AnsiAwareBuffer()) => {
-        const buffer = new AnsiAwareBuffer();
-        buffer.append("|", {});
-        buffer.append(" ".repeat(left), {});
-        buffer.appendBuffer(content);
-        buffer.append(" ".repeat(Math.max(0, contentWidth - content.length)), {});
-        buffer.append(" ".repeat(right), {});
-        buffer.append("|", {});
-        return buffer;
-    };
-}
-
-function createHeader(
-    width: number,
-    offset: number,
-    color: ReturnType<typeof createColorFormat>
-): (title: string) => AnsiAwareBuffer {
-    return (title: string) => {
-        const dashes = width - title.length - offset;
-        const left = Math.floor(dashes / 2);
-        const right = dashes - left;
-        const buffer = new AnsiAwareBuffer();
-        buffer.append(`+${"-".repeat(left)} `, {});
-        buffer.append(title, color);
-        buffer.append(` ${"-".repeat(right)}+`, {});
-        return buffer;
-    };
-}
 
 function formatSessionTable(counts: KillCounts, teamKills: TeamMemberKills = {}): AnsiAwareBuffer {
     const WIDTH = width - 2;
@@ -566,14 +534,13 @@ export function getLifetimeKillData(): LifetimeKillData | null {
 export {type KillRecord, type DailyKillSummary, type GlobalKillStats};
 export {getAllRecords, getDistinctDates, getKillsByDate as getKillsByDateFromDB, getGlobalKillStats as getGlobalKillStatsFromDB};
 
-class KillCounter {
-    private client: Client;
+class KillCounter extends BaseCounter {
     private kills: KillCounts = {};
     private teamKills: TeamMemberKills = {};
     private migrationDone = false;
 
     constructor(client: Client) {
-        this.client = client;
+        super(client);
         killCounterInstance = this;
 
         // Load initial data from storage
@@ -591,18 +558,16 @@ class KillCounter {
             this.loadTeamKills(isTeamMemberKills(initialTeam) ? initialTeam : {});
         }
 
-        characterStorage.onChange(STORAGE_KEY, (newValue) => {
+        this.onStorageChange(STORAGE_KEY, (newValue) => {
             this.loadTotals(isNumberRecord(newValue) ? newValue : {});
             this.migrateIfNeeded();
         });
-        characterStorage.onChange(SESSION_STORAGE_KEY, (newValue) => {
+        this.onStorageChange(SESSION_STORAGE_KEY, (newValue) => {
             this.loadSession(isSessionRecord(newValue) ? newValue : {});
         });
-        characterStorage.onChange(TEAM_KILLS_STORAGE_KEY, (newValue) => {
+        this.onStorageChange(TEAM_KILLS_STORAGE_KEY, (newValue) => {
             this.loadTeamKills(isTeamMemberKills(newValue) ? newValue : {});
         });
-
-        this.client.on("reset", () => this.resetSession());
 
         window.addEventListener("beforeunload", this.persistTotals);
         window.addEventListener("beforeunload", this.persistSessions);
@@ -657,12 +622,16 @@ class KillCounter {
         this.kills = newKills;
     }
 
+    protected onReset(): void {
+        this.resetSession();
+    }
+
     private persistTotals = () => {
         const totals: Record<string, number> = {};
         Object.entries(this.kills).forEach(([name, entry]) => {
             totals[name] = entry.myTotal;
         });
-        characterStorage.set(STORAGE_KEY, totals);
+        this.setStorage(STORAGE_KEY, totals);
     };
 
     private loadSession(
@@ -688,7 +657,7 @@ class KillCounter {
                 sessions[name] = {mySession: entry.mySession, teamSession: entry.teamSession};
             }
         });
-        characterStorage.set(SESSION_STORAGE_KEY, sessions);
+        this.setStorage(SESSION_STORAGE_KEY, sessions);
     };
 
     private loadTeamKills(teamKills: TeamMemberKills = {}): void {
@@ -703,7 +672,7 @@ class KillCounter {
                 filtered[player] = mobs;
             }
         });
-        characterStorage.set(TEAM_KILLS_STORAGE_KEY, filtered);
+        this.setStorage(TEAM_KILLS_STORAGE_KEY, filtered);
     };
 
     private ensureEntry(name: string): KillEntry {


### PR DESCRIPTION
@
Salvaged from the stale `claude/sleepy-goodall-d5CPp` branch (May 2026) during a remote-branch cleanup. Cherry-picked onto current master with no conflicts — the three target files had zero commits on master since the branch point.

## What

Extracts duplication shared by `kill.ts`, `improveCounter.ts` and `deliveryStats.ts` into two modules. Net **-36 lines**.

- **`BaseCounter.ts`** — abstract base holding the lifecycle all three repeat: subscribe to client `reset`, plus a `selfPersisting` guard so a counter writing its own `characterStorage` value does not re-enter its own `onChange` handler. Typed against `CharacterStorageSchema` so `setStorage`/`onStorageChange` stay key-safe.
- **`counterTableUtils.ts`** — the ASCII table helpers. `createPad()` does ANSI-aware truncation: it walks `AnsiAwareBuffer` segments and slices mid-segment while preserving each segment format state, instead of cutting a raw string and corrupting colour runs.

`createPad`/`createHeader` were previously defined near-identically in all three files.

## Verification

- `npx tsc --noEmit` — clean
- `yarn test` — 171 files, 1746 tests passed
- `yarn build` — succeeds (only the pre-existing sql.js `node:fs`/`node:crypto` externalisation warnings)
@