### PR TITLE
docs: document odloz_magie, labirynt and refresh aliases

### DIFF
--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -166,3 +166,25 @@ Zakresy dzialaja rosnaco (`1-7`) i malejaco (`7-1`). Maksymalnie 50 iteracji.
 | `/woz` | Przelacz tryb wozu (wlacz/wylacz) |
 
 > **Wskazowka:** Tryb wozu wlacza sie i wylacza automatycznie przy wsiadaniu/zsiadaniu, wstawaniu i zwracaniu pojazdu. Alias `/woz` pozwala przelaczyc go recznie, gdyby automatyczne wykrywanie zawiodlo. W trybie wozu przycisk trybu ruchu jest zablokowany.
+
+## Odkladanie magii
+
+| Komenda | Opis |
+|---------|------|
+| `/odloz_magie [pojemnik]` | Odloz magie do pojemnika |
+
+## Labirynty
+
+| Komenda | Opis |
+|---------|------|
+| `/labirynt` | Przelacz tryb labiryntu (dynamicznie usuwa nieistniejace wyjscia) |
+| `/labirynt_mapa` | Przelacz mapper Labiryntu Rinde |
+| `/raon_mapa` | Przelacz mapper Labiryntu Raon |
+
+## Odswiezanie danych
+
+| Komenda | Opis |
+|---------|------|
+| `/refresh_magics` | Wymus odswiezenie danych magii |
+| `/refresh_keys` | Wymus odswiezenie danych kluczy magii |
+| `/refresh_knowledge` | Wymus odswiezenie danych wiedzy |


### PR DESCRIPTION
@
Salvage from the stale `claude/document-missing-aliases-Hiyjw` branch (Mar 2026, 460 commits behind) during a remote-branch cleanup.

That branch grew `ALIASES.md` from 168 to 313 lines, but ~19 of its 21 added sections duplicated docs that have since filled out — `COMBAT.md` (Walka, Kolejka ataku, Zaslanianie, Rozkazy druzyny, Okno walki, Zabici), `NAVIGATION.md` (Mapa, Automatyczne chodzenie, Roza wiatrow, Multibindy), `INVENTORY.md` (Pojemniki, Depozyty, Naprawa, Lampa, Ocena sprzetu), `TRACKING.md` (Umiejetnosci, Paczki), `BINDS.md` (Tymczasowe bindy, Bindy wrogow) and `SHORTCUTS.md`. `ALIASES.md` is explicitly *"Inne aliasy — Pozostale aliasy i funkcje"*, the catch-all for what the category docs do **not** cover, so merging it would have created six sync obligations. It also predated `Zakresy ($i)`, `Kolorowanie`, `Zlom`, `Oswajanie` and `Woz/bryczka`, so a straight merge would have *removed* newer docs.

These three sections were the only ones not documented anywhere. Each alias re-verified against current master:

| Alias | Registered at |
|---|---|
| `/odloz_magie` | `odlozMagie.ts:93` |
| `/labirynt` | `labyrinth.ts:181` |
| `/labirynt_mapa` | `rindeLabyrinthMapper.ts:390` |
| `/raon_mapa` | `raonLabyrinthMapper.ts:912` |
| `/refresh_magics` | `dataRefresh.ts:10` |
| `/refresh_keys` | `dataRefresh.ts:24` |
| `/refresh_knowledge` | `dataRefresh.ts:38` |

The source branch is deleted once this lands. Docs-only; no code touched.
@