### PR TITLE
feat(examples): add GMCP inspector plugin

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@ Ten katalog zawiera przykładowe pluginy demonstrujące system pluginów Arkadia
 1. **simple-highlighter-plugin.ts** - Prosty plugin do podświetlania słów kolorami
 2. **example-plugin.ts** - Kompleksowy przykład pokazujący różne funkcje API
 3. **combat-alert-plugin.ts** - Zaawansowany plugin śledzący statystyki walki
+4. **gmcp-inspector-plugin.ts** - Podgląd surowych zdarzeń GMCP (filtrowanie, pauza, kopiowanie); przydatny przy pisaniu własnych pluginów
 
 ## 🚀 Serwer Deweloperski
 

--- a/examples/gmcp-inspector-plugin.ts
+++ b/examples/gmcp-inspector-plugin.ts
@@ -1,0 +1,270 @@
+/**
+ * Inspektor GMCP
+ *
+ * Podglad surowych zdarzen GMCP przychodzacych z serwera — przydatny przy
+ * pisaniu wlasnych pluginow i przy zglaszaniu bledow.
+ *
+ * Funkcje:
+ * - Okno z lista zdarzen GMCP (najnowsze na koncu), ze znacznikiem czasu
+ * - Filtrowanie po sciezce (np. `char.vitals`, `room`)
+ * - Pauza / wznowienie zbierania, czyszczenie listy
+ * - Kopiowanie calego bufora do schowka (JSON)
+ * - Automatyczne przewijanie, wylaczane gdy przewiniesz liste w gore
+ *
+ * Okno jest trwale (`registerPersistentPopup`), wiec po przypieciu wraca po
+ * przeladowaniu strony. Otwiera sie z menu popupow ("Inspektor GMCP"), a
+ * zdarzenia zbierane sa dopiero po pierwszym otwarciu okna — plugin nie
+ * nasluchuje w tle, dopoki go nie potrzebujesz.
+ *
+ * Jak uzyc:
+ * 1. Zbuduj: `yarn build:examples`
+ * 2. Uruchom serwer: `yarn serve:examples`
+ * 3. Dodaj URL `http://localhost:3030/plugins/gmcp-inspector-plugin.js`
+ *    w sekcji "Skrypty" w kliencie
+ */
+
+import type { PluginApi, PluginInfo, PersistentPopupHandle } from '@arkadia/plugin-types';
+
+/** Ile zdarzen trzymamy w buforze — starsze sa odrzucane. */
+const MAX_ENTRIES = 200;
+
+interface GmcpEntry {
+  time: string;
+  path: string;
+  value: unknown;
+}
+
+/**
+ * `api.events.on` przekazuje listener prosto do klienta i NIE jest sprzatane
+ * automatycznie przy wyladowaniu pluginu (inaczej niz triggery z tagiem czy
+ * popupy z `api.ui`). Trzymamy wiec referencje na poziomie modulu, zeby
+ * `destroy()` mialo co wyrejestrowac.
+ */
+let activeApi: PluginApi | null = null;
+let activeGmcpListener: ((data: { path?: string; value?: unknown }) => void) | null = null;
+
+export async function init(api: PluginApi): Promise<PluginInfo> {
+  const entries: GmcpEntry[] = [];
+  let filter = '';
+  let paused = false;
+  let popup: PersistentPopupHandle | null = null;
+  let listenerAttached = false;
+
+  // Elementy budujemy raz i trzymamy referencje, zeby kazde zdarzenie
+  // dopisywalo jeden wiersz zamiast przerysowywac cala liste.
+  let logElement: HTMLPreElement | null = null;
+  let scrollElement: HTMLDivElement | null = null;
+  let countElement: HTMLSpanElement | null = null;
+
+  function formatValue(value: unknown): string {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch (error) {
+      return `<nie udalo sie sformatowac: ${String(error)}>`;
+    }
+  }
+
+  function formatEntry(entry: GmcpEntry): string {
+    return `[${entry.time}] ${entry.path}\n${formatValue(entry.value)}\n`;
+  }
+
+  function matchesFilter(entry: GmcpEntry): boolean {
+    if (!filter) return true;
+    return entry.path.toLowerCase().includes(filter.toLowerCase());
+  }
+
+  /** Czy lista jest przewinieta na sam dol (z niewielkim marginesem). */
+  function isAtBottom(): boolean {
+    if (!scrollElement) return true;
+    const { scrollTop, scrollHeight, clientHeight } = scrollElement;
+    return scrollHeight - scrollTop - clientHeight < 24;
+  }
+
+  function updateCount(): void {
+    if (!countElement) return;
+    const shown = entries.filter(matchesFilter).length;
+    countElement.textContent =
+      shown === entries.length
+        ? `${entries.length}/${MAX_ENTRIES}`
+        : `${shown}/${entries.length}`;
+  }
+
+  /** Pelne przerysowanie — uzywane przy zmianie filtra i czyszczeniu. */
+  function renderAll(): void {
+    if (!logElement) return;
+    logElement.textContent = entries.filter(matchesFilter).map(formatEntry).join('\n');
+    updateCount();
+    if (scrollElement) scrollElement.scrollTop = scrollElement.scrollHeight;
+  }
+
+  function appendEntry(entry: GmcpEntry): void {
+    if (!logElement || !matchesFilter(entry)) {
+      updateCount();
+      return;
+    }
+    const stick = isAtBottom();
+    logElement.textContent += (logElement.textContent ? '\n' : '') + formatEntry(entry);
+    updateCount();
+    // Trzymamy sie dolu tylko wtedy, gdy uzytkownik sam nie przewinal w gore.
+    if (stick && scrollElement) scrollElement.scrollTop = scrollElement.scrollHeight;
+  }
+
+  function handleGmcp(data: { path?: string; value?: unknown }): void {
+    if (paused) return;
+    const entry: GmcpEntry = {
+      time: new Date().toLocaleTimeString(),
+      path: data.path ?? '(brak sciezki)',
+      value: data.value,
+    };
+    entries.push(entry);
+    if (entries.length > MAX_ENTRIES) {
+      entries.shift();
+      // Bufor sie przewinal, wiec pierwszy wiersz zniknal — przerysuj calosc.
+      renderAll();
+      return;
+    }
+    appendEntry(entry);
+  }
+
+  function button(label: string, onClick: () => void): HTMLButtonElement {
+    const el = document.createElement('button');
+    el.type = 'button';
+    el.className = 'btn btn-sm btn-secondary';
+    el.textContent = label;
+    el.addEventListener('click', onClick);
+    return el;
+  }
+
+  function createContent(): Node {
+    const container = document.createElement('div');
+    container.className = 'd-flex flex-column gap-2';
+
+    const description = document.createElement('p');
+    description.className = 'mb-0 small text-muted';
+    description.textContent =
+      'Surowe zdarzenia GMCP z serwera. Najnowsze na koncu.';
+
+    const controls = document.createElement('div');
+    controls.className = 'd-flex gap-2 align-items-center flex-wrap';
+
+    const filterInput = document.createElement('input');
+    filterInput.type = 'text';
+    filterInput.className = 'form-control form-control-sm';
+    filterInput.style.maxWidth = '180px';
+    filterInput.placeholder = 'Filtr sciezki...';
+    filterInput.value = filter;
+    filterInput.addEventListener('input', () => {
+      filter = filterInput.value.trim();
+      renderAll();
+    });
+
+    const pauseButton = button(paused ? 'Wznow' : 'Pauza', () => {
+      paused = !paused;
+      pauseButton.textContent = paused ? 'Wznow' : 'Pauza';
+      pauseButton.classList.toggle('btn-warning', paused);
+      pauseButton.classList.toggle('btn-secondary', !paused);
+    });
+    pauseButton.classList.toggle('btn-warning', paused);
+    pauseButton.classList.toggle('btn-secondary', !paused);
+
+    const clearButton = button('Wyczysc', () => {
+      entries.length = 0;
+      renderAll();
+    });
+
+    const copyButton = button('Kopiuj', () => {
+      const payload = JSON.stringify(entries.filter(matchesFilter), null, 2);
+      void navigator.clipboard?.writeText(payload).then(
+        () => {
+          copyButton.textContent = 'Skopiowano';
+          setTimeout(() => (copyButton.textContent = 'Kopiuj'), 1500);
+        },
+        () => {
+          copyButton.textContent = 'Blad kopiowania';
+          setTimeout(() => (copyButton.textContent = 'Kopiuj'), 1500);
+        },
+      );
+    });
+
+    const count = document.createElement('span');
+    count.className = 'ms-auto small text-muted';
+    countElement = count;
+
+    controls.append(filterInput, pauseButton, clearButton, copyButton, count);
+
+    const scroll = document.createElement('div');
+    scroll.style.height = '20rem';
+    scroll.style.overflowY = 'auto';
+    scroll.style.padding = '0.5rem';
+    scroll.style.borderRadius = '0.25rem';
+    scroll.style.background = 'var(--popup-body-bg, rgba(0, 0, 0, 0.25))';
+    scroll.style.border = '1px solid var(--popup-border-color, rgba(255, 255, 255, 0.1))';
+
+    const log = document.createElement('pre');
+    log.className = 'mb-0';
+    log.style.whiteSpace = 'pre-wrap';
+    log.style.wordBreak = 'break-word';
+    log.style.fontSize = '0.8rem';
+
+    scroll.appendChild(log);
+    container.append(description, controls, scroll);
+
+    logElement = log;
+    scrollElement = scroll;
+    renderAll();
+
+    return container;
+  }
+
+  const handle = await api.ui.registerPersistentPopup({
+    id: 'gmcp-inspector',
+    title: 'Inspektor GMCP',
+    createContent,
+  });
+  popup = handle;
+
+  // Nasluchujemy dopiero gdy okno jest faktycznie potrzebne — plugin dodany i
+  // nigdy nie otwarty nie kosztuje nic poza rejestracja wpisu w menu.
+  function attachListener(): void {
+    if (listenerAttached) return;
+    api.events.on('gmcp', handleGmcp);
+    activeApi = api;
+    activeGmcpListener = handleGmcp;
+    listenerAttached = true;
+  }
+
+  // Popup przypiety/zadokowany wraca po przeladowaniu strony — wtedy zbieramy
+  // od razu, bez czekania na klikniecie w menu.
+  if (handle.wasRestored) {
+    attachListener();
+  }
+
+  api.ui.addPopupMenuEntry('Inspektor GMCP', () => {
+    attachListener();
+    void popup?.open();
+  });
+
+  return {
+    name: 'Inspektor GMCP',
+    version: '1.0.0',
+    author: 'Zespol Arkadia',
+    description: 'Podglad surowych zdarzen GMCP z filtrowaniem, pauza i kopiowaniem',
+  };
+}
+
+/**
+ * Czyszczenie przy wyladowaniu pluginu.
+ *
+ * Popupy i wpisy w menu utworzone przez `api.ui` sprzatane sa automatycznie
+ * przez PluginApi, ale listenery zdarzen NIE — `api.events.on` to zwykly
+ * passthrough do `client.on`. Bez tego `off` listener zylby dalej po usunieciu
+ * pluginu i dopisywal do bufora, ktorego nikt juz nie oglada.
+ */
+export async function destroy(): Promise<void> {
+  if (activeApi && activeGmcpListener) {
+    activeApi.events.off('gmcp', activeGmcpListener);
+  }
+  activeApi = null;
+  activeGmcpListener = null;
+  console.log('[Inspektor GMCP] Czyszczenie...');
+}

