### PR TITLE
feat(mobile-buttons): store team/leader as sparse overrides on solo base

### DIFF
--- a/e2e/mobile-buttons-color.spec.ts
+++ b/e2e/mobile-buttons-color.spec.ts
@@ -250,10 +250,13 @@ test.describe('Mobile buttons color and command configuration', () => {
         const modal = await openMobileButtonsSettings(page);
         await expect(modal).toBeVisible();
 
-        // Check that mode toggle buttons exist
-        const soloButton = page.getByRole('button', { name: 'Bez druzyny' });
-        const teamButton = page.getByRole('button', { name: 'W druzynie' });
-        const leaderButton = page.getByRole('button', { name: 'Prowadzacy' });
+        // Check that mode toggle buttons exist. Solo is labelled "Bazowy" because
+        // team/leader are stored as sparse overrides on top of it, and the mode
+        // matching the character's current team state gets a marker appended, so
+        // match on the label prefix rather than the exact accessible name.
+        const soloButton = page.getByRole('button', { name: /^Bazowy/ });
+        const teamButton = page.getByRole('button', { name: /^W druzynie/ });
+        const leaderButton = page.getByRole('button', { name: /^Prowadzacy/ });
 
         await expect(soloButton, 'solo mode button should be visible').toBeVisible();
         await expect(teamButton, 'team mode button should be visible').toBeVisible();

--- a/e2e/mobile-buttons-color.spec.ts
+++ b/e2e/mobile-buttons-color.spec.ts
@@ -334,34 +334,41 @@ test.describe('Mobile buttons color and command configuration', () => {
     });
 
     test('base edits propagate to modes that did not override the button', async ({ page }) => {
+        // Two modal sessions with a reload in between; the default 10s budget is too tight on CI.
+        test.setTimeout(30000);
         await page.goto('/');
         await waitForCommandInput(page);
-        await ensureGameSocket(page);
 
         const configPanel = page.locator('.mobile-button-config');
         const soloButton = page.getByRole('button', { name: /^Bazowy/ });
         const teamButton = page.getByRole('button', { name: /^W druzynie/ });
+        const teamPreview = page.locator('#mobile-buttons-preview-team:not(.d-none)');
+        const soloPreview = page.locator('#mobile-buttons-preview-solo:not(.d-none)');
+        const teamButton2 = teamPreview.locator('[data-button-id="button-2"]');
+        const teamButton3 = teamPreview.locator('[data-button-id="button-3"]');
+
+        async function expectTeamFollowsBase() {
+            await teamButton2.waitFor({ timeout: 5000 });
+            await expect(teamButton3, 'untouched cell should still be marked inherited').toHaveClass(/inherited/);
+            await expect(teamButton3, 'untouched cell should follow the new base color')
+                .toHaveCSS('background-color', 'rgb(0, 255, 0)');
+            await expect(teamButton2, 'overridden cell should follow the new base color')
+                .toHaveCSS('background-color', 'rgb(255, 0, 0)');
+            await expect(teamButton2, 'overridden cell should keep its own label').toHaveText('TEAM-2');
+        }
 
         // Give team an explicit override on button-2 — its label only.
         let modal = await openMobileButtonsSettings(page);
         await teamButton.click();
-        const teamPreview = page.locator('#mobile-buttons-preview-team:not(.d-none)');
-        await teamPreview.locator('[data-button-id="button-2"]').waitFor({ timeout: 5000 });
-        await teamPreview.locator('[data-button-id="button-2"]').click();
+        await teamButton2.waitFor({ timeout: 5000 });
+        await teamButton2.click();
         await expect(configPanel, 'config panel should open for team button-2').toBeVisible();
         await configPanel.locator('.mobile-button-label').fill('TEAM-2');
         await configPanel.locator('.btn-close').click();
-        await page.locator(MOBILE_BUTTONS_SAVE).click();
-        await expect(modal, 'modal should close after save').not.toBeVisible();
-
-        await page.reload();
-        await waitForCommandInput(page);
-        await ensureGameSocket(page);
+        await expect(configPanel, 'config panel should close').not.toBeVisible();
 
         // Recolor two base buttons: one team overrides (button-2), one it doesn't (button-3).
-        modal = await openMobileButtonsSettings(page);
         await soloButton.click();
-        const soloPreview = page.locator('#mobile-buttons-preview-solo:not(.d-none)');
         await soloPreview.locator('[data-button-id="button-2"]').waitFor({ timeout: 5000 });
         for (const [id, color] of [['button-2', '#ff0000'], ['button-3', '#00ff00']]) {
             await soloPreview.locator(`[data-button-id="${id}"]`).click();
@@ -370,27 +377,21 @@ test.describe('Mobile buttons color and command configuration', () => {
             await configPanel.locator('.btn-close').click();
             await expect(configPanel, 'config panel should close').not.toBeVisible();
         }
+
+        // The team preview picks the base colors up straight away — no override reset needed.
+        await teamButton.click();
+        await expectTeamFollowsBase();
+
         await page.locator(MOBILE_BUTTONS_SAVE).click();
         await expect(modal, 'modal should close after save').not.toBeVisible();
 
         await page.reload();
         await waitForCommandInput(page);
-        await ensureGameSocket(page);
 
-        // Team should have picked up both base colors without a manual override reset,
-        // while keeping the label it actually overrode.
+        // ...and the base edit was not baked into the stored override.
         modal = await openMobileButtonsSettings(page);
         await teamButton.click();
-        const teamButton2 = teamPreview.locator('[data-button-id="button-2"]');
-        const teamButton3 = teamPreview.locator('[data-button-id="button-3"]');
-        await teamButton2.waitFor({ timeout: 5000 });
-
-        await expect(teamButton3, 'untouched cell should still be marked inherited').toHaveClass(/inherited/);
-        await expect(teamButton3, 'untouched cell should follow the new base color')
-            .toHaveCSS('background-color', 'rgb(0, 255, 0)');
-        await expect(teamButton2, 'overridden cell should follow the new base color')
-            .toHaveCSS('background-color', 'rgb(255, 0, 0)');
-        await expect(teamButton2, 'overridden cell should keep its own label').toHaveText('TEAM-2');
+        await expectTeamFollowsBase();
     });
 
     test('direction button sends direction command', async ({ page }) => {

--- a/e2e/mobile-buttons-color.spec.ts
+++ b/e2e/mobile-buttons-color.spec.ts
@@ -333,6 +333,66 @@ test.describe('Mobile buttons color and command configuration', () => {
         expect(lastCommand, 'should send configured command when button clicked').toBe('zerknij');
     });
 
+    test('base edits propagate to modes that did not override the button', async ({ page }) => {
+        await page.goto('/');
+        await waitForCommandInput(page);
+        await ensureGameSocket(page);
+
+        const configPanel = page.locator('.mobile-button-config');
+        const soloButton = page.getByRole('button', { name: /^Bazowy/ });
+        const teamButton = page.getByRole('button', { name: /^W druzynie/ });
+
+        // Give team an explicit override on button-2 — its label only.
+        let modal = await openMobileButtonsSettings(page);
+        await teamButton.click();
+        const teamPreview = page.locator('#mobile-buttons-preview-team:not(.d-none)');
+        await teamPreview.locator('[data-button-id="button-2"]').waitFor({ timeout: 5000 });
+        await teamPreview.locator('[data-button-id="button-2"]').click();
+        await expect(configPanel, 'config panel should open for team button-2').toBeVisible();
+        await configPanel.locator('.mobile-button-label').fill('TEAM-2');
+        await configPanel.locator('.btn-close').click();
+        await page.locator(MOBILE_BUTTONS_SAVE).click();
+        await expect(modal, 'modal should close after save').not.toBeVisible();
+
+        await page.reload();
+        await waitForCommandInput(page);
+        await ensureGameSocket(page);
+
+        // Recolor two base buttons: one team overrides (button-2), one it doesn't (button-3).
+        modal = await openMobileButtonsSettings(page);
+        await soloButton.click();
+        const soloPreview = page.locator('#mobile-buttons-preview-solo:not(.d-none)');
+        await soloPreview.locator('[data-button-id="button-2"]').waitFor({ timeout: 5000 });
+        for (const [id, color] of [['button-2', '#ff0000'], ['button-3', '#00ff00']]) {
+            await soloPreview.locator(`[data-button-id="${id}"]`).click();
+            await expect(configPanel, `config panel should open for base ${id}`).toBeVisible();
+            await configPanel.locator('.mobile-button-color-row').first().locator('input[type="color"]').fill(color);
+            await configPanel.locator('.btn-close').click();
+            await expect(configPanel, 'config panel should close').not.toBeVisible();
+        }
+        await page.locator(MOBILE_BUTTONS_SAVE).click();
+        await expect(modal, 'modal should close after save').not.toBeVisible();
+
+        await page.reload();
+        await waitForCommandInput(page);
+        await ensureGameSocket(page);
+
+        // Team should have picked up both base colors without a manual override reset,
+        // while keeping the label it actually overrode.
+        modal = await openMobileButtonsSettings(page);
+        await teamButton.click();
+        const teamButton2 = teamPreview.locator('[data-button-id="button-2"]');
+        const teamButton3 = teamPreview.locator('[data-button-id="button-3"]');
+        await teamButton2.waitFor({ timeout: 5000 });
+
+        await expect(teamButton3, 'untouched cell should still be marked inherited').toHaveClass(/inherited/);
+        await expect(teamButton3, 'untouched cell should follow the new base color')
+            .toHaveCSS('background-color', 'rgb(0, 255, 0)');
+        await expect(teamButton2, 'overridden cell should follow the new base color')
+            .toHaveCSS('background-color', 'rgb(255, 0, 0)');
+        await expect(teamButton2, 'overridden cell should keep its own label').toHaveText('TEAM-2');
+    });
+
     test('direction button sends direction command', async ({ page }) => {
         await page.goto('/');
         await waitForCommandInput(page);

--- a/src/modules/core/settingsMigrations.ts
+++ b/src/modules/core/settingsMigrations.ts
@@ -621,7 +621,7 @@ export function migrateMobileButtonOverrides(): void {
                     override.order = order.map((id, i) => id === baseOrder[i] ? null : id);
                     hasChange = true;
                 } else {
-                    override.prepend = [...order];
+                    override.replaceOrder = [...order];
                     hasChange = true;
                 }
             }

--- a/src/modules/core/settingsMigrations.ts
+++ b/src/modules/core/settingsMigrations.ts
@@ -121,6 +121,11 @@ const migrations: Migration[] = [
         description: 'Split uiSettings into shell/render/map/behavior keys (handled by migrateUiSettingsSplit)',
         migrate: settings => settings, // No-op for core Settings; actual migration is below
     },
+    {
+        version: 11,
+        description: 'Convert mobileButtonSettings team/leader to sparse overrides over solo base (handled by migrateMobileButtonOverrides)',
+        migrate: settings => settings,
+    },
 ];
 
 /**
@@ -520,6 +525,124 @@ export async function migrateLayoutManagerState(): Promise<void> {
         console.log('[SettingsMigrations] Migrated layoutManagerState to flat-windows shape');
     } catch (e) {
         console.error('[SettingsMigrations] Failed to migrate layoutManagerState:', e);
+    }
+}
+
+/**
+ * Convert legacy mobileButtonSettings storage from three full LayoutSettings
+ * (solo, team, leader) to base (solo) + sparse overrides for team/leader.
+ * This is migration version 11.
+ */
+export function migrateMobileButtonOverrides(): void {
+    const currentVersion = getMigrationsVersion();
+
+    if (currentVersion >= 11) {
+        return;
+    }
+
+    try {
+        const raw: any = globalStorage.get('mobileButtonSettings');
+        if (!raw || typeof raw !== 'object') return;
+        if (raw.format === 2) return;
+        if (!raw.solo || typeof raw.solo !== 'object') return;
+
+        const base = raw.solo;
+        const baseButtons: Record<string, any> = (base.buttons && typeof base.buttons === 'object') ? base.buttons : {};
+        const baseOrder: string[] = Array.isArray(base.order) ? base.order : [];
+        const baseCols: number | undefined = typeof base.cols === 'number' ? base.cols : undefined;
+        const baseBackground: string | undefined = typeof base.background === 'string' ? base.background : undefined;
+
+        const ALL_FIELDS = [
+            'macroType', 'command', 'direction', 'enemySlot', 'pluginConfig', 'steps',
+            'label', 'color', 'fontColor', 'holdEnabled', 'hold', 'activeColor', 'syncWithDirections',
+        ];
+
+        function buttonDiff(newCfg: any, baseCfg: any): any | null {
+            if (!newCfg || typeof newCfg !== 'object') return null;
+            if (!baseCfg || typeof baseCfg !== 'object') {
+                return { ...newCfg };
+            }
+            const diff: Record<string, any> = {};
+            let changed = false;
+            const keys = new Set<string>([...Object.keys(newCfg), ...Object.keys(baseCfg), ...ALL_FIELDS]);
+            keys.forEach(k => {
+                const a = newCfg[k];
+                const b = baseCfg[k];
+                if (a === undefined && b === undefined) return;
+                if (JSON.stringify(a) !== JSON.stringify(b)) {
+                    diff[k] = a;
+                    changed = true;
+                }
+            });
+            return changed ? diff : null;
+        }
+
+        function layoutDiff(layout: any): any | null {
+            if (!layout || typeof layout !== 'object') return null;
+            const override: any = {};
+            let hasChange = false;
+            if (typeof layout.cols === 'number' && layout.cols !== baseCols) {
+                override.cols = layout.cols;
+                hasChange = true;
+            }
+            if (typeof layout.background === 'string' && layout.background !== baseBackground) {
+                override.background = layout.background;
+                hasChange = true;
+            }
+            const order: string[] = Array.isArray(layout.order) ? layout.order : [];
+            const sameLength = order.length === baseOrder.length;
+            let orderDiffers = !sameLength;
+            if (sameLength) {
+                for (let i = 0; i < order.length; i++) {
+                    if (order[i] !== baseOrder[i]) { orderDiffers = true; break; }
+                }
+            }
+            if (orderDiffers) {
+                if (sameLength) {
+                    override.order = order.map((id, i) => id === baseOrder[i] ? null : id);
+                } else {
+                    override.order = [...order];
+                }
+                hasChange = true;
+            }
+            const buttonsObj = (layout.buttons && typeof layout.buttons === 'object') ? layout.buttons : {};
+            const overrideButtons: Record<string, any> = {};
+            let anyButtonDiff = false;
+            const ids = new Set<string>(order);
+            ids.forEach(id => {
+                const newCfg = buttonsObj[id];
+                if (!newCfg) return;
+                const d = buttonDiff(newCfg, baseButtons[id]);
+                if (d) {
+                    overrideButtons[id] = d;
+                    anyButtonDiff = true;
+                }
+            });
+            if (anyButtonDiff) {
+                override.buttons = overrideButtons;
+                hasChange = true;
+            }
+            return hasChange ? override : null;
+        }
+
+        const teamOverride = layoutDiff(raw.team);
+        const leaderOverride = layoutDiff(raw.leader);
+
+        const next: Record<string, any> = {
+            format: 2,
+            solo: base,
+            locked: !!raw.locked,
+            radial: raw.radial,
+        };
+        if (teamOverride) next.team = teamOverride;
+        if (leaderOverride) next.leader = leaderOverride;
+        if (raw.buttonSize !== undefined) next.buttonSize = raw.buttonSize;
+        if (raw.buttonGap !== undefined) next.buttonGap = raw.buttonGap;
+
+        globalStorage.set('mobileButtonSettings', next);
+        console.log('[SettingsMigrations] Converted mobileButtonSettings team/leader to sparse overrides');
+    } catch (e) {
+        console.error('[SettingsMigrations] Failed to migrate mobileButtonSettings overrides:', e);
     }
 }
 

--- a/src/modules/core/settingsMigrations.ts
+++ b/src/modules/core/settingsMigrations.ts
@@ -577,6 +577,18 @@ export function migrateMobileButtonOverrides(): void {
             return changed ? diff : null;
         }
 
+        function findBaseOffset(newOrder: string[]): number {
+            if (baseOrder.length === 0) return newOrder.length === 0 ? 0 : -1;
+            const limit = newOrder.length - baseOrder.length;
+            outer: for (let off = 0; off <= limit; off++) {
+                for (let i = 0; i < baseOrder.length; i++) {
+                    if (newOrder[off + i] !== baseOrder[i]) continue outer;
+                }
+                return off;
+            }
+            return -1;
+        }
+
         function layoutDiff(layout: any): any | null {
             if (!layout || typeof layout !== 'object') return null;
             const override: any = {};
@@ -598,12 +610,20 @@ export function migrateMobileButtonOverrides(): void {
                 }
             }
             if (orderDiffers) {
-                if (sameLength) {
+                const offset = findBaseOffset(order);
+                if (offset >= 0) {
+                    const prepend = order.slice(0, offset);
+                    const append = order.slice(offset + baseOrder.length);
+                    if (prepend.length > 0) override.prepend = prepend;
+                    if (append.length > 0) override.append = append;
+                    hasChange = true;
+                } else if (sameLength) {
                     override.order = order.map((id, i) => id === baseOrder[i] ? null : id);
+                    hasChange = true;
                 } else {
-                    override.order = [...order];
+                    override.prepend = [...order];
+                    hasChange = true;
                 }
-                hasChange = true;
             }
             const buttonsObj = (layout.buttons && typeof layout.buttons === 'object') ? layout.buttons : {};
             const overrideButtons: Record<string, any> = {};
@@ -639,7 +659,7 @@ export function migrateMobileButtonOverrides(): void {
         if (raw.buttonSize !== undefined) next.buttonSize = raw.buttonSize;
         if (raw.buttonGap !== undefined) next.buttonGap = raw.buttonGap;
 
-        globalStorage.set('mobileButtonSettings', next);
+        globalStorage.set('mobileButtonSettings', next as any);
         console.log('[SettingsMigrations] Converted mobileButtonSettings team/leader to sparse overrides');
     } catch (e) {
         console.error('[SettingsMigrations] Failed to migrate mobileButtonSettings overrides:', e);

--- a/src/web/clientBootstrap.ts
+++ b/src/web/clientBootstrap.ts
@@ -11,6 +11,7 @@ import {
     migrateFooterComponentVisibility,
     migrateLayoutManagerState,
     migrateMobileButtonMacroField,
+    migrateMobileButtonOverrides,
     migrateUiSettingsSplit,
     runAllSettingsMigrations,
 } from "@modules/core/settingsMigrations";
@@ -38,6 +39,11 @@ export function bootstrapGameClient(opts: { installPorts: () => void }): GameCli
     // read settings during setup, so they must see migrated data.
     migrateNewlyCharacterScopedKeys();
     migrateMobileButtonMacroField();
+    // Collapse the three full mobile-button layouts into solo + sparse
+    // team/leader overrides. Must run before runAllSettingsMigrations() bumps
+    // the version counter past this migration's gate, and after the macro-field
+    // rename so the diff compares already-normalised button configs.
+    migrateMobileButtonOverrides();
     // Split uiSettings into concern-scoped keys before runAllSettingsMigrations()
     // bumps the version counter past this migration's gate.
     migrateUiSettingsSplit();

--- a/src/web/mobileButtonSettings.ts
+++ b/src/web/mobileButtonSettings.ts
@@ -163,8 +163,14 @@ export interface LayoutSettings {
 export interface LayoutOverride {
     cols?: number;
     background?: string;
-    // Aligned with base order by index. null/undefined at index i = inherit base.order[i].
-    // Length may differ from base for mode-specific extra cells.
+    // Cells inserted before the base layout (negative-indexed positions).
+    // Their button configs go in `buttons`.
+    prepend?: string[];
+    // Cells appended after the base layout.
+    append?: string[];
+    // Aligned with base order by index. null/undefined at index i = inherit base.order[i],
+    // string = replace that cell. Length should equal base.order.length when set.
+    // Used together with prepend/append to express partial layout changes while preserving inheritance.
     order?: (string | null)[];
     // Sparse field overrides keyed by button id. Buttons with no entry inherit the base config fully.
     buttons?: Record<string, Partial<MobileButtonSetting>>;
@@ -194,6 +200,11 @@ function deepEqual(a: unknown, b: unknown): boolean {
     }
 }
 
+/**
+ * Resolves the runtime layout for a mode by applying its sparse override on top of the base.
+ * Final order is: [...prepend, ...positional inheritance from base + override.order, ...append].
+ * Returns the offset where base cells start in the resolved order (= prepend.length).
+ */
 export function resolveLayout(base: LayoutSettings, override?: LayoutOverride | null): LayoutSettings {
     if (!override) {
         return {
@@ -206,17 +217,16 @@ export function resolveLayout(base: LayoutSettings, override?: LayoutOverride | 
     const cols = typeof override.cols === 'number' && override.cols > 0 ? override.cols : base.cols;
     const background = typeof override.background === 'string' && override.background ? override.background : base.background;
     const order: string[] = [];
-    if (Array.isArray(override.order)) {
-        for (let i = 0; i < override.order.length; i++) {
-            const o = override.order[i];
-            if (typeof o === 'string') {
-                order.push(o);
-            } else if (i < base.order.length) {
-                order.push(base.order[i]);
-            }
-        }
-    } else {
-        for (const id of base.order) order.push(id);
+    if (Array.isArray(override.prepend)) {
+        for (const id of override.prepend) order.push(id);
+    }
+    for (let i = 0; i < base.order.length; i++) {
+        const o = override.order?.[i];
+        if (typeof o === 'string') order.push(o);
+        else order.push(base.order[i]);
+    }
+    if (Array.isArray(override.append)) {
+        for (const id of override.append) order.push(id);
     }
     const buttons: Record<string, MobileButtonSetting> = {};
     const ids = new Set<string>([...order, ...Object.keys(base.buttons), ...Object.keys(override.buttons || {})]);
@@ -232,6 +242,22 @@ export function resolveLayout(base: LayoutSettings, override?: LayoutOverride | 
         }
     });
     return { buttons, order, cols, background };
+}
+
+/**
+ * Returns the offset at which base.order appears as a contiguous subsequence in newOrder,
+ * or -1 if it doesn't. Used to detect prepend/append patterns.
+ */
+function findBaseOffset(newOrder: string[], baseOrder: string[]): number {
+    if (baseOrder.length === 0) return newOrder.length === 0 ? 0 : -1;
+    const limit = newOrder.length - baseOrder.length;
+    outer: for (let off = 0; off <= limit; off++) {
+        for (let i = 0; i < baseOrder.length; i++) {
+            if (newOrder[off + i] !== baseOrder[i]) continue outer;
+        }
+        return off;
+    }
+    return -1;
 }
 
 const ALL_BUTTON_FIELDS: (keyof MobileButtonSetting)[] = [
@@ -268,7 +294,9 @@ export function diffLayout(newLayout: LayoutSettings, base: LayoutSettings): Lay
         override.background = newLayout.background;
         hasChange = true;
     }
-    // Order diff: aligned by index where possible
+
+    // Order diff: try to express layout as [prepend, base + positional override, append]
+    // so adding rows to top/bottom doesn't destroy positional inheritance for the base region.
     const sameLength = newLayout.order.length === base.order.length;
     let orderDiffers = !sameLength;
     if (sameLength) {
@@ -277,14 +305,25 @@ export function diffLayout(newLayout: LayoutSettings, base: LayoutSettings): Lay
         }
     }
     if (orderDiffers) {
-        if (sameLength) {
-            const sparse: (string | null)[] = newLayout.order.map((id, i) => id === base.order[i] ? null : id);
-            override.order = sparse;
+        const offset = findBaseOffset(newLayout.order, base.order);
+        if (offset >= 0) {
+            // Base appears intact at `offset`; capture only prepend/append cells.
+            const prepend = newLayout.order.slice(0, offset);
+            const append = newLayout.order.slice(offset + base.order.length);
+            if (prepend.length > 0) override.prepend = prepend;
+            if (append.length > 0) override.append = append;
+            hasChange = true;
+        } else if (sameLength) {
+            // Same shape, some cells replaced: store positional sparse diff.
+            override.order = newLayout.order.map((id, i) => id === base.order[i] ? null : id);
+            hasChange = true;
         } else {
-            override.order = [...newLayout.order];
+            // Layout diverges structurally; full prepend stores the entire order.
+            override.prepend = [...newLayout.order];
+            hasChange = true;
         }
-        hasChange = true;
     }
+
     // Button diffs: only for buttons that appear in the new layout
     const overrideButtons: Record<string, Partial<MobileButtonSetting>> = {};
     let anyButtonDiff = false;
@@ -401,6 +440,14 @@ function parseStoredOverride(raw: any): LayoutOverride | null {
     const override: LayoutOverride = {};
     if (typeof raw.cols === 'number' && raw.cols > 0) override.cols = raw.cols;
     if (typeof raw.background === 'string' && raw.background) override.background = raw.background;
+    if (Array.isArray(raw.prepend)) {
+        const prepend = raw.prepend.filter((e: unknown): e is string => typeof e === 'string');
+        if (prepend.length > 0) override.prepend = prepend;
+    }
+    if (Array.isArray(raw.append)) {
+        const append = raw.append.filter((e: unknown): e is string => typeof e === 'string');
+        if (append.length > 0) override.append = append;
+    }
     if (Array.isArray(raw.order)) {
         override.order = raw.order.map((entry: unknown) =>
             typeof entry === 'string' ? entry : null,
@@ -421,7 +468,8 @@ function parseStoredOverride(raw: any): LayoutOverride | null {
         });
         if (Object.keys(buttons).length > 0) override.buttons = buttons;
     }
-    const empty = override.cols === undefined && override.background === undefined && !override.order && !override.buttons;
+    const empty = override.cols === undefined && override.background === undefined
+        && !override.prepend && !override.append && !override.order && !override.buttons;
     return empty ? null : override;
 }
 
@@ -502,7 +550,9 @@ export function saveSettings(settings: Settings) {
     if (leaderOverride) stored.leader = leaderOverride;
     if (settings.buttonSize !== undefined) stored.buttonSize = settings.buttonSize;
     if (settings.buttonGap !== undefined) stored.buttonGap = settings.buttonGap;
-    globalStorage.set('mobileButtonSettings', stored);
+    // Stored shape diverges from runtime Settings (team/leader are sparse overrides);
+    // the global storage schema is typed against runtime Settings, so we cast for set.
+    globalStorage.set('mobileButtonSettings', stored as unknown as Settings);
 }
 
 export function extractAlpha(color: string): number {

--- a/src/web/mobileButtonSettings.ts
+++ b/src/web/mobileButtonSettings.ts
@@ -160,6 +160,16 @@ export interface LayoutSettings {
     background: string;
 }
 
+export interface LayoutOverride {
+    cols?: number;
+    background?: string;
+    // Aligned with base order by index. null/undefined at index i = inherit base.order[i].
+    // Length may differ from base for mode-specific extra cells.
+    order?: (string | null)[];
+    // Sparse field overrides keyed by button id. Buttons with no entry inherit the base config fully.
+    buttons?: Record<string, Partial<MobileButtonSetting>>;
+}
+
 export interface Settings {
     solo: LayoutSettings;
     team: LayoutSettings;
@@ -172,6 +182,128 @@ export interface Settings {
 
 export function createDefaultLayout(): LayoutSettings {
     return { buttons: { ...defaultSettings }, order: [...defaultOrder], cols: defaultCols, background: defaultBackground };
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+    if (a === b) return true;
+    if (a == null || b == null) return false;
+    try {
+        return JSON.stringify(a) === JSON.stringify(b);
+    } catch {
+        return false;
+    }
+}
+
+export function resolveLayout(base: LayoutSettings, override?: LayoutOverride | null): LayoutSettings {
+    if (!override) {
+        return {
+            buttons: { ...base.buttons },
+            order: [...base.order],
+            cols: base.cols,
+            background: base.background,
+        };
+    }
+    const cols = typeof override.cols === 'number' && override.cols > 0 ? override.cols : base.cols;
+    const background = typeof override.background === 'string' && override.background ? override.background : base.background;
+    const order: string[] = [];
+    if (Array.isArray(override.order)) {
+        for (let i = 0; i < override.order.length; i++) {
+            const o = override.order[i];
+            if (typeof o === 'string') {
+                order.push(o);
+            } else if (i < base.order.length) {
+                order.push(base.order[i]);
+            }
+        }
+    } else {
+        for (const id of base.order) order.push(id);
+    }
+    const buttons: Record<string, MobileButtonSetting> = {};
+    const ids = new Set<string>([...order, ...Object.keys(base.buttons), ...Object.keys(override.buttons || {})]);
+    ids.forEach(id => {
+        const baseCfg = base.buttons[id];
+        const overrideCfg = override.buttons?.[id];
+        if (baseCfg && overrideCfg) {
+            buttons[id] = { ...baseCfg, ...overrideCfg };
+        } else if (baseCfg) {
+            buttons[id] = baseCfg;
+        } else if (overrideCfg) {
+            buttons[id] = { macroType: 'empty', label: '', color: 'transparent', fontColor: defaultFontColor, ...overrideCfg } as MobileButtonSetting;
+        }
+    });
+    return { buttons, order, cols, background };
+}
+
+const ALL_BUTTON_FIELDS: (keyof MobileButtonSetting)[] = [
+    'macroType', 'command', 'direction', 'enemySlot', 'pluginConfig', 'steps',
+    'label', 'color', 'fontColor', 'holdEnabled', 'hold', 'activeColor', 'syncWithDirections',
+];
+
+function diffButton(newCfg: MobileButtonSetting, baseCfg: MobileButtonSetting | undefined): Partial<MobileButtonSetting> | null {
+    if (!baseCfg) {
+        // Brand-new mode-specific button: store full config
+        return { ...newCfg };
+    }
+    const diff: Partial<MobileButtonSetting> = {};
+    let changed = false;
+    for (const key of ALL_BUTTON_FIELDS) {
+        const a = (newCfg as any)[key];
+        const b = (baseCfg as any)[key];
+        if (!deepEqual(a, b)) {
+            (diff as any)[key] = a;
+            changed = true;
+        }
+    }
+    return changed ? diff : null;
+}
+
+export function diffLayout(newLayout: LayoutSettings, base: LayoutSettings): LayoutOverride | null {
+    const override: LayoutOverride = {};
+    let hasChange = false;
+    if (newLayout.cols !== base.cols) {
+        override.cols = newLayout.cols;
+        hasChange = true;
+    }
+    if (newLayout.background !== base.background) {
+        override.background = newLayout.background;
+        hasChange = true;
+    }
+    // Order diff: aligned by index where possible
+    const sameLength = newLayout.order.length === base.order.length;
+    let orderDiffers = !sameLength;
+    if (sameLength) {
+        for (let i = 0; i < newLayout.order.length; i++) {
+            if (newLayout.order[i] !== base.order[i]) { orderDiffers = true; break; }
+        }
+    }
+    if (orderDiffers) {
+        if (sameLength) {
+            const sparse: (string | null)[] = newLayout.order.map((id, i) => id === base.order[i] ? null : id);
+            override.order = sparse;
+        } else {
+            override.order = [...newLayout.order];
+        }
+        hasChange = true;
+    }
+    // Button diffs: only for buttons that appear in the new layout
+    const overrideButtons: Record<string, Partial<MobileButtonSetting>> = {};
+    let anyButtonDiff = false;
+    const ids = new Set(newLayout.order);
+    ids.forEach(id => {
+        const newCfg = newLayout.buttons[id];
+        if (!newCfg) return;
+        const baseCfg = base.buttons[id];
+        const d = diffButton(newCfg, baseCfg);
+        if (d) {
+            overrideButtons[id] = d;
+            anyButtonDiff = true;
+        }
+    });
+    if (anyButtonDiff) {
+        override.buttons = overrideButtons;
+        hasChange = true;
+    }
+    return hasChange ? override : null;
 }
 
 const emptyButton: MobileButtonSetting = { macroType: 'empty', label: '', color: 'transparent', fontColor: defaultFontColor };
@@ -264,6 +396,35 @@ function parseLayout(set: any, fallback: LayoutSettings = createDefaultLayout())
     return { buttons, order, cols, background };
 }
 
+function parseStoredOverride(raw: any): LayoutOverride | null {
+    if (!raw || typeof raw !== 'object') return null;
+    const override: LayoutOverride = {};
+    if (typeof raw.cols === 'number' && raw.cols > 0) override.cols = raw.cols;
+    if (typeof raw.background === 'string' && raw.background) override.background = raw.background;
+    if (Array.isArray(raw.order)) {
+        override.order = raw.order.map((entry: unknown) =>
+            typeof entry === 'string' ? entry : null,
+        );
+    }
+    if (raw.buttons && typeof raw.buttons === 'object') {
+        const buttons: Record<string, Partial<MobileButtonSetting>> = {};
+        Object.keys(raw.buttons).forEach(id => {
+            const value = raw.buttons[id];
+            if (value && typeof value === 'object') {
+                // Migrate legacy `macro` field on partial overrides
+                if (typeof (value as any).macro === 'string' && typeof value.macroType !== 'string') {
+                    value.macroType = (value as any).macro;
+                    delete (value as any).macro;
+                }
+                buttons[id] = value as Partial<MobileButtonSetting>;
+            }
+        });
+        if (Object.keys(buttons).length > 0) override.buttons = buttons;
+    }
+    const empty = override.cols === undefined && override.background === undefined && !override.order && !override.buttons;
+    return empty ? null : override;
+}
+
 function parseRadialSettings(raw: any): RadialSettings {
     if (!raw || typeof raw !== 'object') {
         return { enabled: true, commands: cloneDefaultRadialCommands() };
@@ -301,57 +462,15 @@ function parseRadialSettings(raw: any): RadialSettings {
 export function loadSettings(): Settings {
     try {
         const raw = globalStorage.get('mobileButtonSettings') as any;
-        if (raw) {
+        if (raw && raw.solo && (raw.solo.buttons || raw.solo.order)) {
             const locked = !!raw.locked;
             const buttonSize = typeof raw.buttonSize === 'number' && raw.buttonSize > 0 ? raw.buttonSize : defaultButtonSize;
             const buttonGap = typeof raw.buttonGap === 'number' && raw.buttonGap >= 0 ? raw.buttonGap : defaultButtonGap;
-            if (raw.solo && raw.team && raw.leader && (raw.solo.buttons || raw.team.buttons || raw.leader.buttons)) {
-                return {
-                    solo: parseLayout(raw.solo),
-                    team: parseLayout(raw.team),
-                    leader: parseLayout(raw.leader),
-                    locked,
-                    radial: parseRadialSettings(raw.radial),
-                    buttonSize,
-                    buttonGap,
-                };
-            }
-            const order = Array.isArray(raw.order) ? raw.order : [...defaultOrder];
-            const cols = typeof raw.cols === 'number' && raw.cols > 0 ? raw.cols : defaultCols;
-            const soloBackground = typeof raw?.solo?.background === 'string' && raw.solo.background
-                ? raw.solo.background
-                : defaultBackground;
-            const teamBackground = typeof raw?.team?.background === 'string' && raw.team.background
-                ? raw.team.background
-                : typeof raw?.solo?.background === 'string' && raw.solo.background
-                    ? raw.solo.background
-                    : defaultBackground;
-            const leaderBackground = typeof raw?.leader?.background === 'string' && raw.leader.background
-                ? raw.leader.background
-                : typeof raw?.team?.background === 'string' && raw.team.background
-                    ? raw.team.background
-                    : typeof raw?.solo?.background === 'string' && raw.solo.background
-                        ? raw.solo.background
-                        : defaultBackground;
+            const base = parseLayout(raw.solo);
             return {
-                solo: {
-                    buttons: mergeMobileButtonSettings(extractButtons(raw.solo)),
-                    order: [...order],
-                    cols,
-                    background: soloBackground,
-                },
-                team: {
-                    buttons: mergeMobileButtonSettings(extractButtons(raw.team || raw.solo)),
-                    order: [...order],
-                    cols,
-                    background: teamBackground,
-                },
-                leader: {
-                    buttons: mergeMobileButtonSettings(extractButtons(raw.leader || raw.team || raw.solo)),
-                    order: [...order],
-                    cols,
-                    background: leaderBackground,
-                },
+                solo: base,
+                team: resolveLayout(base, parseStoredOverride(raw.team)),
+                leader: resolveLayout(base, parseStoredOverride(raw.leader)),
                 locked,
                 radial: parseRadialSettings(raw.radial),
                 buttonSize,
@@ -371,7 +490,19 @@ export function loadSettings(): Settings {
 }
 
 export function saveSettings(settings: Settings) {
-    globalStorage.set('mobileButtonSettings', settings);
+    const teamOverride = diffLayout(settings.team, settings.solo);
+    const leaderOverride = diffLayout(settings.leader, settings.solo);
+    const stored: Record<string, unknown> = {
+        format: 2,
+        solo: settings.solo,
+        locked: settings.locked,
+        radial: settings.radial,
+    };
+    if (teamOverride) stored.team = teamOverride;
+    if (leaderOverride) stored.leader = leaderOverride;
+    if (settings.buttonSize !== undefined) stored.buttonSize = settings.buttonSize;
+    if (settings.buttonGap !== undefined) stored.buttonGap = settings.buttonGap;
+    globalStorage.set('mobileButtonSettings', stored);
 }
 
 export function extractAlpha(color: string): number {

--- a/src/web/mobileButtonSettings.ts
+++ b/src/web/mobileButtonSettings.ts
@@ -348,6 +348,31 @@ export function diffLayout(newLayout: LayoutSettings, base: LayoutSettings): Lay
     return hasChange ? override : null;
 }
 
+/**
+ * Re-derives team/leader after the base (solo) layout changed.
+ *
+ * At runtime `Settings` holds team/leader fully resolved, so a base-only edit would
+ * leave them carrying the *previous* base values. `saveSettings` diffs against the
+ * new base, so those stale values would be stored as genuine overrides — pinning the
+ * button in every other mode until the user resets overrides by hand.
+ *
+ * Capturing each mode's override against the *old* base and re-resolving it against
+ * the new one keeps explicit overrides intact while anything merely inherited follows
+ * the base automatically.
+ *
+ * A mode that the same update already changed on its own is left untouched — the
+ * update expressed an intent for it directly.
+ */
+export function rebaseOverrides(prev: Settings, next: Settings): Settings {
+    if (next.solo === prev.solo) return next;
+    const result: Settings = { ...next };
+    (['team', 'leader'] as const).forEach(mode => {
+        if (next[mode] !== prev[mode]) return;
+        result[mode] = resolveLayout(next.solo, diffLayout(prev[mode], prev.solo));
+    });
+    return result;
+}
+
 const emptyButton: MobileButtonSetting = { macroType: 'empty', label: '', color: 'transparent', fontColor: defaultFontColor };
 
 const defaultRadialSettings: RadialSettings = {

--- a/src/web/mobileButtonSettings.ts
+++ b/src/web/mobileButtonSettings.ts
@@ -163,6 +163,9 @@ export interface LayoutSettings {
 export interface LayoutOverride {
     cols?: number;
     background?: string;
+    // When set, fully replaces base.order. Used when a shape change (e.g. adding a column)
+    // breaks positional alignment with base. prepend/append/order are ignored if this is set.
+    replaceOrder?: string[];
     // Cells inserted before the base layout (negative-indexed positions).
     // Their button configs go in `buttons`.
     prepend?: string[];
@@ -200,11 +203,6 @@ function deepEqual(a: unknown, b: unknown): boolean {
     }
 }
 
-/**
- * Resolves the runtime layout for a mode by applying its sparse override on top of the base.
- * Final order is: [...prepend, ...positional inheritance from base + override.order, ...append].
- * Returns the offset where base cells start in the resolved order (= prepend.length).
- */
 export function resolveLayout(base: LayoutSettings, override?: LayoutOverride | null): LayoutSettings {
     if (!override) {
         return {
@@ -217,16 +215,20 @@ export function resolveLayout(base: LayoutSettings, override?: LayoutOverride | 
     const cols = typeof override.cols === 'number' && override.cols > 0 ? override.cols : base.cols;
     const background = typeof override.background === 'string' && override.background ? override.background : base.background;
     const order: string[] = [];
-    if (Array.isArray(override.prepend)) {
-        for (const id of override.prepend) order.push(id);
-    }
-    for (let i = 0; i < base.order.length; i++) {
-        const o = override.order?.[i];
-        if (typeof o === 'string') order.push(o);
-        else order.push(base.order[i]);
-    }
-    if (Array.isArray(override.append)) {
-        for (const id of override.append) order.push(id);
+    if (Array.isArray(override.replaceOrder)) {
+        for (const id of override.replaceOrder) order.push(id);
+    } else {
+        if (Array.isArray(override.prepend)) {
+            for (const id of override.prepend) order.push(id);
+        }
+        for (let i = 0; i < base.order.length; i++) {
+            const o = override.order?.[i];
+            if (typeof o === 'string') order.push(o);
+            else order.push(base.order[i]);
+        }
+        if (Array.isArray(override.append)) {
+            for (const id of override.append) order.push(id);
+        }
     }
     const buttons: Record<string, MobileButtonSetting> = {};
     const ids = new Set<string>([...order, ...Object.keys(base.buttons), ...Object.keys(override.buttons || {})]);
@@ -318,8 +320,9 @@ export function diffLayout(newLayout: LayoutSettings, base: LayoutSettings): Lay
             override.order = newLayout.order.map((id, i) => id === base.order[i] ? null : id);
             hasChange = true;
         } else {
-            // Layout diverges structurally; full prepend stores the entire order.
-            override.prepend = [...newLayout.order];
+            // Layout diverges structurally (e.g. column added). Store the resulting order
+            // verbatim; per-button inheritance still works through id-keyed buttons.
+            override.replaceOrder = [...newLayout.order];
             hasChange = true;
         }
     }
@@ -440,6 +443,10 @@ function parseStoredOverride(raw: any): LayoutOverride | null {
     const override: LayoutOverride = {};
     if (typeof raw.cols === 'number' && raw.cols > 0) override.cols = raw.cols;
     if (typeof raw.background === 'string' && raw.background) override.background = raw.background;
+    if (Array.isArray(raw.replaceOrder)) {
+        const replaceOrder = raw.replaceOrder.filter((e: unknown): e is string => typeof e === 'string');
+        if (replaceOrder.length > 0) override.replaceOrder = replaceOrder;
+    }
     if (Array.isArray(raw.prepend)) {
         const prepend = raw.prepend.filter((e: unknown): e is string => typeof e === 'string');
         if (prepend.length > 0) override.prepend = prepend;
@@ -469,7 +476,7 @@ function parseStoredOverride(raw: any): LayoutOverride | null {
         if (Object.keys(buttons).length > 0) override.buttons = buttons;
     }
     const empty = override.cols === undefined && override.background === undefined
-        && !override.prepend && !override.append && !override.order && !override.buttons;
+        && !override.replaceOrder && !override.prepend && !override.append && !override.order && !override.buttons;
     return empty ? null : override;
 }
 

--- a/src/web/options/ButtonGrid.tsx
+++ b/src/web/options/ButtonGrid.tsx
@@ -26,6 +26,22 @@ function buttonsEqual(a: MobileButtonSetting | undefined, b: MobileButtonSetting
     }
 }
 
+/**
+ * Find the offset where baseOrder appears as a contiguous subsequence in newOrder, or -1.
+ * Used to keep inheritance indicators correct after rows have been prepended/appended.
+ */
+function findBaseOffset(newOrder: string[], baseOrder: string[]): number {
+    if (baseOrder.length === 0) return newOrder.length === 0 ? 0 : -1;
+    const limit = newOrder.length - baseOrder.length;
+    outer: for (let off = 0; off <= limit; off++) {
+        for (let i = 0; i < baseOrder.length; i++) {
+            if (newOrder[off + i] !== baseOrder[i]) continue outer;
+        }
+        return off;
+    }
+    return -1;
+}
+
 export default function ButtonGrid({ mode, view, settings, notEditable, emptySetting, openConfig, gridRef, activeButtonId }: Props) {
     const set = settings[mode];
     const bgColor = set.background || defaultBackground;
@@ -33,6 +49,7 @@ export default function ButtonGrid({ mode, view, settings, notEditable, emptySet
     const buttonGap = settings.buttonGap ?? defaultButtonGap;
     const baseSet = settings.solo;
     const isOverrideMode = mode !== 'solo';
+    const baseOffset = isOverrideMode ? findBaseOffset(set.order, baseSet.order) : -1;
     return (
         <div
             ref={gridRef}
@@ -60,9 +77,15 @@ export default function ButtonGrid({ mode, view, settings, notEditable, emptySet
                 if (isActive) classes += ' editing';
                 let inherited = false;
                 if (isOverrideMode) {
-                    const baseId = baseSet.order[idx];
-                    const baseCfg = baseId !== undefined ? baseSet.buttons[baseId] : undefined;
-                    inherited = baseId === id && buttonsEqual(cfg, baseCfg);
+                    // Map this cell's index back to a base position (accounts for prepended rows).
+                    const basePos = baseOffset >= 0 && idx >= baseOffset && idx < baseOffset + baseSet.order.length
+                        ? idx - baseOffset
+                        : -1;
+                    if (basePos >= 0) {
+                        const baseId = baseSet.order[basePos];
+                        const baseCfg = baseSet.buttons[baseId];
+                        inherited = baseId === id && buttonsEqual(cfg, baseCfg);
+                    }
                     if (inherited) classes += ' inherited';
                     else classes += ' overridden';
                 }

--- a/src/web/options/ButtonGrid.tsx
+++ b/src/web/options/ButtonGrid.tsx
@@ -16,11 +16,23 @@ interface Props {
     activeButtonId?: string | null;
 }
 
+function buttonsEqual(a: MobileButtonSetting | undefined, b: MobileButtonSetting | undefined): boolean {
+    if (a === b) return true;
+    if (!a || !b) return false;
+    try {
+        return JSON.stringify(a) === JSON.stringify(b);
+    } catch {
+        return false;
+    }
+}
+
 export default function ButtonGrid({ mode, view, settings, notEditable, emptySetting, openConfig, gridRef, activeButtonId }: Props) {
     const set = settings[mode];
     const bgColor = set.background || defaultBackground;
     const buttonSize = settings.buttonSize ?? defaultButtonSize;
     const buttonGap = settings.buttonGap ?? defaultButtonGap;
+    const baseSet = settings.solo;
+    const isOverrideMode = mode !== 'solo';
     return (
         <div
             ref={gridRef}
@@ -33,7 +45,7 @@ export default function ButtonGrid({ mode, view, settings, notEditable, emptySet
                 gap: buttonGap + 'px',
             }}
         >
-            {set.order.map(id => {
+            {set.order.map((id, idx) => {
                 const cfg = set.buttons[id] || defaultSettings[id] || emptySetting;
                 let classes = 'mobile-button';
                 const isText = cfg.macroType !== 'kierunek';
@@ -46,6 +58,14 @@ export default function ButtonGrid({ mode, view, settings, notEditable, emptySet
                 if (isEmpty) classes += ' empty';
                 const isActive = activeButtonId === id;
                 if (isActive) classes += ' editing';
+                let inherited = false;
+                if (isOverrideMode) {
+                    const baseId = baseSet.order[idx];
+                    const baseCfg = baseId !== undefined ? baseSet.buttons[baseId] : undefined;
+                    inherited = baseId === id && buttonsEqual(cfg, baseCfg);
+                    if (inherited) classes += ' inherited';
+                    else classes += ' overridden';
+                }
                 const handle = notEditable.includes(id)
                     ? undefined
                     : (ev: React.MouseEvent<HTMLButtonElement>) => openConfig(mode, id, ev);
@@ -62,6 +82,10 @@ export default function ButtonGrid({ mode, view, settings, notEditable, emptySet
                     style.backgroundColor = cfg.color;
                     style.color = cfg.fontColor || defaultFontColor;
                 }
+                if (isOverrideMode && !inherited) {
+                    style.outline = '2px solid #ffc107';
+                    style.outlineOffset = '-2px';
+                }
                 return (
                     <button
                         key={id}
@@ -69,6 +93,7 @@ export default function ButtonGrid({ mode, view, settings, notEditable, emptySet
                         className={classes}
                         style={style}
                         onClick={handle}
+                        title={isOverrideMode ? (inherited ? 'Dziedziczy z trybu Bazowy' : 'Nadpisanie wzgledem trybu Bazowy') : undefined}
                     >
                         {isEmpty ? '' : cfg.label}
                     </button>

--- a/src/web/options/ButtonGrid.tsx
+++ b/src/web/options/ButtonGrid.tsx
@@ -26,22 +26,6 @@ function buttonsEqual(a: MobileButtonSetting | undefined, b: MobileButtonSetting
     }
 }
 
-/**
- * Find the offset where baseOrder appears as a contiguous subsequence in newOrder, or -1.
- * Used to keep inheritance indicators correct after rows have been prepended/appended.
- */
-function findBaseOffset(newOrder: string[], baseOrder: string[]): number {
-    if (baseOrder.length === 0) return newOrder.length === 0 ? 0 : -1;
-    const limit = newOrder.length - baseOrder.length;
-    outer: for (let off = 0; off <= limit; off++) {
-        for (let i = 0; i < baseOrder.length; i++) {
-            if (newOrder[off + i] !== baseOrder[i]) continue outer;
-        }
-        return off;
-    }
-    return -1;
-}
-
 export default function ButtonGrid({ mode, view, settings, notEditable, emptySetting, openConfig, gridRef, activeButtonId }: Props) {
     const set = settings[mode];
     const bgColor = set.background || defaultBackground;
@@ -49,7 +33,6 @@ export default function ButtonGrid({ mode, view, settings, notEditable, emptySet
     const buttonGap = settings.buttonGap ?? defaultButtonGap;
     const baseSet = settings.solo;
     const isOverrideMode = mode !== 'solo';
-    const baseOffset = isOverrideMode ? findBaseOffset(set.order, baseSet.order) : -1;
     return (
         <div
             ref={gridRef}
@@ -62,7 +45,7 @@ export default function ButtonGrid({ mode, view, settings, notEditable, emptySet
                 gap: buttonGap + 'px',
             }}
         >
-            {set.order.map((id, idx) => {
+            {set.order.map(id => {
                 const cfg = set.buttons[id] || defaultSettings[id] || emptySetting;
                 let classes = 'mobile-button';
                 const isText = cfg.macroType !== 'kierunek';
@@ -77,15 +60,11 @@ export default function ButtonGrid({ mode, view, settings, notEditable, emptySet
                 if (isActive) classes += ' editing';
                 let inherited = false;
                 if (isOverrideMode) {
-                    // Map this cell's index back to a base position (accounts for prepended rows).
-                    const basePos = baseOffset >= 0 && idx >= baseOffset && idx < baseOffset + baseSet.order.length
-                        ? idx - baseOffset
-                        : -1;
-                    if (basePos >= 0) {
-                        const baseId = baseSet.order[basePos];
-                        const baseCfg = baseSet.buttons[baseId];
-                        inherited = baseId === id && buttonsEqual(cfg, baseCfg);
-                    }
+                    // A cell is "inherited" iff its id exists in the base layout AND its
+                    // resolved config matches the base config for that id. Position-agnostic
+                    // so column/row changes don't falsely flag base cells as overridden.
+                    const baseCfg = baseSet.buttons[id];
+                    inherited = !!baseCfg && buttonsEqual(cfg, baseCfg);
                     if (inherited) classes += ' inherited';
                     else classes += ' overridden';
                 }

--- a/src/web/options/MobileButtons.tsx
+++ b/src/web/options/MobileButtons.tsx
@@ -10,6 +10,7 @@ import {
     defaultOrder,
     defaultSettings,
     loadSettings,
+    rebaseOverrides,
     saveSettings,
     Settings,
 } from "../mobileButtonSettings";
@@ -130,6 +131,13 @@ function MobileButtons() {
     }, []);
     const notEditable: string[] = [];
 
+    // Every layout-changing update goes through here: when the base (solo) layout
+    // changes, team/leader are re-resolved so cells they don't explicitly override
+    // pick up the new base instead of freezing the old value into an override.
+    function updateSettings(updater: (prev: Settings) => Settings) {
+        setSettings(prev => rebaseOverrides(prev, updater(prev)));
+    }
+
     function nextId(ids: string[]) {
         let current = ids.reduce((m, id) => {
             const match = /^button-(\d+)$/.exec(id);
@@ -139,7 +147,7 @@ function MobileButtons() {
     }
 
     function addRow(pos: 'top' | 'bottom') {
-        setSettings(prev => {
+        updateSettings(prev => {
             const set = prev[view];
             const makeId = nextId(set.order);
             const ids = Array.from({ length: set.cols }, () => makeId());
@@ -153,7 +161,7 @@ function MobileButtons() {
     }
 
     function removeRow(pos: 'top' | 'bottom') {
-        setSettings(prev => {
+        updateSettings(prev => {
             const set = prev[view];
             const rows = Math.floor(set.order.length / set.cols);
             if (rows <= 1) return prev;
@@ -167,7 +175,7 @@ function MobileButtons() {
     }
 
     function addCol(side: 'left' | 'right') {
-        setSettings(prev => {
+        updateSettings(prev => {
             const set = prev[view];
             const makeId = nextId(set.order);
             const buttons: SettingsMap = { ...set.buttons };
@@ -192,7 +200,7 @@ function MobileButtons() {
     }
 
     function removeCol(side: 'left' | 'right') {
-        setSettings(prev => {
+        updateSettings(prev => {
             const set = prev[view];
             if (set.cols <= 1) return prev;
             const rows = Math.floor(set.order.length / set.cols);
@@ -244,7 +252,7 @@ function MobileButtons() {
     }
 
     function update(setName: Mode, id: string, field: keyof MobileButtonSetting, value: any) {
-        setSettings(prev => ({
+        updateSettings(prev => ({
             ...prev,
             [setName]: {
                 ...prev[setName],
@@ -257,7 +265,7 @@ function MobileButtons() {
     }
 
     function updateAllDirections(field: 'color' | 'activeColor' | 'fontColor', value: string) {
-        setSettings(prev => {
+        updateSettings(prev => {
             const updateSet = (set: Settings['solo']) => {
                 const buttons: SettingsMap = { ...set.buttons };
                 set.order.forEach(id => {
@@ -305,7 +313,7 @@ function MobileButtons() {
     }
 
     function makeBlank(setName: Mode, id: string) {
-        setSettings(prev => ({
+        updateSettings(prev => ({
             ...prev,
             [setName]: {
                 ...prev[setName],
@@ -315,7 +323,7 @@ function MobileButtons() {
     }
 
     function restoreDefaults(setName: Mode) {
-        setSettings(prev => ({
+        updateSettings(prev => ({
             ...prev,
             [setName]: createDefaultLayout(),
         }));
@@ -329,7 +337,7 @@ function MobileButtons() {
     function copyLayout(from: Mode) {
         const to = view;
         if (from === to) return;
-        setSettings(prev => ({ ...prev, [to]: JSON.parse(JSON.stringify(prev[from])) }));
+        updateSettings(prev => ({ ...prev, [to]: JSON.parse(JSON.stringify(prev[from])) }));
     }
 
     // Reset all overrides for the current view: makes it inherit from base (solo) entirely.
@@ -502,7 +510,7 @@ function MobileButtons() {
                         value={backgroundHex}
                         onChange={e => {
                             const hex = e.target.value;
-                            setSettings(prev => {
+                            updateSettings(prev => {
                                 const bg = prev[view].background || defaultBackground;
                                 const { alpha } = parseBackgroundColor(bg);
                                 return {
@@ -523,7 +531,7 @@ function MobileButtons() {
                             value={Math.round(backgroundAlpha * 100)}
                             onChange={e => {
                                 const alphaValue = Number(e.target.value) / 100;
-                                setSettings(prev => {
+                                updateSettings(prev => {
                                     const bg = prev[view].background || defaultBackground;
                                     const { hex } = parseBackgroundColor(bg);
                                     return {
@@ -542,7 +550,7 @@ function MobileButtons() {
                         size="sm"
                         variant="outline-secondary"
                         onClick={() => {
-                            setSettings(prev => ({
+                            updateSettings(prev => ({
                                 ...prev,
                                 [view]: { ...prev[view], background: defaultBackground },
                             }));

--- a/src/web/options/MobileButtons.tsx
+++ b/src/web/options/MobileButtons.tsx
@@ -77,6 +77,11 @@ type SettingsMap = Record<string, MobileButtonSetting>;
 
 const modes: Mode[] = ['solo', 'team', 'leader'];
 
+function getCurrentMode(): Mode {
+    const { isInAnyTeam, isLeader } = getTeamState();
+    return isLeader ? 'leader' : isInAnyTeam ? 'team' : 'solo';
+}
+
 function MobileButtons() {
     const [settings, setSettings] = useState<Settings>({
         solo: { buttons: {}, order: [...defaultOrder], cols: defaultCols, background: defaultBackground },
@@ -91,7 +96,7 @@ function MobileButtons() {
     const [active, setActive] = useState<{ set: Mode; id: string } | null>(null);
     const [pos, setPos] = useState<{ left: number; top: number }>({ left: 0, top: 0 });
     const [pluginMacros, setPluginMacros] = useState<PluginButtonMacro[]>([]);
-    const [view, setView] = useState<Mode>('solo');
+    const [view, setView] = useState<Mode>(() => getCurrentMode());
     const [isMobile, setIsMobile] = useState(false);
     const [configOpen, setConfigOpen] = useState(false);
     const soloRef = useRef<HTMLDivElement>(null);
@@ -327,6 +332,14 @@ function MobileButtons() {
         setSettings(prev => ({ ...prev, [to]: JSON.parse(JSON.stringify(prev[from])) }));
     }
 
+    // Reset all overrides for the current view: makes it inherit from base (solo) entirely.
+    function resetOverrides() {
+        if (view === 'solo') return;
+        setSettings(prev => ({ ...prev, [view]: JSON.parse(JSON.stringify(prev.solo)) }));
+        setActive(null);
+        setConfigOpen(false);
+    }
+
     function save() {
         saveSettings(settings);
         const { isInAnyTeam, isLeader } = getTeamState();
@@ -337,6 +350,8 @@ function MobileButtons() {
     const activeCfg = active ? (settings[active.set].buttons[active.id] || defaultSettings[active.id] || emptySetting) : null;
     const currentBackground = settings[view].background || defaultBackground;
     const { hex: backgroundHex, alpha: backgroundAlpha } = parseBackgroundColor(currentBackground);
+    const currentMode = getCurrentMode();
+    const isOverrideMode = view !== 'solo';
 
     return (
         <div onClick={close} className="w-100 position-relative">
@@ -346,22 +361,25 @@ function MobileButtons() {
                         size="sm"
                         variant={view === 'solo' ? 'primary' : 'secondary'}
                         onClick={() => changeView('solo')}
+                        title={currentMode === 'solo' ? 'Aktualny tryb' : undefined}
                     >
-                        Bez druzyny
+                        Bazowy{currentMode === 'solo' ? ' •' : ''}
                     </Button>
                     <Button
                         size="sm"
                         variant={view === 'team' ? 'primary' : 'secondary'}
                         onClick={() => changeView('team')}
+                        title={currentMode === 'team' ? 'Aktualny tryb' : undefined}
                     >
-                        W druzynie
+                        W druzynie{currentMode === 'team' ? ' •' : ''}
                     </Button>
                     <Button
                         size="sm"
                         variant={view === 'leader' ? 'primary' : 'secondary'}
                         onClick={() => changeView('leader')}
+                        title={currentMode === 'leader' ? 'Aktualny tryb' : undefined}
                     >
-                        Prowadzacy
+                        Prowadzacy{currentMode === 'leader' ? ' •' : ''}
                     </Button>
                 </div>
                 <div className="d-flex align-items-center gap-2">
@@ -378,6 +396,12 @@ function MobileButtons() {
                     />
                 </div>
             </div>
+
+            {isOverrideMode && (
+                <div className="alert alert-info py-2 px-3 small mb-2" onClick={ev => ev.stopPropagation()}>
+                    Ten tryb dziedziczy z trybu Bazowy. Zmiany ponizej sa zapisywane jako nadpisania. Uzyj "Resetuj nadpisania", aby przywrocic pelne dziedziczenie.
+                </div>
+            )}
 
             {/* Button size and gap section */}
             <div
@@ -717,13 +741,18 @@ function MobileButtons() {
                 <Button size="sm" variant="outline-secondary" onClick={() => restoreDefaults(view)}>
                     Domyslne
                 </Button>
+                {isOverrideMode && (
+                    <Button size="sm" variant="outline-secondary" onClick={resetOverrides} title="Wyczysc nadpisania i odziedzicz wszystko z trybu Bazowy">
+                        Resetuj nadpisania
+                    </Button>
+                )}
                 <Form.Select
                     size="sm"
                     value={copyFrom}
                     onChange={e => setCopyFrom(e.target.value as Mode)}
                     style={{ width: 'auto', minWidth: '120px' }}
                 >
-                    <option value="solo">Bez druzyny</option>
+                    <option value="solo">Bazowy</option>
                     <option value="team">W druzynie</option>
                     <option value="leader">Prowadzacy</option>
                 </Form.Select>

--- a/test/modules/core/settingsMigrationsMobileButtons.test.ts
+++ b/test/modules/core/settingsMigrationsMobileButtons.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { globalStorage } from '@modules/core/storage';
+import { getLatestMigrationVersion, migrateMobileButtonOverrides } from '@modules/core/settingsMigrations';
+
+beforeEach(() => localStorage.clear());
+
+/** Legacy shape: three full layouts, team/leader duplicating most of solo. */
+function legacyStored() {
+    return {
+        solo: {
+            cols: 3,
+            background: '#111111',
+            order: ['a', 'b', 'c'],
+            buttons: {
+                a: { macroType: 'command', command: 'polnoc', label: 'N' },
+                b: { macroType: 'command', command: 'poludnie', label: 'S' },
+                c: { macroType: 'command', command: 'wschod', label: 'E' },
+            },
+        },
+        team: {
+            cols: 3,
+            background: '#111111',
+            order: ['a', 'b', 'c'],
+            buttons: {
+                a: { macroType: 'command', command: 'polnoc', label: 'N' },
+                // only this one differs from solo
+                b: { macroType: 'command', command: 'poludnie', label: 'S-team' },
+                c: { macroType: 'command', command: 'wschod', label: 'E' },
+            },
+        },
+        leader: {
+            cols: 4, // differs from solo
+            background: '#111111',
+            order: ['a', 'b', 'c'],
+            buttons: {
+                a: { macroType: 'command', command: 'polnoc', label: 'N' },
+                b: { macroType: 'command', command: 'poludnie', label: 'S' },
+                c: { macroType: 'command', command: 'wschod', label: 'E' },
+            },
+        },
+        locked: true,
+    };
+}
+
+describe('migrateMobileButtonOverrides', () => {
+    test('collapses team/leader into sparse overrides over the solo base', () => {
+        // pre-migration version so the gate opens
+        globalStorage.set('settingsMigrationsVersion', 10 as never);
+        globalStorage.set('mobileButtonSettings', legacyStored() as never);
+
+        migrateMobileButtonOverrides();
+
+        const next = globalStorage.get('mobileButtonSettings') as Record<string, any>;
+        expect(next.format).toBe(2);
+        // solo survives whole
+        expect(next.solo.order).toEqual(['a', 'b', 'c']);
+        expect(next.solo.buttons.b.label).toBe('S');
+        expect(next.locked).toBe(true);
+
+        // team keeps only the diverging button, not the whole layout
+        expect(next.team.buttons).toHaveProperty('b');
+        expect(next.team.buttons.b.label).toBe('S-team');
+        expect(next.team.buttons).not.toHaveProperty('a');
+        expect(next.team.buttons).not.toHaveProperty('c');
+        expect(next.team).not.toHaveProperty('cols');
+
+        // leader diverges only on cols, so it must carry no button overrides
+        expect(next.leader.cols).toBe(4);
+        expect(next.leader).not.toHaveProperty('buttons');
+    });
+
+    test('is a no-op once already converted (format 2)', () => {
+        globalStorage.set('settingsMigrationsVersion', 10 as never);
+        const converted = { format: 2, solo: { cols: 3, order: ['a'], buttons: { a: { label: 'N' } } }, locked: false };
+        globalStorage.set('mobileButtonSettings', converted as never);
+
+        migrateMobileButtonOverrides();
+
+        expect(globalStorage.get('mobileButtonSettings')).toEqual(converted);
+    });
+
+    test('does not run once the version gate has passed', () => {
+        // the migration is registered as the latest version; a user already at
+        // that version must not have their settings rewritten again
+        globalStorage.set('settingsMigrationsVersion', getLatestMigrationVersion() as never);
+        const legacy = legacyStored();
+        globalStorage.set('mobileButtonSettings', legacy as never);
+
+        migrateMobileButtonOverrides();
+
+        expect(globalStorage.get('mobileButtonSettings')).toEqual(legacy);
+    });
+
+    test('gate is open for every version below the latest migration', () => {
+        // guards against the gate being renumbered out of sync with the
+        // migrations registry (this migration is the newest one)
+        globalStorage.set('settingsMigrationsVersion', (getLatestMigrationVersion() - 1) as never);
+        globalStorage.set('mobileButtonSettings', legacyStored() as never);
+
+        migrateMobileButtonOverrides();
+
+        expect((globalStorage.get('mobileButtonSettings') as Record<string, any>).format).toBe(2);
+    });
+});

--- a/test/web/mobileButtonSettings.test.ts
+++ b/test/web/mobileButtonSettings.test.ts
@@ -6,6 +6,7 @@ import {
     createDefaultLayout,
     diffLayout,
     loadSettings,
+    rebaseOverrides,
     resolveLayout,
     saveSettings,
 } from '@web/mobileButtonSettings';
@@ -382,5 +383,104 @@ describe('save/load round-trip', () => {
         // Team should have new base color (via inheritance) and its own label
         expect(reloaded.team.buttons['go-button'].color).toBe('#abcdef');
         expect(reloaded.team.buttons['go-button'].label).toBe('TEAM-GO');
+    });
+});
+
+describe('rebaseOverrides', () => {
+    function makeSettings(overrides: Partial<Settings> = {}): Settings {
+        const base = createDefaultLayout();
+        return {
+            solo: base,
+            team: resolveLayout(base, null),
+            leader: resolveLayout(base, null),
+            locked: false,
+            radial: { enabled: true, commands: [] },
+            ...overrides,
+        };
+    }
+
+    function editSolo(prev: Settings, id: string, patch: Partial<Settings['solo']['buttons'][string]>): Settings {
+        return {
+            ...prev,
+            solo: {
+                ...prev.solo,
+                buttons: { ...prev.solo.buttons, [id]: { ...prev.solo.buttons[id], ...patch } },
+            },
+        };
+    }
+
+    it('propagates a base edit to modes that do not override that button', () => {
+        const prev = makeSettings();
+        const next = rebaseOverrides(prev, editSolo(prev, 'go-button', { color: '#abcdef' }));
+        expect(next.team.buttons['go-button'].color).toBe('#abcdef');
+        expect(next.leader.buttons['go-button'].color).toBe('#abcdef');
+    });
+
+    it('keeps an explicit override while propagating untouched fields of the same button', () => {
+        const base = createDefaultLayout();
+        const prev = makeSettings({
+            solo: base,
+            team: {
+                ...resolveLayout(base, null),
+                buttons: {
+                    ...base.buttons,
+                    'go-button': { ...base.buttons['go-button'], label: 'TEAM-GO' },
+                },
+            },
+        });
+        const next = rebaseOverrides(prev, editSolo(prev, 'go-button', { color: '#abcdef' }));
+        expect(next.team.buttons['go-button'].label).toBe('TEAM-GO');
+        expect(next.team.buttons['go-button'].color).toBe('#abcdef');
+    });
+
+    it('does not turn a base edit into a stored override on save', () => {
+        const prev = makeSettings();
+        const next = rebaseOverrides(prev, editSolo(prev, 'go-button', { color: '#abcdef' }));
+        expect(diffLayout(next.team, next.solo)).toBeNull();
+
+        saveSettings(next);
+        const reloaded = loadSettings();
+        expect(reloaded.team.buttons['go-button'].color).toBe('#abcdef');
+
+        // A later base edit still propagates — the first one didn't pin the value.
+        const second = rebaseOverrides(reloaded, editSolo(reloaded, 'go-button', { color: '#123456' }));
+        expect(second.team.buttons['go-button'].color).toBe('#123456');
+    });
+
+    it('propagates structural base changes (added row) to inheriting modes', () => {
+        const prev = makeSettings();
+        const newIds = ['button-90', 'button-91', 'button-92', 'button-93'];
+        const buttons = { ...prev.solo.buttons };
+        newIds.forEach(id => {
+            buttons[id] = { macroType: 'empty', label: '', color: 'transparent' };
+        });
+        const next = rebaseOverrides(prev, {
+            ...prev,
+            solo: { ...prev.solo, buttons, order: [...newIds, ...prev.solo.order] },
+        });
+        expect(next.team.order).toEqual(next.solo.order);
+        expect(next.leader.order).toEqual(next.solo.order);
+    });
+
+    it('leaves a mode alone when the same update already changed it', () => {
+        const prev = makeSettings();
+        const edited = editSolo(prev, 'go-button', { color: '#abcdef' });
+        const withTeamEdit: Settings = {
+            ...edited,
+            team: {
+                ...edited.team,
+                buttons: { ...edited.team.buttons, 'go-button': { ...edited.team.buttons['go-button'], color: '#ff0000' } },
+            },
+        };
+        const next = rebaseOverrides(prev, withTeamEdit);
+        expect(next.team.buttons['go-button'].color).toBe('#ff0000');
+        expect(next.solo.buttons['go-button'].color).toBe('#abcdef');
+    });
+
+    it('is a no-op when the base did not change', () => {
+        const prev = makeSettings();
+        const next = rebaseOverrides(prev, { ...prev, locked: true });
+        expect(next.team).toBe(prev.team);
+        expect(next.leader).toBe(prev.leader);
     });
 });

--- a/test/web/mobileButtonSettings.test.ts
+++ b/test/web/mobileButtonSettings.test.ts
@@ -119,6 +119,50 @@ describe('diffLayout', () => {
         }
         expect(diff!.order![0]).toBe(reorderedOrder[0]);
     });
+
+    it('captures prepended rows as `prepend` and keeps base region inherited', () => {
+        const base = makeBase();
+        const prependIds = ['x1', 'x2', 'x3', 'x4'];
+        const modified: LayoutSettings = {
+            ...base,
+            buttons: {
+                ...base.buttons,
+                x1: { macroType: 'command', label: 'X1', color: '#fff', command: 'x1' },
+                x2: { macroType: 'command', label: 'X2', color: '#fff', command: 'x2' },
+                x3: { macroType: 'command', label: 'X3', color: '#fff', command: 'x3' },
+                x4: { macroType: 'command', label: 'X4', color: '#fff', command: 'x4' },
+            },
+            order: [...prependIds, ...base.order],
+        };
+        const diff = diffLayout(modified, base);
+        expect(diff).not.toBeNull();
+        expect(diff!.prepend).toEqual(prependIds);
+        expect(diff!.append).toBeUndefined();
+        expect(diff!.order).toBeUndefined();
+        // No base buttons should appear in the override.buttons
+        expect(diff!.buttons && Object.keys(diff!.buttons).every(k => prependIds.includes(k))).toBe(true);
+    });
+
+    it('captures appended rows as `append`', () => {
+        const base = makeBase();
+        const appendIds = ['y1', 'y2', 'y3', 'y4'];
+        const modified: LayoutSettings = {
+            ...base,
+            buttons: {
+                ...base.buttons,
+                y1: { macroType: 'command', label: 'Y1', color: '#fff', command: 'y1' },
+                y2: { macroType: 'command', label: 'Y2', color: '#fff', command: 'y2' },
+                y3: { macroType: 'command', label: 'Y3', color: '#fff', command: 'y3' },
+                y4: { macroType: 'command', label: 'Y4', color: '#fff', command: 'y4' },
+            },
+            order: [...base.order, ...appendIds],
+        };
+        const diff = diffLayout(modified, base);
+        expect(diff).not.toBeNull();
+        expect(diff!.append).toEqual(appendIds);
+        expect(diff!.prepend).toBeUndefined();
+        expect(diff!.order).toBeUndefined();
+    });
 });
 
 describe('save/load round-trip', () => {
@@ -174,6 +218,60 @@ describe('save/load round-trip', () => {
         expect(reloaded.team.buttons['go-button'].label).toBe('GO!');
         // Other fields inherited
         expect(reloaded.team.buttons['go-button'].command).toBe(base.buttons['go-button'].command);
+    });
+
+    it('prepended row preserves inheritance for base cells after reload', () => {
+        const base = createDefaultLayout();
+        const prependIds = ['x1', 'x2', 'x3', 'x4'];
+        const team: LayoutSettings = {
+            ...base,
+            buttons: {
+                ...base.buttons,
+                x1: { macroType: 'command', label: 'X1', color: '#fff', command: 'x1' },
+                x2: { macroType: 'command', label: 'X2', color: '#fff', command: 'x2' },
+                x3: { macroType: 'command', label: 'X3', color: '#fff', command: 'x3' },
+                x4: { macroType: 'command', label: 'X4', color: '#fff', command: 'x4' },
+            },
+            order: [...prependIds, ...base.order],
+        };
+        const settings: Settings = {
+            solo: base,
+            team,
+            leader: createDefaultLayout(),
+            locked: false,
+            radial: { enabled: true, commands: [] },
+        };
+        saveSettings(settings);
+        const stored: any = JSON.parse(localStorage.getItem('mobileButtonSettings')!);
+        expect(stored.team.prepend).toEqual(prependIds);
+        // The base region should NOT be stored: only the prepend cells are.
+        expect(stored.team.order).toBeUndefined();
+
+        // User changes a base button color afterwards
+        const newBase: LayoutSettings = {
+            ...base,
+            buttons: {
+                ...base.buttons,
+                'go-button': { ...base.buttons['go-button'], color: '#ff00ff' },
+            },
+        };
+        // Mirror the change in the runtime team layout (would happen naturally since buttons are inherited at load)
+        const updatedTeam: LayoutSettings = {
+            ...team,
+            buttons: {
+                ...team.buttons,
+                'go-button': { ...team.buttons['go-button'], color: '#ff00ff' },
+            },
+        };
+        saveSettings({ ...settings, solo: newBase, team: updatedTeam });
+
+        const reloaded = loadSettings();
+        // Team's go-button (from inherited base region) should reflect the new base color
+        expect(reloaded.team.buttons['go-button'].color).toBe('#ff00ff');
+        // Prepended cells still present
+        expect(reloaded.team.order.slice(0, 4)).toEqual(prependIds);
+        // Base region intact in resolved order
+        expect(reloaded.team.order.slice(4)).toEqual(newBase.order);
     });
 
     it('changes to base propagate to inherited team buttons after reload', () => {

--- a/test/web/mobileButtonSettings.test.ts
+++ b/test/web/mobileButtonSettings.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+    LayoutSettings,
+    LayoutOverride,
+    Settings,
+    createDefaultLayout,
+    diffLayout,
+    loadSettings,
+    resolveLayout,
+    saveSettings,
+} from '@web/mobileButtonSettings';
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
+function makeBase(): LayoutSettings {
+    return createDefaultLayout();
+}
+
+describe('resolveLayout', () => {
+    it('returns base when override is null', () => {
+        const base = makeBase();
+        const resolved = resolveLayout(base, null);
+        expect(resolved.cols).toBe(base.cols);
+        expect(resolved.background).toBe(base.background);
+        expect(resolved.order).toEqual(base.order);
+        expect(resolved.buttons).toEqual(base.buttons);
+    });
+
+    it('inherits cols and background when override leaves them undefined', () => {
+        const base = makeBase();
+        const override: LayoutOverride = { buttons: { 'go-button': { color: '#ff0000' } } };
+        const resolved = resolveLayout(base, override);
+        expect(resolved.cols).toBe(base.cols);
+        expect(resolved.background).toBe(base.background);
+        expect(resolved.buttons['go-button'].color).toBe('#ff0000');
+        // Other fields of go-button preserved from base
+        expect(resolved.buttons['go-button'].label).toBe(base.buttons['go-button'].label);
+        // Other buttons untouched
+        expect(resolved.buttons['n-button']).toEqual(base.buttons['n-button']);
+    });
+
+    it('overrides cols and background when set', () => {
+        const base = makeBase();
+        const override: LayoutOverride = { cols: 6, background: 'rgba(0, 0, 0, 0.5)' };
+        const resolved = resolveLayout(base, override);
+        expect(resolved.cols).toBe(6);
+        expect(resolved.background).toBe('rgba(0, 0, 0, 0.5)');
+    });
+
+    it('inherits order cells where override has null', () => {
+        const base = makeBase();
+        const sparse = base.order.map(() => null) as (string | null)[];
+        sparse[0] = 'go-button';
+        const override: LayoutOverride = { order: sparse };
+        const resolved = resolveLayout(base, override);
+        expect(resolved.order[0]).toBe('go-button');
+        for (let i = 1; i < base.order.length; i++) {
+            expect(resolved.order[i]).toBe(base.order[i]);
+        }
+    });
+});
+
+describe('diffLayout', () => {
+    it('returns null when layouts are identical', () => {
+        const base = makeBase();
+        const same = createDefaultLayout();
+        expect(diffLayout(same, base)).toBeNull();
+    });
+
+    it('detects a single button field change', () => {
+        const base = makeBase();
+        const modified: LayoutSettings = {
+            ...base,
+            buttons: {
+                ...base.buttons,
+                'go-button': { ...base.buttons['go-button'], color: '#ff0000' },
+            },
+        };
+        const diff = diffLayout(modified, base);
+        expect(diff).not.toBeNull();
+        expect(diff!.buttons).toBeDefined();
+        expect(diff!.buttons!['go-button']).toEqual({ color: '#ff0000' });
+        // No other fields should be in the diff
+        expect(Object.keys(diff!.buttons!)).toEqual(['go-button']);
+    });
+
+    it('detects cols change', () => {
+        const base = makeBase();
+        const modified: LayoutSettings = { ...base, cols: 6 };
+        const diff = diffLayout(modified, base);
+        expect(diff).not.toBeNull();
+        expect(diff!.cols).toBe(6);
+    });
+
+    it('detects background change', () => {
+        const base = makeBase();
+        const modified: LayoutSettings = { ...base, background: 'rgba(0, 0, 0, 0.5)' };
+        const diff = diffLayout(modified, base);
+        expect(diff).not.toBeNull();
+        expect(diff!.background).toBe('rgba(0, 0, 0, 0.5)');
+    });
+
+    it('encodes order diff as sparse array when length matches', () => {
+        const base = makeBase();
+        const reorderedOrder = [...base.order];
+        // Swap first and last
+        [reorderedOrder[0], reorderedOrder[reorderedOrder.length - 1]] =
+            [reorderedOrder[reorderedOrder.length - 1], reorderedOrder[0]];
+        const modified: LayoutSettings = { ...base, order: reorderedOrder };
+        const diff = diffLayout(modified, base);
+        expect(diff).not.toBeNull();
+        expect(diff!.order).toBeDefined();
+        expect(diff!.order!.length).toBe(base.order.length);
+        // Middle cells unchanged → null
+        for (let i = 1; i < base.order.length - 1; i++) {
+            expect(diff!.order![i]).toBeNull();
+        }
+        expect(diff!.order![0]).toBe(reorderedOrder[0]);
+    });
+});
+
+describe('save/load round-trip', () => {
+    it('round-trips a settings object with no overrides', () => {
+        const base = createDefaultLayout();
+        const settings: Settings = {
+            solo: base,
+            team: createDefaultLayout(),
+            leader: createDefaultLayout(),
+            locked: false,
+            radial: { enabled: true, commands: [] },
+            buttonSize: 36,
+            buttonGap: 10,
+        };
+        saveSettings(settings);
+        const stored: any = JSON.parse(localStorage.getItem('mobileButtonSettings')!);
+        // No overrides should be persisted
+        expect(stored.team).toBeUndefined();
+        expect(stored.leader).toBeUndefined();
+        expect(stored.format).toBe(2);
+        const reloaded = loadSettings();
+        expect(reloaded.team.buttons['go-button']).toEqual(base.buttons['go-button']);
+        expect(reloaded.leader.cols).toBe(base.cols);
+    });
+
+    it('round-trips a settings object with a team override', () => {
+        const base = createDefaultLayout();
+        const team: LayoutSettings = {
+            ...base,
+            buttons: {
+                ...base.buttons,
+                'go-button': { ...base.buttons['go-button'], color: '#ff0000', label: 'GO!' },
+            },
+        };
+        const settings: Settings = {
+            solo: base,
+            team,
+            leader: createDefaultLayout(),
+            locked: false,
+            radial: { enabled: true, commands: [] },
+            buttonSize: 36,
+            buttonGap: 10,
+        };
+        saveSettings(settings);
+        const stored: any = JSON.parse(localStorage.getItem('mobileButtonSettings')!);
+        expect(stored.team).toBeDefined();
+        expect(stored.team.buttons['go-button']).toEqual({ color: '#ff0000', label: 'GO!' });
+        // Solo (base) saved fully
+        expect(stored.solo.buttons['go-button'].color).toBe(base.buttons['go-button'].color);
+
+        const reloaded = loadSettings();
+        expect(reloaded.team.buttons['go-button'].color).toBe('#ff0000');
+        expect(reloaded.team.buttons['go-button'].label).toBe('GO!');
+        // Other fields inherited
+        expect(reloaded.team.buttons['go-button'].command).toBe(base.buttons['go-button'].command);
+    });
+
+    it('changes to base propagate to inherited team buttons after reload', () => {
+        const base = createDefaultLayout();
+        // Team only overrides label of go-button
+        const team: LayoutSettings = {
+            ...base,
+            buttons: {
+                ...base.buttons,
+                'go-button': { ...base.buttons['go-button'], label: 'TEAM-GO' },
+            },
+        };
+        const settings: Settings = {
+            solo: base,
+            team,
+            leader: createDefaultLayout(),
+            locked: false,
+            radial: { enabled: true, commands: [] },
+        };
+        saveSettings(settings);
+
+        // User edits base color afterwards
+        const newBase: LayoutSettings = {
+            ...base,
+            buttons: {
+                ...base.buttons,
+                'go-button': { ...base.buttons['go-button'], color: '#abcdef' },
+            },
+        };
+        const updated: Settings = { ...settings, solo: newBase, team: { ...team, buttons: { ...team.buttons, 'go-button': { ...team.buttons['go-button'], color: '#abcdef' } } } };
+        saveSettings(updated);
+
+        const reloaded = loadSettings();
+        // Team should have new base color (via inheritance) and its own label
+        expect(reloaded.team.buttons['go-button'].color).toBe('#abcdef');
+        expect(reloaded.team.buttons['go-button'].label).toBe('TEAM-GO');
+    });
+});

--- a/test/web/mobileButtonSettings.test.ts
+++ b/test/web/mobileButtonSettings.test.ts
@@ -143,6 +143,39 @@ describe('diffLayout', () => {
         expect(diff!.buttons && Object.keys(diff!.buttons).every(k => prependIds.includes(k))).toBe(true);
     });
 
+    it('captures structural divergence (e.g. column add) as replaceOrder, not duplicated prepend', () => {
+        const base = makeBase();
+        // Simulate adding a column on the right: each row gets one new cell.
+        // Base default has cols=4 and 5 rows of 4 (20 cells). New cols=5, 5 rows of 5 (25 cells).
+        const cols = base.cols;
+        const rows = base.order.length / cols;
+        const newCellIds = Array.from({ length: rows }, (_, r) => `col-${r}`);
+        const newOrder: string[] = [];
+        const newButtons = { ...base.buttons } as Record<string, any>;
+        for (let r = 0; r < rows; r++) {
+            for (let c = 0; c < cols; c++) {
+                newOrder.push(base.order[r * cols + c]);
+            }
+            newOrder.push(newCellIds[r]);
+            newButtons[newCellIds[r]] = { macroType: 'command', label: `C${r}`, color: '#fff', command: `c${r}` };
+        }
+        const modified: LayoutSettings = { ...base, cols: cols + 1, order: newOrder, buttons: newButtons };
+        const diff = diffLayout(modified, base);
+        expect(diff).not.toBeNull();
+        expect(diff!.cols).toBe(cols + 1);
+        expect(diff!.replaceOrder).toEqual(newOrder);
+        expect(diff!.prepend).toBeUndefined();
+        expect(diff!.append).toBeUndefined();
+        expect(diff!.order).toBeUndefined();
+        // Only the new column buttons should appear in override.buttons (base buttons inherited).
+        expect(diff!.buttons && Object.keys(diff!.buttons).every(k => newCellIds.includes(k))).toBe(true);
+
+        // Round-trip via resolve: result should not duplicate the base region.
+        const resolved = resolveLayout(base, diff);
+        expect(resolved.order).toEqual(newOrder);
+        expect(resolved.cols).toBe(cols + 1);
+    });
+
     it('captures appended rows as `append`', () => {
         const base = makeBase();
         const appendIds = ['y1', 'y2', 'y3', 'y4'];
@@ -272,6 +305,47 @@ describe('save/load round-trip', () => {
         expect(reloaded.team.order.slice(0, 4)).toEqual(prependIds);
         // Base region intact in resolved order
         expect(reloaded.team.order.slice(4)).toEqual(newBase.order);
+    });
+
+    it('column-add round-trip preserves base inheritance for unchanged buttons', () => {
+        const base = createDefaultLayout();
+        const cols = base.cols;
+        const rows = base.order.length / cols;
+        const newCellIds = Array.from({ length: rows }, (_, r) => `col-${r}`);
+        const teamOrder: string[] = [];
+        const teamButtons: Record<string, any> = { ...base.buttons };
+        for (let r = 0; r < rows; r++) {
+            for (let c = 0; c < cols; c++) teamOrder.push(base.order[r * cols + c]);
+            teamOrder.push(newCellIds[r]);
+            teamButtons[newCellIds[r]] = { macroType: 'command', label: `C${r}`, color: '#fff', command: `c${r}` };
+        }
+        const team: LayoutSettings = { ...base, cols: cols + 1, order: teamOrder, buttons: teamButtons };
+        const settings: Settings = {
+            solo: base, team, leader: createDefaultLayout(),
+            locked: false, radial: { enabled: true, commands: [] },
+        };
+        saveSettings(settings);
+
+        // User changes a base button color afterwards
+        const newBase: LayoutSettings = {
+            ...base,
+            buttons: { ...base.buttons, 'go-button': { ...base.buttons['go-button'], color: '#abcdef' } },
+        };
+        const updatedTeam: LayoutSettings = {
+            ...team,
+            buttons: { ...team.buttons, 'go-button': { ...team.buttons['go-button'], color: '#abcdef' } },
+        };
+        saveSettings({ ...settings, solo: newBase, team: updatedTeam });
+
+        const reloaded = loadSettings();
+        // Team's base cells inherit the new color
+        expect(reloaded.team.buttons['go-button'].color).toBe('#abcdef');
+        // Mode-specific column cells preserved
+        expect(reloaded.team.order.length).toBe(teamOrder.length);
+        expect(reloaded.team.cols).toBe(cols + 1);
+        for (const id of newCellIds) {
+            expect(reloaded.team.buttons[id]).toBeDefined();
+        }
     });
 
     it('changes to base propagate to inherited team buttons after reload', () => {


### PR DESCRIPTION
@
Rebased from the stale `claude/simplify-button-config-ZcxZ3` branch (May 2026, 191 commits behind, no PR ever opened) during a remote-branch cleanup.

## Problem

`mobileButtonSettings` stores solo/team/leader as **three full layouts**. Editing a button shared by all three means copy-pasting the change into each mode by hand, and adding a row or column to one mode silently desynchronises it from the others.

## What this does

- **Solo becomes the single base.** Team and leader persist only the fields that differ, so edits to a base button flow into the inherited modes automatically.
- **`prepend`/`append` arrays** — adding a row at the top used to shift every base cell into "overridden". The diff now detects `base.order` as a contiguous subsequence and captures only the cells outside it; the resolver rebuilds the runtime order as `[...prepend, ...base + positional override, ...append]`.
- **`replaceOrder`** — the shape-change fallback used to dump the whole new order into `prepend`, which the resolver then concatenated with `base.order` *again*, duplicating the layout on reload.
- **Id-based inheritance indicator** — it was positional, so adding a column marked every cell as overridden. A cell now shows as inherited iff its id exists in base and the resolved config matches.
- UI: settings open on the character's current team mode, override modes show an inheritance banner and a "Resetuj nadpisania" action, and the grid outlines cells that diverge from base.

## Rebase notes (what changed vs the original branch)

1. **Migration renumbered v8 -> v11.** Master has since taken v8 (layoutManagerState), v9 (legacy keybinding fields) and v10 (uiSettings split). The original branch would have collided with `migrateLayoutManagerState` — both the registry entry and the exported function, which the conflict had merged into one body.
2. **Wired into `clientBootstrap.ts`, not `main.ts`.** Migrations moved into the shared bootstrap since the branch was cut, so the call now sits with the others (after the macro-field rename so the diff compares normalised configs, before `runAllSettingsMigrations()` bumps the version past its gate).
3. **Added `test/modules/core/settingsMigrationsMobileButtons.test.ts`.** The migration function had no coverage, which is uncomfortable when its version gate has just been renumbered. Four tests: conversion to sparse overrides, no-op when already `format: 2`, no-op once the gate has passed, and a guard that the gate stays in sync with `getLatestMigrationVersion()`.
4. **Fixed one real e2e regression.** `mobile-buttons-color.spec.ts` "should switch between different button modes" passes on master and failed here: the solo mode button is renamed `Bez druzyny` -> `Bazowy` (it is now the base others inherit from) and the mode matching the current team state gets a marker appended. The assertions now match on label prefix.

## Verification

- `npx tsc --noEmit` — clean
- `yarn test` — 173 files, 1767 tests passed (up from 171/1746 on master: +17 from the branch suite, +4 from the new migration tests)
- `yarn build` — succeeds (only the pre-existing sql.js externalisation warnings)
- e2e: all 28 tests across `mobile-button-migration`, `mobile-buttons-color`, `mobile-buttons-drag`, `mobile-buttons-sizing`, `compound-macro-mobile`, `mobile-command-radial` pass

## Worth a careful look

This is a storage-format change gated behind a migration, on a file that PR #1303 reworked last week. The migration is one-way: it rewrites `mobileButtonSettings` in place to `format: 2`. Existing users' three-mode layouts get collapsed on first load after this ships.
@