--- a/test/examples/gmcpInspectorPlugin.test.ts
+++ b/test/examples/gmcpInspectorPlugin.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Behavioural tests for the GMCP inspector example plugin.
+ *
+ * The plugin is driven through a PluginApi double rather than the real
+ * PluginApiImpl (that lifecycle is already covered by
+ * test/client/PluginManager.integration.test.ts). What matters here is the
+ * plugin's own contract: it must not listen to GMCP until the user opens the
+ * window, and it must unsubscribe on destroy — `api.events.on` is a plain
+ * passthrough to `client.on`, so nothing cleans the listener up for it.
+ */
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+type GmcpListener = (data: { path?: string; value?: unknown }) => void;
+
+interface PopupDouble {
+    id: string;
+    title: string;
+    createContent: () => Node | Promise<Node>;
+    open: ReturnType<typeof vi.fn>;
+    wasRestored: boolean;
+}
+
+function makeApi(opts: { wasRestored?: boolean } = {}) {
+    const listeners = new Map<string, Set<GmcpListener>>();
+    let popup: PopupDouble | null = null;
+    let menuEntry: { label: string; onSelect: () => void } | null = null;
+
+    const api = {
+        events: {
+            on: vi.fn((event: string, listener: GmcpListener) => {
+                if (!listeners.has(event)) listeners.set(event, new Set());
+                listeners.get(event)!.add(listener);
+            }),
+            off: vi.fn((event: string, listener: GmcpListener) => {
+                listeners.get(event)?.delete(listener);
+            }),
+            emit: vi.fn(),
+        },
+        ui: {
+            registerPersistentPopup: vi.fn(async (config: any) => {
+                popup = {
+                    id: config.id,
+                    title: config.title,
+                    createContent: config.createContent,
+                    open: vi.fn(async () => {}),
+                    wasRestored: !!opts.wasRestored,
+                };
+                return popup;
+            }),
+            addPopupMenuEntry: vi.fn((label: string, onSelect: () => void) => {
+                menuEntry = { label, onSelect };
+                return { remove: vi.fn() };
+            }),
+        },
+    };
+
+    return {
+        api,
+        listenerCount: (event: string) => listeners.get(event)?.size ?? 0,
+        fire: (event: string, payload: { path?: string; value?: unknown }) => {
+            listeners.get(event)?.forEach(l => l(payload));
+        },
+        getPopup: () => popup,
+        getMenuEntry: () => menuEntry,
+    };
+}
+
+async function loadPlugin() {
+    vi.resetModules();
+    return import('../../examples/gmcp-inspector-plugin');
+}
+
+describe('gmcp-inspector example plugin', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('registers a persistent popup and a menu entry on init', async () => {
+        const plugin = await loadPlugin();
+        const h = makeApi();
+
+        const info = await plugin.init(h.api as any);
+
+        expect(h.getPopup()?.id).toBe('gmcp-inspector');
+        expect(h.getMenuEntry()?.label).toBe('Inspektor GMCP');
+        expect(info.name).toBe('Inspektor GMCP');
+
+        await plugin.destroy();
+    });
+
+    test('does not subscribe to gmcp until the window is opened', async () => {
+        const plugin = await loadPlugin();
+        const h = makeApi();
+
+        await plugin.init(h.api as any);
+        expect(h.listenerCount('gmcp')).toBe(0);
+
+        h.getMenuEntry()!.onSelect();
+        expect(h.listenerCount('gmcp')).toBe(1);
+        expect(h.getPopup()!.open).toHaveBeenCalled();
+
+        await plugin.destroy();
+    });
+
+    test('subscribes immediately when the popup was restored from a previous session', async () => {
+        const plugin = await loadPlugin();
+        const h = makeApi({ wasRestored: true });
+
+        await plugin.init(h.api as any);
+
+        expect(h.listenerCount('gmcp')).toBe(1);
+
+        await plugin.destroy();
+    });
+
+    test('opening twice does not stack duplicate listeners', async () => {
+        const plugin = await loadPlugin();
+        const h = makeApi();
+
+        await plugin.init(h.api as any);
+        h.getMenuEntry()!.onSelect();
+        h.getMenuEntry()!.onSelect();
+
+        expect(h.listenerCount('gmcp')).toBe(1);
+
+        await plugin.destroy();
+    });
+
+    test('renders received gmcp events into the popup content', async () => {
+        const plugin = await loadPlugin();
+        const h = makeApi();
+
+        await plugin.init(h.api as any);
+        h.getMenuEntry()!.onSelect();
+
+        const content = (await h.getPopup()!.createContent()) as HTMLElement;
+        h.fire('gmcp', { path: 'char.vitals', value: { hp: 100 } });
+
+        const log = content.querySelector('pre')!;
+        expect(log.textContent).toContain('char.vitals');
+        expect(log.textContent).toContain('"hp": 100');
+
+        await plugin.destroy();
+    });
+
+    test('destroy unsubscribes the gmcp listener', async () => {
+        const plugin = await loadPlugin();
+        const h = makeApi();
+
+        await plugin.init(h.api as any);
+        h.getMenuEntry()!.onSelect();
+        expect(h.listenerCount('gmcp')).toBe(1);
+
+        await plugin.destroy();
+
+        expect(h.api.events.off).toHaveBeenCalledWith('gmcp', expect.any(Function));
+        expect(h.listenerCount('gmcp')).toBe(0);
+    });
+
+    test('destroy is safe when the window was never opened', async () => {
+        const plugin = await loadPlugin();
+        const h = makeApi();
+
+        await plugin.init(h.api as any);
+        await expect(plugin.destroy()).resolves.toBeUndefined();
+        expect(h.api.events.off).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
@
Rebuilt from the idea in the stale `codex/add-debugging-plugin-for-gmcp-events` branch (Nov 2025, PR #1227 closed, 1,180 commits behind), which is deleted as part of a remote-branch cleanup.

## Why rebuilt rather than rebased

The original put a `document.createElement`-based plugin under `src/client/plugins/` plus a builtin-plugin registry (`BUILTIN_PLUGIN_DEFINITIONS`, `PluginManager` loading support, a management surface in `options/Scripts.tsx`). Since then `src/client` became DOM-free with an ESLint boundary rule enforcing it, so that implementation cannot be rebased — a DOM-building module under `src/client/` is exactly what the rule forbids.

An example plugin is also the better home: no builtin-plugin infrastructure needed, and it doubles as documentation of the plugin API. Master has no GMCP debug facility at all, so the need was still unmet.

## What it does

A popup listing raw GMCP events, newest last, timestamped with pretty-printed JSON, capped at 200 entries. Beyond the original:

- **Path filter** (`char.vitals`, `room`, ...)
- **Pause/resume**, **clear**, and **copy the buffer as JSON** to the clipboard
- **Auto-scroll that stops following when you scroll up**, and resumes at the bottom
- Rows are appended individually instead of re-rendering the whole log on every event
- Persistent popup — survives reload when pinned
- **The GMCP listener attaches lazily on first open.** A plugin installed but never opened costs nothing but a menu entry. It attaches immediately if the popup was restored from a previous session.

## One API sharp edge worth knowing

`api.events.on` is a plain passthrough to `client.on` and is **not** cleaned up by `PluginApi` on unload — unlike tagged triggers and `api.ui` popups/menu entries, which are. Without an explicit `off`, the listener outlives the plugin and keeps appending to a buffer nobody is watching. `destroy()` unsubscribes explicitly, and the tests lock that behaviour in.

## Verification

- `yarn build:examples` — compiles
- `npx tsc --noEmit -p examples/tsconfig.json` — clean (esbuild does not type-check, so this is checked separately)
- `npx tsc --noEmit` — clean
- `yarn test` — 174 files, 1774 tests passed (+7 new)

New `test/examples/gmcpInspectorPlugin.test.ts` drives the plugin through a `PluginApi` double and covers: popup + menu-entry registration, no subscription before first open, immediate subscription when restored, no duplicate listeners on repeated open, events rendering into the popup content, unsubscribe on destroy, and destroy being safe when never opened.
@